### PR TITLE
rosdistro sync, Fri Nov 26 18:29:10 2021

### DIFF
--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -640,6 +640,8 @@ self: super: {
 
  marti-dbw-msgs = self.callPackage ./marti-dbw-msgs {};
 
+ marti-introspection-msgs = self.callPackage ./marti-introspection-msgs {};
+
  marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
 
  marti-perception-msgs = self.callPackage ./marti-perception-msgs {};
@@ -1402,6 +1404,8 @@ self: super: {
 
  rqt-srv = self.callPackage ./rqt-srv {};
 
+ rqt-tf-tree = self.callPackage ./rqt-tf-tree {};
+
  rqt-top = self.callPackage ./rqt-top {};
 
  rqt-topic = self.callPackage ./rqt-topic {};
@@ -1471,6 +1475,8 @@ self: super: {
  smac-planner = self.callPackage ./smac-planner {};
 
  smclib = self.callPackage ./smclib {};
+
+ snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
  soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
 

--- a/distros/foxy/launch-ros/default.nix
+++ b/distros/foxy/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-launch-ros";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "a81941707aa3d0fd3198bb5e141b4b47ddad51e814505495443e63dc3b7bbc15";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "7d10ce97263d536c8e8df45a1d9511f768258eeaff8d513db6b1059f7ca51df6";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing-ament-cmake/default.nix
+++ b/distros/foxy/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ament-cmake";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "a064c0f530e5b5a3ce5646f56f10e892ff2d4b762524efbba2a3e999f496ef8d";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "61612d103e39c58e80e541a1da607c03aea60428015cefa72677d8c99374c667";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-testing-ros/default.nix
+++ b/distros/foxy/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ros";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "83fa54f06992419d0cabba68f755f302c55218365fd554a32b6eaf81a989f672";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "d8ec06ed8a03a8bb98dbd72ccd807c2aebe74c143069841eef60081e80a51878";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing/default.nix
+++ b/distros/foxy/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "20df90419e4935a3ec96271ff166caefb57ee152c09d81acab0cc2c642256fa7";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "8679329fed9f48b2cd93c3ee518c221492689275cccec7b6268bd76b0390f1e8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-xml/default.nix
+++ b/distros/foxy/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-xml";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "05e43bc92517b4efb7ece09c6de555d2bb13531eb627c48e301989bfe4924458";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "018c546129aa1abbc630f4dc15a2cb802da981400a25211013336e1f51921a87";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-yaml/default.nix
+++ b/distros/foxy/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-yaml";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "89f98fdf66fbfc9a6de99a7c322b6be8cf4b00e821e6ddd20ab150c9862c942b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "ae40846ac9279b6102fca1f57e58b165183da854821a3fb3b9fcaadd640dda38";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch/default.nix
+++ b/distros/foxy/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "bd9e09df4c229b5d930ce2c9d98fe7dafb66780eaaf157a05734a37f120062d6";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "498b5b1e0e9aed08a72fcbdc20800999788fecb9fc6616b2ef9a8df821f786b4";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/librealsense2/default.nix
+++ b/distros/foxy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-foxy-librealsense2";
-  version = "2.48.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "e690af321d9a44456920751bf885d94acbdcff9e6448fe3d9707ac0a28868700";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "236df4c248e311f132814ba9884da6c72a2731dfffb8451a935e9065655d7f03";
   };
 
   buildType = "ament_cmake";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400, L500 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/marti-can-msgs/default.nix
+++ b/distros/foxy/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-can-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_can_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "e4a3a9871888963ce96e4dd7a31bab93c90aa6456a0b8d12d8880a40f1e0a049";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_can_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "378a52bb42f7d0e2a15ef0fb0c5de0e193921a1f512db195d06a5876275a4a13";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-common-msgs/default.nix
+++ b/distros/foxy/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-common-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_common_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "92c19118cbe50cf76047f1ebf2543952f4cb0584f45a5da58ad90b930b3b118c";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_common_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0b08252c37bcaf8a68d2327c9fb0fea091c659bb3ff1e6aa208570cf24414982";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-dbw-msgs/default.nix
+++ b/distros/foxy/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-dbw-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_dbw_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a92839b609b425d4ac56f9904630f74ac48ee8b4ba63f16c3d4d69b9c219e119";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_dbw_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "935ee0e10ba191473c4158f64e95f8f8020106da60f647837cbee5dd239e6ed1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-introspection-msgs/default.nix
+++ b/distros/foxy/marti-introspection-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-marti-introspection-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_introspection_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "a7098e03bc8ea72e87d82fde4c3fa353edb43f856bf2947438f9948b37c696b1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''marti_introspection_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/marti-nav-msgs/default.nix
+++ b/distros/foxy/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-nav-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_nav_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "5f1d3b0d852da6735c561b7a6886e1aa412a65592a8b40d1054f19217a3c141f";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_nav_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "51768a9a78ddf9166ab41cbe785971b2361d807b9902a6c021c1b61685d4bb84";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-perception-msgs/default.nix
+++ b/distros/foxy/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-perception-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_perception_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "fe2e9840b60079964bd83c07bd5bb9e01bbd3b0b33095301510c06e609f030cb";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_perception_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "01cac831601fcd0294d8ef8b06670c4516f1d5255bb6b6db5647b1a397b42745";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-sensor-msgs/default.nix
+++ b/distros/foxy/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-marti-sensor-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_sensor_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "83f60894f864fc337c8062b43dd8882b8c6049633820048a1cad35988eb0d682";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_sensor_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "d2c4a05d7186475c3a9c8bc3a33d36c45450ff528814a9f5f6e0e8ad919f9327";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-status-msgs/default.nix
+++ b/distros/foxy/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-status-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_status_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ce0887450594257488da2c152d966dbdc97e3cb65181f036ccd9e91140d2efa0";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_status_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "e5f409447bec9e82e53b6d1b40c0a8a207b27dcc856e789ef408e74115bd8af7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-visualization-msgs/default.nix
+++ b/distros/foxy/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-visualization-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_visualization_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "bd7e870ac87fe110ff8dadafd2da2e4de67c89da2f1c036755d603a8070fee53";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_visualization_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "dc29bd78e7f35d749ad4f42ee97e553f13708fddc25f4ade11d42a96df35a2d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-driver/default.nix
+++ b/distros/foxy/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-driver";
-  version = "2.0.6-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "97b634a178f624c46625e9f5b9747a80990bc70d922d385cb4bdb13f166a8f94";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "0b1f964cc71ee6428ee367e2ef73fffa44fc38eaebf75c8b631e0adbcfe89dd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-examples/default.nix
+++ b/distros/foxy/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-examples";
-  version = "2.0.6-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "9aadaa34a27851b3662819f7070c66e51d80c03cde6ee8544fd17f953cb24f19";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "e1f21e690ac94751da283429f407bcff938b0a9b688cc754d727af4c5a5dde7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-msgs/default.nix
+++ b/distros/foxy/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-msgs";
-  version = "2.0.6-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "eb02317ed916db8170e11d793f1cb62af6cc17942775c130f3215709775e14f8";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "a6d7c6d73602016384be6e30c49f0efa37f948d0f28579a44c784d3dfcab921f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "62688ea5e6548ce5269d20b220cae703282b13692c68db4d336d4a4d206d6be7";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "35303adf34ac5e6ac500d195bf152e10afe1e762be459a683189dad256997727";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-core";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "92035d8a31eed965e7f897344e6aabfb99b1eddf52c7a2810c11fdcdc76693fd";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "06c3ff565271ece7e1d6ad65bbb751139095d849e067df4c9232c37f4b5582f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "2204048d999d8fca2ec2ebd3ab75e09d4369198b804bb6c78f5edf4f29900db0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "0249b9f79b0b392c7a1ea01787ec2e5a39cc52254180b6695e4e612f11bc610f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners-ompl/default.nix
+++ b/distros/foxy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners-ompl";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "401effdfd12eded28fdbc04f79d50d0fc758faa803ad51ccef263db39d58d6df";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "7395427cb1428547cadf70aa029c4a68ecb9a7c0b620ea8fc4e420a57ef8d38f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "4e61882f3d880a4d2a6cdfb6d1afe621740a9b4a0709b50a4fb75708e7ce3133";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "b5b0000f46272aab3843969f747eb745ca9df2b8347b643df13ab533d8b2dc54";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "c950632eced55edafc03244652f0b247a23500857db457f052d81d3860f3aa96";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "668a9748c983a9ecabf918ffc080f8552903f8dfdf611b47a47ab4765ded32f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "f87cd28ea01ab9df58fd5253f114e6a64bea499066f554575adf465cbe6fb20d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "24ffc7994309a36618dc992c89a08a0297afee3691e46e998a639e3da3e7f36a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "920374d42cbebfbde353d6f8a8d5b443a0895806050486ec63d7cb0290fb3842";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "ac10f22cb72ef1b2f470860dca3d676e90e003dcdead035b032368d0d07fcbff";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "e2b1055f1d26184da227fd5032becad282d94296bca20a5a370301d09d447ae4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "3e9a76eb47d1b2d513d1b346a134ed16679c6a28bc7dca5e0fb2af9d44ade812";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-perception/default.nix
+++ b/distros/foxy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-perception";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "9a4a75bea7adf7b89996685fff3d0a57eb63152718980b9a7ddb99b1ce212b38";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "a6c90bb96142a5ce2ac759a0ba828016631d33f692d2cdb258e50a991f441a3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "cd72676e502dc113a909cf72ea1f2215424422305d8cb4a1b4ebc0d912c766cb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "5f1e1319d0f3735b636d1ffdb9004431cdf73b3f6ddabdcbac28b1026c8b9021";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "4207b5518088adc2942de2178c33a45b398af7491b2c850df56d0f00654d061a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "fa053b5f669dcee7bde786306fba8d9e5c0cbc164f63081215728c73155ff602";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
   propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rclcpp rclcpp-action srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "13bccb8e892f2c9c0c58214d07dd99a79b8d6050325443a3000d042e825bbdab";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "b6fe6dec1200210067c6632b533d138f6813c93b326d83fb23c72fbdea0a793e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "8066063d76956eecaa567673a82fc4a7efd41a02945a7cb999757a1470fb28cc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "d427fdd7e25d63d1e06d13fc3050b6c290b37dfcd208ac9684c0c3d23926bf7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "effe9fbc158d5b7567bea99b0ed2bffa5a3a13ca6be05dcb2d96d0eb38394c2d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "51105f6d7b90d73bd440c3e9367b6607e4f2546fb3cda767de9e6ac44ace7967";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "d991f0af0b7c480235171c04345b7cac794f1e077f1808c5d52680ef8812ded1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "5a541e9d48a4385e4c03b2bab7578862215a1265357b38555bc653f456ec26b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "c7781b833da0f2b33881acca467de072b41c2348e7922dcd9b24f14d1727e845";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "8ea419f3f54038a728b82fde54083a69af31375a8f13231c3874fcddde006283";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "51b75e062ceee8f4e0053cf9742bb222ff9c695fa7f4dc1efeaea66b292401a2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "44daaeaa66f0aac439278827dd1c72ef3a3b79f142a653ef9887538c7dfed35a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ros-testing ];
-  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "8c63e85a853c872845be336c39133afbf1e8dc1c2e99ce1fa2df675181ee69b5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "bbb4fcffcf9b181b949f1028208fd61b5288c4fbfd1c781edaee4f796a5319fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "9558e12c8864ce187299ae0b7e5a81b1e846e1451d2b1ef96096d81c322a9f78";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "e4924ad34713461a6a4b7738f3e17c3d352e5844bc27db66f1eb9145e0851ca1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rc-genicam-api/default.nix
+++ b/distros/foxy/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-foxy-rc-genicam-api";
-  version = "2.5.6-r1";
+  version = "2.5.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.5.6-1.tar.gz";
-    name = "2.5.6-1.tar.gz";
-    sha256 = "20a621c8649a6f5b336f6237f9c635cde01fc8ae280a91d472658414bc404e2a";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.5.12-1.tar.gz";
+    name = "2.5.12-1.tar.gz";
+    sha256 = "703174f821ddb554ad13dbb567e4f8f0f58072f6f2e09171b248d18425be06b9";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rc-genicam-driver/default.nix
+++ b/distros/foxy/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, image-transport, rc-common-msgs, rc-genicam-api, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rc-genicam-driver";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros2-release/archive/release/foxy/rc_genicam_driver/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "277dbe5453658c31c06dacba050321e1927191291d447b211bf6a8476ea1a3ab";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros2-release/archive/release/foxy/rc_genicam_driver/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "a02d5980198bbce997671ee666873f397ef4687f093b0b8efda3734738a580d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.2.2-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "89a37b2dd32f614a9eeba9dc849aa87946ac4523774870f789b42525ee39c184";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "9d8d0bd3e56c0ad46580fb6ea458761a6bc9590db6152f0d71620aea73f90708";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.2.2-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "40859a26b5750a72eedcba7fc9fd235f81058129f15f0de00a123416b0869bbd";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "e283cd48d576c999fcc27f39694ec9b199e9dab6f26c37b0a153b9c83150175b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
-  propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge diagnostic-updater eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.2.2-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "89a1f38d901e6e973ada9dc9133b6ceb1d7281f979d292305553de4c09d87122";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "8d238db512b7d475f2eb9b284dfcb039cc64dbe6c409b2b10549fc12ba4384e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2launch/default.nix
+++ b/distros/foxy/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2launch";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "1ed537ffec0cae359ffbe196cb97b46eb317c4b97a170a256108794c2ee8d05b";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "4cf0b51485beb3fd7a64bfda267bec57069cc200f59eb7a727f62be4ee73fa63";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-tf-tree/default.nix
+++ b/distros/foxy/rqt-tf-tree/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-rqt-tf-tree";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/foxy/rqt_tf_tree/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "46bba17833ddafac6af4a99df252632907b7087c38c4943bb59c325baaf0612e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.mock ];
+  propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
+
+  meta = {
+    description = ''rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "ab5846516a3684bf791cc1e923939afd3b99ded6172f80dcd79b76c4193f7231";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "990af5d23f730ca6252e53081955126790cbc5e2563af5ad61e7bfa41655c260";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-move-group moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a72717119a52ea030fbccda142e144388e47f8394ba2645acad2eeb2c3bc85d4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "24b31e5514646cedca412a8fbc6913639592b141f6b77df39d6b21f005b9fa33";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "9c20d95494ba163d4f598766232b878dd176d841b12c0d600c9106838c22c725";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "0ed38dbf02f5db6c8903721304c67d744f113762762c916eef7129e8e21647aa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface warehouse-ros-mongo ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-move-group moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/snowbot-operating-system/default.nix
+++ b/distros/foxy/snowbot-operating-system/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, geometry-msgs, pluginlib, rviz-common, rviz-rendering }:
+buildRosPackage {
+  pname = "ros-foxy-snowbot-operating-system";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/foxy/snowbot_operating_system/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "e8347b0ff55173286f290afc16a95e7cc4d3fcd4e2f11f206ab9f29715f535eb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rviz-common rviz-rendering ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The weather outside is frightful'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/swri-console-util/default.nix
+++ b/distros/foxy/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-console-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_console_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "6502d1a8aa80509383cdadbd789cd34c9198ef8ba131a4ebd0a709a74dda2c3a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_console_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "7ac8042ad5ada08f5a618e576f8dd284009113a5ef980eff8576b1cc07d88723";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-dbw-interface/default.nix
+++ b/distros/foxy/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-swri-dbw-interface";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_dbw_interface/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "604ceb6a5625b911893fc2f6514eda3492f18ffef80570b5984af51042aacc8f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_dbw_interface/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "7c1bd224d9dc07d2ff4da57a93f0fbb3db014eb4d4a8384c8fea794af8884f60";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-geometry-util/default.nix
+++ b/distros/foxy/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-swri-geometry-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_geometry_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "99e918d64c921238611f549051ed85b58851296aaff0a2a66737686a69a2340f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_geometry_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "ebe0d24b2efdad12e36597ee3734c1a1a62055e438f960e64377760c89db0d4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-image-util/default.nix
+++ b/distros/foxy/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-swri-image-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_image_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "a31c90aee6ce468170955328f65f17c5524dbd3967f279ea8499f5fdd4e92e7c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_image_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "5c5efdd09cfbddd9a9c055498ebc740c4cb2a3d89f2c1f6a8caf76d1dadf8f3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-math-util/default.nix
+++ b/distros/foxy/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-math-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_math_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "6cbd84092cad5d0405b7a94a504f4f07c99315761013f3ddbdf06dd31c85ba2d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_math_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "52f51dfba83dbc21a8efe1aa1fd43d5632649acf63f3a78815aaaa5e1789a27d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-opencv-util/default.nix
+++ b/distros/foxy/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-foxy-swri-opencv-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_opencv_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "5e8db7110c473d71d7baf5744f4fc524227832355a275cc2ed0b9b23414b10f4";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_opencv_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "167e60dbd2012b88070b474c85628728dac3fa8db318c57895e0ba2d2d698ee2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-prefix-tools/default.nix
+++ b/distros/foxy/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-swri-prefix-tools";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_prefix_tools/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "2db51a91f5d9a464a7c1e8ee21900af2b4c2a72743b98907439680ddf097aa9c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_prefix_tools/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "8820840166871532f1aa6ffe3feeed6d744467324f33201488d7b33db14d364a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-roscpp/default.nix
+++ b/distros/foxy/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-swri-roscpp";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_roscpp/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "370c1c75fa10889b13132580264c99dafffe109a7476312d7c2d122a0077bb83";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_roscpp/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "3a38676a083821c0228aadadfb8096a2d8ebcf04cb8ecbe8d199bc772cbaca6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-route-util/default.nix
+++ b/distros/foxy/swri-route-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-swri-route-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_route_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "671465b4777416c002bbb27a9d28dcb87ea257508d8aff00b554231e9958a46f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_route_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "4e7846bf3a72a3115c2642f8c665a114933df9cfb5d974141318374e9bbf05a4";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ boost marti-common-msgs marti-nav-msgs rclcpp swri-geometry-util swri-math-util swri-roscpp swri-transform-util visualization-msgs ];
+  propagatedBuildInputs = [ boost marti-common-msgs marti-nav-msgs rclcpp swri-geometry-util swri-math-util swri-roscpp swri-transform-util tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/swri-serial-util/default.nix
+++ b/distros/foxy/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-foxy-swri-serial-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_serial_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "74cfaf9e19c30f9a9c2e60f9ea1a15659ece2c82346dd2fb3595f1e7e8c65b8b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_serial_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "1590cd00137823164d760f196553be51395f1069cd7b20180ea68c429c62053e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-system-util/default.nix
+++ b/distros/foxy/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-system-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_system_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "73068a1eba73ec858215f1608301e3fe5b26b14fcd737a8b001f192a7d5469ef";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_system_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "2924b3b8daa430b1a2142fe122588f75f7c67d19b1222331179cbfc3a38214a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-transform-util/default.nix
+++ b/distros/foxy/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-swri-transform-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_transform_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "c9edd0533958c99070d25d2afe047f2f65579a6b5724bbc4d586d7eadf9dc6aa";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_transform_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "b7ea5b7420551928f282fee717706cfb3192e62bd50247c6f6be5f43ccedfca5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gazebo-ros2-control-demos/default.nix
+++ b/distros/galactic/gazebo-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-galactic-gazebo-ros2-control-demos";
-  version = "0.0.4-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control_demos/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "12d07745dbc087faf59b6a3f0f77851201fa4e89d4e31890c9c4372813293569";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control_demos/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "65421af8156175ba1045bd4703db2e429403be1c9a53c8c6a5c814c933651cb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gazebo-ros2-control/default.nix
+++ b/distros/galactic/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-gazebo-ros2-control";
-  version = "0.0.4-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "35ba04700277f5249f016d58c533a6401ec5c39b4c17d633a400c58d71d1c9c8";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "29bb894caccc9e9339d42b4f3f5a4e29542cfbdc018f8aceb770d58e3f5f20ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -392,6 +392,8 @@ self: super: {
 
  hardware-interface = self.callPackage ./hardware-interface {};
 
+ hash-library-vendor = self.callPackage ./hash-library-vendor {};
+
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
  iceoryx-binding-c = self.callPackage ./iceoryx-binding-c {};
@@ -519,6 +521,8 @@ self: super: {
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
 
  marti-dbw-msgs = self.callPackage ./marti-dbw-msgs {};
+
+ marti-introspection-msgs = self.callPackage ./marti-introspection-msgs {};
 
  marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
 
@@ -1216,9 +1220,13 @@ self: super: {
 
  rqt-srv = self.callPackage ./rqt-srv {};
 
+ rqt-tf-tree = self.callPackage ./rqt-tf-tree {};
+
  rqt-top = self.callPackage ./rqt-top {};
 
  rqt-topic = self.callPackage ./rqt-topic {};
+
+ rtabmap-ros = self.callPackage ./rtabmap-ros {};
 
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
 
@@ -1279,6 +1287,8 @@ self: super: {
  smacc2-msgs = self.callPackage ./smacc2-msgs {};
 
  smclib = self.callPackage ./smclib {};
+
+ snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
  soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
@@ -1414,13 +1424,29 @@ self: super: {
 
  turtle-tf2-py = self.callPackage ./turtle-tf2-py {};
 
+ turtlebot3 = self.callPackage ./turtlebot3 {};
+
+ turtlebot3-bringup = self.callPackage ./turtlebot3-bringup {};
+
+ turtlebot3-cartographer = self.callPackage ./turtlebot3-cartographer {};
+
+ turtlebot3-description = self.callPackage ./turtlebot3-description {};
+
+ turtlebot3-example = self.callPackage ./turtlebot3-example {};
+
  turtlebot3-fake-node = self.callPackage ./turtlebot3-fake-node {};
 
  turtlebot3-gazebo = self.callPackage ./turtlebot3-gazebo {};
 
  turtlebot3-msgs = self.callPackage ./turtlebot3-msgs {};
 
+ turtlebot3-navigation2 = self.callPackage ./turtlebot3-navigation2 {};
+
+ turtlebot3-node = self.callPackage ./turtlebot3-node {};
+
  turtlebot3-simulations = self.callPackage ./turtlebot3-simulations {};
+
+ turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
  turtlesim = self.callPackage ./turtlesim {};
 

--- a/distros/galactic/hash-library-vendor/default.nix
+++ b/distros/galactic/hash-library-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-hash-library-vendor";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tier4/hash_library_vendor-release/archive/release/galactic/hash_library_vendor/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "571f885109fc8700a37b96607f96d8e8e70506a48acec360c144d4a9f996e886";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''ROS2 vendor package for stbrumme/hash-library'';
+    license = with lib.licenses; [ asl20 "Zlib License" ];
+  };
+}

--- a/distros/galactic/librealsense2/default.nix
+++ b/distros/galactic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-galactic-librealsense2";
-  version = "2.48.0-r2";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/galactic/librealsense2/2.48.0-2.tar.gz";
-    name = "2.48.0-2.tar.gz";
-    sha256 = "a041d44b269f2ef41485eebefb5264bf8910df794c07e831120ec0f55a68208d";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/galactic/librealsense2/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "88e333ca6f64ae1f947874633771f6efee8f3aa873d397458debe620bb8d44f8";
   };
 
   buildType = "ament_cmake";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400, L500 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/marti-can-msgs/default.nix
+++ b/distros/galactic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-marti-can-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_can_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "0d5e37a4a4a602d8e08d676ecb1d4f2cc3386ab900d230604d9aee861305329f";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_can_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "c84d6b73cbf61e2f310c3f77ec14953adb625df5660e9ee99146293a1d152eab";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/marti-common-msgs/default.nix
+++ b/distros/galactic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-marti-common-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_common_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "eac35ebb1560e46cbc5e7d9da185d872829d1d6de969fc26d14ac8d225ec82e0";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_common_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "585d9415da2376c1833698a26afa0cdb09dd8cadba7aa4296b13f9bbcdf3827b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/marti-dbw-msgs/default.nix
+++ b/distros/galactic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-marti-dbw-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_dbw_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "30c85029706f37e4a5b0ca28438e1fcfd89faa2f74eb9d2f8bd6371effec42b0";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_dbw_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "5a9911555baf2193cf06b608fba4b1acffa794c5e17dd77e1d10d14b8319d59f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/marti-introspection-msgs/default.nix
+++ b/distros/galactic/marti-introspection-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-marti-introspection-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_introspection_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "e1cf624950cfab6c14ec3c3e1806ad095332e06a59f87d6d8acdbbaa4d967c54";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''marti_introspection_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/marti-nav-msgs/default.nix
+++ b/distros/galactic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-marti-nav-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_nav_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "d8c5314b1650a1d144c9046aa50ec7abede4c8c80a9192480e8ceae2bf1a16f2";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_nav_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "75c192c11a81a05ade6f3df4a32227781d20049e384ca7c2dd56b88a99604a97";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/marti-perception-msgs/default.nix
+++ b/distros/galactic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-marti-perception-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_perception_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "68f75885da65f5822060c67e683f3f846e0692106f30d6c440f067da5b7250f7";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_perception_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "e8c38fcf04fb8366c044e7a7a1f008626dd9f0150861b7949e7ff15d6798f012";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/marti-sensor-msgs/default.nix
+++ b/distros/galactic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-marti-sensor-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_sensor_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "5456fb1c174cd01b01472df6b5c44068d7b1e0e06da84da0dda7ac59779f9bb6";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_sensor_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b63cca472a7f7c24a23e9f9860a3dcc8244e2efb8699a8df150c56510d34cecb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/marti-status-msgs/default.nix
+++ b/distros/galactic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-marti-status-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_status_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "3b7a194dfccd11cebaa1e8ad78bbc29f2449abc7696b15bb6d8910e9e29113dd";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_status_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "2c75a884abc4388ca1ed4771846f6ecd667d04ae3c44c0e1e855533659b77a6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/marti-visualization-msgs/default.nix
+++ b/distros/galactic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-marti-visualization-msgs";
-  version = "1.1.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_visualization_msgs/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "aa5072d64a71497b8a303c2d8c289cbf56830e414b66c3917f8a6c9237373688";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/galactic/marti_visualization_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7c813003517abb0225b01f3211d16fa6256dab4d9982c44092790c9531b80746";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-driver";
-  version = "2.0.6-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "2cabac46a1400fcda68a48cb93936373bf328e0aff1d58f3d5a54271ae0ecdcb";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "82fec9b7ad690fdc6bffd4ee19a85974f031b723e338ebfe2968a11dbcd03b86";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-examples";
-  version = "2.0.6-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "621fac1b63964ba95e41e876c4fe1549ebcfd09405dd34cdc6c5d731a5f2e300";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "a2c35e019e68efd777b07f638938e68883cba5eda5b6ed525ab60bab0a7fd8c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-msgs";
-  version = "2.0.6-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "206693798af81eb36087eb6b456b1a71802bd9aa15a94a7f6f6ce1f5a627c386";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "297b628ad931e9f1055a5e8824d1734ddfe644a59ffa90838eacecdf01306d98";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rc-genicam-api/default.nix
+++ b/distros/galactic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-galactic-rc-genicam-api";
-  version = "2.5.6-r1";
+  version = "2.5.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/galactic/rc_genicam_api/2.5.6-1.tar.gz";
-    name = "2.5.6-1.tar.gz";
-    sha256 = "51fc487557e1cd25ca9e2248e3c99e3a280335289857db11192d28f586519aa1";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/galactic/rc_genicam_api/2.5.12-1.tar.gz";
+    name = "2.5.12-1.tar.gz";
+    sha256 = "ae1ec1a577d6e34166df7ac90d2676c1c1e6ef81b2c2cba10b4a67441fe956a1";
   };
 
   buildType = "cmake";

--- a/distros/galactic/rc-genicam-driver/default.nix
+++ b/distros/galactic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, image-transport, rc-common-msgs, rc-genicam-api, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rc-genicam-driver";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_driver_ros2-release/archive/release/galactic/rc_genicam_driver/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "983e29322738289a3220b25ae7f69b8b9cb47d2bbe57ba6ef12539687c68f9d9";
+    url = "https://github.com/ros2-gbp/rc_genicam_driver_ros2-release/archive/release/galactic/rc_genicam_driver/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "31dc010c6c47efc65258c28f774d3df5bfc008970188295566f8c59ab6bb1e14";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-camera-msgs/default.nix
+++ b/distros/galactic/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera-msgs";
-  version = "3.2.2-r2";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.2-2.tar.gz";
-    name = "3.2.2-2.tar.gz";
-    sha256 = "5a4b1627446662459a841a631d59d7a8d4b7d82a926ecba4f481c75b7e693cfc";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "a3edf50c8fc2fd0a4b18614a49bd7b94dab94294fcec0d13ac5fe931025ed346";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-camera/default.nix
+++ b/distros/galactic/realsense2-camera/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera";
-  version = "3.2.2-r2";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.2-2.tar.gz";
-    name = "3.2.2-2.tar.gz";
-    sha256 = "790f619dc14c37640238117073c0c51982db4f94a4ea4e65e6397fdbcef1d08a";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "7d93c3e45ecc700fa0ced10bb6fee870d909839e802501077aa471f1bc4d32e9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
-  propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge diagnostic-updater eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/realsense2-description/default.nix
+++ b/distros/galactic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-description";
-  version = "3.2.2-r2";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.2-2.tar.gz";
-    name = "3.2.2-2.tar.gz";
-    sha256 = "394c8ad4e49ca3e8ca8fcc6fa50c64689ffcb2de83f1b3c0e0864799e2d2ee24";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "5a12d964f9742e97a944c6070d36a9b3d922f023ae4c69122f0932318d6b3b2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-tf-tree/default.nix
+++ b/distros/galactic/rqt-tf-tree/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-rqt-tf-tree";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/galactic/rqt_tf_tree/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "205ee5f0d4ef4a8969238995ab35d20dc0a1d72a444ea5999b844116fbfc4d72";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.mock ];
+  propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
+
+  meta = {
+    description = ''rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rtabmap-ros/default.nix
+++ b/distros/galactic/rtabmap-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rtabmap-ros";
+  version = "0.20.15-r2";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/galactic/rtabmap_ros/0.20.15-2.tar.gz";
+    name = "0.20.15-2.tar.gz";
+    sha256 = "6dd3c53c5bf8dacaa5c42f12e9314391648d89a0d3a0f1d6986202f73300506b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pcl rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces class-loader compressed-depth-image-transport compressed-image-transport cv-bridge geometry-msgs image-geometry image-transport laser-geometry message-filters nav-msgs nav2-common octomap octomap-msgs pcl-conversions pluginlib rclcpp rclcpp-components rclpy rosgraph-msgs rosidl-default-runtime rtabmap rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs std-srvs stereo-msgs tf2 tf2-eigen tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map's ros-pkg. RTAB-Map is a RGB-D SLAM approach with real-time constraints.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/snowbot-operating-system/default.nix
+++ b/distros/galactic/snowbot-operating-system/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, geometry-msgs, pluginlib, rviz-common, rviz-rendering }:
+buildRosPackage {
+  pname = "ros-galactic-snowbot-operating-system";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/galactic/snowbot_operating_system/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "90f62b486ee1072369986e31abe1dafd4147c35e55166a8e5387e7c684730f07";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rviz-common rviz-rendering ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The weather outside is frightful'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/swri-console-util/default.nix
+++ b/distros/galactic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-swri-console-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_console_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "f0f4dda4845cb5f027d5103dcd7e1641aefdbbad3d90759ca8806c47654f35a0";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_console_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "403c7597167446b0862e39f49f58c7aae3107c71851007ca5466127fc51c24c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-dbw-interface/default.nix
+++ b/distros/galactic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-swri-dbw-interface";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_dbw_interface/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "f69cef07cc4adf8cd1fde2718bdb19f743d87a462e8e520b5864317917b0c0ca";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_dbw_interface/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "196c6d5122cb565883af349fe76adca71e0dceb86e32bd408a9c703156fc5c94";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-geometry-util/default.nix
+++ b/distros/galactic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-swri-geometry-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_geometry_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "683cf356409d220ec046cf4496a9cdf3b0b0dbef7695535ed8334943a5ef6b5c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_geometry_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "e6a177c737ddc547556e046586c8030fe1d89c9daaa32ae169e5cc1406c3e687";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-image-util/default.nix
+++ b/distros/galactic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-swri-image-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_image_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "e3a30aac2ebdcee2ef252a58ceec7eac853353a4d0663ebf59a8610f880618e7";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_image_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "37d8abbc5d824315ebbb7e99135e6cbd6a39a37f267dc7895b0f6f95352a8019";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-math-util/default.nix
+++ b/distros/galactic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-swri-math-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_math_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "6098284416b684fcd530dde8eebe11a064dd8ac8d25db43116a94d7e0a07392d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_math_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "1c5ee1d7c512420387f83f82ec6af7ec68e18de150deee485fa947e62847925a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-opencv-util/default.nix
+++ b/distros/galactic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-galactic-swri-opencv-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_opencv_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "2da763ecd9e1c7c59ae9df7323fea3ea621cf2ce00780c991cca952601a90cc0";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_opencv_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "4b29bdf2923b95b6992e4848abd37e847076bafd2508fce6128aacbef904c0f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-prefix-tools/default.nix
+++ b/distros/galactic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-swri-prefix-tools";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_prefix_tools/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "4460692d26a37a44ce375d19e334a123e0ec0e8c8fd7d0bc505341374c8a72c0";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_prefix_tools/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "644c15a3b4a6aa473f59770c1e740237df074b5cc67f012d3c785553b7ae58f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-roscpp/default.nix
+++ b/distros/galactic/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-swri-roscpp";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_roscpp/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "1f7bfd33988623fadb44ccf5d0e93747e6bfa5e47c4c876c5addfaebb0c356fc";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_roscpp/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "b7b754aad7a4de40147df74e47ab5225117c692648c055728baf8152686aa605";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-route-util/default.nix
+++ b/distros/galactic/swri-route-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-swri-route-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_route_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "697c1db6b89cbe27fde77fc7136bd094d14720ab077a512670ba9c71dc85ff40";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_route_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "5a590f468faded6cbcfb8e089b31e842e04a5ccf875d51d38d65e812531c70fe";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ boost marti-common-msgs marti-nav-msgs rclcpp swri-geometry-util swri-math-util swri-roscpp swri-transform-util visualization-msgs ];
+  propagatedBuildInputs = [ boost marti-common-msgs marti-nav-msgs rclcpp swri-geometry-util swri-math-util swri-roscpp swri-transform-util tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/swri-serial-util/default.nix
+++ b/distros/galactic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-galactic-swri-serial-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_serial_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "c03cede2e989b80f787d31092ebb8530fb7b7eaf5bc255e3f59a8a4aca5a0f02";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_serial_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "4bc907f422665d03b8a9b99e0833f97019726d79e1824115ffd427746f5f48aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-system-util/default.nix
+++ b/distros/galactic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-swri-system-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_system_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "6871be4ebcc1dbf2656aa8c754b9987723c40bfb9aae7618b16765084df26834";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_system_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "6cc3dba9637825817e35ca7515eb407ba70d9d9f8579f2f7557a046b37e3093d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-transform-util/default.nix
+++ b/distros/galactic/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-swri-transform-util";
-  version = "3.3.2-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_transform_util/3.3.2-2.tar.gz";
-    name = "3.3.2-2.tar.gz";
-    sha256 = "873ace610f76cf34d1e8191e94e2ef1e591e8b6e899c642893e3b5583672e02d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_transform_util/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "7d98f6a960869476f2e7fc0f3e3736e6884208fbd00c00a7104510c44e572fb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot3-bringup/default.nix
+++ b/distros/galactic/turtlebot3-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, hls-lfcd-lds-driver, robot-state-publisher, rviz2, turtlebot3-description, turtlebot3-node }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-bringup";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_bringup/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "2fdc5851275e052d20f44a7e72c45be96cacb93080946cc11bb9b40e31c434a5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ hls-lfcd-lds-driver robot-state-publisher rviz2 turtlebot3-description turtlebot3-node ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for starting the TurtleBot3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-cartographer/default.nix
+++ b/distros/galactic/turtlebot3-cartographer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cartographer-ros }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-cartographer";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_cartographer/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "3d8801ab3e3732e8c7a54188f880d7b63bb2d2d4483bfe0a2d826bcc410a4ec1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ cartographer-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for cartographer'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-description/default.nix
+++ b/distros/galactic/turtlebot3-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, urdf }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-description";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_description/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "601542ee32fe9d6ddb7b4e14244f0f0e3b2378fd08362872d00eb408f2c8c849";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''3D models of the TurtleBot3 for simulation and visualization'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-example/default.nix
+++ b/distros/galactic/turtlebot3-example/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclpy, sensor-msgs, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-example";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_example/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "eebee251aad08a5e9cbfb4653df932d354998c7e9fb82dc42a4c3565af76547b";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclpy sensor-msgs turtlebot3-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package provides four basic examples for TurtleBot3 (i.e., interactive marker, object detection, patrol and position control).'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-navigation2/default.nix
+++ b/distros/galactic/turtlebot3-navigation2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-navigation2";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_navigation2/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "7db70abb6c3c439138c650627c90f6745ccbdb372875942f1ce131a28b5ae020";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ nav2-bringup ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for navigation2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-node/default.nix
+++ b/distros/galactic/turtlebot3-node/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, geometry-msgs, message-filters, nav-msgs, rclcpp, rcutils, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-node";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_node/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "b032c1cb330f29ccda9b96487ccc4c0f4a7cf71ab372252634a5b79beae8fe22";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ dynamixel-sdk geometry-msgs message-filters nav-msgs rclcpp rcutils sensor-msgs std-msgs std-srvs tf2 tf2-ros turtlebot3-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TurtleBot3 driver node that include diff drive controller, odometry and tf node'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-teleop/default.nix
+++ b/distros/galactic/turtlebot3-teleop/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rclpy }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-teleop";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_teleop/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "613126ecf1d29785355ee138fe3ce55efb6af8057f921404d53dc0ba906c775c";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs rclpy ];
+
+  meta = {
+    description = ''Teleoperation node using keyboard for TurtleBot3.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3/default.nix
+++ b/distros/galactic/turtlebot3/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-bringup, turtlebot3-cartographer, turtlebot3-description, turtlebot3-example, turtlebot3-navigation2, turtlebot3-node, turtlebot3-teleop }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3";
+  version = "2.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "c404e32991ca23fa864d0744d9deb6541030e5d6ef5d657a8ad99ba97f868df5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ turtlebot3-bringup turtlebot3-cartographer turtlebot3-description turtlebot3-example turtlebot3-navigation2 turtlebot3-node turtlebot3-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 packages for TurtleBot3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/find-object-2d/default.nix
+++ b/distros/melodic/find-object-2d/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, genmsg, image-transport, message-filters, qt5, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-find-object-2d";
-  version = "0.6.2-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/find_object_2d-release/archive/release/melodic/find_object_2d/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "7f868aa64cabd58c39cc11179f4d935c4c8399d9ebc5a59a561f352831eae527";
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/melodic/find_object_2d/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "bb19a36951a2bd531bd45af05d8b1a98084eb5eb3042f700f9bc7e77260d9648";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge image-transport message-filters qt5.qtbase roscpp rospy sensor-msgs std-msgs std-srvs tf ];
-  nativeBuildInputs = [ catkin genmsg ];
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cv-bridge image-transport message-filters message-runtime qt5.qtbase roscpp rospy sensor-msgs std-msgs std-srvs tf ];
+  nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The find_object_2d package'';

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3002,7 +3002,11 @@ self: super: {
 
  qb-chain-control = self.callPackage ./qb-chain-control {};
 
+ qb-chain-controllers = self.callPackage ./qb-chain-controllers {};
+
  qb-chain-description = self.callPackage ./qb-chain-description {};
+
+ qb-chain-msgs = self.callPackage ./qb-chain-msgs {};
 
  qb-device = self.callPackage ./qb-device {};
 
@@ -3746,6 +3750,24 @@ self: super: {
 
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
+ rwt-app-chooser = self.callPackage ./rwt-app-chooser {};
+
+ rwt-image-view = self.callPackage ./rwt-image-view {};
+
+ rwt-moveit = self.callPackage ./rwt-moveit {};
+
+ rwt-nav = self.callPackage ./rwt-nav {};
+
+ rwt-plot = self.callPackage ./rwt-plot {};
+
+ rwt-robot-monitor = self.callPackage ./rwt-robot-monitor {};
+
+ rwt-speech-recognition = self.callPackage ./rwt-speech-recognition {};
+
+ rwt-steer = self.callPackage ./rwt-steer {};
+
+ rwt-utils-3rdparty = self.callPackage ./rwt-utils-3rdparty {};
+
  rx-service-tools = self.callPackage ./rx-service-tools {};
 
  rxcpp-vendor = self.callPackage ./rxcpp-vendor {};
@@ -3887,6 +3909,8 @@ self: super: {
  smach-viewer = self.callPackage ./smach-viewer {};
 
  smclib = self.callPackage ./smclib {};
+
+ snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
  social-navigation-layers = self.callPackage ./social-navigation-layers {};
 
@@ -4387,6 +4411,8 @@ self: super: {
  visualization-msgs = self.callPackage ./visualization-msgs {};
 
  visualization-osg = self.callPackage ./visualization-osg {};
+
+ visualization-rwt = self.callPackage ./visualization-rwt {};
 
  visualization-tutorials = self.callPackage ./visualization-tutorials {};
 

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.48.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "308d0ec8226c4baceeadc7aa65889d25df4901863c2734b23e91403ed0236a2c";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "2cf92cf8482e3621398b09dd66ae3dd96c01e34ff3e0906531b75ba71f2a5fc7";
   };
 
   buildType = "cmake";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400, L500 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/microstrain-inertial-driver/default.nix
+++ b/distros/melodic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-driver";
-  version = "2.0.5-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "cc8be1871ac28751841e4ed673e2a4d287b1b5b08032dafd75a5ffa4df4e8f69";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "afb32d55985276398213021f33dfd0daccd7181708889c1078dbd33b64b08566";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-examples/default.nix
+++ b/distros/melodic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-examples";
-  version = "2.0.5-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "9a8115be6c5402bcede175dc5a16fee30882b81cf26e05a69139f96ef16b91b7";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "5eca406f6d57598bf5769c2bdbfc6ffd0556f851244119ae9b62cbc45dad8dd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-msgs/default.nix
+++ b/distros/melodic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-msgs";
-  version = "2.0.5-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "2023fa36096dfef2411900c4173b29c290c7e2f24d00a0729230dd051a007341";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "4ebf38d44efd51c7d8d534f92c69cef1f1da0ecf9fdf4a2380cb06a68158e6fb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-chain-control/default.nix
+++ b/distros/melodic/qb-chain-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-chain-control";
-  version = "2.0.0";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_control/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "b24868d85ac57809f85562dd92fae1ca2c99950d820b4f3a78e3df006e3d66b4";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_control/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "0f47c3e17ad0602362d4fa703f861bc377e95bf7b97ebdb72369857f3eb1b1a2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-chain-controllers/default.nix
+++ b/distros/melodic/qb-chain-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, geometry-msgs, interactive-markers, qb-chain-msgs, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, trac-ik-lib }:
+buildRosPackage {
+  pname = "ros-melodic-qb-chain-controllers";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_controllers/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "e3014675e32d30d33f52650b4f48c5d69e3fbc307b2f8243f6bc416b6422c8c3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-msgs controller-interface geometry-msgs interactive-markers qb-chain-msgs roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros trac-ik-lib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the specific controllers for qbrobotics® kinematic structures, e.g. the qbdelta controller.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qb-chain-description/default.nix
+++ b/distros/melodic/qb-chain-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-chain-description";
-  version = "2.0.0";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_description/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "fe4822d09d3d0b0ec0a6b337799c04774d1a775d700962cb6e5fd043c836d7c2";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_description/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "b207696afd55b5ed57d59f6b3739afa243d184c3c779d8dfd8b9d07855a42837";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-chain-msgs/default.nix
+++ b/distros/melodic/qb-chain-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-qb-chain-msgs";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_msgs/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "cd8d08303aa64391babdeadf53fc68c5c25df4c3718665a703e4ffa907df6592";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''message to control end-effector pose, robot sitiffness and velocity'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qb-chain/default.nix
+++ b/distros/melodic/qb-chain/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-chain-control, qb-chain-description }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-chain-control, qb-chain-controllers, qb-chain-description, qb-chain-msgs }:
 buildRosPackage {
   pname = "ros-melodic-qb-chain";
-  version = "2.0.0";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "e21beffe73643665345d9027e82e376dd9b4cad3b1e429653276333060221e60";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "129a5060e66b66399afd5e6d2e7f4de57eb9dd101c06689f83eaf7a8413d0a8f";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-chain-control qb-chain-description ];
+  propagatedBuildInputs = [ qb-chain-control qb-chain-controllers qb-chain-description qb-chain-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rc-genicam-api/default.nix
+++ b/distros/melodic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-api";
-  version = "2.5.6-r1";
+  version = "2.5.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.5.6-1.tar.gz";
-    name = "2.5.6-1.tar.gz";
-    sha256 = "902f6cc0d8a886664bca7e2e0b9301991d986aa632945975df5d794a57c171a4";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.5.12-1.tar.gz";
+    name = "2.5.12-1.tar.gz";
+    sha256 = "8c9d0a6bf77ddb0dc4f00a375d8aab35d4c60d0cb43fb4a12c71c320e80a0953";
   };
 
   buildType = "cmake";

--- a/distros/melodic/rc-genicam-driver/default.nix
+++ b/distros/melodic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-driver";
-  version = "0.6.1-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "649606695422e7f7cdbe614404434dcf60e2922abfe7d839aa463a3fa6096fae";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "4d65f8a833a5ca220b564c5c663951e571bc7f969f3d27ead05be5d49982d747";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/melodic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rc-hand-eye-calibration-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "0fc4ed0f1cf427c040ec7db8387f9d07404b3edc68ef2802b6bfcce2ab466105";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "1ec1067c217bdef0a3c5e30b3bde1dbc415cb3c531853d593273aabef2edeb9a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-pick-client/default.nix
+++ b/distros/melodic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-pick-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "e3f5296e818834456cd6faa979a2f2e18370cddb81600cb8ac28ebfaf3227bd6";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "8e4b3c36d1fd8c068236e6390631a69a297d9f9ecc8d5b1f9666cd2b45c4e63a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-roi-manager-gui/default.nix
+++ b/distros/melodic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-melodic-rc-roi-manager-gui";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "3ffa307c635080207ddb6c8a90ce0e65135e501b849059199b093b4aa4edd19d";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "7aff5ae94d6898964c7859b230a3380a31f74c6f4af924a90b0caf64fffa8999";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-silhouettematch-client/default.nix
+++ b/distros/melodic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-silhouettematch-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "b4a5d4ccd2301e171b489be4002b073b2d7140b254f62cb43cf977050e1d4c7f";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "60b0b638e9e7dd2916e95f4dafdac396665ba00a4da4e1d2c542130c73e639d3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-tagdetect-client/default.nix
+++ b/distros/melodic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-tagdetect-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "03afbb41710552ab519ed2b284f24a1d7cf501b153661cc25994fa21ea85dc3c";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "a8bf4f7f7f185ee22adaa73df2f53ebdd6a74eadb385784cb16a5840bc905433";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-description/default.nix
+++ b/distros/melodic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-description";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "80596819b33dabed21c77e73233ce9b4879908bfe7771b371901c8b6954b4832";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "621d2975c45002d2114671c16b9781934a274675019e26c0ec7594bbf8ca37bb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-driver/default.nix
+++ b/distros/melodic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-driver";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "31ebf811e9c8d660b4e12e592cb17812ddea22251755070df2981bf3655e2ea0";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "6a0ca88bd27602bdf4f5fff8470f91f1bcf0fa6479aca677e4c41d9faac380b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard/default.nix
+++ b/distros/melodic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "888b202662f7d7e64f86933f50f6f1df5b04e0497634e7b3de2e88798e147e47";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "686f98970cd7ea2cab688a10ab7f819b0db8da05e3f84c4cb26844751958e81b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-generation, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "0188482ed8dbff76805463de0a0c25cf9e47c63722ec80b4e0d6a76b97f37b4f";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "481e740a9e28f8241e1ed5009090839286e3a0e50589414c5f4b6ecac6f07d12";
   };
 
   buildType = "catkin";
+  buildInputs = [ message-generation ];
   propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "a80b157219097f419989219ec949e27a0f47d8f87b9e8cc50f0b84b6027fdd84";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "a759b19b2843ec5eba48734b1f30c1be35691d41f040f6622d33ef62adea20b7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rwt-app-chooser/default.nix
+++ b/distros/melodic/rwt-app-chooser/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, app-manager, catkin, phantomjs, pythonPackages, rosbridge-server, rostest, roswww, sound-play }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-app-chooser";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_app_chooser/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "d895ce642f710dec08e1dbebe7de978bcc9977b03bf135dbbf53b17a4afcf69e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ phantomjs pythonPackages.selenium rostest ];
+  propagatedBuildInputs = [ app-manager rosbridge-server roswww sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The simple web frontend for app_manager'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/rwt-image-view/default.nix
+++ b/distros/melodic/rwt-image-view/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, image-publisher, message-generation, message-runtime, rosbridge-server, rospy, rostest, roswww, rviz, rwt-utils-3rdparty, std-srvs, web-video-server }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-image-view";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_image_view/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "4636e54ee0c17a57480aeb4114e5c0686504da5eec5b8ffb1c44f237f1c8241a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ image-publisher rostest rviz ];
+  propagatedBuildInputs = [ message-runtime rosbridge-server rospy roswww rwt-utils-3rdparty std-srvs web-video-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_image_view package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rwt-moveit/default.nix
+++ b/distros/melodic/rwt-moveit/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, interactive-marker-proxy, kdl-parser, message-generation, message-runtime, moveit-msgs, orocos-kdl, robot-state-publisher, rosbridge-server, rospy, roswww, rwt-utils-3rdparty, sensor-msgs, std-msgs, tf, tf2-web-republisher, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-moveit";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_moveit/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "4cc126eb4bb0bd7be316e06cc2a2421ae8aa3d17089f5dbc759b8d2d3cd57204";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ interactive-marker-proxy kdl-parser message-runtime moveit-msgs orocos-kdl robot-state-publisher rosbridge-server rospy roswww rwt-utils-3rdparty sensor-msgs std-msgs tf tf2-web-republisher visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a web user interface of <a href="http://moveit.ros.org/">MoveIt!</a> on top of visualizer in <a href="http://wiki.ros.org/ros3djs">ros3djs</a>.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rwt-nav/default.nix
+++ b/distros/melodic/rwt-nav/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, image-publisher, map-server, move-base-msgs, rosbridge-server, roscpp, rostest, roswww, rviz, rwt-utils-3rdparty, tf, web-video-server }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-nav";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_nav/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b923c3c3f2e4c7a35710d91171ec49aa8ca4046ca24969fcac3b35169f389bd0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ image-publisher map-server move-base-msgs rostest rviz ];
+  propagatedBuildInputs = [ geometry-msgs rosbridge-server roscpp roswww rwt-utils-3rdparty tf web-video-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_nav package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rwt-plot/default.nix
+++ b/distros/melodic/rwt-plot/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rosbridge-server, rospy, rostest, roswww, rwt-utils-3rdparty, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-plot";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_plot/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "442f7110a879b5d107aa19b676910acf811ebe1d030568cc86e476244222b249";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ geometry-msgs rosbridge-server rospy roswww rwt-utils-3rdparty std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rwt_plot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rwt-robot-monitor/default.nix
+++ b/distros/melodic/rwt-robot-monitor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, rosbridge-server, rostest, roswww, rwt-plot, rwt-utils-3rdparty }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-robot-monitor";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_robot_monitor/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b78fe02256cf1b24be648221fa89df0e81e61f19a2e37d34ee608650be8be79d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ diagnostic-aggregator rostest ];
+  propagatedBuildInputs = [ diagnostic-msgs rosbridge-server roswww rwt-plot rwt-utils-3rdparty ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_robot_monitor package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rwt-speech-recognition/default.nix
+++ b/distros/melodic/rwt-speech-recognition/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosbridge-server, roslaunch, rostest, roswww, rwt-utils-3rdparty, speech-recognition-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-speech-recognition";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_speech_recognition/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "3777c5129e7fea8791bfdbcf97400e38f57064ffc3e0c12fe75b78e6ffbfc24e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ rosbridge-server roswww rwt-utils-3rdparty speech-recognition-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_speech_recognition package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rwt-steer/default.nix
+++ b/distros/melodic/rwt-steer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, image-publisher, rosbridge-server, rostest, roswww, rviz, rwt-utils-3rdparty, web-video-server }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-steer";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_steer/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "db2abd4a820bfb28b5bfa98bfaee23a0ac800040288ccd66049e21b75fd38871";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ image-publisher rostest rviz ];
+  propagatedBuildInputs = [ rosbridge-server roswww rwt-utils-3rdparty web-video-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_steer package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rwt-utils-3rdparty/default.nix
+++ b/distros/melodic/rwt-utils-3rdparty/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-rwt-utils-3rdparty";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/rwt_utils_3rdparty/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "3a6f48ed988311ffcab9a6bbdef0c4f5cc1be08e3c35470e2b3f57bc1076d870";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_utils_3rdparty package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/snowbot-operating-system/default.nix
+++ b/distros/melodic/snowbot-operating-system/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-melodic-snowbot-operating-system";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/melodic/snowbot_operating_system/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "145a02fd03c5c381fa5977d08caec58bb309d92f078e720eba657af259bcc705";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The weather outside is frightful'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/visualization-rwt/default.nix
+++ b/distros/melodic/visualization-rwt/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rwt-app-chooser, rwt-image-view, rwt-moveit, rwt-plot, rwt-speech-recognition, rwt-utils-3rdparty }:
+buildRosPackage {
+  pname = "ros-melodic-visualization-rwt";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/melodic/visualization_rwt/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "8aa62e182a1ec6a2f54cd4701d81358c7de4c3e7d99272003243c2c5cead42dc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rwt-app-chooser rwt-image-view rwt-moveit rwt-plot rwt-speech-recognition rwt-utils-3rdparty ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>visualization packages using rwt</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/camera-calibration/default.nix
+++ b/distros/noetic/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, message-filters, rospy, rostest, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-camera-calibration";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/camera_calibration/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "3a608f8df6412fc0bf6f338119e5856ac49d133f16cae13e151abd8c262895ca";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/camera_calibration/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "b350a3340fc9dbd6af21518aec375e7ade56e2a5b18f8cebba679a8e3e824557";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cv-bridge/default.nix
+++ b/distros/noetic/cv-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, opencv3, python3, python3Packages, rosconsole, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cv-bridge";
-  version = "1.15.0-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/cv_bridge/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "62b9751b8a29f6ee3ca3d24f59dcd29ebdfba92e0002f3c2a23d333612dd3dcb";
+    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/cv_bridge/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "e6a11ec534e810c25eea0b8a28ad0a7f48afe616ba27d489c82800f4e8d19e28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depth-image-proc/default.nix
+++ b/distros/noetic/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cv-bridge, eigen-conversions, image-geometry, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-depth-image-proc";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/depth_image_proc/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "f1b044486256c1f7b6d48cefd360fc18b5109472a778314a9c20632db19b2663";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/depth_image_proc/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "e128d95349edb03074707f85d3a5d2eb46cf00e24c3c8dff1d6c0e44a316ca8a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/euslisp/default.nix
+++ b/distros/noetic/euslisp/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
+buildRosPackage {
+  pname = "ros-noetic-euslisp";
+  version = "9.28.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/euslisp-release/archive/release/noetic/euslisp/9.28.0-1.tar.gz";
+    name = "9.28.0-1.tar.gz";
+    sha256 = "e96dd4d4acd2d76c5b1fa660982b54e0e06efd9746a6f7ce7909dc128abccd95";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake-modules mk ];
+  propagatedBuildInputs = [ libGL libGLU libjpeg libpng postgresql xorg.fontadobe100dpi xorg.fontadobe75dpi xorg.fontbh100dpi xorg.fontbh75dpi xorg.fontbhlucidatypewriter100dpi xorg.fontbhlucidatypewriter75dpi xorg.fontbitstream100dpi xorg.fontbitstream75dpi xorg.libX11 xorg.libXext ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''EusLisp is an integrated programming system for the
+  research on intelligent robots based on Common Lisp and
+  Object-Oriented programming'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -692,6 +692,8 @@ self: super: {
 
  ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
 
+ euslisp = self.callPackage ./euslisp {};
+
  executive-smach = self.callPackage ./executive-smach {};
 
  executive-smach-visualization = self.callPackage ./executive-smach-visualization {};
@@ -2568,6 +2570,22 @@ self: super: {
 
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
+ rwt-app-chooser = self.callPackage ./rwt-app-chooser {};
+
+ rwt-image-view = self.callPackage ./rwt-image-view {};
+
+ rwt-nav = self.callPackage ./rwt-nav {};
+
+ rwt-plot = self.callPackage ./rwt-plot {};
+
+ rwt-robot-monitor = self.callPackage ./rwt-robot-monitor {};
+
+ rwt-speech-recognition = self.callPackage ./rwt-speech-recognition {};
+
+ rwt-steer = self.callPackage ./rwt-steer {};
+
+ rwt-utils-3rdparty = self.callPackage ./rwt-utils-3rdparty {};
+
  rx-service-tools = self.callPackage ./rx-service-tools {};
 
  safety-limiter = self.callPackage ./safety-limiter {};
@@ -3016,6 +3034,8 @@ self: super: {
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
 
+ visualization-rwt = self.callPackage ./visualization-rwt {};
+
  visualization-tutorials = self.callPackage ./visualization-tutorials {};
 
  viz = self.callPackage ./viz {};
@@ -3047,6 +3067,12 @@ self: super: {
  vrpn-client-ros = self.callPackage ./vrpn-client-ros {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warthog-control = self.callPackage ./warthog-control {};
+
+ warthog-description = self.callPackage ./warthog-description {};
+
+ warthog-msgs = self.callPackage ./warthog-msgs {};
 
  web-video-server = self.callPackage ./web-video-server {};
 

--- a/distros/noetic/image-geometry/default.nix
+++ b/distros/noetic/image-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, opencv3, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-geometry";
-  version = "1.15.0-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/image_geometry/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "5a279f3d91dd86ad7d0fadd782aa4622e4a94d6a969766844908ead57318df72";
+    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/image_geometry/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "c1876437e6591c63987f60a88b94be33e615636475258dd843eb139d3258dc62";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-pipeline/default.nix
+++ b/distros/noetic/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration, catkin, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-noetic-image-pipeline";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_pipeline/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "53a2f7e77bfc7df1998aceac5ddb531284d228ec6f739b51b7af035ec1226956";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_pipeline/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "25d283c1577252bc76918226c497102bf0b6a4011ee564476057167e5b3a9c25";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-proc/default.nix
+++ b/distros/noetic/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-transport, nodelet, nodelet-topic-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-proc";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_proc/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "712ef2d9d3602daa643c50e2ca841ae5125995651065726eaf9439fcf24a93db";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_proc/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "f1edc97b5e95327a66a6dcb3d81c621f6a14ca504045c9e799a5e832a18d5b9a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-publisher/default.nix
+++ b/distros/noetic/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-publisher";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_publisher/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "e3e11ebfaa0b10f559cb4cb941ed38611d72b2ce0da7ddb1437b127bfeae9f92";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_publisher/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "04cdb1afadfb60be9f09d024cdd364c76c5a2d3719809e9bf7d78fb83a7fa93e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-rotate/default.nix
+++ b/distros/noetic/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, nodelet, roscpp, rostest, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-image-rotate";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_rotate/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "b94ef742d380068f7218f0bca639a69bb1bc50a7df01b147c056d1773a7d2487";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_rotate/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "3d851d658c52efe381146978e95d31fbf0b932fa2ebcd32a2b99e54741834f65";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-view/default.nix
+++ b/distros/noetic/image-view/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, gtk3, image-transport, message-filters, message-generation, nodelet, rosconsole, roscpp, rostest, sensor-msgs, std-srvs, stereo-msgs }:
+{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, image-transport, message-filters, message-generation, nodelet, rosconsole, roscpp, rostest, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-view";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_view/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "a515a45455748772fb12078e7b3d0bf081a97d13c7f20c0df8779d58c06b7352";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/image_view/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "7bfe9fd5e1007a49a8307ebc8afa9cfcf4314159ab1fa1af3a43ac9ff8a9a521";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation sensor-msgs stereo-msgs ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge dynamic-reconfigure gtk3 image-transport message-filters nodelet rosconsole roscpp std-srvs ];
+  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge dynamic-reconfigure image-transport message-filters nodelet rosconsole roscpp std-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/librealsense2/default.nix
+++ b/distros/noetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-noetic-librealsense2";
-  version = "2.48.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "bce0dfe9b6fb802f781aa8f284eb44fb8519dcbed4622564429dbb50f6ed5565";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "309e30be33aaf0a794f4ee3291356806ea6d238c0798f70f0388d2cec9a08ba0";
   };
 
   buildType = "cmake";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400, L500 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "2.0.5-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "7e5a38d105071c1a302574d8eff766c45ef94e49da0168680e927e24e3057a4e";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b8b2de615ef0a733ff497b3e51a8ec8224273bd052a4ce4a60e3f7a742077f7e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "2.0.5-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "c6356c1d62d204dc8c0460268992a5b888a3295954b63cddf8869487a18c9fc5";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "55f97a880265cf79c58a8e5b905b7adf973954ad9664f12faf94b24e77ed3caa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "2.0.5-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "c5d476ee4f6aa3e4d9b5c59bc60028bc6d0da3c80b3f1efeea7238f3116f670c";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "f73162a44ddbe97fdcfc7d6c04d67d34a9c18cf646086fa174c23dd1b371e3cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-fanuc-description/default.nix
+++ b/distros/noetic/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-fanuc-description";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_description/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "31108faf6aaa718dd4670aec0f02d0d07083b409cca3503662be4057aafd674f";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "517b2216d7bbb6b14cac50556294a3d79d2f80da8851d799555b1a82eb18db44";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-fanuc-moveit-config";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_moveit_config/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "4ea489ad7afe24d099756bdb73668b1b6223f8e9db4e8e8d3b33ec22275af968";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "5c2471a150b4ab84eb81b1c63e794eb982f9f600401f6d80666d5775d4f044c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-panda-description/default.nix
+++ b/distros/noetic/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-panda-description";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_description/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "5fa6bda81b6bdbc7d881bfe593c83aa83e90dae976359c1dac53048b5fd180ec";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "85a92c552a02e2aebd256f06253b2f188cfd606ca40f639a63757fe94f650f4e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, rviz, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-panda-moveit-config";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_moveit_config/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "d6034a340b4f68f226dd7f801648b12f44b081c602d302bc2c924cdd0ccf706a";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "e5b5da7f3f30a6e0ddd98c802432f99fa526c623d00780c1c4e66759c3813164";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-pr2-description/default.nix
+++ b/distros/noetic/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-pr2-description";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_pr2_description/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "4ab818bf5e2edeb7d0de2b95a05fb496f9996130300832173b179fc4cd043121";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_pr2_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "df362edff68e3769c672f3105d63ae675d27e0f3f15a2d54f6e79ab00aa14aa1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/noetic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_ikfast_manipulator_plugin/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "74508ac6108455bd769405fe25761edc983c878f4e550e98722fed5f5f5d1f2c";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_ikfast_manipulator_plugin/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "7b9a978e377e94714f8f1a13e6ca778e300453ffdc7d98f4a869989b3fddac11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, robot-state-publisher, rviz, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-moveit-config";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_moveit_config/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "a61f43ef1736827212f31ab2267df97013d0c4c4daf215bfc711950ce1821a1e";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "0d77142a1dc3fc0ee9b1bc1a21ca67939ac01345de09d456f0cec0cd36af22b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/noetic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-pg70-support";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_pg70_support/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "3dd2bad13bc6d85c996744ebac996b016d441026a2ea28816e912447f4bf6f6e";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_pg70_support/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "12d22c95034d670242999e2fb67155c8a5fadc627e03003d67e636b92457dbef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-support/default.nix
+++ b/distros/noetic/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-support";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_support/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c211113420080b2d7a0220450c08eb5ad644fea1dd690d0b4f3a80e9d76ba7db";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_support/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "ea64280d527970b6d0740709f21d84e8e2333c5f1eb2519ea51bbb6658a78d9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources/default.nix
+++ b/distros/noetic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "676d396be3f8fecbdb7d6a41a2b49613e440b955d51737517be177ecd2f2b136";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "70ef3cd5af45c756157a24608eaa89ffaa87619c3b02b50559b727f78fdff247";
   };
 
   buildType = "catkin";

--- a/distros/noetic/power-msgs/default.nix
+++ b/distros/noetic/power-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-power-msgs";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/power_msgs-release/archive/release/noetic/power_msgs/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0ffc282953f4d9de6d8e6f86ab896d457b9b6d3a38448af09c35d63dd2507c71";
+    url = "https://github.com/fetchrobotics-gbp/power_msgs-release/archive/release/noetic/power_msgs/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "696eff7295d1352040e3223f176fa488815f14ef05066ee6ab43e479791d4120";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-chain-control/default.nix
+++ b/distros/noetic/qb-chain-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-chain-control";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_control/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "9c12af9deea8cf9dbfc05b2a240db768bd294bed0e2d4991bb6a0462ce96fcdf";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_control/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "8775ed6b10a3e32d8c41b193d9c670d74ead9033f5c5eb515e3934c5ffe77ae3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-chain-controllers/default.nix
+++ b/distros/noetic/qb-chain-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, geometry-msgs, interactive-markers, qb-chain-msgs, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, trac-ik-lib }:
 buildRosPackage {
   pname = "ros-noetic-qb-chain-controllers";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_controllers/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "0cc99d8e9ba87bd9fcbb0eb83379e028b89e286d2877c32b633e26c3134dd97b";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_controllers/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "0918717350f04738e900128dfb7785a82ba24e24210c4c18eb9c09d1d98bfd91";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-chain-description/default.nix
+++ b/distros/noetic/qb-chain-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-chain-description";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_description/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "25dafabe178d4c499ed7dba04283ad553ac0438976107bc0aec294623d5e8ff2";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_description/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "24ec3edb5cc1bfaae15f5c699e51ceb98809166699f17165f25c10dcc2844cec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-chain-msgs/default.nix
+++ b/distros/noetic/qb-chain-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-qb-chain-msgs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_msgs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "d4feec1101c5abd18c9c562a98c948241f84bbf563dd9f66faa54807164397f1";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain_msgs/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "3d69347661c1f4ea1dbdd44be95438819e1c8a22f4339d287b623ed1fe0cac48";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/qb-chain/default.nix
+++ b/distros/noetic/qb-chain/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-chain-control, qb-chain-controllers, qb-chain-description, qb-chain-msgs }:
 buildRosPackage {
   pname = "ros-noetic-qb-chain";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "efff631b51b51d78a9cdb05a6e9ad716dd5a874483b27ccf6ada8e84f01350a2";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/noetic/qb_chain/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "14c7b8585b56cf1cc62704abcad7117cd796506c326e7f003bda83a1698705ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-api/default.nix
+++ b/distros/noetic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-api";
-  version = "2.5.6-r1";
+  version = "2.5.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.5.6-1.tar.gz";
-    name = "2.5.6-1.tar.gz";
-    sha256 = "cd16648e83edf078aa516398e05f192161ce08329f0eb7cfa77b0182c3ac7ef8";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.5.12-1.tar.gz";
+    name = "2.5.12-1.tar.gz";
+    sha256 = "05f3bd6a1b968b510f2f21be68adf4c089c32f3d3a2a1b81d6fb1d4f3cb966a8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rc-genicam-driver/default.nix
+++ b/distros/noetic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-driver";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "21cd16cab196500eec1db9999ffa2db433bba99cb7d7802a51d2f3cf6602753a";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "efffb85a04740a78ff27ce2556e5cef809371d1e5ad1624455c953bf126ea58b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/noetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rc-hand-eye-calibration-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "bffdfa0ff2f0e8ae876f04d5236989317dd66ad2e8efc48d392fb6248696ccf0";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "6ec7f891026a63058ea6b2c3c2516d4780d7525a4100e0efd5eee8dbd86553ac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-pick-client/default.nix
+++ b/distros/noetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-pick-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "fa4ca16e95a32dacd9a3b47507750ee4081c16a2993edaf6dbc74ef38f057d94";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "f3f6744392d979b541428e6baba79db332295232adcbb4223cd6b4bf9c6e30e1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-roi-manager-gui/default.nix
+++ b/distros/noetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-noetic-rc-roi-manager-gui";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "68646c068bb0f66d27c976a6bf96de1bbb98392fb176f200349c15d5bbce287a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "19b5a99d946e942578255ad7e492d4c427a947812f4789af01c4937b58b4e4f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-silhouettematch-client/default.nix
+++ b/distros/noetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-silhouettematch-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "d96bfe3bbb355c443895feaf5bacc9ba4111627742a558ba43355f18ee206fd4";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "9c1b76daf6850be40457324fc3a05087f310f1948312b65181679f53588f0946";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-tagdetect-client/default.nix
+++ b/distros/noetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-tagdetect-client";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "a2a684032221405a92ba245d2af1a3602d74bd294faf9ba290375249f1fbf67f";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "a998f52aba14807852fb27e7945dc5d9c7f60037fd7009c861dd6e0c8ab726f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-description/default.nix
+++ b/distros/noetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-description";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "6468fc3852b1f01483e5751ed8f436775f232c07137f8f948981505d6e77137c";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "3794077fe641b35ae3a0fba0cfd10c7e67f2ef44373ada0b16f6b65e4de20697";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-driver/default.nix
+++ b/distros/noetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-driver";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "048a1dfb6875158327ddc6fadacc225c9edddb1c7f83e2a57ecb40343c59360d";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "18cdbf2a9e849eb91b29bb889c296e4ec579aa533e9866532317b81b441edf9b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard/default.nix
+++ b/distros/noetic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard";
-  version = "3.2.3-r1";
+  version = "3.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "b0d41d24073a2ea14befc789bd7f23840e844278b03a22f305107b7905e71d06";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.2.4-1.tar.gz";
+    name = "3.2.4-1.tar.gz";
+    sha256 = "dc0ff43e305b3f3507dcb8775babca5c466b8fd1fc0c191311b7cdacc76957e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/realsense2-camera/default.nix
+++ b/distros/noetic/realsense2-camera/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-generation, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-camera";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "7a03daf61c66952736ae82144cc88d354ba7a1883b7b59091db5e4cff0bad2fb";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "a03a1817362e6cdb2634429010226be1b64b64371a0622b588e65ec8bc4fb1e3";
   };
 
   buildType = "catkin";
+  buildInputs = [ message-generation ];
   propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/realsense2-description/default.nix
+++ b/distros/noetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-description";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "c986f289f83fca204f50e85d2d33f3a2784e5267c8f5aa07bf2b547b1265e8be";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "07386187411d8fbaa4fd63fdd7e00116f73bfa7c40105b7a5bb0199d4e9b3585";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.7-r3";
+  version = "0.1.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.7-3.tar.gz";
-    name = "0.1.7-3.tar.gz";
-    sha256 = "8a385e0dccb4cbca7d1f7ffee9ac9a52a98ad261cce2a4f81974ec147079a298";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.7-4.tar.gz";
+    name = "0.1.7-4.tar.gz";
+    sha256 = "724c458d1158afc7a0fd30d0c0f27eb69911e82448109eb4bbc50c3642b194a5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, rm-description, rm-gazebo, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.7-r3";
+  version = "0.1.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.7-3.tar.gz";
-    name = "0.1.7-3.tar.gz";
-    sha256 = "cced513a80e500ac41365668df44ef4df96f78c2a016b6b6fc4636f00fe1f3f5";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.7-4.tar.gz";
+    name = "0.1.7-4.tar.gz";
+    sha256 = "0605a9c780415c3c261d3a10eb8dc0c0bc4bbd6b36f022ab85a5b6e53dd627a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.7-r3";
+  version = "0.1.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.7-3.tar.gz";
-    name = "0.1.7-3.tar.gz";
-    sha256 = "513ff4146b0c5f95cace971c65735d9f38bf7816387044bd3488b4cacf7b4893";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.7-4.tar.gz";
+    name = "0.1.7-4.tar.gz";
+    sha256 = "dc79cce8a1986346bd9381483eb164b360fc0cbf61a528b85439955f04b059c7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-description/default.nix
+++ b/distros/noetic/rm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rm-description";
-  version = "0.1.7-r3";
+  version = "0.1.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.7-3.tar.gz";
-    name = "0.1.7-3.tar.gz";
-    sha256 = "ce1edcca5d7d79f4efb39108eb0ff9e1a7348a270c601e0c81abb57298c80bd7";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.7-4.tar.gz";
+    name = "0.1.7-4.tar.gz";
+    sha256 = "1470e78b4939ea96d15657aab38ad091b072978c8328b81d099e4135bf692c28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.7-r3";
+  version = "0.1.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.7-3.tar.gz";
-    name = "0.1.7-3.tar.gz";
-    sha256 = "483da5a38f0a7d3a4534c4e6980aac1c6876acff5148e891e8866b98d2afe4be";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.7-4.tar.gz";
+    name = "0.1.7-4.tar.gz";
+    sha256 = "06254ba3055b0cfe93c9312ca0f3201d3be0bf8fcdb8190afea843d5fffc2d37";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.7-r3";
+  version = "0.1.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.7-3.tar.gz";
-    name = "0.1.7-3.tar.gz";
-    sha256 = "d75b09754f020e9536cba1101f76ab0524171188abbc8dc7be8783154e9864d6";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.7-4.tar.gz";
+    name = "0.1.7-4.tar.gz";
+    sha256 = "30af91eafacbf2eba6f70205af82ed45c9715d10da9b6105fcc8bb30539f61f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.7-r3";
+  version = "0.1.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.7-3.tar.gz";
-    name = "0.1.7-3.tar.gz";
-    sha256 = "5cbfcb09b9b23668ecbe61880c234908ad0c86754819dbfd7cb4a970b8d729b9";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.7-4.tar.gz";
+    name = "0.1.7-4.tar.gz";
+    sha256 = "b6cca7c05179d2148fa9599e07aef3159b9ab61cb71f38d501f8ab89eda4c477";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-topic/default.nix
+++ b/distros/noetic/rqt-topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rostopic, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-topic";
-  version = "0.4.12-r1";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_topic-release/archive/release/noetic/rqt_topic/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "ac32159686cce10c8a5044b83eafca0ac1af5b0d8fad4cefa593980ad7f79ad2";
+    url = "https://github.com/ros-gbp/rqt_topic-release/archive/release/noetic/rqt_topic/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "71b19f1b04cac8826e67b6cea1759cd4ede002eadbfeae9421a675e1bcdba30e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rwt-app-chooser/default.nix
+++ b/distros/noetic/rwt-app-chooser/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, app-manager, catkin, rosbridge-server, roswww, sound-play }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-app-chooser";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_app_chooser/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "daf177b82d3c801ef0616c58c07e335b08a066620fc468ab40c18e0c5e66b576";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ app-manager rosbridge-server roswww sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The simple web frontend for app_manager'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/rwt-image-view/default.nix
+++ b/distros/noetic/rwt-image-view/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, image-publisher, message-generation, message-runtime, rosbridge-server, rospy, rostest, roswww, rviz, rwt-utils-3rdparty, std-srvs, web-video-server }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-image-view";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_image_view/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "f1af2a9ea9b22d1bb9f9541f73ce19e714d82d6c0a262d2d13d752c1f4184ab4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ image-publisher rostest rviz ];
+  propagatedBuildInputs = [ message-runtime rosbridge-server rospy roswww rwt-utils-3rdparty std-srvs web-video-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_image_view package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rwt-nav/default.nix
+++ b/distros/noetic/rwt-nav/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, image-publisher, map-server, move-base-msgs, rosbridge-server, roscpp, rostest, roswww, rviz, rwt-utils-3rdparty, tf, web-video-server }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-nav";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_nav/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "f534ff93678ed6450b339fa932c4742d22ea852275bee69dd4f71e872f0a5492";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ image-publisher map-server move-base-msgs rostest rviz ];
+  propagatedBuildInputs = [ geometry-msgs rosbridge-server roscpp roswww rwt-utils-3rdparty tf web-video-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_nav package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rwt-plot/default.nix
+++ b/distros/noetic/rwt-plot/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rosbridge-server, rospy, rostest, roswww, rwt-utils-3rdparty, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-plot";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_plot/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "9ad07f82adc4a449ddf4e898c31dc1196868c23cf5c47732b4d7418a85e78e64";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ geometry-msgs rosbridge-server rospy roswww rwt-utils-3rdparty std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rwt_plot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rwt-robot-monitor/default.nix
+++ b/distros/noetic/rwt-robot-monitor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, rosbridge-server, rostest, roswww, rwt-plot, rwt-utils-3rdparty }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-robot-monitor";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_robot_monitor/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "b7c64d784969afd1de6a4a4061f6f32d620a9eece985773e8c5dfbb7d67b215c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ diagnostic-aggregator rostest ];
+  propagatedBuildInputs = [ diagnostic-msgs rosbridge-server roswww rwt-plot rwt-utils-3rdparty ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_robot_monitor package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rwt-speech-recognition/default.nix
+++ b/distros/noetic/rwt-speech-recognition/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosbridge-server, roslaunch, rostest, roswww, rwt-utils-3rdparty, speech-recognition-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-speech-recognition";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_speech_recognition/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "b5fdcff1cf76090761045ed4a5321835c0dea1a51fd1ac54e3a48ef71f480e0b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ rosbridge-server roswww rwt-utils-3rdparty speech-recognition-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_speech_recognition package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rwt-steer/default.nix
+++ b/distros/noetic/rwt-steer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, image-publisher, rosbridge-server, rostest, roswww, rviz, rwt-utils-3rdparty, web-video-server }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-steer";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_steer/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "ef01c5f7b4513522cfaaa9a29a46804879659b020c16643a624e9b6a254bd751";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ image-publisher rostest rviz ];
+  propagatedBuildInputs = [ rosbridge-server roswww rwt-utils-3rdparty web-video-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_steer package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rwt-utils-3rdparty/default.nix
+++ b/distros/noetic/rwt-utils-3rdparty/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-rwt-utils-3rdparty";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/rwt_utils_3rdparty/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "f3ec7faa0955de68a7bd6bf197af4ff6ff680a69591bcba13617b380ca8b7056";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rwt_utils_3rdparty package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sob-layer/default.nix
+++ b/distros/noetic/sob-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, dynamic-reconfigure, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-sob-layer";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/dorezyuk/sob_layer-release/archive/release/noetic/sob_layer/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "36f7c92005ca9a03b8b335f36b46dddedf04d70ba03aabffcd38d7820697259c";
+    url = "https://github.com/dorezyuk/sob_layer-release/archive/release/noetic/sob_layer/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "299f36006f303aaadc08ae0c47f92ccb4890517ae524e3290939dd1035cdf68b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/stereo-image-proc/default.nix
+++ b/distros/noetic/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-noetic-stereo-image-proc";
-  version = "1.15.3-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/stereo_image_proc/1.15.3-1.tar.gz";
-    name = "1.15.3-1.tar.gz";
-    sha256 = "4c6bb1d6b65ac2678615ee36de06708d68fef9f1aaacefe2faefb1c185f235ee";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/noetic/stereo_image_proc/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "237fcc2babed3db90c04c6e43c4a67e10b1bf5fc4be0b653e8a4e2e16b7a1e67";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, libyamlcpp, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "3eceda79dd221da6953501e23970205d56bfe9a362770d8094e8eb0f5f5b5266";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "283ba90bc45bdd323af151ed971a7eb20cc8ac95982cecff2010075f45df5031";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-environment/default.nix
+++ b/distros/noetic/tesseract-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-kinematics, tesseract-scene-graph, tesseract-srdf, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-environment";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "38eb9c8ce2aee6602a4276c2b288156b19f0ad189baf292bf701b9cb51f346bb";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "3075ed89bacf4c76b7a8c3f7d40a3f2d68a779b75e4269731f748a28bba052b3";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "fa84bdf657d5e0958414125f96208ca53faeee820b2c443a0e200bb8fcad8184";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "97dfb6bd078b1cb002efc4b0f2a0ed91a07b55d3d64a6a819d0a982cb0062746";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "deac10351f396271c9e0c195b9ff93c487bf45c21e50d1ce8b39203f72f21745";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "2991b6926054b23146ce277b8aa6c115cc9d4fde52e4fba2a6779cfca249858f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "cc335bdab7cff12ccdf7ea6dc1fccabea2f7c8111d352d10b9d5c293d920bf3d";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "333961f0293197e3398b419c2fe4c76d04f403f8d3ed8e0efc68225b7e7d6eb2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "b5a55189d5994f4de6fa23dc807591c6bddeafdb1c5a8ef8000cdd733bbb0d58";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "5b8b2f7f645621c1fc86087126116fb864ec34e8c6ddb830b3458de7ca240b23";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-state-solver/default.nix
+++ b/distros/noetic/tesseract-state-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-state-solver";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "291853f1151aba54147357fb2d4a1471f0e14d6be72b23014842e4f0e0374cc8";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "27968bce59931eb14d6a3f211f6f1a23a53ef7ac0e0f9c6638ffac275e7a29ba";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "f59949e16d76c7fe6d58f84dab9c9b3c584235f77cf9f60a4e717ea2a08e653c";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "6d8bef275328f75d6e140e9bf0e321559e20449c77e1bdcd46336ca95ebad48a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "9427bd53461be3ad7049a4c43a735b811680783c93c3fca46508081f8ae69414";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "1e938ba32bfd73bb522d9ea240ff916af6bd08b29a0306e8afaa7246639b8bd9";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "6138c78b23dcfce327bba1c1f00bcfc3a0b358a49db300f9767096e133fc866e";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "bc7c09853547e90a0e4172a0bd771fa9433e202da4630d35fcdabede4930b68e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/velodyne-description/default.nix
+++ b/distros/noetic/velodyne-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-description";
-  version = "1.0.12-r1";
+  version = "1.0.12-r2";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_description/1.0.12-1.tar.gz";
-    name = "1.0.12-1.tar.gz";
-    sha256 = "44a7e306175507df35c7165e1daa76275c630e02d352f18f5ec21550a96bac38";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_description/1.0.12-2.tar.gz";
+    name = "1.0.12-2.tar.gz";
+    sha256 = "71e6ce02f0e44d46ae2cce832b97c0a9355c8f744d2e5754f2b7c75e9264b66e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-gazebo-plugins/default.nix
+++ b/distros/noetic/velodyne-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-gazebo-plugins";
-  version = "1.0.12-r1";
+  version = "1.0.12-r2";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_gazebo_plugins/1.0.12-1.tar.gz";
-    name = "1.0.12-1.tar.gz";
-    sha256 = "02690c7e046e0afe57daa7c41aa1e49f0c1d52b2340b9d06fdebe05f9a214e26";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_gazebo_plugins/1.0.12-2.tar.gz";
+    name = "1.0.12-2.tar.gz";
+    sha256 = "596cc5dfcb6057361b67eeb9204f142bd149329d5c0751adc34904f85eb888af";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-simulator/default.nix
+++ b/distros/noetic/velodyne-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-description, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-simulator";
-  version = "1.0.12-r1";
+  version = "1.0.12-r2";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_simulator/1.0.12-1.tar.gz";
-    name = "1.0.12-1.tar.gz";
-    sha256 = "8960ed95157b60c216310020ad4978f88ed477ef9d5b3683ee8160044f871907";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_simulator/1.0.12-2.tar.gz";
+    name = "1.0.12-2.tar.gz";
+    sha256 = "a36f0f8acacb53dbc16b0ca8778762e824ee7127c8bc6baf3a1a026e468de520";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vision-opencv/default.nix
+++ b/distros/noetic/vision-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry }:
 buildRosPackage {
   pname = "ros-noetic-vision-opencv";
-  version = "1.15.0-r1";
+  version = "1.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/vision_opencv/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "b586a0f0e0e4fe0cce9980cdf8f8f9f7d1633fe6c2ba13ed5dce0e3c553e5e9d";
+    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/vision_opencv/1.16.0-1.tar.gz";
+    name = "1.16.0-1.tar.gz";
+    sha256 = "d981b709aa5f94a2464ffc0f1c2974ac064380ebd62d2a29a8a61d81958b1032";
   };
 
   buildType = "catkin";

--- a/distros/noetic/visualization-rwt/default.nix
+++ b/distros/noetic/visualization-rwt/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rwt-app-chooser, rwt-image-view, rwt-plot, rwt-speech-recognition, rwt-utils-3rdparty }:
+buildRosPackage {
+  pname = "ros-noetic-visualization-rwt";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/visualization_rwt-release/archive/release/noetic/visualization_rwt/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "9f7696b756cb58f68b4bef7f5c615a2e152b0f94b351c4bd82997faec77afa02";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rwt-app-chooser rwt-image-view rwt-plot rwt-speech-recognition rwt-utils-3rdparty ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>visualization packages using rwt</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/warthog-control/default.nix
+++ b/distros/noetic/warthog-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
+buildRosPackage {
+  pname = "ros-noetic-warthog-control";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_control/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "b927bd618505eeb8b7122022fe506a3040eee2aa2cdd538a763611c061fd5301";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller interactive-marker-twist-server joint-state-controller joy robot-localization teleop-twist-joy topic-tools twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Controllers for Warthog'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/warthog-description/default.nix
+++ b/distros/noetic/warthog-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-warthog-description";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_description/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "eb838c4e56ce768fa28c4fea06dd0419e3499cbea9b4a2b59ca4dc22afa365de";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF robot description for Warthog'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/warthog-msgs/default.nix
+++ b/distros/noetic/warthog-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-warthog-msgs";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_msgs/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "7483b73cd036db69780df722539d21fe7cfdc08d255017acda6ef53bef84b719";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages exclusive to Warthog, especially for representing low-level motor commands and sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 0811495d8c1d2de1dd4ecbad9efbadfd89b68e6f.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *launch 0.10.6-r1 --> 0.10.7-r1*
* *launch-ros 0.11.4-r1 --> 0.11.5-r1*
* *launch-testing 0.10.6-r1 --> 0.10.7-r1*
* *launch-testing-ament-cmake 0.10.6-r1 --> 0.10.7-r1*
* *launch-testing-ros 0.11.4-r1 --> 0.11.5-r1*
* *launch-xml 0.10.6-r1 --> 0.10.7-r1*
* *launch-yaml 0.10.6-r1 --> 0.10.7-r1*
* *librealsense2 2.48.0-r1 --> 2.50.0-r1*
* *marti-can-msgs 1.2.0-r1 --> 1.3.0-r1*
* *marti-common-msgs 1.2.0-r1 --> 1.3.0-r1*
* *marti-dbw-msgs 1.2.0-r1 --> 1.3.0-r1*
* *marti-introspection-msgs 1.3.0-r1*
* *marti-nav-msgs 1.2.0-r1 --> 1.3.0-r1*
* *marti-perception-msgs 1.2.0-r1 --> 1.3.0-r1*
* *marti-sensor-msgs 1.2.0-r1 --> 1.3.0-r1*
* *marti-status-msgs 1.2.0-r1 --> 1.3.0-r1*
* *marti-visualization-msgs 1.2.0-r1 --> 1.3.0-r1*
* *microstrain-inertial-driver 2.0.6-r1 --> 2.1.0-r1*
* *microstrain-inertial-examples 2.0.6-r1 --> 2.1.0-r1*
* *microstrain-inertial-msgs 2.0.6-r1 --> 2.1.0-r1*
* *moveit 2.2.1-r1 --> 2.2.2-r1*
* *moveit-common 2.2.1-r1 --> 2.2.2-r1*
* *moveit-core 2.2.1-r1 --> 2.2.2-r1*
* *moveit-kinematics 2.2.1-r1 --> 2.2.2-r1*
* *moveit-planners 2.2.1-r1 --> 2.2.2-r1*
* *moveit-planners-ompl 2.2.1-r1 --> 2.2.2-r1*
* *moveit-plugins 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-benchmarks 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-move-group 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-occupancy-map-monitor 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-perception 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-planning 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-planning-interface 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-robot-interaction 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-visualization 2.2.1-r1 --> 2.2.2-r1*
* *moveit-ros-warehouse 2.2.1-r1 --> 2.2.2-r1*
* *moveit-runtime 2.2.1-r1 --> 2.2.2-r1*
* *moveit-servo 2.2.1-r1 --> 2.2.2-r1*
* *moveit-simple-controller-manager 2.2.1-r1 --> 2.2.2-r1*
* *rc-genicam-api 2.5.6-r1 --> 2.5.12-r1*
* *rc-genicam-driver 0.2.0-r1 --> 0.2.1-r1*
* *realsense2-camera 3.2.2-r1 --> 3.2.3-r1*
* *realsense2-camera-msgs 3.2.2-r1 --> 3.2.3-r1*
* *realsense2-description 3.2.2-r1 --> 3.2.3-r1*
* *ros2launch 0.11.4-r1 --> 0.11.5-r1*
* *rqt-tf-tree 1.0.3-r1*
* *run-move-group 2.2.1-r1 --> 2.2.2-r1*
* *run-moveit-cpp 2.2.1-r1 --> 2.2.2-r1*
* *run-ompl-constrained-planning 2.2.1-r1 --> 2.2.2-r1*
* *snowbot-operating-system 0.1.0-r1*
* *swri-console-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-dbw-interface 3.3.2-r2 --> 3.4.0-r1*
* *swri-geometry-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-image-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-math-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-opencv-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-prefix-tools 3.3.2-r2 --> 3.4.0-r1*
* *swri-roscpp 3.3.2-r2 --> 3.4.0-r1*
* *swri-route-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-serial-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-system-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-transform-util 3.3.2-r2 --> 3.4.0-r1*

Galactic Changes:
-----------------
* *gazebo-ros2-control 0.0.4-r1 --> 0.0.6-r1*
* *gazebo-ros2-control-demos 0.0.4-r1 --> 0.0.6-r1*
* *hash-library-vendor 0.1.0-r1*
* *librealsense2 2.48.0-r2 --> 2.50.0-r1*
* *marti-can-msgs 1.1.0-r3 --> 1.3.0-r1*
* *marti-common-msgs 1.1.0-r3 --> 1.3.0-r1*
* *marti-dbw-msgs 1.1.0-r3 --> 1.3.0-r1*
* *marti-introspection-msgs 1.3.0-r1*
* *marti-nav-msgs 1.1.0-r3 --> 1.3.0-r1*
* *marti-perception-msgs 1.1.0-r3 --> 1.3.0-r1*
* *marti-sensor-msgs 1.1.0-r3 --> 1.3.0-r1*
* *marti-status-msgs 1.1.0-r3 --> 1.3.0-r1*
* *marti-visualization-msgs 1.1.0-r3 --> 1.3.0-r1*
* *microstrain-inertial-driver 2.0.6-r1 --> 2.1.0-r1*
* *microstrain-inertial-examples 2.0.6-r1 --> 2.1.0-r1*
* *microstrain-inertial-msgs 2.0.6-r1 --> 2.1.0-r1*
* *rc-genicam-api 2.5.6-r1 --> 2.5.12-r1*
* *rc-genicam-driver 0.2.0-r1 --> 0.2.1-r1*
* *realsense2-camera 3.2.2-r2 --> 3.2.3-r1*
* *realsense2-camera-msgs 3.2.2-r2 --> 3.2.3-r1*
* *realsense2-description 3.2.2-r2 --> 3.2.3-r1*
* *rqt-tf-tree 1.0.3-r1*
* *rtabmap-ros 0.20.15-r2*
* *snowbot-operating-system 0.1.0-r1*
* *swri-console-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-dbw-interface 3.3.2-r2 --> 3.4.0-r1*
* *swri-geometry-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-image-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-math-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-opencv-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-prefix-tools 3.3.2-r2 --> 3.4.0-r1*
* *swri-roscpp 3.3.2-r2 --> 3.4.0-r1*
* *swri-route-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-serial-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-system-util 3.3.2-r2 --> 3.4.0-r1*
* *swri-transform-util 3.3.2-r2 --> 3.4.0-r1*
* *turtlebot3 2.1.2-r2*
* *turtlebot3-bringup 2.1.2-r2*
* *turtlebot3-cartographer 2.1.2-r2*
* *turtlebot3-description 2.1.2-r2*
* *turtlebot3-example 2.1.2-r2*
* *turtlebot3-navigation2 2.1.2-r2*
* *turtlebot3-node 2.1.2-r2*
* *turtlebot3-teleop 2.1.2-r2*

Melodic Changes:
----------------
* *find-object-2d 0.6.2-r1 --> 0.6.4-r2*
* *librealsense2 2.48.0-r1 --> 2.50.0-r1*
* *microstrain-inertial-driver 2.0.5-r1 --> 2.1.0-r1*
* *microstrain-inertial-examples 2.0.5-r1 --> 2.1.0-r1*
* *microstrain-inertial-msgs 2.0.5-r1 --> 2.1.0-r1*
* *qb-chain 2.0.0 --> 2.2.3-r1*
* *qb-chain-control 2.0.0 --> 2.2.3-r1*
* *qb-chain-controllers 2.2.3-r1*
* *qb-chain-description 2.0.0 --> 2.2.3-r1*
* *qb-chain-msgs 2.2.3-r1*
* *rc-genicam-api 2.5.6-r1 --> 2.5.12-r1*
* *rc-genicam-driver 0.6.1-r1 --> 0.6.3-r1*
* *rc-hand-eye-calibration-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-pick-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-roi-manager-gui 3.2.3-r1 --> 3.2.4-r1*
* *rc-silhouettematch-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-tagdetect-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-visard 3.2.3-r1 --> 3.2.4-r1*
* *rc-visard-description 3.2.3-r1 --> 3.2.4-r1*
* *rc-visard-driver 3.2.3-r1 --> 3.2.4-r1*
* *realsense2-camera 2.3.1-r1 --> 2.3.2-r1*
* *realsense2-description 2.3.1-r1 --> 2.3.2-r1*
* *rwt-app-chooser 0.1.1-r1*
* *rwt-image-view 0.1.1-r1*
* *rwt-moveit 0.1.1-r1*
* *rwt-nav 0.1.1-r1*
* *rwt-plot 0.1.1-r1*
* *rwt-robot-monitor 0.1.1-r1*
* *rwt-speech-recognition 0.1.1-r1*
* *rwt-steer 0.1.1-r1*
* *rwt-utils-3rdparty 0.1.1-r1*
* *snowbot-operating-system 0.0.1-r1*
* *visualization-rwt 0.1.1-r1*

Noetic Changes:
---------------
* *camera-calibration 1.15.3-r1 --> 1.16.0-r1*
* *cv-bridge 1.15.0-r1 --> 1.16.0-r1*
* *depth-image-proc 1.15.3-r1 --> 1.16.0-r1*
* *euslisp 9.28.0-r1*
* *image-geometry 1.15.0-r1 --> 1.16.0-r1*
* *image-pipeline 1.15.3-r1 --> 1.16.0-r1*
* *image-proc 1.15.3-r1 --> 1.16.0-r1*
* *image-publisher 1.15.3-r1 --> 1.16.0-r1*
* *image-rotate 1.15.3-r1 --> 1.16.0-r1*
* *image-view 1.15.3-r1 --> 1.16.0-r1*
* *librealsense2 2.48.0-r1 --> 2.50.0-r1*
* *microstrain-inertial-driver 2.0.5-r1 --> 2.1.0-r1*
* *microstrain-inertial-examples 2.0.5-r1 --> 2.1.0-r1*
* *microstrain-inertial-msgs 2.0.5-r1 --> 2.1.0-r1*
* *moveit-resources 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-fanuc-description 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-fanuc-moveit-config 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-panda-description 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-panda-moveit-config 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-pr2-description 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-moveit-config 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-pg70-support 0.8.1-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-support 0.8.1-r1 --> 0.8.2-r1*
* *power-msgs 0.4.1-r1 --> 0.4.2-r1*
* *qb-chain 2.2.2-r1 --> 2.2.3-r1*
* *qb-chain-control 2.2.2-r1 --> 2.2.3-r1*
* *qb-chain-controllers 2.2.2-r1 --> 2.2.3-r1*
* *qb-chain-description 2.2.2-r1 --> 2.2.3-r1*
* *qb-chain-msgs 2.2.2-r1 --> 2.2.3-r1*
* *rc-genicam-api 2.5.6-r1 --> 2.5.12-r1*
* *rc-genicam-driver 0.6.2-r1 --> 0.6.3-r1*
* *rc-hand-eye-calibration-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-pick-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-roi-manager-gui 3.2.3-r1 --> 3.2.4-r1*
* *rc-silhouettematch-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-tagdetect-client 3.2.3-r1 --> 3.2.4-r1*
* *rc-visard 3.2.3-r1 --> 3.2.4-r1*
* *rc-visard-description 3.2.3-r1 --> 3.2.4-r1*
* *rc-visard-driver 3.2.3-r1 --> 3.2.4-r1*
* *realsense2-camera 2.3.1-r1 --> 2.3.2-r1*
* *realsense2-description 2.3.1-r1 --> 2.3.2-r1*
* *rm-common 0.1.7-r3 --> 0.1.7-r4*
* *rm-control 0.1.7-r3 --> 0.1.7-r4*
* *rm-dbus 0.1.7-r3 --> 0.1.7-r4*
* *rm-description 0.1.7-r3 --> 0.1.7-r4*
* *rm-gazebo 0.1.7-r3 --> 0.1.7-r4*
* *rm-hw 0.1.7-r3 --> 0.1.7-r4*
* *rm-msgs 0.1.7-r3 --> 0.1.7-r4*
* *rqt-topic 0.4.12-r1 --> 0.4.13-r1*
* *rwt-app-chooser 0.1.1-r2*
* *rwt-image-view 0.1.1-r2*
* *rwt-nav 0.1.1-r2*
* *rwt-plot 0.1.1-r2*
* *rwt-robot-monitor 0.1.1-r2*
* *rwt-speech-recognition 0.1.1-r2*
* *rwt-steer 0.1.1-r2*
* *rwt-utils-3rdparty 0.1.1-r2*
* *sob-layer 0.1.0-r1 --> 0.1.1-r1*
* *stereo-image-proc 1.15.3-r1 --> 1.16.0-r1*
* *tesseract-common 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-environment 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-geometry 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-kinematics 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-scene-graph 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-srdf 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-state-solver 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-support 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-urdf 0.6.6-r1 --> 0.6.7-r1*
* *tesseract-visualization 0.6.6-r1 --> 0.6.7-r1*
* *velodyne-description 1.0.12-r1 --> 1.0.12-r2*
* *velodyne-gazebo-plugins 1.0.12-r1 --> 1.0.12-r2*
* *velodyne-simulator 1.0.12-r1 --> 1.0.12-r2*
* *vision-opencv 1.15.0-r1 --> 1.16.0-r1*
* *visualization-rwt 0.1.1-r2*
* *warthog-control 0.1.4-r1*
* *warthog-description 0.1.4-r1*
* *warthog-msgs 0.1.4-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] roseus
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

