### PR TITLE
rosdistro sync, Fri Dec 24 13:06:19 2021

### DIFF
--- a/distros/foxy/apex-test-tools/default.nix
+++ b/distros/foxy/apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/foxy/apex_test_tools/0.0.2-1/apex_test_tools-release-release-foxy-apex_test_tools-0.0.2-1.tar.gz";
     name = "apex_test_tools-release-release-foxy-apex_test_tools-0.0.2-1.tar.gz";
-    sha256 = "892bad4ede47e5e159b2d8ced4a6381f116176ecc5469783003c5cdf350ed661";
+    sha256 = "5397b4f6725e6f7a8ade5832dd802bbe9b9506fa69f2ab7402c6ebb840c3a260";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "9c0917f474b30a4ccf030e893c9ab545df2bd84ccdaee9d59303fa16edf9f57c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "d684bf9f752a2bb6883634da7b42a5998f7bdeb059ad94303c374b6e6bb02e93";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "31ceda0aa15c3307c7224c0b73d493725d8e80f3d7dc642a6965d0ba3270adfb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f31fd09f6cbb418bb79d5045a96778c57a01d1779803d858571c2c285dbbd49a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "ce30b80b22a9c7ae38545ab826c51cb6e0d9aff52c5498005c0ea72fdac32127";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f4416d7723aa175d4a44c92eb6c5431a016cf9ab8ea981076d6c075ffe04afcd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.5.0-1.tar.gz";
     name = "2.5.0-1.tar.gz";
-    sha256 = "003a4af776f2fc24b0b26badf132debcb2d3bced66d26afe87b3ff334302207b";
+    sha256 = "f0a68dd33a86dcaefdea50269f6153d84bde5d8d14a1f1333be4fafa644158d4";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -1488,6 +1488,8 @@ self: super: {
 
  soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
 
+ sol-vendor = self.callPackage ./sol-vendor {};
+
  sophus = self.callPackage ./sophus {};
 
  spacenav = self.callPackage ./spacenav {};

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "df8645db8b63409e18c84b88cde8dbfd258d9e2a73bb9001fa16d0a3db5a7b05";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "091c6826f0fd87b6986a1076f7bbbcb9d9c268d03d7b3dae1f2f3abfdbe906c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "f684378cd33a456d8e5ae016529466bc995ae3e972a23c61e8eb63b2fddc9aa3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "600de705069247b9cfa29478740332d2c8e7aae411d056911e1e6b6a855fb731";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "5bcdcbd23030d7117b3a1b1743104cac324c3d296e23a4ac486a28a267d1d14a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "eb49f25eebd4ec1c6f802382986281b51b4e4776232e08ecaca1d94978667802";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "182f29a6830a99f947dadd6b9db5bf7067f6b0ad264d25b65aeb9b4edd6b6bca";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "b7eb5cfd64b6d4d5012fc06cb66057b98a3eff525775e38c0eefe721e848d7c1";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/sol-vendor/default.nix
+++ b/distros/foxy/sol-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ouxt-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-sol-vendor";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/sol_vendor-release/archive/release/foxy/sol_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "f609b6a2ebf599844df510d6ead990bb5558090ae7bc2335f7ef75874ecad8fb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''vendor package for the sol2 library'';
+    license = with lib.licenses; [ asl20 mit ];
+  };
+}

--- a/distros/foxy/test-apex-test-tools/default.nix
+++ b/distros/foxy/test-apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/foxy/test_apex_test_tools/0.0.2-1/apex_test_tools-release-release-foxy-test_apex_test_tools-0.0.2-1.tar.gz";
     name = "apex_test_tools-release-release-foxy-test_apex_test_tools-0.0.2-1.tar.gz";
-    sha256 = "8f2a8281836a6ef61d778b7196cd77998aa4557285574064931e62e925832e5e";
+    sha256 = "275623d9706e2f131b95b40c5f3b082069078ece9a0bb76f2dfc3e4359cf763d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "1dd96a196c859a7f5d569e4e7e35f12772c0f46d8596db13401ef33d23334a03";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c5c65fc11729d718ff5610ba59f3317cb5c361adb5f284ab0db3a966938d1afa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-controller-interface";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "856352ede3a21bd1d609325eda685b006c6331127d7432c6d2e11b6e24a3b51b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8f8b7021de671ee198237708741f11d49e12e5ca680a1903e5f5ae4f499076d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "3b5bf8482a9e76a2365ac1b29f21a9b5d10225d1c9e8a8de22552feadfbc9344";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0848bb9a09dda6a50a834efff91a535c508719a369f6bd957e58300bc5f2552a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "eb12ca098efd1f2995759918c04d69455d0db70fe386ec8715e3e07ed3329427";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "12272b014df400223ef58491776cdcce9b098d31934679b653a873691d3a5e0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/costmap-queue/default.nix
+++ b/distros/galactic/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-costmap-queue";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "541ae20b1549cb36446773cab3fb74907e15ce17c11abb7c6e610a40f0631642";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4d18e6206e45a4d6a9e21d5abe63e9d246728c250fc58d6f9ba89a7980f664a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-core/default.nix
+++ b/distros/galactic/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-core";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "126b11f8178c1987b23a67c688cfba61885f27985f2f857ec95a1b8bde867c17";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "343c56ea4a20d6ade91653f66d6938417d7130e96c4aaec6e9d31d03efdf7506";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-critics/default.nix
+++ b/distros/galactic/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-critics";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1afa333d2286986bc6b1084c1c8038057cd2e118b90869bc853d156b8b71510f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "cb8cbe611191ffb5bfcd1252fc3b075af80751ab740066d0b77dc2771b540bdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-msgs/default.nix
+++ b/distros/galactic/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a487aff5fc8384321db9591a01f5008906e24aa9c5e7e6abc598eb785b97cc66";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f7041cbe2aee081532271dbc3e3f98c4dec1d31f095634ed8a60a60275eed764";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-plugins/default.nix
+++ b/distros/galactic/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-dwb-plugins";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "9ce9f687b15e3ed482928a353c01be0cbd16a132eb03a9350e24d621d8becc97";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ef559f61041b39fb6874608286144f43dc9871fd3bd59f53e294236ef250e827";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -560,6 +560,8 @@ self: super: {
 
  microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
 
+ microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
+
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
@@ -666,6 +668,8 @@ self: super: {
 
  nav2-regulated-pure-pursuit-controller = self.callPackage ./nav2-regulated-pure-pursuit-controller {};
 
+ nav2-rotation-shim-controller = self.callPackage ./nav2-rotation-shim-controller {};
+
  nav2-rviz-plugins = self.callPackage ./nav2-rviz-plugins {};
 
  nav2-simple-commander = self.callPackage ./nav2-simple-commander {};
@@ -709,6 +713,8 @@ self: super: {
  octomap = self.callPackage ./octomap {};
 
  octomap-msgs = self.callPackage ./octomap-msgs {};
+
+ octomap-ros = self.callPackage ./octomap-ros {};
 
  octovis = self.callPackage ./octovis {};
 
@@ -1286,6 +1292,10 @@ self: super: {
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
 
+ sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};
+
+ sick-safetyscanners-base = self.callPackage ./sick-safetyscanners-base {};
+
  simple-launch = self.callPackage ./simple-launch {};
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
@@ -1301,6 +1311,8 @@ self: super: {
  soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
  soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+
+ sol-vendor = self.callPackage ./sol-vendor {};
 
  spacenav = self.callPackage ./spacenav {};
 

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-galactic-hardware-interface";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "175ab31444041670e4ae1e6247d65bc6a310e26855d88b553737498b5c32fe46";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "4f6f8024adf7e7e86fc20ab30e7470e4346408eeb2c0a9541dedf7c22d9d2289";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-driver";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6a86484b20dc12bebb29ca18109420808704b3c0156bdefebe12c273537a75d5";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e68005a93770f9ba7eb98784daa2440dfccc6228a6c9370f60425283c3a63162";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-examples";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e3c79a6503fd1a55d323666f82b7849e6db290314e53be81b5319979a1d282b9";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "b986b25b816fe368624f934b1ff5268b2e98663d5565e4680e0c41bc2906428e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-msgs";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "f38ad19922b33586f5be9162b3752b3065733a99146b67948ffbc7fc5a3e7053";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "30a60df04baf0849c3ea67a07f59986b17394d302269487faf0aa7800ff869fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-rqt/default.nix
+++ b/distros/galactic/microstrain-inertial-rqt/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-microstrain-inertial-rqt";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_rqt/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ea6d19111e06227515075a9c0cba6d227ef91fc98e59918389e896c69faeae33";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs microstrain-inertial-msgs nav-msgs rclpy rqt-gui rqt-gui-py std-msgs ];
+
+  meta = {
+    description = ''The microstrain_inertial_rqt package provides several RQT widgets to view the status of Microstrain devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/nav-2d-msgs/default.nix
+++ b/distros/galactic/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "44f80572c68d54931e0d7835188492d91fd43a1f545d820de4bca9dab5888b98";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "05f16cab1259272e2deee134ea2f639f1551120237c9be5a9a653be798cc7433";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav-2d-utils/default.nix
+++ b/distros/galactic/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-utils";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "64212975a2c4fbfcbe253af5f01f1b8043a09e31f08d89290e5739705b4ae5dc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a116ec232c5e0e402a458826b6141a75fd918def35f914486b1bf425848c587c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-amcl/default.nix
+++ b/distros/galactic/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-amcl";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "470fd987afb8b7b89a6b7436bd100d77cdb17006e6410352aead9356bd38739f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "52741f51ccf7df564b0eb37b8be6e7e8b2d8ee16337c466d6c475cb294fb4306";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-behavior-tree/default.nix
+++ b/distros/galactic/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-behavior-tree";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "62aa89bbc15158d35afb0e48ae4d6fdad8ac0f9812e4c65b6ff107ea67a9c81f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "571eba2c3c71418b8f3c2362f21f37ed751517f6a957acd3a6882ffa59bca6df";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bringup/default.nix
+++ b/distros/galactic/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bringup";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "45ea86c7df2e10aa08fdc0cae49e093ea569958c2c644adafec98f5fffd39f89";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f7bfdc6242b6123e94b59ff0d0a2024cfaa24b1f46abc6cac16e7a9232b0f92c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bt-navigator/default.nix
+++ b/distros/galactic/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bt-navigator";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a0c8b12aa92bdbd37b4863bda080e56d2bbbd024b1708962699f455e0c6ea035";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3921f6bcaf09c4543955b3cbef3e67b8d0dc6b4dabb19ef69d9b05722c55184d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-common/default.nix
+++ b/distros/galactic/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-common";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b5c7e4a0a0758adaa79f0b372f73e752a200696149754002345493f8aa71d862";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b06f687cd1bba43ad3fb3dd6f8d919ba6b75dde126a4d280189ecd6b6f9a4c34";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-controller/default.nix
+++ b/distros/galactic/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-controller";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1219e279144466db73c7b1d877a358ce2221a9d417ce980ff9db8927c70be83c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "bb1ce4164d7fbf65f728abb669428af1b9684670f71b4a38e213fbd490dc2b8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-core/default.nix
+++ b/distros/galactic/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-core";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a2fa6012aa27251b3e5ab98b7d17f0a25058501126252af3173d74885fbf0ef2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8d6bfad443f6f8600747d8ff0a719293f4f4b23974b27f1002c1770e80bab929";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-costmap-2d/default.nix
+++ b/distros/galactic/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-costmap-2d";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "918e7b8f803013a38f38f7c6405c9765ba38c1493258c6429c8a30e511543a61";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "dc26b6e385625b8cf9b41847398e099c6776ff2a5f49d933c481f0548cec0ccb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-dwb-controller/default.nix
+++ b/distros/galactic/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-galactic-nav2-dwb-controller";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b3e7e1518928747c71e19c97d9696cdfc9d825b505d5d2d5f3f2b130b681126c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9ae330b3f9fbcb7f0fbf60151c48937204eb17b1d774e4b17fa34ce32b7a9879";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-gazebo-spawner/default.nix
+++ b/distros/galactic/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-gazebo-spawner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "d57c036d486adaa41ab7fa70b23850b543a83ea222a07ecadc3e7d4b09a23651";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c39156475df3d313df0e07e2b207f97d3a25eb3a44e641a7c46c07d6f2c6f919";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-lifecycle-manager/default.nix
+++ b/distros/galactic/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-lifecycle-manager";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "43201d9dc1735125a9e9f4a62357c59b0b2c6bed60d6c90ef7270fc3617b3ed3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0678d785879f8fed41038e525678308bc512fc4ab32dc18b694e9b56e57e86b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-map-server/default.nix
+++ b/distros/galactic/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-nav2-map-server";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "75b188e55038a73ab14bf294cbb5e4f404f323380375c8677468a7eee1baf697";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "597d13449dd14ffddc7c499fd9f8c524094de21a35c35d0434c208033d5130bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-msgs/default.nix
+++ b/distros/galactic/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b48a600d1567b77d40ec9e7fe14b79a863d3fb1bd0f2f462dc43667301228dce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "83eb817059d99b723f7838f3336351a7a48ef52a6f065f18b207afa8de506b17";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-navfn-planner/default.nix
+++ b/distros/galactic/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-navfn-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "32918500a35865d53cd5bec273debe6dd03b0c9e71ac4939028d5ee23400d8e5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "48e09a42db2c35079a21fc89bb87e5b0a8cf181c87469846a4b3ade07d5e756f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-planner/default.nix
+++ b/distros/galactic/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "824b39d8bc34e535b701d81f0ac2d4e1a92e8760886f3de26b9531995f52a2ce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "2a3602549d958381fe64d9cab965f7ff28db872af7bcd8df8853e38c8628d6de";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-recoveries/default.nix
+++ b/distros/galactic/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-recoveries";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0b02b1847728ee9b1a328eaa406be05c23b311502f5c562af7b219cda9ad848b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "caef9dee9228b16182fdb604dd12a51b255bfdfa5c0491985749cce533d86b49";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-regulated-pure-pursuit-controller";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "ba19334ad711048d27988e12b886ac3526e0c4940f5a3c5dbbbfab52cd790ea4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f13615c9eb011d4cb1cf6007b4898f9564ce6e214f039a96ff51a09922820d77";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rotation-shim-controller/default.nix
+++ b/distros/galactic/nav2-rotation-shim-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-nav2-rotation-shim-controller";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "852e2a3e117b6ef70ed2b4bdb958db5a4a308f0de6bf9e14989098cfb8bcba7e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common nav2-controller nav2-regulated-pure-pursuit-controller ];
+  propagatedBuildInputs = [ angles geometry-msgs nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Rotation Shim Controller'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/nav2-rviz-plugins/default.nix
+++ b/distros/galactic/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rviz-plugins";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "d876f89a392f9199520a05b4a553170af808eaddfab397235ad07ebc6cb5f457";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6a3dcbb3d8e77bbdf9fdb7336c3fe0eef9c1c9f3c8ec1012ae9343105615c197";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-simple-commander/default.nix
+++ b/distros/galactic/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-simple-commander";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "fc153e56e98c556ac57bebbb07faaba3deef55741b8ad98c24d51285a01c8922";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "24c57bae60bfd30dceb62f3685eba2b29c23da4120b4aa004bd52e16b145587b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-smac-planner/default.nix
+++ b/distros/galactic/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-smac-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "99b7144f9e96d9f26a64f61c423960ffeb6655e739c209fb0f2a37ea8d115954";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8ee8003ac342a71d0cc4c6b86afc3dfb262ad7ba278096cd54afb6ce7c6db528";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-system-tests/default.nix
+++ b/distros/galactic/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-system-tests";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "af0e973d832ccf43758ad631fb048e535bdf7736b9b51360272f20bf6d55bc49";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "5525c11d8458084fcfa2c0cdaec2075afd3a10c5480b480faee95d84827bc21a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-theta-star-planner/default.nix
+++ b/distros/galactic/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-theta-star-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b691123c9d585d659206bc14356080707d22cbe66fadc8c2054048222170eed5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "eba62b8571927c432c441a86f39c42ea2eaa610af486a6a267458defe8169795";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-util/default.nix
+++ b/distros/galactic/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-util";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b1df4faec8bd0bf43b78c51324bcb8d85a802d71e93f69df2aa26c91cd46e315";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a6c599717e569696086a85db0d59d4201a2a680d3005cd422590f759eaa0fd07";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-voxel-grid/default.nix
+++ b/distros/galactic/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nav2-voxel-grid";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "3bf9e8b9007143d784c20929e1bd706865b6d6002ce22ff872973d96e0d0a20f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b07a8b6dab8bdd9bd3583cb703299564623f17285fad51cf282660b5b6a14298";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-waypoint-follower/default.nix
+++ b/distros/galactic/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-waypoint-follower";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5deddbaa934c323eadf05f72b6e2af5ef5d1a34f5f091cd5c43324d83563e5ae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4946626f3049ac302bb685978dfcdff6f45d0784d8d86be5efd0a61eed4ac4c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/navigation2/default.nix
+++ b/distros/galactic/navigation2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-galactic-navigation2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "dd1ac8a8552b178c3fbb83da9f49cabf9a7e48e5ea2cbd9c1f10852200f1ee67";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0debc66cb77c39a716184bc4b44cf824133e181bb6ea73b243a62f2dd9e8eb29";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-regulated-pure-pursuit-controller nav2-rviz-plugins nav2-smac-planner nav2-util nav2-voxel-grid nav2-waypoint-follower ];
+  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-regulated-pure-pursuit-controller nav2-rotation-shim-controller nav2-rviz-plugins nav2-smac-planner nav2-util nav2-voxel-grid nav2-waypoint-follower ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/octomap-ros/default.nix
+++ b/distros/galactic/octomap-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-octomap-ros";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/galactic/octomap_ros/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "8c4842e8369ac1c1fcc29d4347724c4630a219df1b76d3ec1e56de28757225b7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ octomap octomap-msgs sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''octomap_ros provides conversion functions between ROS and OctoMap's native types.
+    This enables a convenvient use of the octomap package in ROS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rmw-cyclonedds-cpp/default.nix
+++ b/distros/galactic/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rmw-cyclonedds-cpp";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "2fc03f09537ea23892b56d173f50b10728f057ae6b56cccbd13848e253c89d6e";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "f86f6503f2b9cb5bac39e1582afd46867521eef1ca9266f4944922ba69c8d207";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control-test-assets";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "71cbb3533b3a9876e488871e9acb2120ef4ee5b506b09db8131bf53359e7fd05";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "d69ccc2ff88c42f88e3338efe9d139183592bcd61a5105bc11af222a3c037784";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "537000c224e9bd7e777d544be7be999a246d43f617b94e0d0577f2b5bbe55e8e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7350186da2c823a4950e143b0800c8a3c7f6cb3495c4344270bb26cdb2ae1d9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-galactic-ros2controlcli";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "8f132b92e674ec1003f95fca10501f023fa51ce3a2e07b1809a21787dc0058fb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "31fa4dbf44a46ea0d1535a4ca86b3c33d4ad3374af24031055881d52a40d6ee6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/sick-safetyscanners-base/default.nix
+++ b/distros/galactic/sick-safetyscanners-base/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake }:
+buildRosPackage {
+  pname = "ros-galactic-sick-safetyscanners-base";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/galactic/sick_safetyscanners_base/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cb34ad712a00f433ad3307ea7c1cc09621a41501fd99f6ee89b042809edda8d3";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Provides an Interface to read the sensor output of a SICK
+  Safety Scanner'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/galactic/sick-safetyscanners2-interfaces/default.nix
+++ b/distros/galactic/sick-safetyscanners2-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-sick-safetyscanners2-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners2_interfaces-release/archive/release/galactic/sick_safetyscanners2_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "745e3a59706875ad05ddb1dcb835e24bca73c9fd5831ee08030cd662c2da11bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces for the sick_safetyscanners ros2 driver'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/galactic/sol-vendor/default.nix
+++ b/distros/galactic/sol-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ouxt-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-sol-vendor";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/sol_vendor-release/archive/release/galactic/sol_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "99769c78a3822a4f526d248b6c9dd58a2194b0d7649c31d854f6c60a738ea92c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''vendor package for the sol2 library'';
+    license = with lib.licenses; [ asl20 mit ];
+  };
+}

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-galactic-transmission-interface";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6fe17a028b83308eb08eaf5314b0477685c4f7c7d013498940ed4908a3aeb3d0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "3a24d8b87edc6b3acc0f2480628bed0377d44b8b871a2affd5624786b669061c";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/hpp-fcl/default.nix
+++ b/distros/melodic/hpp-fcl/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/1.0.1-2.tar.gz";
     name = "1.0.1-2.tar.gz";
-    sha256 = "f6c9669e0b2cf9cbc04bfc89014ae8a82b0895e65eec29d65ca557ca6d375a41";
+    sha256 = "2fdf0400d19ccdc82b6788b4715d5adf11af7e3159f8cd87f5a401ddd3fb53f5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/octomap-rviz-plugins/default.nix
+++ b/distros/melodic/octomap-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap, octomap-msgs, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-melodic-octomap-rviz-plugins";
-  version = "0.2.2-r1";
+  version = "0.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_rviz_plugins-release/archive/release/melodic/octomap_rviz_plugins/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d1b11e67430f976ea17a6899ec116266d7b62f8e62fa579b67eb8393b72d1695";
+    url = "https://github.com/ros-gbp/octomap_rviz_plugins-release/archive/release/melodic/octomap_rviz_plugins/0.2.4-2.tar.gz";
+    name = "0.2.4-2.tar.gz";
+    sha256 = "8f5bf0f81a1734bd921fbb238890d39f32aad30f614d6b7437a42715ff8cb1b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, fmt, geometry-msgs, message-generation, message-runtime, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, std-msgs, tinyxml-2, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "62d1cebbdde80171d4f859e4b9687390713bca5871ef3fdce9e4ab3481a20780";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "cb910c6f597bbbdaad4527f5588e17a7665cb7f4d97e2c862615523bd55f46dd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-benchmark/default.nix
+++ b/distros/melodic/rdl-benchmark/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_benchmark/3.2.0-1/rdl_release-release-melodic-rdl_benchmark-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_benchmark-3.2.0-1.tar.gz";
-    sha256 = "b3764041b76d8541b11d5acdb176bed3be086ec1b953a41aa2b56b42898d34aa";
+    sha256 = "d351794b18247cd31330fe3a9d7a84cd41c5bd8b65b3f9ed11a9abae582fed82";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-cmake/default.nix
+++ b/distros/melodic/rdl-cmake/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_cmake/3.2.0-1/rdl_release-release-melodic-rdl_cmake-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_cmake-3.2.0-1.tar.gz";
-    sha256 = "dd87bce11db76a5bd23cb7919bd886b93bb97b99df3396b824b6132619dacb7e";
+    sha256 = "30c5695aa0bb0847d991d05020be78e50d5795c51b832eeb17990da8c0488bc2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-dynamics/default.nix
+++ b/distros/melodic/rdl-dynamics/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_dynamics/3.2.0-1/rdl_release-release-melodic-rdl_dynamics-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_dynamics-3.2.0-1.tar.gz";
-    sha256 = "02996f90bf325b1c47f8b436761468a0af9662aa937ec90250cf10ecd7107fa0";
+    sha256 = "85053786c16693de1bd832d6f81307d41d63b593e2f2b54cd32d8adca0a03bf1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-msgs/default.nix
+++ b/distros/melodic/rdl-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_msgs/3.2.0-1/rdl_release-release-melodic-rdl_msgs-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_msgs-3.2.0-1.tar.gz";
-    sha256 = "338e4d203d43511f7232d2528f44364d36c739eb86f5de1b791e68ea2e9273d2";
+    sha256 = "e51406d626a0114ed044ee5e90462bc10737ed057a5abf50f808fdea52cd6ddf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-ros-tools/default.nix
+++ b/distros/melodic/rdl-ros-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_ros_tools/3.2.0-1/rdl_release-release-melodic-rdl_ros_tools-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_ros_tools-3.2.0-1.tar.gz";
-    sha256 = "3d535dc2d58a675a64d78d2b30820586f00b16e350008e146e9ac19415e0c926";
+    sha256 = "36c236da8fa738216e65211f173f73a203d2b99a582e396aabf170e26d841483";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-urdfreader/default.nix
+++ b/distros/melodic/rdl-urdfreader/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_urdfreader/3.2.0-1/rdl_release-release-melodic-rdl_urdfreader-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_urdfreader-3.2.0-1.tar.gz";
-    sha256 = "acf08d42afc98a4ffb76a16dfc67124f19f3adeb56167f886322019cb3fc83ee";
+    sha256 = "21e9d728f57fa66aa13948bb25fd1900aa5926410fe533b6e92da0f8acf00ffa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl/default.nix
+++ b/distros/melodic/rdl/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl/3.2.0-1/rdl_release-release-melodic-rdl-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl-3.2.0-1.tar.gz";
-    sha256 = "697a892941f85b37eb08270936b94605ef7745c4aa2f7788f64b1a4974b5bf46";
+    sha256 = "402f1c9db58df28b9506bff1ae06cafb299e6a076cb46a1bc44f8bfc9019436e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/azure-iot-sdk-c/default.nix
+++ b/distros/noetic/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-azure-iot-sdk-c";
-  version = "1.7.0-r4";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.7.0-4.tar.gz";
-    name = "1.7.0-4.tar.gz";
-    sha256 = "a15053f5d1ea349991c07839eaf8c8a8eaa33fdb2c98ad7ae0fd898c1b638aa8";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "99981f9fd418f28de05e290b3dac70eaa09c3b1a0654353e51f02477fa6322bd";
   };
 
   buildType = "cmake";

--- a/distros/noetic/psen-scan-v2/default.nix
+++ b/distros/noetic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, fmt, geometry-msgs, message-generation, message-runtime, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, std-msgs, tinyxml-2, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-psen-scan-v2";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "649e51d059c20a671ce9e27b178b8ffa72683dc98c8020ae43d5e34bd64d6961";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "75519fa20b8f20507e9e17f83ba0cc3ca72f60165f78dce6309b65bf43712dd7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sr-hand-detector/default.nix
+++ b/distros/noetic/sr-hand-detector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-sr-hand-detector";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "385459fd4dab5b1d61eb25e3b609f0567501c9298d04db36ba3a65948ff637c2";
+    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "354b8355e441f1149d5dc9ede3ec74a32a1120d3289c6d3d6dbe1ff5449954bb";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 6178a8c42f31f1a70d9fec3e68c4bfb8e1e299c0.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *controller-interface 0.8.1-r1 --> 0.9.0-r1*
* *controller-manager 0.8.1-r1 --> 0.9.0-r1*
* *controller-manager-msgs 0.8.1-r1 --> 0.9.0-r1*
* *hardware-interface 0.8.1-r1 --> 0.9.0-r1*
* *ros2-control 0.8.1-r1 --> 0.9.0-r1*
* *ros2-control-test-assets 0.8.1-r1 --> 0.9.0-r1*
* *ros2controlcli 0.8.1-r1 --> 0.9.0-r1*
* *sol-vendor 0.0.3-r1*
* *transmission-interface 0.8.1-r1 --> 0.9.0-r1*

Galactic Changes:
-----------------
* *controller-interface 1.2.0-r1 --> 1.3.0-r1*
* *controller-manager 1.2.0-r1 --> 1.3.0-r1*
* *controller-manager-msgs 1.2.0-r1 --> 1.3.0-r1*
* *costmap-queue 1.0.7-r1 --> 1.0.8-r1*
* *dwb-core 1.0.7-r1 --> 1.0.8-r1*
* *dwb-critics 1.0.7-r1 --> 1.0.8-r1*
* *dwb-msgs 1.0.7-r1 --> 1.0.8-r1*
* *dwb-plugins 1.0.7-r1 --> 1.0.8-r1*
* *hardware-interface 1.2.0-r1 --> 1.3.0-r1*
* *microstrain-inertial-driver 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-examples 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-msgs 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-rqt 2.3.0-r1*
* *nav-2d-msgs 1.0.7-r1 --> 1.0.8-r1*
* *nav-2d-utils 1.0.7-r1 --> 1.0.8-r1*
* *nav2-amcl 1.0.7-r1 --> 1.0.8-r1*
* *nav2-behavior-tree 1.0.7-r1 --> 1.0.8-r1*
* *nav2-bringup 1.0.7-r1 --> 1.0.8-r1*
* *nav2-bt-navigator 1.0.7-r1 --> 1.0.8-r1*
* *nav2-common 1.0.7-r1 --> 1.0.8-r1*
* *nav2-controller 1.0.7-r1 --> 1.0.8-r1*
* *nav2-core 1.0.7-r1 --> 1.0.8-r1*
* *nav2-costmap-2d 1.0.7-r1 --> 1.0.8-r1*
* *nav2-dwb-controller 1.0.7-r1 --> 1.0.8-r1*
* *nav2-gazebo-spawner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-lifecycle-manager 1.0.7-r1 --> 1.0.8-r1*
* *nav2-map-server 1.0.7-r1 --> 1.0.8-r1*
* *nav2-msgs 1.0.7-r1 --> 1.0.8-r1*
* *nav2-navfn-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-recoveries 1.0.7-r1 --> 1.0.8-r1*
* *nav2-regulated-pure-pursuit-controller 1.0.7-r1 --> 1.0.8-r1*
* *nav2-rotation-shim-controller 1.0.8-r1*
* *nav2-rviz-plugins 1.0.7-r1 --> 1.0.8-r1*
* *nav2-simple-commander 1.0.7-r1 --> 1.0.8-r1*
* *nav2-smac-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-system-tests 1.0.7-r1 --> 1.0.8-r1*
* *nav2-theta-star-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-util 1.0.7-r1 --> 1.0.8-r1*
* *nav2-voxel-grid 1.0.7-r1 --> 1.0.8-r1*
* *nav2-waypoint-follower 1.0.7-r1 --> 1.0.8-r1*
* *navigation2 1.0.7-r1 --> 1.0.8-r1*
* *octomap-ros 0.4.2-r1*
* *rmw-cyclonedds-cpp 0.22.3-r1 --> 0.22.4-r1*
* *ros2-control 1.2.0-r1 --> 1.3.0-r1*
* *ros2-control-test-assets 1.2.0-r1 --> 1.3.0-r1*
* *ros2controlcli 1.2.0-r1 --> 1.3.0-r1*
* *sick-safetyscanners-base 1.0.1-r1*
* *sick-safetyscanners2-interfaces 1.0.0-r1*
* *sol-vendor 0.0.3-r1*
* *transmission-interface 1.2.0-r1 --> 1.3.0-r1*

Melodic Changes:
----------------
* *octomap-rviz-plugins 0.2.2-r1 --> 0.2.4-r2*
* *psen-scan-v2 0.3.3-r1 --> 0.3.4-r1*

Noetic Changes:
---------------
* *azure-iot-sdk-c 1.7.0-r4 --> 1.8.0-r1*
* *psen-scan-v2 0.3.3-r1 --> 0.3.4-r1*
* *sr-hand-detector 0.0.8-r1 --> 0.0.9-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

