### PR TITLE
rosdistro sync, Fri Nov  5 13:26:53 2021

### DIFF
--- a/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-foxy-aws-robomaker-small-warehouse-world";
-  version = "1.0.1-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/foxy/aws_robomaker_small_warehouse_world/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "186aeccb81a6a5d0cf66bc81d17d679ce8d5c249325dc52abfd61bc1ed262683";
+    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/foxy/aws_robomaker_small_warehouse_world/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "a827658ed4aaa59b639eb887926240c024e936f4f6a113dfaa992cd478360633";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "4aed297fd1cab9e95aed271f43e536d15e3ba73233bd9adb72bde9a504358a74";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "9c0917f474b30a4ccf030e893c9ab545df2bd84ccdaee9d59303fa16edf9f57c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "5dd3e58b14aac07124df8bb7870cf4f4c7801a1dca09893fc92db741d3696731";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "31ceda0aa15c3307c7224c0b73d493725d8e80f3d7dc642a6965d0ba3270adfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ffe49b312ab3aaa3f9c9fb3aa95c5fafde3e726b293492371b1ae83dd7b4158b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "ce30b80b22a9c7ae38545ab826c51cb6e0d9aff52c5498005c0ea72fdac32127";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "c2cdfcda793c14569cc1719ce0becf03a902a8e47c635c16e114a0ab42a3a559";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "4e42693754ccfb0f105b1591bda1538daca4561a1073e7d637d6e73bf8d1d855";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "0a2a2229c787e95776efcc7100f953292717ac1830b969ed1a664e7190ee7bf6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "333c70f402be38a68ac976aced8e5eada812f66a897a112680cbfe84898e7af3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/foxy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-force-torque-sensor-broadcaster";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "186838b2d1584f1faf22fc287fac28bd3791d1c7b5690de93d7120a822170933";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "5cd4eefe34f18f5cffa1449dbcad04ab1c9cd440c159a6296c5c4a781fdc3da5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "7aafcf126b6f77b573fca05092e4203c74a1ba0894e9c734f5801f0b6addf43d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "fb7795ab3f389525a5acc6c084b13360f5e15df5f10b513088483f126d6f2d11";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-ros2-control-demos/default.nix
+++ b/distros/foxy/gazebo-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control-demos";
-  version = "0.0.3-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "5b5eec14876bd5ef49ca3b40312baac5bdaea4983c96074b4e5ec4bcae8a40be";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "efa40ad700814bb02f19eaaedab0687990210c0f4eea9ddab49fcd17b2df14a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-ros2-control/default.nix
+++ b/distros/foxy/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control";
-  version = "0.0.3-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "5a673206efaca88a5fe5dd2a52a8f35d9beb64f3e4243f5bc4d2b8cdf82decd6";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "a22bc0a8ed474a0c5943cd4ff4f8303e34b357e3e2792cdddc0cf6fc4061e8b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -656,13 +656,25 @@ self: super: {
 
  mavros = self.callPackage ./mavros {};
 
+ mavros-extras = self.callPackage ./mavros-extras {};
+
  mavros-msgs = self.callPackage ./mavros-msgs {};
 
  menge-vendor = self.callPackage ./menge-vendor {};
 
  message-filters = self.callPackage ./message-filters {};
 
+ micro-ros-diagnostic-bridge = self.callPackage ./micro-ros-diagnostic-bridge {};
+
+ micro-ros-diagnostic-msgs = self.callPackage ./micro-ros-diagnostic-msgs {};
+
  micro-ros-msgs = self.callPackage ./micro-ros-msgs {};
+
+ microstrain-inertial-driver = self.callPackage ./microstrain-inertial-driver {};
+
+ microstrain-inertial-examples = self.callPackage ./microstrain-inertial-examples {};
+
+ microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
@@ -1244,6 +1256,8 @@ self: super: {
 
  rosapi = self.callPackage ./rosapi {};
 
+ rosapi-msgs = self.callPackage ./rosapi-msgs {};
+
  rosauth = self.callPackage ./rosauth {};
 
  rosbag2 = self.callPackage ./rosbag2 {};
@@ -1273,6 +1287,8 @@ self: super: {
  rosbridge-server = self.callPackage ./rosbridge-server {};
 
  rosbridge-suite = self.callPackage ./rosbridge-suite {};
+
+ rosbridge-test-msgs = self.callPackage ./rosbridge-test-msgs {};
 
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
 
@@ -1694,19 +1710,13 @@ self: super: {
 
  webots-ros2 = self.callPackage ./webots-ros2 {};
 
- webots-ros2-abb = self.callPackage ./webots-ros2-abb {};
-
  webots-ros2-control = self.callPackage ./webots-ros2-control {};
 
  webots-ros2-core = self.callPackage ./webots-ros2-core {};
 
- webots-ros2-demos = self.callPackage ./webots-ros2-demos {};
-
  webots-ros2-driver = self.callPackage ./webots-ros2-driver {};
 
  webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
-
- webots-ros2-examples = self.callPackage ./webots-ros2-examples {};
 
  webots-ros2-importer = self.callPackage ./webots-ros2-importer {};
 
@@ -1722,11 +1732,7 @@ self: super: {
 
  webots-ros2-turtlebot = self.callPackage ./webots-ros2-turtlebot {};
 
- webots-ros2-tutorials = self.callPackage ./webots-ros2-tutorials {};
-
  webots-ros2-universal-robot = self.callPackage ./webots-ros2-universal-robot {};
-
- webots-ros2-ur-e-description = self.callPackage ./webots-ros2-ur-e-description {};
 
  wiimote = self.callPackage ./wiimote {};
 

--- a/distros/foxy/gripper-controllers/default.nix
+++ b/distros/foxy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-gripper-controllers";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "41e08495122298123068172f6414908d365ecdca7d6a271ac98e8b6bea42fc2b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "959447fe35b065e479574a725503388ff1e7508d7be4554f67bd033ca5f63696";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "5323961c9d16de5226e8f3a4324f41402b75ee1b5fad27bdde64fc64330cd737";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "df8645db8b63409e18c84b88cde8dbfd258d9e2a73bb9001fa16d0a3db5a7b05";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-sensor-broadcaster/default.nix
+++ b/distros/foxy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-sensor-broadcaster";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "e0944943f7bf8b7a854c0686f2bfa25b618e0cd42eed4daec2f331d3a81c163e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "6215c5aed3720f67d2a35d3a2b63b3acc5b53dfad1d4ac03b639ad2627ea1d4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-broadcaster";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "347f3ab84b2a1c86e28a937e7bc19608a843f3a8c978ae7c9fd7477cec6d5842";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "21326858c82c50fcee6b5d2350fa12aa463a39cd701c3e81becd2109b102d13e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "5b5bb31473bcadd06bf569142bd9c9be2e30f8db8834ce16ff426e1d4a98f1fc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "40b56fa010177893f2b4f4b79c91d8479ecfe5ba4863d5492929e9f8beaad4a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "eb932423febd3cbeddd39c666b05bfcd253735887d3dcaa0e328783f3758ff53";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ae5af702242eed133b0113d231ff1f3f051e1f23f0aeed6012d08a3df2e34850";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/libmavconn/default.nix
+++ b/distros/foxy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-libmavconn";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "1ace47d553aa6a398fe4d2b90cb52dec75cd86114a724df6631da74eea737604";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "128f16112ed4da3414b2bd8f30c2f3eef024ae1f59e9e262f48695529937db09";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros-extras/default.nix
+++ b/distros/foxy/mavros-extras/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-mavros-extras";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_extras/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "bf80c13f592c97e1568d3af5f866cf055034c67997fd343afeed1cf8b7a0e4eb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ angles ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common gtest ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
+
+  meta = {
+    description = ''Extra nodes and plugins for <a href="http://wiki.ros.org/mavros">MAVROS</a>.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/foxy/mavros-msgs/default.nix
+++ b/distros/foxy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "6f9d25bfb7647eab9067758e347c9821a892465d88ebf0cd36f0d53672d0ff1f";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "63c525d4121d4db463fdcc5bd6c0f7e9c00329d7ada37a5cd18ca3040f267df4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros/default.nix
+++ b/distros/foxy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "2eb8ca5204643e4a9434677433e9505f301f6b2eb280c49dfb28f48e7c300a6c";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "2daa692df531889235701ba2f411183bbb71f64786e13e70cb7896e910c1381c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/micro-ros-diagnostic-bridge/default.nix
+++ b/distros/foxy/micro-ros-diagnostic-bridge/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, micro-ros-diagnostic-msgs, osrf-testing-tools-cpp, rclcpp, ros-environment }:
+buildRosPackage {
+  pname = "ros-foxy-micro-ros-diagnostic-bridge";
+  version = "0.2.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/micro_ros_diagnostics-release/archive/release/foxy/micro_ros_diagnostic_bridge/0.2.0-4.tar.gz";
+    name = "0.2.0-4.tar.gz";
+    sha256 = "06d9d96bccd3cc144b1cdcda15d56ce8a4f50723a6218eff0a2ffe1f32873d10";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common diagnostic-msgs micro-ros-diagnostic-msgs osrf-testing-tools-cpp ros-environment ];
+  propagatedBuildInputs = [ diagnostic-msgs micro-ros-diagnostic-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Bridges micro-ROS diagnostic messages and vanilla ROS 2 diagnostic messages.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/micro-ros-diagnostic-msgs/default.nix
+++ b/distros/foxy/micro-ros-diagnostic-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-micro-ros-diagnostic-msgs";
+  version = "0.2.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/micro_ros_diagnostics-release/archive/release/foxy/micro_ros_diagnostic_msgs/0.2.0-4.tar.gz";
+    name = "0.2.0-4.tar.gz";
+    sha256 = "4cc77e0a2ee6aa277f253287c5daa6fc8d67d20c6b66f5809546da79fb948f0f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing  diagnostics related messages and service definitions for micro-ROS.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/microstrain-inertial-driver/default.nix
+++ b/distros/foxy/microstrain-inertial-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-microstrain-inertial-driver";
+  version = "2.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "97b634a178f624c46625e9f5b9747a80990bc70d922d385cb4bdb13f166a8f94";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ curl jq ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-cpplint ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-updater geometry-msgs lifecycle-msgs microstrain-inertial-msgs nav-msgs rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''The ros_mscl package provides a driver for the LORD/Microstrain inertial products.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/microstrain-inertial-examples/default.nix
+++ b/distros/foxy/microstrain-inertial-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-microstrain-inertial-examples";
+  version = "2.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "9aadaa34a27851b3662819f7070c66e51d80c03cde6ee8544fd17f953cb24f19";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ microstrain-inertial-msgs rclcpp rclcpp-components rclpy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Example listener for Parker LORD Sensing inertial device driver ros_mscl (C++).'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/microstrain-inertial-msgs/default.nix
+++ b/distros/foxy/microstrain-inertial-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-microstrain-inertial-msgs";
+  version = "2.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "eb02317ed916db8170e11d793f1cb62af6cc17942775c130f3215709775e14f8";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ geometry-msgs std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''A package that contains ROS message corresponding to microstrain message types.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "dc3794d79ebb75b2edb6fcee1538c1ec89f682d614d1dd75feea34253295c876";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "0b02720e1eb8baedf80c833f3f6e72b99964bf07620c30eab9bf98ba2e966ac7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realtime-tools/default.nix
+++ b/distros/foxy/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realtime-tools";
-  version = "2.1.1-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/foxy/realtime_tools/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "229436487700e89cd204189c2dd38c405579adb4b707c943a0195b12da3509d1";
+    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/foxy/realtime_tools/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "7ccfcdccb6f2398cbe2e563fc7b458640fa6f0efeb5a44e5161eaa232df13a28";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "25d5f1ab4bd9304e06a0867e18a35ef09aee185b96fd342b76e7427ca09e504a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "f684378cd33a456d8e5ae016529466bc995ae3e972a23c61e8eb63b2fddc9aa3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "df6a615b1f10ae67d9973655d6691d13f8fd6faf7457ec0c0190139fb0a65397";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "5bcdcbd23030d7117b3a1b1743104cac324c3d296e23a4ac486a28a267d1d14a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "3df2822aa9ee99cc324f041202562fbf42b194a3846239b2a8f94ef0ecb446c7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "2d4036184a6d44bceaeda165b97428c9fe4dc414dd2500fdfcd5edeebc7cda90";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "0d728afce4d7a5d38cf37bce6ddfd781b3b1ba537f5213b0ab5278e38a961d0e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "182f29a6830a99f947dadd6b9db5bf7067f6b0ad264d25b65aeb9b4edd6b6bca";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosapi-msgs/default.nix
+++ b/distros/foxy/rosapi-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rosapi-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4b938ce93663dbe3bbad372cfea292404907c4d78d0158e4b50540d3e4246761";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+
+  meta = {
+    description = ''Provides service calls for getting ros meta-information, like list of
+    topics, services, params, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rosapi/default.nix
+++ b/distros/foxy/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-nose, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rclpy, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosbridge-library, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosapi";
-  version = "1.0.7-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "11fd323e6db0f18eb886469c75f6c10ed07ccb716b44871a17c5316f9785137b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "00a44f41504ed778d7d9bde89312e1a60741b9ba6bef4dac0d811f3dbf238aa4";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-nose ];
-  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosbridge-library rosidl-default-runtime ];
-  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+  checkInputs = [ ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosapi-msgs rosbridge-library ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = ''Provides service calls for getting ros meta-information, like list of

--- a/distros/foxy/rosbridge-library/default.nix
+++ b/distros/foxy/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-library";
-  version = "1.0.7-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "2e2b6dcb3595131a43ff996926f401d1f08b09ddee45b834da47ed316c6ec653";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9059d37c9bc42860ba1894c818d45c5e04d6c9c37cfd48d5309c9b07e588ed3c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ rosidl-default-generators ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime std-msgs ];
+  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/rosbridge-msgs/default.nix
+++ b/distros/foxy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-msgs";
-  version = "1.0.7-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1f491fdf2569e1d155c7bd12b5a18d520493212d23015e5a1679ee2a1f3324ef";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "417975308528eef3ae1c3ddedd6ed95b8362c970350cee3dfd38149d32647732";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-server/default.nix
+++ b/distros/foxy/rosbridge-server/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-server";
-  version = "1.0.7-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "4a176ab54e8383ee032045889d44144437abd3042eb6ba6696251accf182df20";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b2c8015b63621eefea57b85395ced4336a7551c686eb5d594e906a50cce1da3f";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = ''A WebSocket interface to rosbridge.'';

--- a/distros/foxy/rosbridge-suite/default.nix
+++ b/distros/foxy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-suite";
-  version = "1.0.7-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "4b5a7d549b0e5147fa261a8eea36da6d3bd70a678be2e2088118f90657af29db";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3c8b5f64eea9d127486ae8223c1092e06c633fbf0360e86c4cf0aab5e4e9aa24";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-test-msgs/default.nix
+++ b/distros/foxy/rosbridge-test-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-rosbridge-test-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_test_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0c567109e63e18f00c468fbee2b608bf489b8d408d28c3eb63b899ef9ca722d1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Message and service definitions used in internal tests for rosbridge packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/simple-launch/default.nix
+++ b/distros/foxy/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-simple-launch";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "7ea89fc795caffc229159afefb4ec51e08a0cb3f09dd83c91a7c2cdfa441dab7";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "93a25d9c2fc4e56314b1fa1e3866593d4f221de1e82258852c9e3760b7bcfda0";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "7ecba6d8ac29b6433b5b0d831dd3f146253dd755ed2722ea83a7c531a429cad4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "1dd96a196c859a7f5d569e4e7e35f12772c0f46d8596db13401ef33d23334a03";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "e17a4a4fde06564669ccaa7015fdec292b59b0ae03ca8a2472442894478c2a51";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "0e2d8ba3277b1c3c20892ee4a18b06dd809ec46c32c3c553785f83c0023b912e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-control";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "b910c6e0abd5cbb0ba515bdc8a8f3ef5256536d187cf1dd158f55cbfeb346462";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "8bff749bf38bb472ddddaf27d714ad2d0fab6f6c1ff96385c73eb14c5ffded55";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-core";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "049d92019d36981a716964c59bb9b34858128e8aa5d2ac8fdd909a3d1a84802c";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "74636d17c52cc69e36dcc85867504cdafe3bdf2a862288b3b0120bd4d06a3ccb";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-driver";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "4c4fb4a35a13314a6c34e4a3feac1abce02e525a7111ec3e8e19a37d404f6fc3";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "e97f0158903f453fcd458c2745068b18ee6948955a58e6643740fd979526329d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, nav-msgs, pythonPackages, rclpy, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-core, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "436a1a3283486eb1f0cdc8fb637656691f44d153f72048e85f8ebe84317f851c";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "1629c7c8989dbec69df55659f8c1870c34a8fc603607093728fac8343f112335";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs nav-msgs rclpy rviz2 sensor-msgs std-msgs tf2-ros webots-ros2-core webots-ros2-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster nav-msgs rclpy robot-state-publisher rviz2 sensor-msgs std-msgs tf2-ros webots-ros2-control webots-ros2-driver webots-ros2-msgs ];
 
   meta = {
     description = ''E-puck2 driver for Webots simulated robot'';

--- a/distros/foxy/webots-ros2-importer/default.nix
+++ b/distros/foxy/webots-ros2-importer/default.nix
@@ -5,16 +5,16 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-importer";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d5d7a7457c7a1f739e61210a40113a411e12407e7aaf21c93452d573426807ad";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "acf4ed6c7577dc2b249e57a30e8beb7406112e7fce2b60f78884a28bda51a1cc";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pillow python3Packages.pycodestyle pythonPackages.numpy pythonPackages.pillow pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.numpy python3Packages.pillow python3Packages.pycodestyle pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces python3Packages.lark-parser python3Packages.pycollada xacro ];
 
   meta = {

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-mavic";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "aa08cb5767aff6e02aee8c6de078ea70944865c676ed0badfe1ab0e90d30646a";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "f49bcd4dd880fb02464eec8fdca137c5ae0f3b6e5343ccdfe53738fd30f0747f";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d0e4b0a2c0d604bd42d89596be60eeda8a94e3fd18aea8cfe529902fec136090";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "a1b9a4292c942d11132f3aa0b43e0325c8837893f95e9db2dc7a1dab3d294c9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6873421bd0e2e3a36e8e94e45e55d6a374523476ff25ae61e6a440ffc7816ccc";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "07c82eb3051e59c4bcfe7d0bbf7c0f0bc5a5171999db22359e89f68fcc4faff4";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces rclpy webots-ros2-core ];
+  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-core ];
 
   meta = {
     description = ''Tesla ROS2 interface for Webots.'';

--- a/distros/foxy/webots-ros2-tests/default.nix
+++ b/distros/foxy/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, sensor-msgs, std-msgs, std-srvs, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tests";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "4b4eae86b1636137ca02e21bf09fc8140130643fe2c939ddd9ed703b18b1f570";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "2fa568afca67f7a2596c0f27ee1f7ee936fe57475d765a582a4d553b9b4afa9f";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs ];
-  propagatedBuildInputs = [ rclpy webots-ros2-driver ];
+  buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = ''System tests for `webots_ros2` packages.'';

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, rviz2, webots-ros2-core }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "43623baaf5ad8c1ace288f99066a4afb972aa57cb5189e59ad393a97dc99c823";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "d8e944a0fc5acd73e8d3a0686224fe61f559e6ca868a186fec0794d0714e0a54";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rviz2 webots-ros2-core ];
+  propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster rclpy robot-state-publisher rviz2 tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {
     description = ''TIAGo robots ROS2 interface for Webots.'';

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "cdbd0cad4d4da8947e4cb3a7c880d9613b4da7fef97da583149bc7ce1624a542";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "ff9894c8f982c85c11de7c36ccaa7de953aba67b0383b38a34528204194851b6";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces diff-drive-controller joint-state-broadcaster rclpy webots-ros2-control webots-ros2-driver ];
+  propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller joint-state-broadcaster rclpy robot-state-publisher tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {
     description = ''TurtleBot3 Burger robot ROS2 interface for Webots.'';

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, rviz2, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core, webots-ros2-ur-e-description }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "b5f5af7d30df0be732cf87e77af14355e2080b33fbd3d37252f2b02ac4f0f6eb";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "1aa11ddef8f6a4cb728dc7bcf95e687e346abbbae3593f8584173ab59fa54d82";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces control-msgs rclpy rosgraph-msgs rviz2 sensor-msgs std-msgs trajectory-msgs webots-ros2-core webots-ros2-ur-e-description ];
+  propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller moveit rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver ];
 
   meta = {
     description = ''Universal Robot ROS2 interface for Webots.'';

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-demos, webots-ros2-epuck, webots-ros2-examples, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-tutorials, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-core, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "3b2659f997ee611eb110251eff473ed8d6a372fa1a52730cb7af5df86aeb908d";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "3bb510d932a2e91fd976d9c324f88298380ff49167aa69b51ea1c6da96fe7c2f";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-abb webots-ros2-core webots-ros2-demos webots-ros2-epuck webots-ros2-examples webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-tutorials webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest webots-ros2-tests ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-core webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = ''Interface between Webots and ROS2'';

--- a/distros/galactic/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/galactic/aws-robomaker-small-warehouse-world/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-galactic-aws-robomaker-small-warehouse-world";
-  version = "1.0.1-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/galactic/aws_robomaker_small_warehouse_world/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "7485dfccaa889cdfa621d0e8e7d05236a36fc3021c913123f83edda251bd310c";
+    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/galactic/aws_robomaker_small_warehouse_world/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "846ceec0b2874b4a3af5df80f660ae65dc4d8e1fc13e2d6ea8dd9d62a437ca4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-controller-interface";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "3a421d48b8f4b22a954974fde7bd26412f1cbc2a87ad1375448b47521e656bf4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ef78e5d07b5e2dcb4b4ea184d5b6cf49af998d6576436f38ef79e7f4cf3daa99";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b236a584cd2585b3113f86ce657983b9e20bb89522b7e0dcd7c51de008ff09f9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7c8d79b881edc240529cb2bbaa5f4b56f40605c93c5403901d923bb4f3f027a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "3eaf8a278b08cc982ea42b14a66adcacd02c4735497d3bf0245012a55d6d9dae";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b4e3778a15c258b11cfef949fb8c11dc9f035d5c059c96aec0696492ec6126b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diff-drive-controller/default.nix
+++ b/distros/galactic/diff-drive-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diff-drive-controller";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c32958e98d058c3355048e2e1f180c4e4079f89a97a936b0d42c3f546111a6b0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "667362edaad7780d4f92ddbe767acd226b057d068298420fbb0c43c73f3e3989";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock controller-manager ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/domain-bridge/default.nix
+++ b/distros/galactic/domain-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, libyamlcpp, rclcpp, rcutils, rosbag2-cpp, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, libyamlcpp, rclcpp, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, zstd-vendor }:
 buildRosPackage {
   pname = "ros-galactic-domain-bridge";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/domain_bridge-release/archive/release/galactic/domain_bridge/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c640ea27a3b78595aab2fc36b302130dcaeb7df826e5616350dbe86820940624";
+    url = "https://github.com/ros2-gbp/domain_bridge-release/archive/release/galactic/domain_bridge/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "801b5acd4ffc9bd321ce47eb5a2047210c158feca3433f73be1f5906778c38a1";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common example-interfaces launch launch-testing launch-testing-ament-cmake test-msgs ];
-  propagatedBuildInputs = [ libyamlcpp rclcpp rcutils rosbag2-cpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common example-interfaces launch launch-testing launch-testing-ament-cmake rmw-connextdds rmw-cyclonedds-cpp rmw-fastrtps-cpp rmw-implementation-cmake test-msgs ];
+  propagatedBuildInputs = [ libyamlcpp rclcpp rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp zstd-vendor ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = ''ROS 2 Domain Bridge'';

--- a/distros/galactic/effort-controllers/default.nix
+++ b/distros/galactic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-effort-controllers";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b436d50196946a9a8f57608e78ca91707e5d66859ac67b95ec4fa77cea616876";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "eadb9461f808815ade13462a042b989d868da38b9eb4b285b3d086d93328202c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/force-torque-sensor-broadcaster/default.nix
+++ b/distros/galactic/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-force-torque-sensor-broadcaster";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9497abf9bb9a5458ed0adc6513686a9fb98320e330b8e2935538bf76fc93200b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ac3d651e3c2b90333521f5b7c259004e1729addc598311ec3ab21d9a55eea069";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/forward-command-controller/default.nix
+++ b/distros/galactic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-forward-command-controller";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1a4a32ca280ee44fd6bc14ad4c8a0d8d72349862bfd07d8ed36b706cc7bf2834";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a83327b5012f2a71bfa40fd838aa45c561fcb5b293c204818a372d405710ddc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gazebo-ros2-control-demos/default.nix
+++ b/distros/galactic/gazebo-ros2-control-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-gazebo-ros2-control-demos";
+  version = "0.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control_demos/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "12d07745dbc087faf59b6a3f0f77851201fa4e89d4e31890c9c4372813293569";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rclcpp-action ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers gazebo-ros gazebo-ros2-control hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control ros2-controllers std-msgs velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''gazebo_ros2_control_demos'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/gazebo-ros2-control/default.nix
+++ b/distros/galactic/gazebo-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-galactic-gazebo-ros2-control";
+  version = "0.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "35ba04700277f5249f016d58c533a6401ec5c39b4c17d633a400c58d71d1c9c8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles controller-manager gazebo-dev gazebo-ros hardware-interface pluginlib rclcpp std-msgs urdf yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''gazebo_ros2_control'';
+    license = with lib.licenses; [ bsdOriginal asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -348,6 +348,10 @@ self: super: {
 
  gazebo-ros = self.callPackage ./gazebo-ros {};
 
+ gazebo-ros2-control = self.callPackage ./gazebo-ros2-control {};
+
+ gazebo-ros2-control-demos = self.callPackage ./gazebo-ros2-control-demos {};
+
  gazebo-ros-pkgs = self.callPackage ./gazebo-ros-pkgs {};
 
  geodesy = self.callPackage ./geodesy {};
@@ -530,13 +534,25 @@ self: super: {
 
  mavros = self.callPackage ./mavros {};
 
+ mavros-extras = self.callPackage ./mavros-extras {};
+
  mavros-msgs = self.callPackage ./mavros-msgs {};
 
  menge-vendor = self.callPackage ./menge-vendor {};
 
  message-filters = self.callPackage ./message-filters {};
 
+ micro-ros-diagnostic-bridge = self.callPackage ./micro-ros-diagnostic-bridge {};
+
+ micro-ros-diagnostic-msgs = self.callPackage ./micro-ros-diagnostic-msgs {};
+
  micro-ros-msgs = self.callPackage ./micro-ros-msgs {};
+
+ microstrain-inertial-driver = self.callPackage ./microstrain-inertial-driver {};
+
+ microstrain-inertial-examples = self.callPackage ./microstrain-inertial-examples {};
+
+ microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
@@ -699,6 +715,10 @@ self: super: {
  osrf-testing-tools-cpp = self.callPackage ./osrf-testing-tools-cpp {};
 
  ouster-msgs = self.callPackage ./ouster-msgs {};
+
+ pal-statistics = self.callPackage ./pal-statistics {};
+
+ pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
@@ -1062,6 +1082,8 @@ self: super: {
 
  rosapi = self.callPackage ./rosapi {};
 
+ rosapi-msgs = self.callPackage ./rosapi-msgs {};
+
  rosbag2 = self.callPackage ./rosbag2 {};
 
  rosbag2-bag-v2-plugins = self.callPackage ./rosbag2-bag-v2-plugins {};
@@ -1095,6 +1117,8 @@ self: super: {
  rosbridge-server = self.callPackage ./rosbridge-server {};
 
  rosbridge-suite = self.callPackage ./rosbridge-suite {};
+
+ rosbridge-test-msgs = self.callPackage ./rosbridge-test-msgs {};
 
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
 
@@ -1245,6 +1269,8 @@ self: super: {
  shape-msgs = self.callPackage ./shape-msgs {};
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
+
+ simple-launch = self.callPackage ./simple-launch {};
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
 

--- a/distros/galactic/gripper-controllers/default.nix
+++ b/distros/galactic/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-gripper-controllers";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "04ca14d3eced1f989d983f5755e9b507d0cb765164d38563074426c50e73da97";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ba7afb94d1ef3396520ff4600000201abdb53471da17438248180f92f65c17bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-galactic-hardware-interface";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "79d2ca211a8e342d249811b661fb05bf3c134cd522f4d6027261ffdcfca56b0b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "68ad0dfa1d2b00b29bebe1534e68ca162d9386b75074f939202f2c199f4c3c2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-sensor-broadcaster/default.nix
+++ b/distros/galactic/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-imu-sensor-broadcaster";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1c51e623c342d4411a44470c13233895a7caa3bf37237f1704a9b1e5356dcadb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "66df092cf8782ee7f8656d5b95f4ea23be83c734a7a3bc4bffa4ee24e8750568";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-state-broadcaster/default.nix
+++ b/distros/galactic/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-state-broadcaster";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "807bb0e118ab24356fe408081083f9d5f4d65975596efaa4a73a07fddde40bcd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "07a376f14fd143dcc3ccc5a11267bbc3cfc4cc2ff868349aebfdd55e3331fb7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-trajectory-controller/default.nix
+++ b/distros/galactic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-trajectory-controller";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "4300cae1ce37ae51e76374ea458baa9c1c148b9d1670b92b7bca9e2b4874c95d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ab4e53a35ba89e915e9c6d07449d2900096182eb21fd15fe701acccde2f5856b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/libmavconn/default.nix
+++ b/distros/galactic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-libmavconn";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/libmavconn/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "e1e5c116f69d4f66e5e77966708ccd571018f8cb924add5a57ffa0ae0e1a942f";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/libmavconn/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "1f67c8f0ead8e70d7793eeb3358373247036eba204c61e5471b52dca4899577c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavros-extras/default.nix
+++ b/distros/galactic/mavros-extras/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-mavros-extras";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_extras/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "af3e0eb35e31a74a15b5f8d9918615f5311ad5758add27934f8dc8008028489c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ angles ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common gtest ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
+
+  meta = {
+    description = ''Extra nodes and plugins for <a href="http://wiki.ros.org/mavros">MAVROS</a>.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/galactic/mavros-msgs/default.nix
+++ b/distros/galactic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-mavros-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "85be741c9fb840422699b2318e12410d93aee5cb3ae786b764498bd737531462";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "ffb5519bb93449b87c104dceaf59a12adb241e51de5ca85f5a86858b46bf0373";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavros/default.nix
+++ b/distros/galactic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-mavros";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "4f4a1ad97e98766b84937af980edf3d39880bbf684a47d7638ad1a35918b6e4b";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "911323c0cf10b32afe75ba027d6d4c4b5856599fc043ef2d56ea4f4f438fdddd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/micro-ros-diagnostic-bridge/default.nix
+++ b/distros/galactic/micro-ros-diagnostic-bridge/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, micro-ros-diagnostic-msgs, osrf-testing-tools-cpp, rclcpp, ros-environment }:
+buildRosPackage {
+  pname = "ros-galactic-micro-ros-diagnostic-bridge";
+  version = "0.2.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/micro_ros_diagnostics-release/archive/release/galactic/micro_ros_diagnostic_bridge/0.2.0-4.tar.gz";
+    name = "0.2.0-4.tar.gz";
+    sha256 = "3a31ac06f5cf45b8cebe6a0666465b9713abfd0873f9d780948e9965582b3f29";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common diagnostic-msgs micro-ros-diagnostic-msgs osrf-testing-tools-cpp ros-environment ];
+  propagatedBuildInputs = [ diagnostic-msgs micro-ros-diagnostic-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Bridges micro-ROS diagnostic messages and vanilla ROS 2 diagnostic messages.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/micro-ros-diagnostic-msgs/default.nix
+++ b/distros/galactic/micro-ros-diagnostic-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-micro-ros-diagnostic-msgs";
+  version = "0.2.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/micro_ros_diagnostics-release/archive/release/galactic/micro_ros_diagnostic_msgs/0.2.0-4.tar.gz";
+    name = "0.2.0-4.tar.gz";
+    sha256 = "31ceb40a77d1c2b0fd10295bfd958b702f6d4bd950bc2b30942f387977f413eb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing  diagnostics related messages and service definitions for micro-ROS.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-microstrain-inertial-driver";
+  version = "2.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "2cabac46a1400fcda68a48cb93936373bf328e0aff1d58f3d5a54271ae0ecdcb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ curl jq ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-cpplint ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-updater geometry-msgs lifecycle-msgs microstrain-inertial-msgs nav-msgs rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''The ros_mscl package provides a driver for the LORD/Microstrain inertial products.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-microstrain-inertial-examples";
+  version = "2.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "621fac1b63964ba95e41e876c4fe1549ebcfd09405dd34cdc6c5d731a5f2e300";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ microstrain-inertial-msgs rclcpp rclcpp-components rclpy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Example listener for Parker LORD Sensing inertial device driver ros_mscl (C++).'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-microstrain-inertial-msgs";
+  version = "2.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "206693798af81eb36087eb6b456b1a71802bd9aa15a94a7f6f6ce1f5a627c386";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ geometry-msgs std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''A package that contains ROS message corresponding to microstrain message types.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/pal-statistics-msgs/default.nix
+++ b/distros/galactic/pal-statistics-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-pal-statistics-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/galactic/pal_statistics_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "a3cd5d3a226912558a01ff80c0040814aafba99e0f9f5c90be289aa17a19b4d1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Statistics msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/pal-statistics/default.nix
+++ b/distros/galactic/pal-statistics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclpy }:
+buildRosPackage {
+  pname = "ros-galactic-pal-statistics";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/galactic/pal_statistics/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "9632da8abb431dd0c48276a792fdb20bf26c1a4a665734074cea7de7027e1a70";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost pal-statistics-msgs rclcpp rclpy ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''The pal_statistics package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/position-controllers/default.nix
+++ b/distros/galactic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-position-controllers";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ad08df41c4281f314632f7c3a618d2d8b8b011a2088df9956fbf0908ebf20d38";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "489497b9e8702b757c452857f19a5731f613811f03567027a72797ae5912cc26";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realtime-tools/default.nix
+++ b/distros/galactic/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-realtime-tools";
-  version = "2.1.1-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/galactic/realtime_tools/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "a14f59a183ac57b0724868652268be49e4170b0d6e9c1aaa8685562812a5af6e";
+    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/galactic/realtime_tools/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "4126ff1601cf3dd58c01280a4cf320d53b1350c389918853002332eb445e533b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-battery/default.nix
+++ b/distros/galactic/rmf-battery/default.nix
@@ -2,20 +2,22 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, rmf-cmake-uncrustify, rmf-traffic, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, eigen3-cmake-module, rmf-cmake-uncrustify, rmf-traffic, rmf-utils }:
 buildRosPackage {
   pname = "ros-galactic-rmf-battery";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_battery-release/archive/release/galactic/rmf_battery/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "0ff6497fc75b9ca946780f0396c6b36be04c4568bc3052d67db2a6717ba439de";
+    url = "https://github.com/ros2-gbp/rmf_battery-release/archive/release/galactic/rmf_battery/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "c53f818160791b7c78b6890fe2fceabaa5e6273d0d13132ab6d61188187c7c72";
   };
 
   buildType = "cmake";
+  buildInputs = [ eigen ];
   checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
-  propagatedBuildInputs = [ eigen rmf-traffic rmf-utils ];
+  propagatedBuildInputs = [ rmf-traffic rmf-utils ];
+  nativeBuildInputs = [ eigen3-cmake-module ];
 
   meta = {
     description = ''Package for modelling battery life of robots'';

--- a/distros/galactic/rmf-traffic/default.nix
+++ b/distros/galactic/rmf-traffic/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, libccd, rmf-cmake-uncrustify, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, eigen3-cmake-module, libccd, rmf-cmake-uncrustify, rmf-utils }:
 buildRosPackage {
   pname = "ros-galactic-rmf-traffic";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic-release/archive/release/galactic/rmf_traffic/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2dc63ae78516675b4baa8f03421f6c16c26fe3a4574b294f667950974b1bcfe6";
+    url = "https://github.com/ros2-gbp/rmf_traffic-release/archive/release/galactic/rmf_traffic/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "1619841c430bbb3b8ab456948c07ddfa3be6fcd67fd35d288deac76adebe1d88";
   };
 
   buildType = "cmake";
   checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
-  propagatedBuildInputs = [ eigen libccd rmf-utils ];
+  propagatedBuildInputs = [ eigen eigen3-cmake-module libccd rmf-utils ];
+  nativeBuildInputs = [ eigen3-cmake-module ];
 
   meta = {
     description = ''Package for managing traffic in the Robotics Middleware Framework'';

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control-test-assets";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "67ba677e3968233f97eb5052343ab1be1cbeed746e8f84e853193458e63b6ac0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d30480a4007072f5cfb4ff4c79be194b08baee06f50ccf85e122b6f6b73752fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "3d3c38c005eadf8974b215713e48662a94fee45dc5c6f082a5907b2bea880253";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "59e7d13145805170dba4f28650e99ea18a395beb455f96be2e275e95108a3940";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-controllers/default.nix
+++ b/distros/galactic/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-galactic-ros2-controllers";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c4221f939305d15311c694aa2f6638bdfb82ed5e4dce724d76da4203280c840b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0a0e850ad54a517684704f03527bd749419a4b8d6bb6fcc8d54b6f32083f611f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-galactic-ros2controlcli";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "89ca90181d5776b2e6d9403db3ef6b97b2c2189ea3314cfbbb57840d6c7d3f1f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3e75ae6da2f26e25c715471c983797aeff3fd941e2e61f938dbe96658592169b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rosapi-msgs/default.nix
+++ b/distros/galactic/rosapi-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rosapi-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "16df7c22ad3b61c8706814334e45142f04b60b4e10aa826bfa86c40dd1ad4cb8";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+
+  meta = {
+    description = ''Provides service calls for getting ros meta-information, like list of
+    topics, services, params, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rosapi/default.nix
+++ b/distros/galactic/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosbridge-library, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosapi";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "7bbf4256c6e5bbe6a68b024bca1ab31e93076fe63895009cb422fc570ffdcbcc";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "17a3f60ac078b6ba989ad73315a1bf3fb8834a878238fd2a07a495f07a65561a";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosbridge-library rosidl-default-runtime ];
-  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosapi-msgs rosbridge-library ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = ''Provides service calls for getting ros meta-information, like list of

--- a/distros/galactic/rosbridge-library/default.nix
+++ b/distros/galactic/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-library";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "53679a860c6811c2eebda3526ae774314a82c85678d7c2bce3ac96be7ae66e72";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "28f5c85c61c23bd8e2dab7feca3dae7fc4635633d850e04fce5f4dc332936fa4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ rosidl-default-generators ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime std-msgs ];
+  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rosbridge-msgs/default.nix
+++ b/distros/galactic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-msgs";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "57435d01185c26b228cacc31f231920472cad72abdaac8cce8d7c77f1900eda4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8e54472b3318ebfa8b9b54e19dcfebf1ee048b97df07b27e826205038afca00a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-server/default.nix
+++ b/distros/galactic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-server";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "f481d7c537fbd6185730a88815a99469bfb67b13535db08617e4c9aaef8ffd9b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "408607dce1bbcdb349eb3f5878afbb514a92c1ffe3e54582224b43e94a05ea05";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-suite/default.nix
+++ b/distros/galactic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-suite";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "cf9eb9e026e286c2c0eef53275fd3b8c79c6a2b0da7e76c41ca1c80950fcc15a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "41cd2085c87f97013ccf35a2fe474d51c393b42b280316bf661c6565bdeddfe8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-test-msgs/default.nix
+++ b/distros/galactic/rosbridge-test-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rosbridge-test-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_test_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7e8bbf4c6c6405cd6a7d9827a333766cb28493fc2f0218e545eb761e5abf86ca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Message and service definitions used in internal tests for rosbridge packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rqt-console/default.nix
+++ b/distros/galactic/rqt-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-galactic-rqt-console";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/galactic/rqt_console/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f303a50ac9a5a0aba12c4942a140ee43e017d8674fbb9889db8c522990e8c9b1";
+    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/galactic/rqt_console/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "5d40a7856720945ad968b100e8c03996c87df471015a9608170f3cc7f4ff9305";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/simple-launch/default.nix
+++ b/distros/galactic/simple-launch/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-simple-launch";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/galactic/simple_launch/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d7cfb566f9f919233a42cf0e5d76e2bee8746c6f313ab57eafdf00fcbf2094ba";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ ament-index-python launch launch-ros xacro ];
+
+  meta = {
+    description = ''Python helper class for the ROS 2 launch system'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-galactic-transmission-interface";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "62e47e87cc2572c014b9efe62252c31434a21a6b6c46472a0f30a5574e0e02a0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5d4523752d7f858fc3f6c174832dfc09f71d186a971366687723c21420ca1c72";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velocity-controllers/default.nix
+++ b/distros/galactic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-velocity-controllers";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "017736d8cc6bcf59a3d42780ebb30bea6912f2ca992ca31d32e73c08fbf6d633";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ed095bd439478ba48335b27ff8c76f90b3fe9757684a5249f4a8276a164b5903";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "76f9fac33ea80df5d18c3a53409d7a1b7428277ab065f202208aca263d8cbb8e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "5911b7ac93c5fe546d8ad93c730a939241a90773884fb3946cd623a361fb2e0e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cvp-mesh-planner/default.nix
+++ b/distros/melodic/cvp-mesh-planner/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mbf-mesh-core, mbf-msgs, mbf-utility, mesh-map, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-cvp-mesh-planner";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/cvp_mesh_planner/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c9fddab14156e516e7f3006b6e2b97f5dd197ef85a0e2cf00f70434bde972708";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mbf-mesh-core mbf-msgs mbf-utility mesh-map roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Continuous Vector Field Planner (CVP) mesh planner package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/dijkstra-mesh-planner/default.nix
+++ b/distros/melodic/dijkstra-mesh-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mbf-mesh-core, mbf-msgs, mbf-utility, mesh-map, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-dijkstra-mesh-planner";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/dijkstra_mesh_planner/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "83c7c2cbb2848d5e8be81d6a33412548a8e01c8cea5405a5ae9787b0f2133951";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/dijkstra_mesh_planner/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9b0df6ecfa43cd8dde6d68e8253170f015448b0d74338fe1214af831d4771d9e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-assets/default.nix
+++ b/distros/melodic/drone-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-drone-assets";
-  version = "1.3.9-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "07c8ebaa41c032be699feada64d7820da7690e3660dbcc2c1b62fc4b8d7061d2";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "78de68ca2619e7015c587d3e930b31883ad12eb22d840960e36681fb5e25b77d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-drone-wrapper";
-  version = "1.3.9-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "847a199fcc75336e2bf187ac70eba6cfe68fbff54fe21683696efa917d655ef8";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "3f57d28446b812c2ac8222fa15e39d7ccf03a1ed7e4da881803549b5cd0038f3";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge geometry-msgs mavros mavros-msgs rospy sensor-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge gazebo-ros geometry-msgs mavros mavros-msgs rospy sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.8-r1";
+  version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.6.8-1.tar.gz";
-    name = "2.6.8-1.tar.gz";
-    sha256 = "76e3b67f639023210e9e434eaca30dda22927dfd3d1ee1f5f7da66ee8ba8c2d6";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.6.9-1.tar.gz";
+    name = "2.6.9-1.tar.gz";
+    sha256 = "07ad3559467602369b9a5f49f1e91536451b13c6981379905211a48152694876";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -616,6 +616,8 @@ self: super: {
 
  cv-camera = self.callPackage ./cv-camera {};
 
+ cvp-mesh-planner = self.callPackage ./cvp-mesh-planner {};
+
  dataflow-lite = self.callPackage ./dataflow-lite {};
 
  dataspeed-can = self.callPackage ./dataspeed-can {};
@@ -2089,8 +2091,6 @@ self: super: {
  mesh-msgs-transform = self.callPackage ./mesh-msgs-transform {};
 
  mesh-navigation = self.callPackage ./mesh-navigation {};
-
- mesh-tools = self.callPackage ./mesh-tools {};
 
  message-filters = self.callPackage ./message-filters {};
 
@@ -3736,8 +3736,6 @@ self: super: {
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
 
- rviz-mesh-plugin = self.callPackage ./rviz-mesh-plugin {};
-
  rviz-plugin-tutorials = self.callPackage ./rviz-plugin-tutorials {};
 
  rviz-python-tutorial = self.callPackage ./rviz-python-tutorial {};
@@ -4009,8 +4007,6 @@ self: super: {
  teleop-twist-joy = self.callPackage ./teleop-twist-joy {};
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
-
- tello-driver = self.callPackage ./tello-driver {};
 
  teraranger = self.callPackage ./teraranger {};
 
@@ -4443,8 +4439,6 @@ self: super: {
  warthog-simulator = self.callPackage ./warthog-simulator {};
 
  warthog-viz = self.callPackage ./warthog-viz {};
-
- wave-front-planner = self.callPackage ./wave-front-planner {};
 
  wave-gazebo = self.callPackage ./wave-gazebo {};
 

--- a/distros/melodic/hdf5-map-io/default.nix
+++ b/distros/melodic/hdf5-map-io/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, lvr2 }:
 buildRosPackage {
   pname = "ros-melodic-hdf5-map-io";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/hdf5_map_io/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "5805cfb79152f8350b95260d2eec609ac0292fe571e89f62cdc656454d84f819";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/hdf5_map_io/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "13f5cf1290c667d40005dfb864ec17d5a2329410dfa8714a4574ab4764754c72";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ira-laser-tools/default.nix
+++ b/distros/melodic/ira-laser-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-melodic-ira-laser-tools";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/melodic/ira_laser_tools/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "3f6b86175e481a8d8c96f645f828fb3c7f9627a6d3ae87f1c212bf8a022689c7";
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/melodic/ira_laser_tools/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "6986f1a7ae2ad688a40edb8e0dc5687eca413a21631eaae2c608c6f84fa06541";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jderobot-drones/default.nix
+++ b/distros/melodic/jderobot-drones/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-assets, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-drones";
-  version = "1.3.9-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "14890516849b7dd4ffa62e27fca940f25965f3364cfd6d9b83e87b55db7863dc";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "08cf45db506da549d05fc5797096eaf30e9abc5ce5afebbb41729b48cf62f35e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "d2112673e46f6303562e28623d59b37ca6f427b42a0fc44d839f398ad0c519e7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "09bacd65f752e02741074ed660e7a1a10282dd9ca8e4fe3ff2151617c9a1ce43";
   };
 
   buildType = "catkin";

--- a/distros/melodic/label-manager/default.nix
+++ b/distros/melodic/label-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, genmsg, mesh-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-label-manager";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/label_manager/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "774bbccc5440c62f0a98678e812e4dc07ec909d0d5345cb4d56f867ca2d985b7";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/label_manager/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4dfe909eaef99fc3c632498a58de78e48bff3a2fb7cede0c3a8bfe2043b68ed4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-filters/default.nix
+++ b/distros/melodic/laser-filters/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, dynamic-reconfigure, filters, laser-geometry, message-filters, pluginlib, roscpp, rostest, sensor-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, dynamic-reconfigure, filters, laser-geometry, message-filters, nodelet, pluginlib, roscpp, rostest, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-laser-filters";
-  version = "1.8.11-r1";
+  version = "1.8.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/laser_filters-release/archive/release/melodic/laser_filters/1.8.11-1.tar.gz";
-    name = "1.8.11-1.tar.gz";
-    sha256 = "c04a129db4b21ae1524e819d9f080826d7410449f843a4f3b915a62b4a72e970";
+    url = "https://github.com/ros-gbp/laser_filters-release/archive/release/melodic/laser_filters/1.8.12-1.tar.gz";
+    name = "1.8.12-1.tar.gz";
+    sha256 = "56572bc6cf37f4a6272af04a2a42b3ea757a114962cab9814077d89ebf7ed89b";
   };
 
   buildType = "catkin";
   buildInputs = [ rostest ];
-  propagatedBuildInputs = [ angles dynamic-reconfigure filters laser-geometry message-filters pluginlib roscpp sensor-msgs tf ];
+  propagatedBuildInputs = [ angles dynamic-reconfigure filters laser-geometry message-filters nodelet pluginlib roscpp sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "65f1c9776979280b74dc2b58b55cc898ef2373062a54503be8d08db5054cad41";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "748e88001500626badcdabba9cbf7ed196ce0832804def0bb7440064c293af65";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-core/default.nix
+++ b/distros/melodic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-core";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "31af1e9d675525265e6e3ca83e48c80e6cf11bcb8333f0e065b147f65ff2e494";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "a323bca90523550d24a7519c6a3dd2e764bbd7301f8fa50a33dbbeb25e23d41e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-nav/default.nix
+++ b/distros/melodic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-nav";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "809dbb77c15c1cd7a176028ee593c9e9ae0ef50a9dead45cc452f2e5c0a8b536";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b933f2badf4baed65ef60f18d2abe44849a0519a4d149d217cff644a3ae098c5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-core/default.nix
+++ b/distros/melodic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-core";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "636126e45a131c366e0e7e0e31c5c59d5217c2e8c0cd1b86e80fa6c563e7797b";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c6e3e281027660161d2da10566b8d7010cdfe1f72fa280a5a20b3dfe21017abb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-nav/default.nix
+++ b/distros/melodic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-nav";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "bd6d42e8fced0659ef62e9b8b14a1a81711a2f3e62d4bc420159bd8eae8dff8d";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "ebad654c230672f700b44f59c75fcd19b5ecaaf2ea6fdfc914d84c7a3fe7c624";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-mesh-core/default.nix
+++ b/distros/melodic/mbf-mesh-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mesh-map }:
 buildRosPackage {
   pname = "ros-melodic-mbf-mesh-core";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mbf_mesh_core/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "b46630c003dfda4f59517bedaec6f669ad00b0bd7b51b5adcb3b269ec9a3f0a2";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mbf_mesh_core/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "e90b7695399948cfe2e81f2a1a7a72039bdb08f31e9ec199ad0cf6be03762170";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-mesh-nav/default.nix
+++ b/distros/melodic/mbf-mesh-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mbf-abstract-nav, mbf-mesh-core, mesh-map, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-mbf-mesh-nav";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mbf_mesh_nav/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "11eb0e6b9e89a7116706e3749e81732e87ae95f5f2ad2a111d36d54b415d4497";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mbf_mesh_nav/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "46896c2bdca138edc336f49f3f99e518ded479cfae6619802588809fd0d4bdeb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-msgs/default.nix
+++ b/distros/melodic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-msgs";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "ae9411185c0fd34c0c18731b59f14d1fdb62888d0cc6a83b80183231bab7fa0f";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8a7a97b7cd070f511e22b7704a43efa255c789ad5a2d9542a24512c5ac807053";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-simple-nav/default.nix
+++ b/distros/melodic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-simple-nav";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "d221ca58ceb852c9307cc22301863fe9570a1bba0d23ccde0e8b398227d17fea";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "12abd41fa0ccece720bd8c10ce3bd6fadf4df9e2cc9f31c18ce9bfb7b022912d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-utility/default.nix
+++ b/distros/melodic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-utility";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "e463ee392e1723d2d83edfa86d5cb6b1e725e37a18ec3a43c72f913bb93b455c";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "888b8b553460d22a7a62314810e4e12b0d79102e430bbf5a458bf50d5916216c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-client/default.nix
+++ b/distros/melodic/mesh-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, eigen, jsoncpp, lvr2, pkg-config, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-mesh-client";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_client/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "92bdfddf3c31220bc9fce88f342bdc453db1f646a221862e18d3cfeb8445bd94";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "48261f214dab66360d39ceb3d8ba5091f8c552600b3a484866489fa7ddce98f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-controller/default.nix
+++ b/distros/melodic/mesh-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mbf-mesh-core, mbf-msgs, mbf-utility, mesh-map, roscpp, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mesh-controller";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_controller/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "57650789ffdbdc0d01c69fa22491dcaac27e81875f6a2ca743653ce7d8282a83";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_controller/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6c14f1e1ed563f97d86cf7c10acdb45f67e76cd646965e71651bbaa3a1c7fb12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-layers/default.nix
+++ b/distros/melodic/mesh-layers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mesh-map }:
 buildRosPackage {
   pname = "ros-melodic-mesh-layers";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_layers/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "582abf8dd35ac49906d5ae794999562d74379ad9d03c055405b5680c73812011";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_layers/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "3670389864a814d1be85ca20826d8ac929330466268850b39a44c0bd50aceb6d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-map/default.nix
+++ b/distros/melodic/mesh-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, mesh-client, mesh-msgs-conversions, pluginlib, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-mesh-map";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_map/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "6b8546ff1989bf3ba3e3b9f9e5e90e272c1e0071425a0477879d15f428c03156";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_map/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ced769075211598fadf2945220bde45d0e8121a8f3e8e0517e3339e50204a697";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-msgs-conversions/default.nix
+++ b/distros/melodic/mesh-msgs-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lvr2, mesh-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mesh-msgs-conversions";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_conversions/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "64768b67d148491af1cd698e8a4b9aa78856e14a3d7af935c7ca801c498550e4";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_conversions/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "50b2422e61e2b03c92fc2a1d3e2c77921f4c23a4d7c1859ec56ec6b604f8eb08";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-msgs-hdf5/default.nix
+++ b/distros/melodic/mesh-msgs-hdf5/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hdf5-map-io, label-manager, mesh-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mesh-msgs-hdf5";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_hdf5/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "b1cef484da7c668517763d575498a79ac83ab91031385970f8c036c91327a12c";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_hdf5/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5edca85324e48bd277331b12eddf4955d9c7cddbb3364e5261d9aba2907e8502";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Read and write mesh_msgs to and from hdf5'';
+    description = ''Read mesh_msgs from hdf5'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mesh-msgs-transform/default.nix
+++ b/distros/melodic/mesh-msgs-transform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, mesh-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mesh-msgs-transform";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_transform/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "aa1f0d44f36bffd971f57edfa10ae9523774dd81a8304381292c349e434ec69f";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_transform/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f3944e4d9cd70f65153df38d521afdaecd9e38e888eb4e9c9571676565fd92b6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-msgs/default.nix
+++ b/distros/melodic/mesh-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mesh-msgs";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ba6c804561859c215f9c3cd004171cb5590ec74a942cd4a8f52f5ca8946e6a53";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "af4b068be99fc1027125bc8e7546fcd8b2e2acb92da883a982e1e327ec64b669";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-navigation/default.nix
+++ b/distros/melodic/mesh-navigation/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dijkstra-mesh-planner, mbf-mesh-core, mbf-mesh-nav, mesh-client, mesh-controller, mesh-layers, mesh-map, wave-front-planner }:
+{ lib, buildRosPackage, fetchurl, catkin, cvp-mesh-planner, dijkstra-mesh-planner, mbf-mesh-core, mbf-mesh-nav, mesh-client, mesh-controller, mesh-layers, mesh-map }:
 buildRosPackage {
   pname = "ros-melodic-mesh-navigation";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_navigation/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "3fa49f481b9ce4b032a62fe8b205feed0c67e33fca8abeee58c7a375da685618";
+    url = "https://github.com/uos-gbp/mesh_navigation-release/archive/release/melodic/mesh_navigation/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6c561702fb3a4b4209818b4c2511463461925bd42acfb31f125c0fbca07a57ba";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dijkstra-mesh-planner mbf-mesh-core mbf-mesh-nav mesh-client mesh-controller mesh-layers mesh-map wave-front-planner ];
+  propagatedBuildInputs = [ cvp-mesh-planner dijkstra-mesh-planner mbf-mesh-core mbf-mesh-nav mesh-client mesh-controller mesh-layers mesh-map ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/move-base-flex/default.nix
+++ b/distros/melodic/move-base-flex/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-melodic-move-base-flex";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "d75011e1f13fcf5973a0dad5204346b66315dd8d713d12a974dfc13b3a26a812";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d5e114c10ac44d7e47dd2b5f89a0d739cb6d7970bfbaf336a826ff5b211b899b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "c8905e70f394a421dd865180afb90d018ede6d32c0ae36da496c700432059b7e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "4d3311a9e2222c1ec2cdd168d91a3cc72ee0fd8e9959f0341d0d871067bd569d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "191c1b78cb6c2cdb49be36f66c96013aa724497c4327679cf5230b124a2b925a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "43538664bef82eef474ca651d7b593016debe7320cfe9ff7c2efe0b152df9314";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "5cb37e4bd963188db5e70bb676c6ce79bf55420691e636f0c5630e9de69bc93f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "507f0fa94c38b17508b822103c8fa620a777c74c716034618be77823d8b10c2a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "6bd84db929849ccc66aec928e915394c89f60b78120a142e82fb0f38705cc5b9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "0aaea28e2af2cbcbd6c9f928baf68ebe11e84516242e120eab17820663e1ec8f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.6.3-r1";
+  version = "2.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.3-1.tar.gz";
-    name = "2.6.3-1.tar.gz";
-    sha256 = "1ba8c67025587c618522040b7cb3e881185a89cb42a5578774f5a8ac304e43dd";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.4-1.tar.gz";
+    name = "2.6.4-1.tar.gz";
+    sha256 = "434704c185cf69d766d543a78f030522c6b43127bcde587282dfb50c85fac2f3";
   };
 
   buildType = "cmake";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "9258257983d972f10c08221790b6e3678d5bedd8f2f9f5861693a2c4a2288790";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "048f3a402aaa73cc84f768f099153acc5e7c82395e383bda78cc085731172e1f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler-ros/default.nix
+++ b/distros/melodic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler-ros";
-  version = "1.5.0-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "9ba0903e11cc5eac95d47d4789f1300e097486721ab554adabc3ff791c21edce";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "cc2cb07bc24bbbb1391842457e3d44e5f78c37b8e81ad5d4b716083f7803e809";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.3.1-r1";
+  version = "3.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "c88ba00d0b923695d47f6bfe8c90e6f00036a4b38238a27a9795f9a1a4ee035f";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.3.3-1.tar.gz";
+    name = "3.3.3-1.tar.gz";
+    sha256 = "8402c0b956210bafddff530193d141c156ff00bd4671c1905d00c689868e41dc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration-msgs/default.nix
+++ b/distros/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "f7ad438cebdd4c0e631471ff463aee3afd4a53fe69cbd662c78c99be29b3aaca";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "6731bd47372ae3156e9e51bc287328a17b5cbbceeaaf08bdc2451534abe2b41c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration/default.nix
+++ b/distros/melodic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "d705f4093051c90fef5837cf427685444bf5d3c4a17aada13efb9b4f2211ea56";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "220c011cec369940fdb8feec65009fd585da171bec385fd7c37752df40396f08";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roswww/default.nix
+++ b/distros/melodic/roswww/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, phantomjs, pythonPackages, rosbridge-server, rosgraph, rospack, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbridge-server, rosgraph, rospack, rostest }:
 buildRosPackage {
   pname = "ros-melodic-roswww";
-  version = "0.1.12";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roswww-release/archive/release/melodic/roswww/0.1.12-0.tar.gz";
-    name = "0.1.12-0.tar.gz";
-    sha256 = "108f7156256acfd659a62d57362a1b92e59114962829148cd451b032d450d3f7";
+    url = "https://github.com/ros-gbp/roswww-release/archive/release/melodic/roswww/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "eb82a974660ca3170ed06eebb74536569c53d935861cb6d44fc791f0657f8245";
   };
 
   buildType = "catkin";
   buildInputs = [ pythonPackages.catkin-pkg ];
-  checkInputs = [ phantomjs pythonPackages.selenium rostest ];
+  checkInputs = [ pythonPackages.selenium rostest ];
   propagatedBuildInputs = [ rosbridge-server rosgraph rospack ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-wrapper, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-drone-teleop";
-  version = "1.3.9-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "451f60036c35e5e57a74fcbf5129acbb42c4459286f886f6ba1cc3e51c4db7dd";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "87489e35b416d29a2012f318da05b9090e02589ca580c98e6d4a287fb4150486";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-ground-robot-teleop/default.nix
+++ b/distros/melodic/rqt-ground-robot-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-ground-robot-teleop";
-  version = "1.3.9-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "e35de51c03c4cda07e7bcac3c7891d12ef7d6b24b3c468ed295df04d359499f1";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "889e5838ef66a6a37cf69424708b51bdbe3ce73e1407d6d41d7dcfde40ddfcbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.20-r1";
+  version = "1.13.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.20-1.tar.gz";
-    name = "1.13.20-1.tar.gz";
-    sha256 = "5ae39f7f2e81ba2d5b23f00c8b26a599d4a8b294e9cbee7dfbd7ac9a11e29e0d";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.21-1.tar.gz";
+    name = "1.13.21-1.tar.gz";
+    sha256 = "5197529c70024662c2a6f4923b9b8f8975c82ce784875b1e06a8ba387e67f4bd";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules eigen message-generation urdfdom urdfdom-headers ];
   checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosbag rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf tinyxml-2 urdf visualization-msgs ];
+  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf tinyxml-2 urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "9e2d3893c7b15481b54c99e0d43085d19f2df0137c9c7e6eead1dab271a6d75e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "8acde0d3dfa9ec5b961e3464263f0c3d4aaf6f76b700b28f30b5ea3bb679a8fe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "cc3155c946216c271777e683cf2aa57cbf48869991695d096f45e3bcfa0ad9f1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "89f8781dc61fc6592a0fedb771691d7ea76414c7bdba94017370a828aa8deccb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "56cd70d3089f81f540477790a110981f8905055406bbd6e05392e0a8b30a422e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "c302e8582514ff6dc1f4a148050266247b39b4f6ff1f4696b8a34b480c5a14a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/camera-aravis/default.nix
+++ b/distros/noetic/camera-aravis/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, aravis, camera-info-manager, catkin, dynamic-reconfigure, glib, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-camera-aravis";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "18d356bb4c429a1361c85b14b41de397a1dd2b56d975cb2c643cafb54c50db5a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ glib message-generation ];
+  propagatedBuildInputs = [ aravis camera-info-manager dynamic-reconfigure image-transport message-runtime nodelet roscpp sensor-msgs std-msgs tf tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''camera_aravis: A complete and comfortable GenICam (USB3Vision and GigEVision) based camera driver for ROS (ethernet and usb).'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "4f8b3c15cb4b03656cce48bfc762c79baccd6b5f5517a1c7180abf31b9487265";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "659a24e1128dd853ac5acd95396cadf61c6c18c0837d363a124a7c132b218258";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.8-r1";
+  version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.8-1.tar.gz";
-    name = "2.6.8-1.tar.gz";
-    sha256 = "8031a9803a39d9550122cc3de58730198b88a3c1d17f8fa30f0e806c50b523a0";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.9-1.tar.gz";
+    name = "2.6.9-1.tar.gz";
+    sha256 = "9449ffa6a473d13b3f73a3fa96b1ab6cf45ec6a14caaeb7fbf17afefcc037342";
   };
 
   buildType = "cmake";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -144,6 +144,8 @@ self: super: {
 
  calibration-setup-helper = self.callPackage ./calibration-setup-helper {};
 
+ camera-aravis = self.callPackage ./camera-aravis {};
+
  camera-calibration = self.callPackage ./camera-calibration {};
 
  camera-calibration-parsers = self.callPackage ./camera-calibration-parsers {};
@@ -1502,8 +1504,6 @@ self: super: {
 
  mesh-navigation = self.callPackage ./mesh-navigation {};
 
- mesh-tools = self.callPackage ./mesh-tools {};
-
  message-filters = self.callPackage ./message-filters {};
 
  message-generation = self.callPackage ./message-generation {};
@@ -1635,6 +1635,8 @@ self: super: {
  moveit-servo = self.callPackage ./moveit-servo {};
 
  moveit-setup-assistant = self.callPackage ./moveit-setup-assistant {};
+
+ moveit-sim-controller = self.callPackage ./moveit-sim-controller {};
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
@@ -2446,6 +2448,8 @@ self: super: {
 
  roswtf = self.callPackage ./roswtf {};
 
+ roswww = self.callPackage ./roswww {};
+
  rotate-recovery = self.callPackage ./rotate-recovery {};
 
  route-network = self.callPackage ./route-network {};
@@ -2553,8 +2557,6 @@ self: super: {
  rviz-animated-view-controller = self.callPackage ./rviz-animated-view-controller {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
-
- rviz-mesh-plugin = self.callPackage ./rviz-mesh-plugin {};
 
  rviz-plugin-tutorials = self.callPackage ./rviz-plugin-tutorials {};
 

--- a/distros/noetic/hdf5-map-io/default.nix
+++ b/distros/noetic/hdf5-map-io/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, lvr2 }:
 buildRosPackage {
   pname = "ros-noetic-hdf5-map-io";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/hdf5_map_io/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "690c310577b2abed1587f3a063ba0419bc77797f19721067524f16030cf3842d";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/hdf5_map_io/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "31ca04db6683ffac320887907022e7d8ae3bf6965eb11252d0bf1f6836f4b571";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ira-laser-tools/default.nix
+++ b/distros/noetic/ira-laser-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-noetic-ira-laser-tools";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/noetic/ira_laser_tools/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "547a2b868bc6d8bd607d9c882674e7ebabf411e3afa1cee18244b61d6c4ab822";
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/noetic/ira_laser_tools/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "34d9452ea7b8c7e04c9792f76d8dcd0aa77c5e51191dfec18732d8510d6aa96b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "eecb2701675608b9c0463b9ca7576864b3263251ae4fbe5d61a23e096ca3312c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "37c1a7af9f6a2fab60788e8f554763b4c94a2804c5f5a8199908146e70ea7359";
   };
 
   buildType = "catkin";

--- a/distros/noetic/label-manager/default.nix
+++ b/distros/noetic/label-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, genmsg, mesh-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-label-manager";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/label_manager/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6f518b4fed635ef2f8bb4a4a292f6ad2ef5cbaec5b235acedc73f54aed5502f3";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/label_manager/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "6858c277c528ea94ab7bc1efcd561ff4d9c94680761650220078d4e2f6affd9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "5b61f15bc918149031c6493543fa9d7af44548421a56e211ee414e645404dd41";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "25c6284a619c9572176937821435afa5d1e226febef62343d4303dba51abf533";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "209fa656f4905118e2c768b1d553a7b1e66ce7c9eeef0f7a5c1328df91154aa1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "57826c6c660f14c9fe678653da0428fd137d58774ebbb20264782df330ea6f3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "380f3e58c74a4ba1158e76e0515fd00ce61c1efcc4859d6306a7c2855eea7f91";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "47a6fdc21a98881a91c5e0b40f6de06796ca47ece74a2ec1ea4a6af2068e156d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "2af2e31cb2bc773d65a2f7797225897c5030ae0b0c6e763fc01dc99ade2874e8";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "1a0ba2b82353140490448a01181f08d1776c5b0a68aeee6b3865f2ac10fff733";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "2ef3a7e24223283a9c84a601622f45a891a5e34a8431e69d50e2e249b03ea002";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "6683f6ec95ef0a2706b6ec5e98b6108de0ce79d5e2ecd505e7aa326f57f7c632";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-abstract-core/default.nix
+++ b/distros/noetic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mbf-abstract-core";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_core/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "3d576915bb04e8a422c25aeb2cad8c31c9b8bad64456dbfe7c79542ac5b6e376";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "5833bf85e5c0c3f1b4edf23cc5160185cedc71df5d4f1d07c8f35916e1083a05";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-abstract-nav/default.nix
+++ b/distros/noetic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-mbf-abstract-nav";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_nav/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "648bbe062e7497cf737554a59fd7653f6aa74dd91da0af49a83ca6ebdf17242d";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_nav/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "21fdc9e09d4986ac779e1d539d5357d7023346bd22174cc180850a1e853053d5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-costmap-core/default.nix
+++ b/distros/noetic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-mbf-costmap-core";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_core/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "d3707028367b85f5eb9c4e62278a47fe353d7e856b53d00c5b67c3cbf32aab21";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "9942ff1299b2b7714ff6276b0b42e87c2fefb00e01f758dc65e7d322204538ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-costmap-nav/default.nix
+++ b/distros/noetic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-mbf-costmap-nav";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_nav/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "a645408c903bd0e3a61975ce0918739874cce098d37af94603d78dfdbc54a5f9";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_nav/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "276f86ef47afaf98ea888f4983cca5a170da3eea3c04d9944f0772bc6899eac4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-msgs/default.nix
+++ b/distros/noetic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mbf-msgs";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_msgs/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "23c083d3ba5a607a3abb85791d611112ad960073b2ef52f90aae97811c1f7fe6";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "1f43c2ee455624205424362a51065d378e4a24755d17d0b166c746caf1cc0378";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-simple-nav/default.nix
+++ b/distros/noetic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mbf-simple-nav";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_simple_nav/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "86354de860cc466e8f97c15ebcf32d6a35eff5e859bb7158fb698b439809dd07";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_simple_nav/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "7c6fed059c024b49aa57d66b5c0568bfd3058e6d94f5a16fd48cdcc93c1f046f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-utility/default.nix
+++ b/distros/noetic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mbf-utility";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_utility/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "83b4d1e10170b2d92226320315a771f19809b5429a8c872c892368cf66ac301b";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_utility/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8ddc3f7fa8c0475762d76d57d73a939b36291f4b2f6cfdcd49d97b7e09790c38";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mesh-msgs-conversions/default.nix
+++ b/distros/noetic/mesh-msgs-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lvr2, mesh-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mesh-msgs-conversions";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs_conversions/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "e67224e431f1940b8ad49c207801fbd55da9d2430d7e1c2f230371b579a138d3";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs_conversions/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e69f5498f0167c7d5088658e961b247233b9a4048016d7b82427e05247f3501d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mesh-msgs-hdf5/default.nix
+++ b/distros/noetic/mesh-msgs-hdf5/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hdf5-map-io, label-manager, mesh-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mesh-msgs-hdf5";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs_hdf5/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "88beecc46310337e26e19043aa216d8420ed7c32e609f2199ee6871fcfaa4018";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs_hdf5/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7279fa88fdb99d73322b17b85ba620afa1957bc3ff85ffda44fbef68b30d7ca3";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Read and write mesh_msgs to and from hdf5'';
+    description = ''Read mesh_msgs from hdf5'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/mesh-msgs-transform/default.nix
+++ b/distros/noetic/mesh-msgs-transform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, mesh-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-mesh-msgs-transform";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs_transform/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "0bb89df1f78c87d2b2d6107963c71189086e044a0ca0bfb2bafbe72321c064a3";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs_transform/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "de93526223abf69b02a31e845bb95036c41110e147f4de0fbe40fc21b6d0030c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mesh-msgs/default.nix
+++ b/distros/noetic/mesh-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mesh-msgs";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "08dfa61162be8282356379328097699ba5a051d050c928a1d5a61e9d1c4ddff5";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/noetic/mesh_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4ac4997e202d67691249727fe4aa2a5129ce2292de59ba38a963020dfcdb1853";
   };
 
   buildType = "catkin";

--- a/distros/noetic/move-base-flex/default.nix
+++ b/distros/noetic/move-base-flex/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-noetic-move-base-flex";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/move_base_flex/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "70d41a45b7c83d5a3fd7089cf1daff41118b15ddde8dace0fbcff57e85fc2e0d";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/move_base_flex/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "5f98632ccdf48a5d5ce61e1da7db0f15d36ea302dfa83b0f8f4981b428511a90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-sim-controller/default.nix
+++ b/distros/noetic/moveit-sim-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, ros-control-boilerplate, roscpp, roslint, rosparam-shortcuts }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-sim-controller";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/moveit_sim_controller-release/archive/release/noetic/moveit_sim_controller/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "e14d41295815c0152a42a74bddf9c18e49b5d89a361de3555f50ba5459e9eed9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ moveit-core moveit-ros-planning ros-control-boilerplate roscpp rosparam-shortcuts ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A simulation interface for a hardware interface for ros_control, and loads default joint values from SRDF'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "46e4902fe6f31055311cb20114e74e1ed8c1a2968d6885ef87d2e07937c01843";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "e321efe3082a574e38f4f146871f3a2432bd22b92dc65ed0308bf71f34e39b63";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "0bf34fe27e93592ef055b1054d3ce77d3f9b513b055be16d2831a7b3d5f1d980";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "f6f54f1a64ac975086d386c5cc2918145fb9bdee6aea461ca407f2ffebfb9618";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "71ea814e2bfe5014ec442a9ba7dda9cddb05890ef386ce5150c00b626df9fa3b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "440498b5c18f5041874ce5700cebbae8bc4b7d377ff018539401307f8df602cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "60b9a85b4fae06fc03631f760d63fb981e2b195aa3839f3e1600b26e10dbeeeb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "ff13c761611dc0445ecf4bd20b662f46713d4f1bdccec9e84460ca48587c0bb4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.3-r1";
+  version = "2.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.3-1.tar.gz";
-    name = "2.6.3-1.tar.gz";
-    sha256 = "565952f21af20330a30741b884dad3234faa303e8cebc602e06db48f9fca38d1";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.4-1.tar.gz";
+    name = "2.6.4-1.tar.gz";
+    sha256 = "3344ad8eb1728111af01b13240c2fb355fb7b754f022243f3d282eea16c191b3";
   };
 
   buildType = "cmake";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "66fee8d7dfca075b71630878739c7a60ab0d2e62fb5f808221666a8d540ed4dc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "94175a6f71944f01c2421abfa5f58608c9e89d04791266dc0dafdff1325e33e7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.3.2-r1";
+  version = "3.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.3.2-1.tar.gz";
-    name = "3.3.2-1.tar.gz";
-    sha256 = "3b7b7202186e8d6ef69c360a6ab8992fe9c4dffde89957e68cccfdfc8d8746b9";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.3.3-1.tar.gz";
+    name = "3.3.3-1.tar.gz";
+    sha256 = "576ca97653b011981a118773da6a958eb42b4462f6622f03e46e3b9986b993f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-calibration-msgs/default.nix
+++ b/distros/noetic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-calibration-msgs";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "90dcef12df3501596deef0b54aecae6da568f24a0702d533a16f3503dace8215";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "dcc0c22d1e110b7eb81658606d1431938b2195c86d95bc8f36ee98aae92d665d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-calibration/default.nix
+++ b/distros/noetic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-calibration";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "f90812efe92713874c112e6a8dc83efde3ce72915f102dfcd4f1a8db8e057883";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "02482fe8c6e8ed687cc90c1e67bc3469c049544d0cd05a76c7223270f7d5c4f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roswww/default.nix
+++ b/distros/noetic/roswww/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosbridge-server, rosgraph, rospack, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-roswww";
+  version = "0.1.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/roswww-release/archive/release/noetic/roswww/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "21b7ab479ab18b0a1fb19faee08f5391785ffd27fd60bf15dc9d117b8d755b9e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ python3Packages.catkin-pkg ];
+  checkInputs = [ python3Packages.selenium rostest ];
+  propagatedBuildInputs = [ rosbridge-server rosgraph rospack ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Feathery lightweight web server for ROS, that is based on <a href="http://www.tornadoweb.org/en/stable">Tornado</a> web server module.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "69e9cae3f3533f07476b48d74b400e70d4ab5b1d3b371f84c1871ae6cb04afd1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "a34a786a76ae4afc61a4bed13db1aaefae2e296e8f5e2c96c07365c5cb2dce4b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "09a361ed2644201e29be70f85400c40f9c18309a1531cace4b05e97c9bf7f9cf";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "a961f3b15cbfc65ff730d7988cc38a37fc668d78c6b92906acdd184bae9b7c23";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "12e69a79581bc96e41701b1cef6eb7b84726fffa7ab215adf8046132f64c5b2d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "a31b4e7ce81ea9c5fe1840d847aef19666e8d996221b6928daa2807a381194b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "e71d0b09f84c560ba0b67c39e82e916af1c0e14354f54c09f6e0e3d9f81a084c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "d75c61fdf3817fad496642edf7c46426d4a326ca396bf45c3b749aee883ff20d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-autorace-2020/default.nix
+++ b/distros/noetic/turtlebot3-autorace-2020/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, turtlebot3-autorace-camera, turtlebot3-autorace-core, turtlebot3-autorace-detect, turtlebot3-autorace-driving, turtlebot3-autorace-msgs }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-autorace-2020";
-  version = "1.1.0-r7";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_2020/1.1.0-7.tar.gz";
-    name = "1.1.0-7.tar.gz";
-    sha256 = "e41b55aafd603d76d2b6270a4ed9a2d771da7ac15e90f34823c95a3a432bfac7";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_2020/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "0e67c30118a051aacb31f028ee65edee4aea5955ae5bc7a23bec053e7b4b11c6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-autorace-camera/default.nix
+++ b/distros/noetic/turtlebot3-autorace-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, pythonPackages, rospy, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, python3Packages, pythonPackages, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-autorace-camera";
-  version = "1.1.0-r7";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_camera/1.1.0-7.tar.gz";
-    name = "1.1.0-7.tar.gz";
-    sha256 = "894e634fd19fa53b1e4041e6dfd29588291969d612c78b8e6c2d388d60b2270a";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_camera/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "677cf80fe061c8cc01ba31bcb80ffa83907efd5954e4068878bca8a0fe2eb992";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure pythonPackages.enum34 pythonPackages.numpy pythonPackages.opencv3 rospy sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure python3Packages.opencv3 pythonPackages.enum34 pythonPackages.numpy rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/turtlebot3-autorace-core/default.nix
+++ b/distros/noetic/turtlebot3-autorace-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslaunch, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-autorace-core";
-  version = "1.1.0-r7";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_core/1.1.0-7.tar.gz";
-    name = "1.1.0-7.tar.gz";
-    sha256 = "b12960f4765807e11f6b26b0df57ee7c7905e3ed29847e8ff5b3d7fbebe8b04e";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_core/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "d9bf36bac1fd76e308b7fd9f10c304d07ae8da5ba825d64cec0f631918b861bd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-autorace-detect/default.nix
+++ b/distros/noetic/turtlebot3-autorace-detect/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, move-base-msgs, nav-msgs, pythonPackages, rospy, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, move-base-msgs, nav-msgs, python3Packages, pythonPackages, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-autorace-detect";
-  version = "1.1.0-r7";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_detect/1.1.0-7.tar.gz";
-    name = "1.1.0-7.tar.gz";
-    sha256 = "527fb800331750397222f79a5821b07cd0ddba54391647b70412938e2100b275";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_detect/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "c25b137bb7dac2770de0f40d5b0667edf6f7f125de329dbc0af2f1dd8bafc6d5";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs pythonPackages.enum34 pythonPackages.numpy pythonPackages.opencv3 rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs python3Packages.opencv3 pythonPackages.enum34 pythonPackages.numpy rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/turtlebot3-autorace-driving/default.nix
+++ b/distros/noetic/turtlebot3-autorace-driving/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pythonPackages, rospy, sensor-msgs, std-msgs, tf, turtlebot3-autorace-msgs }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-autorace-driving";
-  version = "1.1.0-r7";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_driving/1.1.0-7.tar.gz";
-    name = "1.1.0-7.tar.gz";
-    sha256 = "5c43ec90714b913c4061502534c7176d20f0e7cd78710252decd93b56464c750";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_driving/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "03f25a6f2c271f2e7c7757818cdb9f9923a5cf22d6c5edc2131e5eb59cc68e1a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-autorace-msgs/default.nix
+++ b/distros/noetic/turtlebot3-autorace-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-autorace-msgs";
-  version = "1.1.0-r7";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_msgs/1.1.0-7.tar.gz";
-    name = "1.1.0-7.tar.gz";
-    sha256 = "4fce4e1f725b2eb980e9c499c2063fa0aab3c0accfb59017f52f91aece9423e1";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_msgs/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "0be60a38d898e2c517a0ce6fba2360255125adbaf9593d1abf76382dcb63bc21";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 197126c8f636d0582cf477ab4f37fec529b8e2fa.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *aws-robomaker-small-warehouse-world 1.0.1-r2 --> 1.0.4-r1*
* *controller-interface 0.8.0-r1 --> 0.8.1-r1*
* *controller-manager 0.8.0-r1 --> 0.8.1-r1*
* *controller-manager-msgs 0.8.0-r1 --> 0.8.1-r1*
* *diff-drive-controller 0.5.0-r1 --> 0.5.1-r1*
* *effort-controllers 0.5.0-r1 --> 0.5.1-r1*
* *force-torque-sensor-broadcaster 0.5.0-r1 --> 0.5.1-r1*
* *forward-command-controller 0.5.0-r1 --> 0.5.1-r1*
* *gazebo-ros2-control 0.0.3-r1 --> 0.0.5-r1*
* *gazebo-ros2-control-demos 0.0.3-r1 --> 0.0.5-r1*
* *gripper-controllers 0.5.0-r1 --> 0.5.1-r1*
* *hardware-interface 0.8.0-r1 --> 0.8.1-r1*
* *imu-sensor-broadcaster 0.5.0-r1 --> 0.5.1-r1*
* *joint-state-broadcaster 0.5.0-r1 --> 0.5.1-r1*
* *joint-state-controller 0.5.0-r1 --> 0.5.1-r1*
* *joint-trajectory-controller 0.5.0-r1 --> 0.5.1-r1*
* *libmavconn 2.0.3-r1 --> 2.0.4-r1*
* *mavros 2.0.3-r1 --> 2.0.4-r1*
* *mavros-extras 2.0.4-r1*
* *mavros-msgs 2.0.3-r1 --> 2.0.4-r1*
* *micro-ros-diagnostic-bridge 0.2.0-r4*
* *micro-ros-diagnostic-msgs 0.2.0-r4*
* *microstrain-inertial-driver 2.0.6-r1*
* *microstrain-inertial-examples 2.0.6-r1*
* *microstrain-inertial-msgs 2.0.6-r1*
* *position-controllers 0.5.0-r1 --> 0.5.1-r1*
* *realtime-tools 2.1.1-r1 --> 2.2.0-r1*
* *ros2-control 0.8.0-r1 --> 0.8.1-r1*
* *ros2-control-test-assets 0.8.0-r1 --> 0.8.1-r1*
* *ros2-controllers 0.5.0-r1 --> 0.5.1-r1*
* *ros2controlcli 0.8.0-r1 --> 0.8.1-r1*
* *rosapi 1.0.7-r1 --> 1.1.0-r1*
* *rosapi-msgs 1.1.0-r1*
* *rosbridge-library 1.0.7-r1 --> 1.1.0-r1*
* *rosbridge-msgs 1.0.7-r1 --> 1.1.0-r1*
* *rosbridge-server 1.0.7-r1 --> 1.1.0-r1*
* *rosbridge-suite 1.0.7-r1 --> 1.1.0-r1*
* *rosbridge-test-msgs 1.1.0-r1*
* *simple-launch 1.1.0-r1 --> 1.2.0-r1*
* *transmission-interface 0.8.0-r1 --> 0.8.1-r1*
* *velocity-controllers 0.5.0-r1 --> 0.5.1-r1*
* *webots-ros2 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-control 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-core 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-driver 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-epuck 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-importer 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-mavic 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-msgs 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-tesla 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-tests 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-tiago 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-turtlebot 1.1.1-r1 --> 1.1.2-r2*
* *webots-ros2-universal-robot 1.1.1-r1 --> 1.1.2-r2*

Galactic Changes:
-----------------
* *aws-robomaker-small-warehouse-world 1.0.1-r1 --> 1.0.4-r1*
* *controller-interface 1.0.0-r1 --> 1.1.0-r1*
* *controller-manager 1.0.0-r1 --> 1.1.0-r1*
* *controller-manager-msgs 1.0.0-r1 --> 1.1.0-r1*
* *diff-drive-controller 1.0.0-r1 --> 1.1.0-r1*
* *domain-bridge 0.3.0-r1 --> 0.4.0-r1*
* *effort-controllers 1.0.0-r1 --> 1.1.0-r1*
* *force-torque-sensor-broadcaster 1.0.0-r1 --> 1.1.0-r1*
* *forward-command-controller 1.0.0-r1 --> 1.1.0-r1*
* *gazebo-ros2-control 0.0.4-r1*
* *gazebo-ros2-control-demos 0.0.4-r1*
* *gripper-controllers 1.0.0-r1 --> 1.1.0-r1*
* *hardware-interface 1.0.0-r1 --> 1.1.0-r1*
* *imu-sensor-broadcaster 1.0.0-r1 --> 1.1.0-r1*
* *joint-state-broadcaster 1.0.0-r1 --> 1.1.0-r1*
* *joint-trajectory-controller 1.0.0-r1 --> 1.1.0-r1*
* *libmavconn 2.0.3-r1 --> 2.0.4-r1*
* *mavros 2.0.3-r1 --> 2.0.4-r1*
* *mavros-extras 2.0.4-r1*
* *mavros-msgs 2.0.3-r1 --> 2.0.4-r1*
* *micro-ros-diagnostic-bridge 0.2.0-r4*
* *micro-ros-diagnostic-msgs 0.2.0-r4*
* *microstrain-inertial-driver 2.0.6-r1*
* *microstrain-inertial-examples 2.0.6-r1*
* *microstrain-inertial-msgs 2.0.6-r1*
* *pal-statistics 2.1.0-r1*
* *pal-statistics-msgs 2.1.0-r1*
* *position-controllers 1.0.0-r1 --> 1.1.0-r1*
* *realtime-tools 2.1.1-r1 --> 2.2.0-r1*
* *rmf-battery 0.1.1-r1 --> 0.1.2-r1*
* *rmf-traffic 1.4.0-r1 --> 1.4.1-r1*
* *ros2-control 1.0.0-r1 --> 1.1.0-r1*
* *ros2-control-test-assets 1.0.0-r1 --> 1.1.0-r1*
* *ros2-controllers 1.0.0-r1 --> 1.1.0-r1*
* *ros2controlcli 1.0.0-r1 --> 1.1.0-r1*
* *rosapi 1.0.8-r1 --> 1.1.0-r1*
* *rosapi-msgs 1.1.0-r1*
* *rosbridge-library 1.0.8-r1 --> 1.1.0-r1*
* *rosbridge-msgs 1.0.8-r1 --> 1.1.0-r1*
* *rosbridge-server 1.0.8-r1 --> 1.1.0-r1*
* *rosbridge-suite 1.0.8-r1 --> 1.1.0-r1*
* *rosbridge-test-msgs 1.1.0-r1*
* *rqt-console 2.0.1-r1 --> 2.0.2-r2*
* *simple-launch 1.2.0-r1*
* *transmission-interface 1.0.0-r1 --> 1.1.0-r1*
* *velocity-controllers 1.0.0-r1 --> 1.1.0-r1*

Melodic Changes:
----------------
* *costmap-cspace 0.11.0-r1 --> 0.11.1-r1*
* *cvp-mesh-planner 1.0.1-r1*
* *dijkstra-mesh-planner 1.0.0-r3 --> 1.0.1-r1*
* *drone-assets 1.3.9-r1 --> 1.3.8-r1*
* *drone-wrapper 1.3.9-r1 --> 1.3.8-r1*
* *eigenpy 2.6.8-r1 --> 2.6.9-r1*
* *hdf5-map-io 1.0.1-r1 --> 1.1.0-r1*
* *ira-laser-tools 1.0.6-r1 --> 1.0.7-r1*
* *jderobot-drones 1.3.9-r1 --> 1.3.8-r1*
* *joystick-interrupt 0.11.0-r1 --> 0.11.1-r1*
* *label-manager 1.0.1-r1 --> 1.1.0-r1*
* *laser-filters 1.8.11-r1 --> 1.8.12-r1*
* *map-organizer 0.11.0-r1 --> 0.11.1-r1*
* *mbf-abstract-core 0.3.4-r1 --> 0.4.0-r1*
* *mbf-abstract-nav 0.3.4-r1 --> 0.4.0-r1*
* *mbf-costmap-core 0.3.4-r1 --> 0.4.0-r1*
* *mbf-costmap-nav 0.3.4-r1 --> 0.4.0-r1*
* *mbf-mesh-core 1.0.0-r3 --> 1.0.1-r1*
* *mbf-mesh-nav 1.0.0-r3 --> 1.0.1-r1*
* *mbf-msgs 0.3.4-r1 --> 0.4.0-r1*
* *mbf-simple-nav 0.3.4-r1 --> 0.4.0-r1*
* *mbf-utility 0.3.4-r1 --> 0.4.0-r1*
* *mesh-client 1.0.0-r3 --> 1.0.1-r1*
* *mesh-controller 1.0.0-r3 --> 1.0.1-r1*
* *mesh-layers 1.0.0-r3 --> 1.0.1-r1*
* *mesh-map 1.0.0-r3 --> 1.0.1-r1*
* *mesh-msgs 1.0.1-r1 --> 1.1.0-r1*
* *mesh-msgs-conversions 1.0.1-r1 --> 1.1.0-r1*
* *mesh-msgs-hdf5 1.0.1-r1 --> 1.1.0-r1*
* *mesh-msgs-transform 1.0.1-r1 --> 1.1.0-r1*
* *mesh-navigation 1.0.0-r3 --> 1.0.1-r1*
* *move-base-flex 0.3.4-r1 --> 0.4.0-r1*
* *neonavigation 0.11.0-r1 --> 0.11.1-r1*
* *neonavigation-common 0.11.0-r1 --> 0.11.1-r1*
* *neonavigation-launch 0.11.0-r1 --> 0.11.1-r1*
* *obj-to-pointcloud 0.11.0-r1 --> 0.11.1-r1*
* *pinocchio 2.6.3-r1 --> 2.6.4-r1*
* *planner-cspace 0.11.0-r1 --> 0.11.1-r1*
* *plotjuggler 3.3.1-r1 --> 3.3.3-r1*
* *plotjuggler-ros 1.5.0-r1 --> 1.6.2-r1*
* *robot-calibration 0.6.4-r1 --> 0.6.5-r1*
* *robot-calibration-msgs 0.6.4-r1 --> 0.6.5-r1*
* *roswww 0.1.12 --> 0.1.13-r1*
* *rqt-drone-teleop 1.3.9-r1 --> 1.3.8-r1*
* *rqt-ground-robot-teleop 1.3.9-r1 --> 1.3.8-r1*
* *rviz 1.13.20-r1 --> 1.13.21-r1*
* *safety-limiter 0.11.0-r1 --> 0.11.1-r1*
* *track-odometry 0.11.0-r1 --> 0.11.1-r1*
* *trajectory-tracker 0.11.0-r1 --> 0.11.1-r1*

Noetic Changes:
---------------
* *camera-aravis 4.0.0-r1*
* *costmap-cspace 0.11.0-r1 --> 0.11.1-r1*
* *eigenpy 2.6.8-r1 --> 2.6.9-r1*
* *hdf5-map-io 1.0.1-r1 --> 1.1.0-r1*
* *ira-laser-tools 1.0.6-r2 --> 1.0.7-r1*
* *joystick-interrupt 0.11.0-r1 --> 0.11.1-r1*
* *label-manager 1.0.1-r1 --> 1.1.0-r1*
* *libmavconn 1.9.0-r1 --> 1.10.0-r1*
* *map-organizer 0.11.0-r1 --> 0.11.1-r1*
* *mavros 1.9.0-r1 --> 1.10.0-r1*
* *mavros-extras 1.9.0-r1 --> 1.10.0-r1*
* *mavros-msgs 1.9.0-r1 --> 1.10.0-r1*
* *mbf-abstract-core 0.3.4-r1 --> 0.4.0-r1*
* *mbf-abstract-nav 0.3.4-r1 --> 0.4.0-r1*
* *mbf-costmap-core 0.3.4-r1 --> 0.4.0-r1*
* *mbf-costmap-nav 0.3.4-r1 --> 0.4.0-r1*
* *mbf-msgs 0.3.4-r1 --> 0.4.0-r1*
* *mbf-simple-nav 0.3.4-r1 --> 0.4.0-r1*
* *mbf-utility 0.3.4-r1 --> 0.4.0-r1*
* *mesh-msgs 1.0.1-r1 --> 1.1.0-r1*
* *mesh-msgs-conversions 1.0.1-r1 --> 1.1.0-r1*
* *mesh-msgs-hdf5 1.0.1-r1 --> 1.1.0-r1*
* *mesh-msgs-transform 1.0.1-r1 --> 1.1.0-r1*
* *move-base-flex 0.3.4-r1 --> 0.4.0-r1*
* *moveit-sim-controller 0.3.0-r1*
* *neonavigation 0.11.0-r1 --> 0.11.1-r1*
* *neonavigation-common 0.11.0-r1 --> 0.11.1-r1*
* *neonavigation-launch 0.11.0-r1 --> 0.11.1-r1*
* *obj-to-pointcloud 0.11.0-r1 --> 0.11.1-r1*
* *pinocchio 2.6.3-r1 --> 2.6.4-r1*
* *planner-cspace 0.11.0-r1 --> 0.11.1-r1*
* *plotjuggler 3.3.2-r1 --> 3.3.3-r1*
* *robot-calibration 0.6.4-r1 --> 0.6.5-r1*
* *robot-calibration-msgs 0.6.4-r1 --> 0.6.5-r1*
* *roswww 0.1.13-r1*
* *safety-limiter 0.11.0-r1 --> 0.11.1-r1*
* *test-mavros 1.9.0-r1 --> 1.10.0-r1*
* *track-odometry 0.11.0-r1 --> 0.11.1-r1*
* *trajectory-tracker 0.11.0-r1 --> 0.11.1-r1*
* *turtlebot3-autorace-2020 1.1.0-r7 --> 1.1.1-r2*
* *turtlebot3-autorace-camera 1.1.0-r7 --> 1.1.1-r2*
* *turtlebot3-autorace-core 1.1.0-r7 --> 1.1.1-r2*
* *turtlebot3-autorace-detect 1.1.0-r7 --> 1.1.1-r2*
* *turtlebot3-autorace-driving 1.1.0-r7 --> 1.1.1-r2*
* *turtlebot3-autorace-msgs 1.1.0-r7 --> 1.1.1-r2*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] roseus
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

