### PR TITLE
rosdistro sync, Fri Dec 10 18:09:02 2021

### DIFF
--- a/distros/foxy/bno055/default.nix
+++ b/distros/foxy/bno055/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-bno055";
-  version = "0.1.1-r3";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/flynneva/bno055-release/archive/release/foxy/bno055/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "858f1d3f3932d7bb4f17ab52a46b6305fe6b2776baf39fec109808de52262d01";
+    url = "https://github.com/flynneva/bno055-release/archive/release/foxy/bno055/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "444f83424513607b8be15beae9fa39e66a5e5d14453fa05d045d511a3ecf3bc2";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/can-dbc-parser/default.nix
+++ b/distros/foxy/can-dbc-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs }:
 buildRosPackage {
   pname = "ros-foxy-can-dbc-parser";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/can_dbc_parser/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a42bada40317be633003986455505424957a9378175a2689d57029e1a3ba990a";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/can_dbc_parser/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "28b18fdf2fe15fb5c33f761f610ae929157099672439fd3c4de70e00efc9671e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/foxy/eigenpy/2.5.0-1.tar.gz";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.5.0-1.tar.gz";
     name = "2.5.0-1.tar.gz";
     sha256 = "f0a68dd33a86dcaefdea50269f6153d84bde5d8d14a1f1333be4fafa644158d4";
   };

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -842,6 +842,10 @@ self: super: {
 
  ouster-msgs = self.callPackage ./ouster-msgs {};
 
+ ouxt-common = self.callPackage ./ouxt-common {};
+
+ ouxt-lint-common = self.callPackage ./ouxt-lint-common {};
+
  pacmod-msgs = self.callPackage ./pacmod-msgs {};
 
  pal-gazebo-worlds = self.callPackage ./pal-gazebo-worlds {};
@@ -951,6 +955,8 @@ self: super: {
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
  position-controllers = self.callPackage ./position-controllers {};
+
+ psen-scan-v2 = self.callPackage ./psen-scan-v2 {};
 
  py-trees-ros = self.callPackage ./py-trees-ros {};
 
@@ -1093,8 +1099,6 @@ self: super: {
  rmf-demos-dashboard-resources = self.callPackage ./rmf-demos-dashboard-resources {};
 
  rmf-demos-gz = self.callPackage ./rmf-demos-gz {};
-
- rmf-demos-ign = self.callPackage ./rmf-demos-ign {};
 
  rmf-demos-maps = self.callPackage ./rmf-demos-maps {};
 
@@ -1667,6 +1671,8 @@ self: super: {
  urdf = self.callPackage ./urdf {};
 
  urdf-test = self.callPackage ./urdf-test {};
+
+ urdf-tutorial = self.callPackage ./urdf-tutorial {};
 
  urdfdom = self.callPackage ./urdfdom {};
 

--- a/distros/foxy/libmavconn/default.nix
+++ b/distros/foxy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-libmavconn";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "128f16112ed4da3414b2bd8f30c2f3eef024ae1f59e9e262f48695529937db09";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "df731f4510691cef211916d4b9815177becba5fac120729e41aac08ba03e5a4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros-extras/default.nix
+++ b/distros/foxy/mavros-extras/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-mavros-extras";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_extras/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "bf80c13f592c97e1568d3af5f866cf055034c67997fd343afeed1cf8b7a0e4eb";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_extras/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "a6c4d04f7e1cb4e12eb942a5d9892672f7b80f2436a8365f8965f0e87d438232";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ angles ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn libyamlcpp mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
 
   meta = {

--- a/distros/foxy/mavros-msgs/default.nix
+++ b/distros/foxy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "63c525d4121d4db463fdcc5bd6c0f7e9c00329d7ada37a5cd18ca3040f267df4";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "99a9498f464e7a8d9ae7f6fc404e6022f05898ea55959d0c58d2751491b2efb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros/default.nix
+++ b/distros/foxy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "2daa692df531889235701ba2f411183bbb71f64786e13e70cb7896e910c1381c";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "a1f068098341b19659a628a415e1742f3ebe9bdae5de594c847fb40f602cf81d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-driver/default.nix
+++ b/distros/foxy/microstrain-inertial-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-driver";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0b1f964cc71ee6428ee367e2ef73fffa44fc38eaebf75c8b631e0adbcfe89dd9";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "4915284eb98ed917871db6e30c03472e03c3180557d53e2d573ab9220f7e9d9b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ curl jq ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-cpplint ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-updater geometry-msgs lifecycle-msgs microstrain-inertial-msgs nav-msgs rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-updater geometry-msgs lifecycle-msgs mavros-msgs microstrain-inertial-msgs nav-msgs nmea-msgs rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ rosidl-default-generators ];
 
   meta = {

--- a/distros/foxy/microstrain-inertial-examples/default.nix
+++ b/distros/foxy/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-examples";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e1f21e690ac94751da283429f407bcff938b0a9b688cc754d727af4c5a5dde7b";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "211203e7307f02e28171451014999e695a287f20aea89cc38986a59543c51b48";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-msgs/default.nix
+++ b/distros/foxy/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a6d7c6d73602016384be6e30c49f0efa37f948d0f28579a44c784d3dfcab921f";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e64419e830a3ffad6770456bd86094df256f97df737ac0ddf29ee03c57a00825";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mrt-cmake-modules/default.nix
+++ b/distros/foxy/mrt-cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mrt-cmake-modules";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/foxy/mrt_cmake_modules/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b7bf3dcf5f190f8287847a109f5fca060184db2fdd4fd29c63cdbafb195b43ef";
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/foxy/mrt_cmake_modules/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5cdfc80bb4ea0a2225701ef2ed428945c0e819eb5ce748f59ab86499b2cb116c";
   };
 
   buildType = "catkin";

--- a/distros/foxy/osqp-vendor/default.nix
+++ b/distros/foxy/osqp-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-foxy-osqp-vendor";
-  version = "0.0.3-r2";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.3-2.tar.gz";
-    name = "0.0.3-2.tar.gz";
-    sha256 = "4263861260987867d44a7ed7925220a96a38247a355045f567cd721378d49950";
+    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "826268ede5aba88290b719cbcafa55226535701b33d6afa7330c7090d6321841";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''Wrapper around osqp that ships with a CMake module'';

--- a/distros/foxy/ouxt-common/default.nix
+++ b/distros/foxy/ouxt-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ouxt-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-ouxt-common";
+  version = "0.0.8-r2";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/ouxt_common-release/archive/release/foxy/ouxt_common/0.0.8-2.tar.gz";
+    name = "0.0.8-2.tar.gz";
+    sha256 = "6ffbece2115efefd24b253933d36fc292319ab1ed18821a9ca25fa5437d5e8cc";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ouxt-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''common settings for OUXT Polaris ROS2 packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ouxt-lint-common/default.nix
+++ b/distros/foxy/ouxt-lint-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-pep257, ament-cmake-xmllint }:
+buildRosPackage {
+  pname = "ros-foxy-ouxt-lint-common";
+  version = "0.0.8-r2";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/ouxt_common-release/archive/release/foxy/ouxt_lint_common/0.0.8-2.tar.gz";
+    name = "0.0.8-2.tar.gz";
+    sha256 = "a0a39b499588769bce6675393941441202dda4d14ff1e425612c23a57b0e954c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-cmake-clang-format ament-cmake-copyright ament-cmake-pep257 ament-cmake-xmllint ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''common linter settings for OUXT Polaris ROS2 packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/psen-scan-v2/default.nix
+++ b/distros/foxy/psen-scan-v2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-cmake-xmllint, ament-index-python, boost, console-bridge, fmt, launch, launch-ros, launch-testing, launch-xml, pythonPackages, rclcpp, rclpy, rcutils, robot-state-publisher, ros-testing, rosbag2-cpp, rosbag2-storage-default-plugins, rviz2, sensor-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-psen-scan-v2";
+  version = "0.20.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/psen_scan_v2-ros2-release/archive/release/foxy/psen_scan_v2/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "1ef11d8b0abcbfdde06f130e65f3b25edd253b1f4b8c6621aab7a2330882a95b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-cmake-ros ament-cmake-xmllint ament-index-python console-bridge launch launch-ros launch-testing launch-xml pythonPackages.pytest rclpy ros-testing rosbag2-cpp rosbag2-storage-default-plugins ];
+  propagatedBuildInputs = [ boost fmt launch-ros rclcpp rcutils robot-state-publisher rviz2 sensor-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS support for the Pilz laser scanner'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/foxy/raptor-dbw-can/default.nix
+++ b/distros/foxy/raptor-dbw-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, geometry-msgs, raptor-dbw-msgs, raptor-pdu, raptor-pdu-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-can";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "fca24aadcaf1b0e28fdc5862e97c01a2ab5cf29a4a6d9f179153883be35a6cd8";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "3e1b0b13b8f0e686eb4e592c4aa4f330fed428a474b874d843ca6b69aeeadad1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-joystick/default.nix
+++ b/distros/foxy/raptor-dbw-joystick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, raptor-dbw-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-joystick";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "179ff82e7809594d36a532b0bccdf072c904ed7a18c66fe58a39d82e90f528cf";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "21b40c3fcb94b0cfb96587d36c26c87e89bb8aa04a9d665c3e216bd6d3187137";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-msgs/default.nix
+++ b/distros/foxy/raptor-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-msgs";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "13bf693aff81e884da8b719805c56c133dbc7407f8206dcd75c470807b030622";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e547e972516b2602a0678d4b7e7f39f02c71867f2c86665020185bd92d9cbde8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu-msgs/default.nix
+++ b/distros/foxy/raptor-pdu-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu-msgs";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "bdddcc6534eb4d4c6d8374ba8ca78f7afffd5dd03fa335f214af1c1a833cd4ef";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d9c680ed10febb546b341c8c2944d0c9a1b9f839aaf5aae4d22f0b386c557b2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu/default.nix
+++ b/distros/foxy/raptor-pdu/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, raptor-pdu-msgs, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "be55a9a3a8fc2ae7a165d70b8142b0af11ebe0f41ba289e60abdabaa4804fa98";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4aed095d2b28abed7b9581a53b55dedbeb2b01006b16bc968e8373f1c0d3021f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-building-sim-common/default.nix
+++ b/distros/foxy/rmf-building-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, menge-vendor, rclcpp, rmf-building-map-msgs, rmf-door-msgs, rmf-lift-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmf-building-sim-common";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_building_sim_common/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "446a62c8436b5c6482ab3681b5def11f0e60317d172e85b8736353407abd9e43";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_building_sim_common/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "8d75d5fea3ac65eb0edab9fbbaeaa367ecbb7ac31b6a173b56e6326a163ab668";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-building-sim-gazebo-plugins/default.nix
+++ b/distros/foxy/rmf-building-sim-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-ros, menge-vendor, opencv3, qt5, rclcpp, rmf-building-sim-common, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmf-building-sim-gazebo-plugins";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_building_sim_gazebo_plugins/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "1262678c8e323bf13cd4f5dd10f4216bdbb4ec5d6dfa5afb9831f0e683f17005";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_building_sim_gazebo_plugins/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "27a9346e3080f843fc568970c5a899599b10517b8b124755ec7c8648aca51f90";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-demos-assets/default.nix
+++ b/distros/foxy/rmf-demos-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-rmf-demos-assets";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_assets/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "e4d053ae69a2efbdee40b7e538bf7569c52f91e7f2a1080343560c6e0ad4302f";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_assets/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "b70ca632792307fc31668abd5a64ca35e8075724a477fccdd17b90dab9f24554";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-demos-dashboard-resources/default.nix
+++ b/distros/foxy/rmf-demos-dashboard-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-rmf-demos-dashboard-resources";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_dashboard_resources/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "d492468c3de125817d8f218a3c1ae293c762737ced1c3aea8833f1ffa976d20b";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_dashboard_resources/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "ac4dab45e78f7c50ce74f0f37e6aae3be2590b4ae991934935dc598dd558acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-demos-gz/default.nix
+++ b/distros/foxy/rmf-demos-gz/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, joy, launch-xml, rmf-building-sim-gazebo-plugins, rmf-demos, rmf-robot-sim-gazebo-plugins, teleop-twist-joy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-plugins, joy, launch-xml, rmf-building-sim-gazebo-plugins, rmf-demos, rmf-robot-sim-gazebo-plugins, teleop-twist-joy }:
 buildRosPackage {
   pname = "ros-foxy-rmf-demos-gz";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_gz/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "717abb6b147b5fbd328521f14a174380bdf92205644c8c0752bf98cf14c852c2";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_gz/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "c17d0b8bcf7adf37d167bd3fcc10feec306f1af12699510913ea64b8e222db35";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ joy launch-xml rmf-building-sim-gazebo-plugins rmf-demos rmf-robot-sim-gazebo-plugins teleop-twist-joy ];
+  propagatedBuildInputs = [ gazebo-plugins joy launch-xml rmf-building-sim-gazebo-plugins rmf-demos rmf-robot-sim-gazebo-plugins teleop-twist-joy ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/rmf-demos-maps/default.nix
+++ b/distros/foxy/rmf-demos-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-rmf-demos-maps";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_maps/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "8617ba05daa898c8a344473d470afc89b0573f29d6fff4b41910acd4f39e2ddb";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_maps/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "e6825a90cdab87f37689211b8faccb30e2a37b39eb3c37f16dad3fea3889c2a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-demos-tasks/default.nix
+++ b/distros/foxy/rmf-demos-tasks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-lift-msgs, rmf-task-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmf-demos-tasks";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_tasks/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "62bebb9f14f2f19a6c12a828590390ffdc9f38d8f908d173e7cb1f18e7ef3e73";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos_tasks/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "c1397fc0cf29bb3c6b2595f73e8283e278cb69d6b4af45fe022495cbf3a8428a";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rmf-demos/default.nix
+++ b/distros/foxy/rmf-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-xml, rmf-building-map-tools, rmf-demos-assets, rmf-demos-maps, rmf-demos-panel, rmf-demos-tasks, rmf-fleet-adapter, rmf-task-ros2, rmf-traffic-ros2, rmf-visualization, rviz2 }:
 buildRosPackage {
   pname = "ros-foxy-rmf-demos";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "82d60e0d9fe5770a3da6933b3fa378b7f38cf023a739a703966b77bee7558722";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/foxy/rmf_demos/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "2ccccf738decc4583f70cd2754a69e64852d12a46d9458018a8be00f21e568f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-robot-sim-common/default.nix
+++ b/distros/foxy/rmf-robot-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-rmf-robot-sim-common";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_robot_sim_common/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "e9c35639b9a4e5f2b1a8d2c3b2d1400251ca58e28cb07ad11a96558b6061a192";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_robot_sim_common/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "190e376e2c67126c9dc175b335ff184cae2ee7a5bbcc58bce72d1accc4fc8d67";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-robot-sim-gazebo-plugins/default.nix
+++ b/distros/foxy/rmf-robot-sim-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, gazebo-dev, gazebo-ros, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-robot-sim-common }:
 buildRosPackage {
   pname = "ros-foxy-rmf-robot-sim-gazebo-plugins";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_robot_sim_gazebo_plugins/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "5ee9d645b6b12ebc1856a43e2c86e56f9cd3f5e4d64aefdf4b3739a44e35c610";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/foxy/rmf_robot_sim_gazebo_plugins/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "c55e49919ad136b8ec6c94dc8f37a6c02b2c462bf6a0e8a1fe994f2c3039d7d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosapi-msgs/default.nix
+++ b/distros/foxy/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rosapi-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4b938ce93663dbe3bbad372cfea292404907c4d78d0158e4b50540d3e4246761";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi_msgs/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "9c38681485c6aa8b1076dde2e3169af56edcaf6f38686f0993ee6010341d32ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosapi/default.nix
+++ b/distros/foxy/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosapi";
-  version = "1.1.0-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "00a44f41504ed778d7d9bde89312e1a60741b9ba6bef4dac0d811f3dbf238aa4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "ce080b970548d05764ab7b30bc7a4d34b1e2044659726d0839e2e1a24599156a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-library/default.nix
+++ b/distros/foxy/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-library";
-  version = "1.1.0-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "9059d37c9bc42860ba1894c818d45c5e04d6c9c37cfd48d5309c9b07e588ed3c";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "a85e02c980019ef7058badb7aab6b7413b774adc100c08d05d860f6bef5be69e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-msgs/default.nix
+++ b/distros/foxy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "417975308528eef3ae1c3ddedd6ed95b8362c970350cee3dfd38149d32647732";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "17b1efc8f8761fb6e37542b13812d1f59211604f319469f1660b26966590f3bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-server/default.nix
+++ b/distros/foxy/rosbridge-server/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-server";
-  version = "1.1.0-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "b2c8015b63621eefea57b85395ced4336a7551c686eb5d594e906a50cce1da3f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "0b3c2b7ed1528ebb9f78b93aa5a1aa29e4bc4001c27b8fe02e5f6ef00244d0d6";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn ];
+  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/foxy/rosbridge-suite/default.nix
+++ b/distros/foxy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-suite";
-  version = "1.1.0-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "3c8b5f64eea9d127486ae8223c1092e06c633fbf0360e86c4cf0aab5e4e9aa24";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "f42d6ab85ddd06a9a48691475f137a3cf7c847d9100e8bdb8d0092da306d3650";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-test-msgs/default.nix
+++ b/distros/foxy/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-test-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_test_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0c567109e63e18f00c468fbee2b608bf489b8d408d28c3eb63b899ef9ca722d1";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_test_msgs/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "3ad2beb0eb2a668fcaea8abe80b7a121250d21911f141d94f3e4f3e02b54a4d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/urdf-tutorial/default.nix
+++ b/distros/foxy/urdf-tutorial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-urdf-tutorial";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/foxy/urdf_tutorial/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "90a070ae9db4203819d830f59f618fdb57146c1dcf26fc1d2d80674e23e35153";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains a number of URDF tutorials.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/bno055/default.nix
+++ b/distros/galactic/bno055/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-bno055";
-  version = "0.1.1-r2";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/bno055-release/archive/release/galactic/bno055/0.1.1-2.tar.gz";
-    name = "0.1.1-2.tar.gz";
-    sha256 = "a1d17f9323dded8540cf06d0fed09ce06e38bd35506ab61ad5760698731d60b7";
+    url = "https://github.com/ros2-gbp/bno055-release/archive/release/galactic/bno055/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "27e2b582a198a75cdf0c5189881d47222e74527e2cac0391a2f4def78f1489c5";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/domain-bridge/default.nix
+++ b/distros/galactic/domain-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, libyamlcpp, rclcpp, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, zstd-vendor }:
 buildRosPackage {
   pname = "ros-galactic-domain-bridge";
-  version = "0.4.0-r1";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/domain_bridge-release/archive/release/galactic/domain_bridge/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "801b5acd4ffc9bd321ce47eb5a2047210c158feca3433f73be1f5906778c38a1";
+    url = "https://github.com/ros2-gbp/domain_bridge-release/archive/release/galactic/domain_bridge/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "07b6329f739006e11a9fdfd9a42c93c6488b72d6f9bf5b9ee4ef11e9779c3fa3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gazebo-ros2-control-demos/default.nix
+++ b/distros/galactic/gazebo-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-galactic-gazebo-ros2-control-demos";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control_demos/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "65421af8156175ba1045bd4703db2e429403be1c9a53c8c6a5c814c933651cb0";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control_demos/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "eea86425ac6232b046bd646a8660e87e3875ba4a669f1d84cc09241d86dfece0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gazebo-ros2-control/default.nix
+++ b/distros/galactic/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-gazebo-ros2-control";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "29bb894caccc9e9339d42b4f3f5a4e29542cfbdc018f8aceb770d58e3f5f20ac";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/galactic/gazebo_ros2_control/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "d28a77d81832a9489fefa63815c31b5c3ddda06e4d176dde525f76a61f106111";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -514,6 +514,8 @@ self: super: {
 
  logging-demo = self.callPackage ./logging-demo {};
 
+ lua-vendor = self.callPackage ./lua-vendor {};
+
  map-msgs = self.callPackage ./map-msgs {};
 
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
@@ -696,7 +698,11 @@ self: super: {
 
  nodl-to-policy = self.callPackage ./nodl-to-policy {};
 
+ nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
+
+ ntrip-client = self.callPackage ./ntrip-client {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
 
@@ -719,6 +725,10 @@ self: super: {
  osrf-testing-tools-cpp = self.callPackage ./osrf-testing-tools-cpp {};
 
  ouster-msgs = self.callPackage ./ouster-msgs {};
+
+ ouxt-common = self.callPackage ./ouxt-common {};
+
+ ouxt-lint-common = self.callPackage ./ouxt-lint-common {};
 
  pal-statistics = self.callPackage ./pal-statistics {};
 
@@ -925,8 +935,6 @@ self: super: {
  rmf-demos-dashboard-resources = self.callPackage ./rmf-demos-dashboard-resources {};
 
  rmf-demos-gz = self.callPackage ./rmf-demos-gz {};
-
- rmf-demos-ign = self.callPackage ./rmf-demos-ign {};
 
  rmf-demos-maps = self.callPackage ./rmf-demos-maps {};
 
@@ -1452,6 +1460,8 @@ self: super: {
 
  tvm-vendor = self.callPackage ./tvm-vendor {};
 
+ twist-mux = self.callPackage ./twist-mux {};
+
  ublox = self.callPackage ./ublox {};
 
  ublox-dgnss = self.callPackage ./ublox-dgnss {};
@@ -1479,6 +1489,8 @@ self: super: {
  urdf = self.callPackage ./urdf {};
 
  urdf-parser-plugin = self.callPackage ./urdf-parser-plugin {};
+
+ urdf-tutorial = self.callPackage ./urdf-tutorial {};
 
  urdfdom = self.callPackage ./urdfdom {};
 

--- a/distros/galactic/grbl-ros/default.nix
+++ b/distros/galactic/grbl-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, grbl-msgs, python3Packages, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-grbl-ros";
-  version = "0.0.15-r2";
+  version = "0.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/grbl_ros-release/archive/release/galactic/grbl_ros/0.0.15-2.tar.gz";
-    name = "0.0.15-2.tar.gz";
-    sha256 = "e42dd0bf624b9c6d4ae7c1399a6049902bcf578f6c4ffbcb7c4a3ebffcc09acb";
+    url = "https://github.com/ros2-gbp/grbl_ros-release/archive/release/galactic/grbl_ros/0.0.16-1.tar.gz";
+    name = "0.0.16-1.tar.gz";
+    sha256 = "13184d926c6e8ae2b47b7dc7397a22ac39838ddf3a06de4a607d2b0d00c08741";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/libmavconn/default.nix
+++ b/distros/galactic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-libmavconn";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/libmavconn/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "1f67c8f0ead8e70d7793eeb3358373247036eba204c61e5471b52dca4899577c";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/libmavconn/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "0d176413dfaeeafeb567aee8b0c06ca653bf03660085ff00b4305425f79bdf1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/lua-vendor/default.nix
+++ b/distros/galactic/lua-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ouxt-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-lua-vendor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/lua_vendor-release/archive/release/galactic/lua_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "190a7055e064d1767bb8958cd0248764ab8b54a1a72072561207b76c2a6211b3";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TODO: Package description'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/mavros-extras/default.nix
+++ b/distros/galactic/mavros-extras/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-mavros-extras";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_extras/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "af3e0eb35e31a74a15b5f8d9918615f5311ad5758add27934f8dc8008028489c";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_extras/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "79e93f86c678e080294c6b4f12fe3c5dfc3b90d2dd2d37103f497bb5f0330141";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ angles ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn libyamlcpp mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
 
   meta = {

--- a/distros/galactic/mavros-msgs/default.nix
+++ b/distros/galactic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-mavros-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "ffb5519bb93449b87c104dceaf59a12adb241e51de5ca85f5a86858b46bf0373";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "df95ba50c9ff1592588b8e0706a17be3bb63ed2c6dcab1d837d6a30014322548";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavros/default.nix
+++ b/distros/galactic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-mavros";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "911323c0cf10b32afe75ba027d6d4c4b5856599fc043ef2d56ea4f4f438fdddd";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "e7578b939f485c5b478ae796e638514cd5f59d4910b0bcaad538340b7b6f8401";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-driver";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "82fec9b7ad690fdc6bffd4ee19a85974f031b723e338ebfe2968a11dbcd03b86";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6a86484b20dc12bebb29ca18109420808704b3c0156bdefebe12c273537a75d5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ curl jq ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-cpplint ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-updater geometry-msgs lifecycle-msgs microstrain-inertial-msgs nav-msgs rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-updater geometry-msgs lifecycle-msgs mavros-msgs microstrain-inertial-msgs nav-msgs nmea-msgs rclcpp-lifecycle rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ rosidl-default-generators ];
 
   meta = {

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-examples";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a2c35e019e68efd777b07f638938e68883cba5eda5b6ed525ab60bab0a7fd8c0";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e3c79a6503fd1a55d323666f82b7849e6db290314e53be81b5319979a1d282b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "297b628ad931e9f1055a5e8824d1734ddfe644a59ffa90838eacecdf01306d98";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f38ad19922b33586f5be9162b3752b3065733a99146b67948ffbc7fc5a3e7053";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mrt-cmake-modules/default.nix
+++ b/distros/galactic/mrt-cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mrt-cmake-modules";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/galactic/mrt_cmake_modules/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "8d00dd6c383e08e96b6af38bc88bd6f7b7e02c1402950cdeba102cdcd06edb62";
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/galactic/mrt_cmake_modules/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "90ae9ca8a6295fbf44d849e1a3e81ae1c29a9bcddf2ac3d2e0e23467678994d2";
   };
 
   buildType = "catkin";

--- a/distros/galactic/nonpersistent-voxel-layer/default.nix
+++ b/distros/galactic/nonpersistent-voxel-layer/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, geometry-msgs, laser-geometry, map-msgs, nav-msgs, nav2-costmap-2d, nav2-msgs, nav2-voxel-grid, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-nonpersistent-voxel-layer";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/nonpersistent_voxel_layer-release/archive/release/galactic/nonpersistent_voxel_layer/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "dfb3454f5456d145eb59748389e30c918baf3d3401e43bdb075829c98c9b70b0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs laser-geometry map-msgs nav-msgs nav2-costmap-2d nav2-msgs nav2-voxel-grid pluginlib rclcpp sensor-msgs std-msgs tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''include
+        This package provides an implementation of a 3D costmap that takes in sensor
+        data from the world, builds a 3D occupancy grid of the data for only one iteration.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/ntrip-client/default.nix
+++ b/distros/galactic/ntrip-client/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ntrip-client";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-ros2-release/archive/release/galactic/ntrip_client/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ccc17605a247e6d1a808adda9ec0b0769e1d20fe391de7e54159b092bf9a9386";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ mavros-msgs nmea-msgs rclpy std-msgs ];
+
+  meta = {
+    description = ''NTRIP client that will publish RTCM corrections to a ROS topic, and optionally subscribe to NMEA messages to send to an NTRIP server'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/osqp-vendor/default.nix
+++ b/distros/galactic/osqp-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-galactic-osqp-vendor";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/galactic/osqp_vendor/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "de39e5484b5e279152fcd20cb5bd3b00202a77f56a276025709adb0a14d5c5e3";
+    url = "https://github.com/tier4/osqp_vendor-release/archive/release/galactic/osqp_vendor/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "366e082d8adb27d1206b58e830e162a5342dfc30ec076ec7f1e0ff786c90f64c";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''Wrapper around osqp that ships with a CMake module'';

--- a/distros/galactic/ouxt-common/default.nix
+++ b/distros/galactic/ouxt-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ouxt-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-ouxt-common";
+  version = "0.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/ouxt_common-release/archive/release/galactic/ouxt_common/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "3945df85b191ec8fe57e665bd72be5a59b30943391e6a62106533ba21e22b99b";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ouxt-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''common settings for OUXT Polaris ROS2 packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ouxt-lint-common/default.nix
+++ b/distros/galactic/ouxt-lint-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-pep257, ament-cmake-xmllint }:
+buildRosPackage {
+  pname = "ros-galactic-ouxt-lint-common";
+  version = "0.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/ouxt_common-release/archive/release/galactic/ouxt_lint_common/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "a87d0ee3b565afb10f1832e04cfb3f96df1cf3b47a448e369de7b8bc162d1375";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-cmake-clang-format ament-cmake-copyright ament-cmake-pep257 ament-cmake-xmllint ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''common linter settings for OUXT Polaris ROS2 packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/python-qt-binding/default.nix
+++ b/distros/galactic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-galactic-python-qt-binding";
-  version = "1.0.7-r2";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/galactic/python_qt_binding/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "a298df8e2f8dd636e6350dcb28261d4b56254f42ad663ebd5df2cb6414a82460";
+    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/galactic/python_qt_binding/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b65c1862a807b6c261582bbfe1388fa5dc599666a0b033cd67b23f3d3a75d1a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-building-sim-common/default.nix
+++ b/distros/galactic/rmf-building-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, menge-vendor, rclcpp, rmf-building-map-msgs, rmf-door-msgs, rmf-lift-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmf-building-sim-common";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_building_sim_common/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "25729574cbe901b27a230dc92be6b2ed2ac838c3c27aa299c4dc2ebd5e98afab";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_building_sim_common/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "0595835d60f45f636b85b98d403981e3824ccfabb5c7246ad5d39f1ce733c546";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-building-sim-gazebo-plugins/default.nix
+++ b/distros/galactic/rmf-building-sim-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-ros, menge-vendor, opencv3, qt5, rclcpp, rmf-building-sim-common, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmf-building-sim-gazebo-plugins";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_building_sim_gazebo_plugins/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "a34af96f650e12e5c7583dd27483dd6761ca17a63c77ac4549247b517254f119";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_building_sim_gazebo_plugins/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "2e44948c730dce3929f15ff41d525fc6de4e571f18c884a7a919d37e41501a82";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-demos-assets/default.nix
+++ b/distros/galactic/rmf-demos-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-rmf-demos-assets";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_assets/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "bc83618e376ab8ab50ad1f6ac3300879b0b8e05dd395c7de9d53da5cb0d936fc";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_assets/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "300a62e8228e4d426f96dc6399d48078e22eda82a3106f439e3bb31111c3dbc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-demos-dashboard-resources/default.nix
+++ b/distros/galactic/rmf-demos-dashboard-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-rmf-demos-dashboard-resources";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_dashboard_resources/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "25396c7f7b36d97ee65351254303f4953c35d01e7a74a4b810ada18851a26a1f";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_dashboard_resources/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "99f57b3ac81a85ebfa7fd1446fe650b24f4b219aaa5b1181a342cb8b7a2a3a06";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-demos-gz/default.nix
+++ b/distros/galactic/rmf-demos-gz/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, joy, launch-xml, rmf-building-sim-gazebo-plugins, rmf-demos, rmf-robot-sim-gazebo-plugins, teleop-twist-joy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-plugins, joy, launch-xml, rmf-building-sim-gazebo-plugins, rmf-demos, rmf-robot-sim-gazebo-plugins, teleop-twist-joy }:
 buildRosPackage {
   pname = "ros-galactic-rmf-demos-gz";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_gz/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "128f8116b657b980c51dc383163926b67ffd7500e476795331d3c48513f40880";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_gz/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "c1a8708a2a7fa755c8194b7a2d9ad78a80a8af7cec57f9157b967976ca29342e";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ joy launch-xml rmf-building-sim-gazebo-plugins rmf-demos rmf-robot-sim-gazebo-plugins teleop-twist-joy ];
+  propagatedBuildInputs = [ gazebo-plugins joy launch-xml rmf-building-sim-gazebo-plugins rmf-demos rmf-robot-sim-gazebo-plugins teleop-twist-joy ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rmf-demos-maps/default.nix
+++ b/distros/galactic/rmf-demos-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-rmf-demos-maps";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_maps/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "757b5ac22ce063c86bc94e309fca78a10a573a066c9380fa778cb69e19dc6ff7";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_maps/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "a39631343c4d211903d615afd7a7e5de349924e779d372e523fd37e81d1a2e86";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-demos-tasks/default.nix
+++ b/distros/galactic/rmf-demos-tasks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-lift-msgs, rmf-task-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmf-demos-tasks";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_tasks/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "4a5db4c9fdb67c78f1282d292a0c97483f30f43572b0601d7f2c29ef4c076a96";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos_tasks/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "51af0ca6ae9dfd4bf442c2e613c82cd316856219d5c6a4880ecf86f2e2729eff";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rmf-demos/default.nix
+++ b/distros/galactic/rmf-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-xml, rmf-building-map-tools, rmf-demos-assets, rmf-demos-maps, rmf-demos-panel, rmf-demos-tasks, rmf-fleet-adapter, rmf-task-ros2, rmf-traffic-ros2, rmf-visualization, rviz2 }:
 buildRosPackage {
   pname = "ros-galactic-rmf-demos";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "8814599919ad0c8aac723b5da1b6830485349f6ba7fc8d743800f99dbf797377";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/galactic/rmf_demos/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "93d6899b323949f6f64d70e9e2ed0b616dd6d771a06edfa4c0f459a55f6d992f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-robot-sim-common/default.nix
+++ b/distros/galactic/rmf-robot-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-rmf-robot-sim-common";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_robot_sim_common/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "d67fd18c16afc4ed32a28b6e22390f2aed0026e0f1d41d64fada21027219d3b9";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_robot_sim_common/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "608f46d3788389a2c76c6e8be002c85c3dabd1a2f2ca51667e8282dad6f67d9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-robot-sim-gazebo-plugins/default.nix
+++ b/distros/galactic/rmf-robot-sim-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, gazebo-dev, gazebo-ros, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-robot-sim-common }:
 buildRosPackage {
   pname = "ros-galactic-rmf-robot-sim-gazebo-plugins";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_robot_sim_gazebo_plugins/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "ab62200b1fd2411f89fc8f08d1c832f63558162738cb63e5bac44f0da4551748";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/galactic/rmf_robot_sim_gazebo_plugins/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "b704f2cd8eae03f986de445b7fdc8b440b089a2e1122e861a4b43c87cda896a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/robot-state-publisher/default.nix
+++ b/distros/galactic/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-galactic-robot-state-publisher";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/galactic/robot_state_publisher/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "b0428425ce47d88be2465f64ab2bc4c2b848e73401cccc07186e1d13b0aa9232";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/galactic/robot_state_publisher/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "6799396fb3c289819c0aad41caad0c52cd32308bb785be496c2f0d969f98ef13";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosapi-msgs/default.nix
+++ b/distros/galactic/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosapi-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "16df7c22ad3b61c8706814334e45142f04b60b4e10aa826bfa86c40dd1ad4cb8";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "cd2e3e4f917930d3004c65b4e0f2c2402b2ee537a05137a80ab0325bcf3cd232";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosapi/default.nix
+++ b/distros/galactic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosapi";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "17a3f60ac078b6ba989ad73315a1bf3fb8834a878238fd2a07a495f07a65561a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "600993ce7090a43af4e80fd52571cd329f253e58f20148785a94d3488710cc45";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-library/default.nix
+++ b/distros/galactic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-library";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "28f5c85c61c23bd8e2dab7feca3dae7fc4635633d850e04fce5f4dc332936fa4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "03a74e0faebda6d0580e97c5efbbb8d98693a513f3371a12e08821c1aeb42480";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-msgs/default.nix
+++ b/distros/galactic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "8e54472b3318ebfa8b9b54e19dcfebf1ee048b97df07b27e826205038afca00a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "dd7cf67fe14b743c3c4d0e90cd21c08e4a3da54e90854ddda0d4391e0f782869";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-server/default.nix
+++ b/distros/galactic/rosbridge-server/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-server";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "408607dce1bbcdb349eb3f5878afbb514a92c1ffe3e54582224b43e94a05ea05";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c3ae8c7d270e211acfac055469a3bcc342c477ee32a0036bb467eb71d4365007";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn ];
+  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/galactic/rosbridge-suite/default.nix
+++ b/distros/galactic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-suite";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "41cd2085c87f97013ccf35a2fe474d51c393b42b280316bf661c6565bdeddfe8";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "03f3a0218a83ab49f29c85c0909d6224cb08675a46869b69d321549f1745841c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-test-msgs/default.nix
+++ b/distros/galactic/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-test-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_test_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "7e8bbf4c6c6405cd6a7d9827a333766cb28493fc2f0218e545eb761e5abf86ca";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_test_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d189e5197386896a7e569acc5d8a94707dbf6856be671e986a98b891374cad62";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/snowbot-operating-system/default.nix
+++ b/distros/galactic/snowbot-operating-system/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, geometry-msgs, pluginlib, rviz-common, rviz-rendering }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, geometry-msgs, pluginlib, rviz-common, rviz-rendering }:
 buildRosPackage {
   pname = "ros-galactic-snowbot-operating-system";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/galactic/snowbot_operating_system/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "90f62b486ee1072369986e31abe1dafd4147c35e55166a8e5387e7c684730f07";
+    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/galactic/snowbot_operating_system/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "38887d073d7444a4e62bdbabd5ed514c3ada7e04dea0fd86814c0911cd01f7ac";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ];
-  propagatedBuildInputs = [ geometry-msgs pluginlib rviz-common rviz-rendering ];
+  propagatedBuildInputs = [ ament-cmake-ros geometry-msgs pluginlib rviz-common rviz-rendering ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/tango-icons-vendor/default.nix
+++ b/distros/galactic/tango-icons-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-galactic-tango-icons-vendor";
-  version = "0.1.0-r2";
+  version = "0.1.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/galactic/tango_icons_vendor/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "c766abd89f574a0d0fb25b2e95ff0e18cee66cb63b4c69e7647db1ecfa7655b7";
+    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/galactic/tango_icons_vendor/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "661aac9d0a3d032cda959eecfaa71c03a100c212d27f09d5f6f2ac53dfd03480";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/twist-mux/default.nix
+++ b/distros/galactic/twist-mux/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-twist-mux";
+  version = "4.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/galactic/twist_mux/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "0d0216eaf197e326ba6e804126646761f009d3a0d83bf3aaad1509a3374ab770";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Twist multiplexer, which multiplex several velocity commands (topics) and
+      allows to priorize or disable them (locks).'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/urdf-tutorial/default.nix
+++ b/distros/galactic/urdf-tutorial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-urdf-tutorial";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/galactic/urdf_tutorial/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "76b30bd11ef4fa37433addf3a6d663f770059f48f20355e60daa4124bbc27762";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains a number of URDF tutorials.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/yaml-cpp-vendor/default.nix
+++ b/distros/galactic/yaml-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-yaml-cpp-vendor";
-  version = "7.1.0-r2";
+  version = "7.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yaml_cpp_vendor-release/archive/release/galactic/yaml_cpp_vendor/7.1.0-2.tar.gz";
-    name = "7.1.0-2.tar.gz";
-    sha256 = "22e96466cb3d9214281e52d89e5a750d1897eb2186ef95a5bb6d9ca6a24ce7d4";
+    url = "https://github.com/ros2-gbp/yaml_cpp_vendor-release/archive/release/galactic/yaml_cpp_vendor/7.1.1-1.tar.gz";
+    name = "7.1.1-1.tar.gz";
+    sha256 = "33afe34c829a9a54ad20728236ca09e692490b2935880f95d4509833fd376545";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/avt-vimba-camera/default.nix
+++ b/distros/melodic/avt-vimba-camera/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, polled-camera, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-proc, image-transport, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-avt-vimba-camera";
-  version = "0.0.12-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/0.0.12-1.tar.gz";
-    name = "0.0.12-1.tar.gz";
-    sha256 = "8902143fcf7f83538d426f6577edfd34e0324eb22ffb37ecc4ff99541d2750af";
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "13e807526426a15d481207dd213bfeb3683ead4e188353da61ead6b0f70a9a3d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-info-manager diagnostic-updater dynamic-reconfigure image-geometry image-proc image-transport message-filters nodelet polled-camera roscpp sensor-msgs std-msgs stereo-image-proc ];
+  propagatedBuildInputs = [ camera-info-manager diagnostic-updater dynamic-reconfigure image-proc image-transport message-filters nodelet roscpp sensor-msgs std-msgs stereo-image-proc ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Wrapper of the Allied Vision Technologies (AVT) VIMBA Ethernet and Firewire SDK.'';
+    description = ''Camera driver for Allied Vision Technologies (AVT) cameras, based on their Vimba SDK.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/cartesian-interface/default.nix
+++ b/distros/melodic/cartesian-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-cartesian-interface";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_interface/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "89669ea66a46f73997d10314571970dda7be6ef6b8844593c3668cfdb02491a6";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_interface/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "cfa1e2ef5420f957e9bfe4c23e983cdab82ef908f1e617e666ce6f696800935f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cartesian-trajectory-controller/default.nix
+++ b/distros/melodic/cartesian-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-cartesian-trajectory-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "f7341c2494a83b7152a8aa0d9d95134091012c2b80b0598ed39b0f767070d685";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "3a184907ecc3236d3bd4fe482503eecd78d764c2071ad79bdca58b0a3f9ba9fb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/melodic/cartesian-trajectory-interpolation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-cartesian-trajectory-interpolation";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_interpolation/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "f8b6831909f4f9bde2ddf08f3d42ae030fd18cc4c0a27b279dfe22a60a6daffc";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_interpolation/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "050821f108081fe72ce6bf58ae02ebb96721283d8eed13f4f8658a2995038e17";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "60f61b4e44577278cd2ab5d1594490732c02eb0cd206394cddbfd9bf1a320cd8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "ab7fb26613d6211c7c1bcc9aae7657d0b7c5ff182a5f2ba96f096f0592f14dda";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.6.9-1.tar.gz";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.9-1.tar.gz";
     name = "2.6.9-1.tar.gz";
     sha256 = "07ad3559467602369b9a5f49f1e91536451b13c6981379905211a48152694876";
   };

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2616,6 +2616,8 @@ self: super: {
 
  optpp-catkin = self.callPackage ./optpp-catkin {};
 
+ opw-kinematics = self.callPackage ./opw-kinematics {};
+
  orocos-kdl = self.callPackage ./orocos-kdl {};
 
  orocos-kinematics-dynamics = self.callPackage ./orocos-kinematics-dynamics {};
@@ -3347,6 +3349,8 @@ self: super: {
  ros-environment = self.callPackage ./ros-environment {};
 
  ros-ethercat-eml = self.callPackage ./ros-ethercat-eml {};
+
+ ros-industrial-cmake-boilerplate = self.callPackage ./ros-industrial-cmake-boilerplate {};
 
  ros-introspection = self.callPackage ./ros-introspection {};
 

--- a/distros/melodic/hpp-fcl/default.nix
+++ b/distros/melodic/hpp-fcl/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/hpp-fcl_catkin-release/archive/release/melodic/hpp-fcl/1.0.1-2.tar.gz";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/1.0.1-2.tar.gz";
     name = "1.0.1-2.tar.gz";
     sha256 = "2fdf0400d19ccdc82b6788b4715d5adf11af7e3159f8cd87f5a401ddd3fb53f5";
   };

--- a/distros/melodic/inorbit-republisher/default.nix
+++ b/distros/melodic/inorbit-republisher/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, roslib, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-inorbit-republisher";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/melodic/inorbit_republisher/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "3cb5d5fc327542c8fece9309e5c6a91d0656bcfc5a917d1cb23c884d363b6d11";
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/melodic/inorbit_republisher/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "45ff6a390ced0998081cd8e7d11dc43c8d17fbf8d23f78763bfcb6896b6080b9";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.pyyaml roslib rospy std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.pyyaml roslib rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "60221f915fbe85501d2afd6ba1030a1b5931dbc22b1cc38610c99609d96549c5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "0aa68e1424b8e21bb3d27cab73f3e7a4c9bee1cf84fb73d5a9a29e99e0a1b7a5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libmavconn/default.nix
+++ b/distros/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "b7ceb6ba0f2edfa9f31e532aaecf1868ec77135792b952ea90f8ee401fb250b4";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "57f9cdb7e7345f295fdc749d03fa0cac0b8e304b2e5ce53b0f6949802c918a0d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "dffd5319d3bf274a0881f4a9f71fe1e6bdf48a537debe5418d6d834eec38a0b2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "a82ba6776ac74a814b8e18f83bb30699948bc26ebe57440a3e4c2e9e0ecdd067";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-extras/default.nix
+++ b/distros/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "e8bef278b6b427a88fc9c0feacaf752a5495aa000b353049fd537580e9e8a81e";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "e1db3f313d9479ba987ecbbd746e48bf8230ffb8cad6ea2c7774d05300eb76b9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-msgs/default.nix
+++ b/distros/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "b368649451c5ca6d9033798ea1f00527e610ee7517fbc9c95417e7457156a8a5";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "baad352954915ba514a609d10d09fad0035d7e786df4258428e66d0a64a65b08";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "ae7a17f356e2c42a60cc9354eac6c13ab925765c3525f7412951a9809f1318e6";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "3fc30fa03dd276f90b669991d20528ad23cfb809cded4251959594463cbee34c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-driver/default.nix
+++ b/distros/melodic/microstrain-inertial-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, mavros-msgs, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-driver";
-  version = "2.1.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "afb32d55985276398213021f33dfd0daccd7181708889c1078dbd33b64b08566";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "f83bc1d208a3ee8a01995daa804d066e3179b3ba5131b20b743399c553eae01d";
   };
 
   buildType = "catkin";
   buildInputs = [ curl jq message-generation roslint ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-aggregator diagnostic-updater geometry-msgs message-runtime microstrain-inertial-msgs nav-msgs roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-aggregator diagnostic-updater geometry-msgs mavros-msgs message-runtime microstrain-inertial-msgs nav-msgs nmea-msgs roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/microstrain-inertial-examples/default.nix
+++ b/distros/melodic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-examples";
-  version = "2.1.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5eca406f6d57598bf5769c2bdbfc6ffd0556f851244119ae9b62cbc45dad8dd8";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "58e1591ba47af5d520d094b32bb5ca6952839810c2ffc9da74a4b1bd9720ed08";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-msgs/default.nix
+++ b/distros/melodic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4ebf38d44efd51c7d8d534f92c69cef1f1da0ecf9fdf4a2380cb06a68158e6fb";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "56922f8cb50381c8cff61218038e0abfe9dd2f5b73507c88f2448e60cbc7500d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "fa3902610a537bc7b2c5ad7896e850994aa61e53dc0e7c3f1853b164f4549239";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "1ba0aafb682f9d177fa2cb97553f5786a35a4455069ef5651868c2500a9561c5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "46f0dc0c0436eeebd5ae30d4213494aed0d00f4deb9d1727bb7f91fb30f60143";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "132fe5a636eca3a9c04a9e883645afc4938e82eb29636e2e858a6e390081123a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "779c3d7095bee356090dcd0973e262c921de444601f6b8a8024865d870f28fa6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "aefd8111a897070ed5cf567bc2e89b0f233d0a09809f9b54ec2601347dc7d2a7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "624fa30551b481e72d807409b2cb56cab755f770425720db13ee4b3fcbbd7641";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "3cec04ea15c44867515cf290dda3099c5b21a27735a5601a35806ef7449c31ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opw-kinematics/default.nix
+++ b/distros/melodic/opw-kinematics/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
+buildRosPackage {
+  pname = "ros-melodic-opw-kinematics";
+  version = "0.4.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/melodic/opw_kinematics/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "a9c07bf7cce9ff8248cf00d681099def8d9dc4736f2a4b89ba54fbe3aee17b64";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ eigen ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''A simple, analytical inverse kinematic library for industrial robots with parallel bases and
+    spherical wrists. Based on the paper &quot;An Analytical Solution of the Inverse Kinematics Problem
+    of Industrial Serial Manipulators with an Ortho-parallel Basis and a Spherical Wrist&quot; by
+    Mathias Brandstötter, Arthur Angerer, and Michael Hofbaur.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.4-1.tar.gz";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.4-1.tar.gz";
     name = "2.6.4-1.tar.gz";
     sha256 = "434704c185cf69d766d543a78f030522c6b43127bcde587282dfb50c85fac2f3";
   };

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "3febcb50d21d9eca8ca0fbe879ec3671d85272195eee89a6d12fa2cc03df6ed2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "36e2704519cec06d7e1ae79608c909c66e48918894a8ea4163f7a68a89e0c300";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-controllers-cartesian/default.nix
+++ b/distros/melodic/ros-controllers-cartesian/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
 buildRosPackage {
   pname = "ros-melodic-ros-controllers-cartesian";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/ros_controllers_cartesian/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "5ded3fcc388472e298f2112c0e38d7ae587bd631f78e2c8c3bb2b84eaa32e2d2";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/ros_controllers_cartesian/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "e3597c556925f2afd4b288b328f82e70e65f205646eaaf58734a332fc6ece64a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/melodic/ros-industrial-cmake-boilerplate/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
+buildRosPackage {
+  pname = "ros-melodic-ros-industrial-cmake-boilerplate";
+  version = "0.2.14-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/melodic/ros_industrial_cmake_boilerplate/0.2.14-2.tar.gz";
+    name = "0.2.14-2.tar.gz";
+    sha256 = "9a6130047e9bbdf8f4b0788ccee0d298f64cc9f690b1b898f3d941cbe5f3f7db";
+  };
+
+  buildType = "cmake";
+  checkInputs = [ clang cppcheck gtest include-what-you-use lcov ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Contains boilerplate cmake script, macros and utils'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "c9d9c9d726f04ef13e0f44ddd632215edf5684a6cc35fd818e52d62becf9b0a6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "91df82482074b066d3932750c965a3645c291faee74f052fc8a78b11683bb087";
   };
 
   buildType = "catkin";

--- a/distros/melodic/snowbot-operating-system/default.nix
+++ b/distros/melodic/snowbot-operating-system/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, roslint, rviz }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, qt5, roslint, rviz }:
 buildRosPackage {
   pname = "ros-melodic-snowbot-operating-system";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/melodic/snowbot_operating_system/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "145a02fd03c5c381fa5977d08caec58bb309d92f078e720eba657af259bcc705";
+    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/melodic/snowbot_operating_system/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "8a31650a6043bba368d396b6d70c776e373b47e6897e9294efad3621f9788baa";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint ];
-  propagatedBuildInputs = [ geometry-msgs pluginlib rviz ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib qt5.qtbase rviz ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/test-mavros/default.nix
+++ b/distros/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "595206215df5d90637c3dc686fa75b7f78881803c423d4bc7b1c3b2e6b6b3bd0";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "926ddb12d415a6f09a4573401e660ab9c0b01fd4f80a2a4734540e31440abba6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "13df3f71a5bf41dc98f5bd5764fd8b6fac567cf57934daeb03f9c0c27f60b767";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "fec23abd07d96f697bb2719220f801d492084cc9db119a3a959bebaf8454d6ab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "377f4ba90ad35334eea4bbf3e67017f0480a087bd4fd3f4e9507db1d66296b6d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "5617657b4446db96375b38f166d345a8fe89f7f4ace2633e6b72639ed7143f21";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-controller/default.nix
+++ b/distros/melodic/twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-twist-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/twist_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "8c275c6ef6b7611f343767f43399b67b5349c1fc4091df5a3773cdec2b0181be";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/twist_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "29963ca38d385ca8d2ee9e79ca9aab624a347d42bb38e5193b98238820ed30c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/avt-vimba-camera/default.nix
+++ b/distros/noetic/avt-vimba-camera/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, polled-camera, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-proc, image-transport, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-noetic-avt-vimba-camera";
-  version = "0.0.12-r2";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/noetic/avt_vimba_camera/0.0.12-2.tar.gz";
-    name = "0.0.12-2.tar.gz";
-    sha256 = "ff2a92ae2d911bb50b0d589f3e2730f58f59a28078fe5fbef6c897f448455736";
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/noetic/avt_vimba_camera/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "49dff7f903af47dab6e53a0fc001016c2254a52a9eff3fd170189ed6584bc692";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-info-manager diagnostic-updater dynamic-reconfigure image-geometry image-proc image-transport message-filters nodelet polled-camera roscpp sensor-msgs std-msgs stereo-image-proc ];
+  propagatedBuildInputs = [ camera-info-manager diagnostic-updater dynamic-reconfigure image-proc image-transport message-filters nodelet roscpp sensor-msgs std-msgs stereo-image-proc ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Wrapper of the Allied Vision Technologies (AVT) VIMBA Ethernet and Firewire SDK.'';
+    description = ''Camera driver for Allied Vision Technologies (AVT) cameras, based on their Vimba SDK.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/cartesian-interface/default.nix
+++ b/distros/noetic/cartesian-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-interface";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "68ec44c6147522d337527352ba97241fc7b71484cb9d7557e939c36ec7da5df3";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "1f2aa6bb27030a2dfc1eabab2549db60369b49ed65f3a5f8452aea0ea4957b8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-trajectory-controller/default.nix
+++ b/distros/noetic/cartesian-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-trajectory-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "b62ba5575808a6cf1c140840e9fc23b39cef01344ddee77af7bcecf53ab0295d";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "a76d6faca9681d71b4d5cb2c8112ebaa045dde95182797cc95c01bb02a34133f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/noetic/cartesian-trajectory-interpolation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-trajectory-interpolation";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "8a54f18bd64bb3aa82c13fc0bf695030c01db3d05b757ab1ea21ef32e941f45f";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "40b4294cc4e8a4072c862714ba343b6a00446c0e79e4d31c420028cd3fbba31d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cnpy/default.nix
+++ b/distros/noetic/cnpy/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, zlib }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, zlib }:
 buildRosPackage {
   pname = "ros-noetic-cnpy";
-  version = "0.0.6-r1";
+  version = "0.0.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/PeterMitrano/cnpy-release/archive/release/noetic/cnpy/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "4976d95c49104d5005fde64175107a526dbe77cea3953e5aebf7caf2d855fb3a";
+    url = "https://github.com/PeterMitrano/cnpy-release/archive/release/noetic/cnpy/0.0.7-3.tar.gz";
+    name = "0.0.7-3.tar.gz";
+    sha256 = "782dc178efb2fd281be33e1d8205e268597dc72086649a1b5695948019f36b20";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake zlib ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''library to read/write .npy and .npz files in C/C++'';

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "ff199fa647a51cd78a4dfc271a1e56aeb2f762ee1848c98cea326ddadd5b4ad6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "80ede502354c62089be299c64f0d40989fd8184cf0116723663ace20afd4f22a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.9-1.tar.gz";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.9-1.tar.gz";
     name = "2.6.9-1.tar.gz";
     sha256 = "9449ffa6a473d13b3f73a3fa96b1ab6cf45ec6a14caaeb7fbf17afefcc037342";
   };

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1268,6 +1268,8 @@ self: super: {
 
  jsk-visualization = self.callPackage ./jsk-visualization {};
 
+ jskeus = self.callPackage ./jskeus {};
+
  julius = self.callPackage ./julius {};
 
  kalman-filter = self.callPackage ./kalman-filter {};
@@ -1363,6 +1365,8 @@ self: super: {
  leo-fw = self.callPackage ./leo-fw {};
 
  leo-gazebo = self.callPackage ./leo-gazebo {};
+
+ leo-msgs = self.callPackage ./leo-msgs {};
 
  leo-robot = self.callPackage ./leo-robot {};
 
@@ -1676,6 +1680,24 @@ self: super: {
 
  multisense-ros = self.callPackage ./multisense-ros {};
 
+ nav2d = self.callPackage ./nav2d {};
+
+ nav2d-exploration = self.callPackage ./nav2d-exploration {};
+
+ nav2d-karto = self.callPackage ./nav2d-karto {};
+
+ nav2d-localizer = self.callPackage ./nav2d-localizer {};
+
+ nav2d-msgs = self.callPackage ./nav2d-msgs {};
+
+ nav2d-navigator = self.callPackage ./nav2d-navigator {};
+
+ nav2d-operator = self.callPackage ./nav2d-operator {};
+
+ nav2d-remote = self.callPackage ./nav2d-remote {};
+
+ nav2d-tutorials = self.callPackage ./nav2d-tutorials {};
+
  nav-2d-msgs = self.callPackage ./nav-2d-msgs {};
 
  nav-2d-utils = self.callPackage ./nav-2d-utils {};
@@ -1743,6 +1765,8 @@ self: super: {
  novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
 
  ntpd-driver = self.callPackage ./ntpd-driver {};
+
+ ntrip-client = self.callPackage ./ntrip-client {};
 
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
 
@@ -2686,6 +2710,8 @@ self: super: {
 
  smclib = self.callPackage ./smclib {};
 
+ snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
+
  sob-layer = self.callPackage ./sob-layer {};
 
  socketcan-bridge = self.callPackage ./socketcan-bridge {};
@@ -3117,6 +3143,8 @@ self: super: {
  xpp-states = self.callPackage ./xpp-states {};
 
  xpp-vis = self.callPackage ./xpp-vis {};
+
+ xsens-mti-driver = self.callPackage ./xsens-mti-driver {};
 
  xv-11-laser-driver = self.callPackage ./xv-11-laser-driver {};
 

--- a/distros/noetic/inorbit-republisher/default.nix
+++ b/distros/noetic/inorbit-republisher/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, roslib, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-inorbit-republisher";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/noetic/inorbit_republisher/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "8b0247307350809ca7eef2d3cac5a07af1393260bee6c3df7d40cb27d7d08e1f";
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/noetic/inorbit_republisher/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "a34967b1e7832b2bc1b9e6000de8e9c7283c47f2eae0d8f6b0c3f579af0d1c2e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.pyyaml roslib rospy std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.pyyaml roslib rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "eb417127ee9ff3012044ae6a98bac8d895116a9e4ec107dd2f356e10f2dd3381";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "5e4fe32e95179e67843f342f9bc7017f51770548d8c6e7eda02238c89410f1ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jskeus/default.nix
+++ b/distros/noetic/jskeus/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, euslisp }:
+buildRosPackage {
+  pname = "ros-noetic-jskeus";
+  version = "1.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jskeus-release/archive/release/noetic/jskeus/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "bb43fd1f54ff95c468ea7bda7cc7063013b11c15b7430eb88dcc7880b8f2257e";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ euslisp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''EusLisp software developed and used by JSK at The University of Tokyo'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/leo-description/default.nix
+++ b/distros/noetic/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-description";
-  version = "1.2.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "0663ddfecbba76660c215c788834866fc816036cf79734261693a906004fbb17";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "45d4e0728755c83bfe5cd646da3f2256d3808f46facd6b6aaba581ebeddf26c7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-msgs/default.nix
+++ b/distros/noetic/leo-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-leo-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "88b887f03b8ae4525fe20f43a2f31bd55b44d75062d4b73ddd010c1d275d98e0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Message and Service definitions for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/leo-teleop/default.nix
+++ b/distros/noetic/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-noetic-leo-teleop";
-  version = "1.2.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "a740dbfb0eff660ad84c01f33eddf6a32a6a05c7bc559b502ca6c56e40de6d84";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "843c4268f9281ad8a9bdb4a2623b546fa849cf45ffef234a9a26da10e7fe4cde";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo/default.nix
+++ b/distros/noetic/leo/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, leo-description, leo-teleop }:
+{ lib, buildRosPackage, fetchurl, catkin, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-noetic-leo";
-  version = "1.2.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "5f08094f385aff7988ecc1dd21d4fe4f9bfb35a651aea18389199d9eeb58a83d";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6dc09bfe60d6aa84be833076fe22b287c279c58fdff7263a79e79ff525982e3b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ leo-description leo-teleop ];
+  propagatedBuildInputs = [ leo-description leo-msgs leo-teleop ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "25c6284a619c9572176937821435afa5d1e226febef62343d4303dba51abf533";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "cd94a62802b93651c7330a46c2b635870a4925fa7822a1de1244272673159ff4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "48ce3c79c16f0156d9708facfdac66eeeef59ca8f24d0ef1ff141253c28d7dff";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "9e8dafb2ce2c95ac7a7ce5413040ec39d105a0e54c5352abedae7eb63da2dcea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "47a6fdc21a98881a91c5e0b40f6de06796ca47ece74a2ec1ea4a6af2068e156d";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "008e99d192c096ce6d51a8d181354331f439a9abc32641f1b430017ba9a3d654";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "1a0ba2b82353140490448a01181f08d1776c5b0a68aeee6b3865f2ac10fff733";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "913e68eb69329741c0b39be3f528d2459dc2d32dd7f3a35db689f3d5b12676d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "6683f6ec95ef0a2706b6ec5e98b6108de0ce79d5e2ecd505e7aa326f57f7c632";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "e42ed7ce40e8116ef3678b28c0b33bc38e8a31f7a3d6a96cf3579b419a69ac32";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, mavros-msgs, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "2.1.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b8b2de615ef0a733ff497b3e51a8ec8224273bd052a4ce4a60e3f7a742077f7e";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "38806f6e30f5f66eb2c72f3e5704f44964d6c49e81a2ee1cf0a10a871ce2e20f";
   };
 
   buildType = "catkin";
   buildInputs = [ curl jq message-generation roslint ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-aggregator diagnostic-updater geometry-msgs message-runtime microstrain-inertial-msgs nav-msgs roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-aggregator diagnostic-updater geometry-msgs mavros-msgs message-runtime microstrain-inertial-msgs nav-msgs nmea-msgs roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "2.1.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "55f97a880265cf79c58a8e5b905b7adf973954ad9664f12faf94b24e77ed3caa";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "842599e110e941288c4b9a860255023ac51685f59dea2f99b020346b327681ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "f73162a44ddbe97fdcfc7d6c04d67d34a9c18cf646086fa174c23dd1b371e3cf";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "61fc2c66dc426c9947ea02377d2ad150ccc8b7bd5bc28c103e6d34ba6359a8f7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nav2d-exploration/default.nix
+++ b/distros/noetic/nav2d-exploration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, nav2d-navigator, pluginlib, roscpp, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-exploration";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_exploration/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "b28cf2ddb5f4ebe6b1b2192bb9788ed7c839a47745d6362089230309a0cc650d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs nav2d-navigator pluginlib roscpp tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package holds a collection of plugins for the RobotNavigator, that provide
+    different cooperative exploration strategies for a team of mobile robots.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d-karto/default.nix
+++ b/distros/noetic/nav2d-karto/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, nav-msgs, nav2d-localizer, nav2d-msgs, roscpp, suitesparse, tbb, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-karto";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_karto/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "a6e7858170e9d813af27e4ec0b818d49ca0cf7c8ee5b05ff5ceee9d9e701190d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs nav-msgs nav2d-localizer nav2d-msgs roscpp suitesparse tbb tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Graph-based Simultaneous Localization and Mapping module.
+    Includes OpenKarto GraphSLAM library by &quot;SRI International&quot;.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d-localizer/default.nix
+++ b/distros/noetic/nav2d-localizer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-localizer";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_localizer/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "aba652974782ebc680b0a5d18ecee1a85de899cc0983c5078957febae191a32c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Wrapper around Particle Filter implementation.
+    The SelfLocalizer can be used as library or as a ros-node.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d-msgs/default.nix
+++ b/distros/noetic/nav2d-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-msgs";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_msgs/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "7a9925f765c7a8511e383261a46cba96ba21180fb991f193bec75f710e6bcc7b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages used for 2D-Navigation.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d-navigator/default.nix
+++ b/distros/noetic/nav2d-navigator/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, nav2d-msgs, nav2d-operator, pluginlib, roscpp, std-srvs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-navigator";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_navigator/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "ce183be0588c405387ab166f3d42e8b01d204a6205a2be4d34e2c40ecc186863";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime nav2d-msgs nav2d-operator pluginlib roscpp std-srvs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a node for higher level navigation of a mobile
+    robot in a planar environment. It needs a map and the robot's position
+    within this map to create a plan for navigation. When used together with
+    a SLAM module it can also be used to perform autonomous exploration of
+    the robot's workspace.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d-operator/default.nix
+++ b/distros/noetic/nav2d-operator/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, message-generation, message-runtime, roscpp, sensor-msgs, tf, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-operator";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_operator/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "ac72183e832843c469d705fbf89c16da594efe0abaa1a85002963e98240dc017";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation tf2-ros ];
+  propagatedBuildInputs = [ costmap-2d message-runtime roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The operator is a lightweight, purely reactive obstacle-avoidance
+    module for mobile robots moving in a planar environment. The operator node
+    works by evaluating a set of predefined motion primitives based on a local
+    costmap and a desired direction. The best evaluated motion command will be
+    send to the mobile base.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d-remote/default.nix
+++ b/distros/noetic/nav2d-remote/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nav2d-navigator, nav2d-operator, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-remote";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_remote/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "f3dfb200f139b41661c5c6e21c8a859c444922af46ba38befc9d1f2a298295b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nav2d-navigator nav2d-operator roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is used to manually control a robot that uses the operator and
+    navigator node from navigation_2d. Currently there is one node to control one
+    robot with a joystick and one to control multiple robots in simulation.
+    It can send commands directly to the operator or start and stop navigator actions.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d-tutorials/default.nix
+++ b/distros/noetic/nav2d-tutorials/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nav2d-exploration, nav2d-karto, nav2d-localizer, nav2d-msgs, nav2d-navigator, nav2d-operator, nav2d-remote }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d-tutorials";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d_tutorials/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "56ecf7b85421c00cbe828e17b78bfacd0dc841cbe4847d659782a8b42716ea0d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nav2d-exploration nav2d-karto nav2d-localizer nav2d-msgs nav2d-navigator nav2d-operator nav2d-remote ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a set of tutorials that run 2D-Navigation within Stage-Simulator.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav2d/default.nix
+++ b/distros/noetic/nav2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nav2d-exploration, nav2d-karto, nav2d-localizer, nav2d-msgs, nav2d-navigator, nav2d-operator, nav2d-remote, nav2d-tutorials }:
+buildRosPackage {
+  pname = "ros-noetic-nav2d";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/skasperski/navigation_2d-release/archive/release/noetic/nav2d/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "28604c2fdf84af889a48f645b663d2b64a04bcbf7564ba70aeec8476296b59ac";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nav2d-exploration nav2d-karto nav2d-localizer nav2d-msgs nav2d-navigator nav2d-operator nav2d-remote nav2d-tutorials ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta-Package containing modules for 2D-Navigation'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "cfbf49df3f8a85b14e23505942c17f038722a1a2b67ef1d6eb25a8c343faa2d5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "cf82e9ebebce7a60148998cd5911bd44643ca67ed1369f55d9f769a95e2e95bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "0ec5d529d6a32571b48c1f4b402668e9df1ddf232fda50e62a838d35af20b07e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "0e6012cd8c6c8c852328da1156ef6c1038f2240b3ba9bc93896cda3b43135c75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "dd96967d57cde68798e59a282118357d8f681148e5f5f482c5800619384e8934";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "16aa39d8c2d133be2c86426a984f51455ef9f86651f0e67b17d0eb1fec1cb98e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ntrip-client/default.nix
+++ b/distros/noetic/ntrip-client/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ntrip-client";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f4de7fad28471c2f4d1307e157b3cf4ff6f953133f241ac801b5b5a2e221fb81";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mavros-msgs nmea-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''NTRIP client that will publish RTCM corrections to a ROS topic, and optionally subscribe to NMEA messages to send to an NTRIP server'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "f7a31748c494bd15abe474bdd76daf31deb1cd42a2187b228a231bac95e130c5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "0fb8c4d1a3819d7f785ec7f2fe9280b727ffa86c7afb665182ae786398d72f82";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.4-1.tar.gz";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.4-1.tar.gz";
     name = "2.6.4-1.tar.gz";
     sha256 = "3344ad8eb1728111af01b13240c2fb355fb7b754f022243f3d282eea16c191b3";
   };

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "bf8e289dbf4028c208697adc015afcd7b8e8f0cf1944790b53b7a88fb61668cf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "ef918034bda9457eb147d47124d9bd275d06142083a5799bada315207c295f07";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qwt-dependency/default.nix
+++ b/distros/noetic/qwt-dependency/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qwt-dependency";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qwt_dependency-release/archive/release/noetic/qwt_dependency/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "1bef3ad78d77bb385cd6981de57d854d8e6dda58ee1a44fc514000c888e5f6bf";
+    url = "https://github.com/ros-gbp/qwt_dependency-release/archive/release/noetic/qwt_dependency/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "23ee6a845be40f3e9c58aedf44210aa08ef1bcaa20d5b5c37968caa2a4aa03e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-calibration-controllers/default.nix
+++ b/distros/noetic/rm-calibration-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, effort-controllers, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-calibration-controllers";
-  version = "0.1.1-r1";
+  version = "0.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "fc9807f8ad601650cf3e885e6606114b9638c74a7cf351e89feb306daa5461f9";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.1-3.tar.gz";
+    name = "0.1.1-3.tar.gz";
+    sha256 = "5385f5e78f42855c490adf9d0fb9e34f50a6ba91a6bee48814cc622b1f5d702e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-chassis-controllers/default.nix
+++ b/distros/noetic/rm-chassis-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-chassis-controllers";
-  version = "0.1.1-r1";
+  version = "0.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "50d4c3c45a996841a88993c09b2930abb9ecb4835e5700c6de3a15285bbfda16";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.1-3.tar.gz";
+    name = "0.1.1-3.tar.gz";
+    sha256 = "16227e980135c252864c7d9c68bb442b2d32b4edfde454863129eef2bb321539";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.7-r4";
+  version = "0.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.7-4.tar.gz";
-    name = "0.1.7-4.tar.gz";
-    sha256 = "724c458d1158afc7a0fd30d0c0f27eb69911e82448109eb4bbc50c3642b194a5";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.8-2.tar.gz";
+    name = "0.1.8-2.tar.gz";
+    sha256 = "2b22d278701759dfc20d8906a2b75f360d702cd954269ef160a5ed9e37c9819f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, rm-description, rm-gazebo, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.7-r4";
+  version = "0.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.7-4.tar.gz";
-    name = "0.1.7-4.tar.gz";
-    sha256 = "0605a9c780415c3c261d3a10eb8dc0c0bc4bbd6b36f022ab85a5b6e53dd627a7";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.8-2.tar.gz";
+    name = "0.1.8-2.tar.gz";
+    sha256 = "efd157dd7d795bcce650d6188ac05d2e50785d0388c59c75fde8c6cd927ae910";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-controllers/default.nix
+++ b/distros/noetic/rm-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-controller }:
 buildRosPackage {
   pname = "ros-noetic-rm-controllers";
-  version = "0.1.1-r1";
+  version = "0.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "3af46e86f087d38dbf5bffa07f8238d879e28cb19c1770418a55ce63dffafa27";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.1-3.tar.gz";
+    name = "0.1.1-3.tar.gz";
+    sha256 = "05554d86404cc251e581c2c2563028d7bd8c92e44ba8ca199de962db555ff462";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.7-r4";
+  version = "0.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.7-4.tar.gz";
-    name = "0.1.7-4.tar.gz";
-    sha256 = "dc79cce8a1986346bd9381483eb164b360fc0cbf61a528b85439955f04b059c7";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.8-2.tar.gz";
+    name = "0.1.8-2.tar.gz";
+    sha256 = "1c2609f762d77aeaff69d77b5116621e214ee111723b172b99b0efcf8dfbd7ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-description/default.nix
+++ b/distros/noetic/rm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rm-description";
-  version = "0.1.7-r4";
+  version = "0.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.7-4.tar.gz";
-    name = "0.1.7-4.tar.gz";
-    sha256 = "1470e78b4939ea96d15657aab38ad091b072978c8328b81d099e4135bf692c28";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.8-2.tar.gz";
+    name = "0.1.8-2.tar.gz";
+    sha256 = "17ba696169d8fe55c2d0b0fe844f5c6f8da2d2efd5c0bd6e0f134c7b12570a00";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.7-r4";
+  version = "0.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.7-4.tar.gz";
-    name = "0.1.7-4.tar.gz";
-    sha256 = "06254ba3055b0cfe93c9312ca0f3201d3be0bf8fcdb8190afea843d5fffc2d37";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.8-2.tar.gz";
+    name = "0.1.8-2.tar.gz";
+    sha256 = "a8087e4cbb3feb8f9183334e8189e31cfa282c38ecc3be80f221703020b3495b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gimbal-controllers/default.nix
+++ b/distros/noetic/rm-gimbal-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-gimbal-controllers";
-  version = "0.1.1-r1";
+  version = "0.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "1521aeb8e4342a29d996ee3c274be2c6c90fa0df7694cd4631f377d0f81b6862";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.1-3.tar.gz";
+    name = "0.1.1-3.tar.gz";
+    sha256 = "612b3f33a9fe4ae93d409f43337609d09909e0eb216ce1cc94f0316106b5cdb0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.7-r4";
+  version = "0.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.7-4.tar.gz";
-    name = "0.1.7-4.tar.gz";
-    sha256 = "30af91eafacbf2eba6f70205af82ed45c9715d10da9b6105fcc8bb30539f61f6";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.8-2.tar.gz";
+    name = "0.1.8-2.tar.gz";
+    sha256 = "174d644c0047c6a7a3a0dc21349907bff7001b3c2de8c5f5e71833726925a6c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.7-r4";
+  version = "0.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.7-4.tar.gz";
-    name = "0.1.7-4.tar.gz";
-    sha256 = "b6cca7c05179d2148fa9599e07aef3159b9ab61cb71f38d501f8ab89eda4c477";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.8-2.tar.gz";
+    name = "0.1.8-2.tar.gz";
+    sha256 = "48910b968e4135eec5de29d3ce421465cd099b83fb8d6a5cb3a0c86c3b4bc43e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-shooter-controllers/default.nix
+++ b/distros/noetic/rm-shooter-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-shooter-controllers";
-  version = "0.1.1-r1";
+  version = "0.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "5a4ebee8b376ae673159daa3915d8dc17736589773119caf52b21f4ee4c63526";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.1-3.tar.gz";
+    name = "0.1.1-3.tar.gz";
+    sha256 = "f296625424d061e81e3794479a6b76d8e857e67555f18990c64b65c7fb3796e9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-state-controller/default.nix
+++ b/distros/noetic/robot-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, kdl-parser, pluginlib, realtime-tools, rm-common, roscpp, roslint, tf2-kdl, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-controller";
-  version = "0.1.1-r1";
+  version = "0.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "75be7d9635cbd80a57c25984d65d2604dd0e6696aef7707e761bf07336b352b1";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.1-3.tar.gz";
+    name = "0.1.1-3.tar.gz";
+    sha256 = "141f326c9938e86964006050b4cf53b83e4377899a3851fb797ad105a160d9c7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-controllers-cartesian/default.nix
+++ b/distros/noetic/ros-controllers-cartesian/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers-cartesian";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "cc34329ae2086aa68679cf294f7d278139e7eee0043c1ce9af75172fba6f4372";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "c9809ea177dcb158ec15cd20bcd3d8de96a6d235db4b04baa825bf653e7dcf36";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.2.13-r1";
+  version = "0.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.13-1.tar.gz";
-    name = "0.2.13-1.tar.gz";
-    sha256 = "f056d28be03eb3ebe6407d7315bac975f73e5a0929c17fb6d925ffccae441d5b";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.14-1.tar.gz";
+    name = "0.2.14-1.tar.gz";
+    sha256 = "8c4388e495af822b2fb4da7c0cc7b2cf1e9031f03ae79bbc363b60976a46a6d0";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rqt-plot/default.nix
+++ b/distros/noetic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-plot";
-  version = "0.4.13-r1";
+  version = "0.4.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.13-1.tar.gz";
-    name = "0.4.13-1.tar.gz";
-    sha256 = "8507faa21362446af958f585d33f525dcc308af701462a4645fd07785bf8aa39";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.13-2.tar.gz";
+    name = "0.4.13-2.tar.gz";
+    sha256 = "f39e892b46c2c4997bababc291468d8da129d8d766a55a0875bf13ff6ffb98ce";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "8d10674d867b52f263e1042fd7ff2b884f41c2bf2113048b0126d73a1e32888b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "c426135ac700f623207b81edd8727548181c58585a422c22c24c543c8f2c717e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/snowbot-operating-system/default.nix
+++ b/distros/noetic/snowbot-operating-system/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, qt5, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-snowbot-operating-system";
+  version = "0.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/snowbot_release/archive/release/noetic/snowbot_operating_system/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "e8927e8d01db9f934bb23f1ccb99d19b0ff796bab8855ff23b8c643c0bf58e29";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib qt5.qtbase rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The weather outside is frightful'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sr-hand-detector/default.nix
+++ b/distros/noetic/sr-hand-detector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-sr-hand-detector";
-  version = "0.0.7-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "77712161a9eeaee8ef841518df0de85dbff230bf860fd466ce4c75580c0a2758";
+    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "385459fd4dab5b1d61eb25e3b609f0567501c9298d04db36ba3a65948ff637c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, libyamlcpp, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "283ba90bc45bdd323af151ed971a7eb20cc8ac95982cecff2010075f45df5031";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "73217c9e35b1f3cd3bf76335670f7e2d2b92bcd7b82df1e65a7a8121307f691c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-environment/default.nix
+++ b/distros/noetic/tesseract-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-kinematics, tesseract-scene-graph, tesseract-srdf, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-environment";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "3075ed89bacf4c76b7a8c3f7d40a3f2d68a779b75e4269731f748a28bba052b3";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "1279398792cdb278b3225a028960a68747aab10bdbe4d4cc961a8bb3819608d7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "97dfb6bd078b1cb002efc4b0f2a0ed91a07b55d3d64a6a819d0a982cb0062746";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "806405f99c8719c879b1b7c60944d9e73ed0670d323cbf73505f4252d7e0c374";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "2991b6926054b23146ce277b8aa6c115cc9d4fde52e4fba2a6779cfca249858f";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "e119de3d804b70bfd710faeca7e4db98b094dc2fa50c2b2f15ec00d3877ab6ad";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "333961f0293197e3398b419c2fe4c76d04f403f8d3ed8e0efc68225b7e7d6eb2";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "34719e15d2dd3605803e6903c39c97b2b9e500725e0670e78f2603b2dbe4c244";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "5b8b2f7f645621c1fc86087126116fb864ec34e8c6ddb830b3458de7ca240b23";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "741fab96e27ab3d056bf250e5f3b77b61cb32762405310b5016e16f9462fdd0b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-state-solver/default.nix
+++ b/distros/noetic/tesseract-state-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-state-solver";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "27968bce59931eb14d6a3f211f6f1a23a53ef7ac0e0f9c6638ffac275e7a29ba";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "16475414eb53d97280a5a2d6eb06581788087b8c636b0ac4c6beb96452a05e1a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "6d8bef275328f75d6e140e9bf0e321559e20449c77e1bdcd46336ca95ebad48a";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "c65f97879f060844ddaf1c768083fad7429acc599782be318e2f4625dcec61ff";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "1e938ba32bfd73bb522d9ea240ff916af6bd08b29a0306e8afaa7246639b8bd9";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "33e347b263d85b400cbd20b06c213bd18ff2bd4c4b18b53e55eef4a9d956d5d3";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.6.7-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "bc7c09853547e90a0e4172a0bd771fa9433e202da4630d35fcdabede4930b68e";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "ce8a56353bf1f3f1875f9efcea54b74468d4ce9d32975f0f4df078b6bd0e13ae";
   };
 
   buildType = "cmake";

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.10.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "a961f3b15cbfc65ff730d7988cc38a37fc668d78c6b92906acdd184bae9b7c23";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "10c551484338db7cf466ad44882489a4e5b578a34d7821c46d2292c7e00c245d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "563117122ca176944a8bdaaf8990585a232b6f356923d2a855cbb39f6399b679";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "53c22fdd38d49e9c36e83fc7c7e8b2b16e421122ea6653d947a58d33cb047631";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "3a4cf80d972cf0f716ef2db3ce5850ad0189b871b3c30e2b1a19b239ddaea6f9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "ecb6b520f3065d02b71e9f9b2164e6886c9999aa92c49277fcb8ed62bcb35bc9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/twist-controller/default.nix
+++ b/distros/noetic/twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-twist-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "9227c502123d4538f51ec94536fe189daf1de5ab3cbf8ccde044c242238f181a";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "1ce2d703821975d1535d64e9e5c182991f4e004fa5ebca3613468eb1521c3494";
   };
 
   buildType = "catkin";

--- a/distros/noetic/xsens-mti-driver/default.nix
+++ b/distros/noetic/xsens-mti-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-xsens-mti-driver";
+  version = "0.2021.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/xsens_mti_driver-release/archive/release/noetic/xsens_mti_driver/0.2021.4-1.tar.gz";
+    name = "0.2021.4-1.tar.gz";
+    sha256 = "841720213947785b0b411b43b9c18967ccdc93b25db700ee22a95a3a89053d84";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs std-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS driver for Xsens MTi IMU sensors'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 5716ca06c15488af795fcbae9c530e201585cd4a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *bno055 0.1.1-r3 --> 0.2.0-r1*
* *can-dbc-parser 1.1.1-r1 --> 1.2.0-r1*
* *libmavconn 2.0.4-r1 --> 2.0.5-r1*
* *mavros 2.0.4-r1 --> 2.0.5-r1*
* *mavros-extras 2.0.4-r1 --> 2.0.5-r1*
* *mavros-msgs 2.0.4-r1 --> 2.0.5-r1*
* *microstrain-inertial-driver 2.1.0-r1 --> 2.2.0-r1*
* *microstrain-inertial-examples 2.1.0-r1 --> 2.2.0-r1*
* *microstrain-inertial-msgs 2.1.0-r1 --> 2.2.0-r1*
* *mrt-cmake-modules 1.0.8-r1 --> 1.0.9-r1*
* *osqp-vendor 0.0.3-r2 --> 0.0.4-r1*
* *ouxt-common 0.0.8-r2*
* *ouxt-lint-common 0.0.8-r2*
* *psen-scan-v2 0.20.0-r1*
* *raptor-dbw-can 1.1.1-r1 --> 1.2.0-r1*
* *raptor-dbw-joystick 1.1.1-r1 --> 1.2.0-r1*
* *raptor-dbw-msgs 1.1.1-r1 --> 1.2.0-r1*
* *raptor-pdu 1.1.1-r1 --> 1.2.0-r1*
* *raptor-pdu-msgs 1.1.1-r1 --> 1.2.0-r1*
* *rmf-building-sim-common 1.3.0-r1 --> 1.3.1-r1*
* *rmf-building-sim-gazebo-plugins 1.3.0-r1 --> 1.3.1-r1*
* *rmf-demos 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-assets 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-dashboard-resources 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-gz 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-maps 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-tasks 1.3.1-r1 --> 1.3.2-r1*
* *rmf-robot-sim-common 1.3.0-r1 --> 1.3.1-r1*
* *rmf-robot-sim-gazebo-plugins 1.3.0-r1 --> 1.3.1-r1*
* *rosapi 1.1.0-r1 --> 1.1.1-r2*
* *rosapi-msgs 1.1.0-r1 --> 1.1.1-r2*
* *rosbridge-library 1.1.0-r1 --> 1.1.1-r2*
* *rosbridge-msgs 1.1.0-r1 --> 1.1.1-r2*
* *rosbridge-server 1.1.0-r1 --> 1.1.1-r2*
* *rosbridge-suite 1.1.0-r1 --> 1.1.1-r2*
* *rosbridge-test-msgs 1.1.0-r1 --> 1.1.1-r2*
* *urdf-tutorial 1.0.0-r1*

Galactic Changes:
-----------------
* *bno055 0.1.1-r2 --> 0.2.0-r1*
* *domain-bridge 0.4.0-r1 --> 0.4.0-r2*
* *gazebo-ros2-control 0.0.6-r1 --> 0.0.7-r1*
* *gazebo-ros2-control-demos 0.0.6-r1 --> 0.0.7-r1*
* *grbl-ros 0.0.15-r2 --> 0.0.16-r1*
* *libmavconn 2.0.4-r1 --> 2.0.5-r1*
* *lua-vendor 0.0.2-r1*
* *mavros 2.0.4-r1 --> 2.0.5-r1*
* *mavros-extras 2.0.4-r1 --> 2.0.5-r1*
* *mavros-msgs 2.0.4-r1 --> 2.0.5-r1*
* *microstrain-inertial-driver 2.1.0-r1 --> 2.2.0-r1*
* *microstrain-inertial-examples 2.1.0-r1 --> 2.2.0-r1*
* *microstrain-inertial-msgs 2.1.0-r1 --> 2.2.0-r1*
* *mrt-cmake-modules 1.0.8-r3 --> 1.0.9-r1*
* *nonpersistent-voxel-layer 2.2.2-r1*
* *ntrip-client 1.0.0-r1*
* *osqp-vendor 0.0.3-r1 --> 0.0.4-r1*
* *ouxt-common 0.0.8-r1*
* *ouxt-lint-common 0.0.8-r1*
* *python-qt-binding 1.0.7-r2 --> 1.0.8-r1*
* *rmf-building-sim-common 1.3.0-r1 --> 1.3.1-r1*
* *rmf-building-sim-gazebo-plugins 1.3.0-r1 --> 1.3.1-r1*
* *rmf-demos 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-assets 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-dashboard-resources 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-gz 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-maps 1.3.1-r1 --> 1.3.2-r1*
* *rmf-demos-tasks 1.3.1-r1 --> 1.3.2-r1*
* *rmf-robot-sim-common 1.3.0-r1 --> 1.3.1-r1*
* *rmf-robot-sim-gazebo-plugins 1.3.0-r1 --> 1.3.1-r1*
* *robot-state-publisher 2.5.1-r1 --> 2.5.2-r1*
* *rosapi 1.1.0-r1 --> 1.1.1-r1*
* *rosapi-msgs 1.1.0-r1 --> 1.1.1-r1*
* *rosbridge-library 1.1.0-r1 --> 1.1.1-r1*
* *rosbridge-msgs 1.1.0-r1 --> 1.1.1-r1*
* *rosbridge-server 1.1.0-r1 --> 1.1.1-r1*
* *rosbridge-suite 1.1.0-r1 --> 1.1.1-r1*
* *rosbridge-test-msgs 1.1.0-r1 --> 1.1.1-r1*
* *snowbot-operating-system 0.1.0-r1 --> 0.1.1-r1*
* *tango-icons-vendor 0.1.0-r2 --> 0.1.0-r3*
* *twist-mux 4.1.0-r1*
* *urdf-tutorial 1.0.0-r1*
* *yaml-cpp-vendor 7.1.0-r2 --> 7.1.1-r1*

Melodic Changes:
----------------
* *avt-vimba-camera 0.0.12-r1 --> 1.0.0-r1*
* *cartesian-interface 0.1.4-r1 --> 0.1.5-r1*
* *cartesian-trajectory-controller 0.1.4-r1 --> 0.1.5-r1*
* *cartesian-trajectory-interpolation 0.1.4-r1 --> 0.1.5-r1*
* *costmap-cspace 0.11.2-r1 --> 0.11.3-r1*
* *inorbit-republisher 0.2.1-r1 --> 0.2.2-r1*
* *joystick-interrupt 0.11.2-r1 --> 0.11.3-r1*
* *libmavconn 1.10.0-r1 --> 1.12.1-r1*
* *map-organizer 0.11.2-r1 --> 0.11.3-r1*
* *mavros 1.10.0-r1 --> 1.12.1-r1*
* *mavros-extras 1.10.0-r1 --> 1.12.1-r1*
* *mavros-msgs 1.10.0-r1 --> 1.12.1-r1*
* *microstrain-inertial-driver 2.1.0-r1 --> 2.2.1-r1*
* *microstrain-inertial-examples 2.1.0-r1 --> 2.2.1-r1*
* *microstrain-inertial-msgs 2.1.0-r1 --> 2.2.1-r1*
* *neonavigation 0.11.2-r1 --> 0.11.3-r1*
* *neonavigation-common 0.11.2-r1 --> 0.11.3-r1*
* *neonavigation-launch 0.11.2-r1 --> 0.11.3-r1*
* *obj-to-pointcloud 0.11.2-r1 --> 0.11.3-r1*
* *opw-kinematics 0.4.4-r1*
* *planner-cspace 0.11.2-r1 --> 0.11.3-r1*
* *ros-controllers-cartesian 0.1.4-r1 --> 0.1.5-r1*
* *ros-industrial-cmake-boilerplate 0.2.14-r2*
* *safety-limiter 0.11.2-r1 --> 0.11.3-r1*
* *snowbot-operating-system 0.0.1-r1 --> 0.0.2-r1*
* *test-mavros 1.10.0-r1 --> 1.12.1-r1*
* *track-odometry 0.11.2-r1 --> 0.11.3-r1*
* *trajectory-tracker 0.11.2-r1 --> 0.11.3-r1*
* *twist-controller 0.1.4-r1 --> 0.1.5-r1*

Noetic Changes:
---------------
* *avt-vimba-camera 0.0.12-r2 --> 1.0.0-r1*
* *cartesian-interface 0.1.4-r1 --> 0.1.5-r1*
* *cartesian-trajectory-controller 0.1.4-r1 --> 0.1.5-r1*
* *cartesian-trajectory-interpolation 0.1.4-r1 --> 0.1.5-r1*
* *cnpy 0.0.6-r1 --> 0.0.7-r3*
* *costmap-cspace 0.11.2-r1 --> 0.11.3-r1*
* *inorbit-republisher 0.2.1-r1 --> 0.2.2-r1*
* *joystick-interrupt 0.11.2-r1 --> 0.11.3-r1*
* *jskeus 1.2.5-r1*
* *leo 1.2.2-r1 --> 2.0.0-r1*
* *leo-description 1.2.2-r1 --> 2.0.0-r1*
* *leo-msgs 2.0.0-r1*
* *leo-teleop 1.2.2-r1 --> 2.0.0-r1*
* *libmavconn 1.10.0-r1 --> 1.12.1-r1*
* *map-organizer 0.11.2-r1 --> 0.11.3-r1*
* *mavros 1.10.0-r1 --> 1.12.1-r1*
* *mavros-extras 1.10.0-r1 --> 1.12.1-r1*
* *mavros-msgs 1.10.0-r1 --> 1.12.1-r1*
* *microstrain-inertial-driver 2.1.0-r1 --> 2.2.1-r1*
* *microstrain-inertial-examples 2.1.0-r1 --> 2.2.1-r1*
* *microstrain-inertial-msgs 2.1.0-r1 --> 2.2.1-r1*
* *nav2d 0.4.3-r1*
* *nav2d-exploration 0.4.3-r1*
* *nav2d-karto 0.4.3-r1*
* *nav2d-localizer 0.4.3-r1*
* *nav2d-msgs 0.4.3-r1*
* *nav2d-navigator 0.4.3-r1*
* *nav2d-operator 0.4.3-r1*
* *nav2d-remote 0.4.3-r1*
* *nav2d-tutorials 0.4.3-r1*
* *neonavigation 0.11.2-r1 --> 0.11.3-r1*
* *neonavigation-common 0.11.2-r1 --> 0.11.3-r1*
* *neonavigation-launch 0.11.2-r1 --> 0.11.3-r1*
* *ntrip-client 1.0.0-r1*
* *obj-to-pointcloud 0.11.2-r1 --> 0.11.3-r1*
* *planner-cspace 0.11.2-r1 --> 0.11.3-r1*
* *qwt-dependency 1.1.1-r1 --> 1.1.1-r2*
* *rm-calibration-controllers 0.1.1-r1 --> 0.1.1-r3*
* *rm-chassis-controllers 0.1.1-r1 --> 0.1.1-r3*
* *rm-common 0.1.7-r4 --> 0.1.8-r2*
* *rm-control 0.1.7-r4 --> 0.1.8-r2*
* *rm-controllers 0.1.1-r1 --> 0.1.1-r3*
* *rm-dbus 0.1.7-r4 --> 0.1.8-r2*
* *rm-description 0.1.7-r4 --> 0.1.8-r2*
* *rm-gazebo 0.1.7-r4 --> 0.1.8-r2*
* *rm-gimbal-controllers 0.1.1-r1 --> 0.1.1-r3*
* *rm-hw 0.1.7-r4 --> 0.1.8-r2*
* *rm-msgs 0.1.7-r4 --> 0.1.8-r2*
* *rm-shooter-controllers 0.1.1-r1 --> 0.1.1-r3*
* *robot-state-controller 0.1.1-r1 --> 0.1.1-r3*
* *ros-controllers-cartesian 0.1.4-r1 --> 0.1.5-r1*
* *ros-industrial-cmake-boilerplate 0.2.13-r1 --> 0.2.14-r1*
* *rqt-plot 0.4.13-r1 --> 0.4.13-r2*
* *safety-limiter 0.11.2-r1 --> 0.11.3-r1*
* *snowbot-operating-system 0.0.5-r1*
* *sr-hand-detector 0.0.7-r1 --> 0.0.8-r1*
* *tesseract-common 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-environment 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-geometry 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-kinematics 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-scene-graph 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-srdf 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-state-solver 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-support 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-urdf 0.6.7-r1 --> 0.6.9-r1*
* *tesseract-visualization 0.6.7-r1 --> 0.6.9-r1*
* *test-mavros 1.10.0-r1 --> 1.12.1-r1*
* *track-odometry 0.11.2-r1 --> 0.11.3-r1*
* *trajectory-tracker 0.11.2-r1 --> 0.11.3-r1*
* *twist-controller 0.1.4-r1 --> 0.1.5-r1*
* *xsens-mti-driver 0.2021.4-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] roseus
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

