### PR TITLE
rosdistro sync, Fri Dec 31 13:28:44 2021

### DIFF
--- a/distros/foxy/actionlib-msgs/default.nix
+++ b/distros/foxy/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-actionlib-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/actionlib_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "8f4f77ee69cffa1b9cf0aade27448e44ee649a6107b08a6e298b62f366fbc3d5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/actionlib_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "33fb6df04e2ca0b411c62a1fb6d51a9b1983a93fad02234ccd2368267341f148";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/apex-test-tools/default.nix
+++ b/distros/foxy/apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/foxy/apex_test_tools/0.0.2-1/apex_test_tools-release-release-foxy-apex_test_tools-0.0.2-1.tar.gz";
     name = "apex_test_tools-release-release-foxy-apex_test_tools-0.0.2-1.tar.gz";
-    sha256 = "892bad4ede47e5e159b2d8ced4a6381f116176ecc5469783003c5cdf350ed661";
+    sha256 = "5397b4f6725e6f7a8ade5832dd802bbe9b9506fa69f2ab7402c6ebb840c3a260";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/avt-vimba-camera/default.nix
+++ b/distros/foxy/avt-vimba-camera/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, camera-info-manager, diagnostic-msgs, diagnostic-updater, image-proc, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-image-proc }:
+buildRosPackage {
+  pname = "ros-foxy-avt-vimba-camera";
+  version = "2001.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/foxy/avt_vimba_camera/2001.1.0-1.tar.gz";
+    name = "2001.1.0-1.tar.gz";
+    sha256 = "78af7ea4ae8548664db0e401394f4f9a090bbf04b9c556f3be808fcb5fd96e30";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ camera-info-manager diagnostic-msgs diagnostic-updater image-proc image-transport message-filters rclcpp rclcpp-components sensor-msgs std-msgs stereo-image-proc ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''Camera driver for Allied Vision Technologies (AVT) cameras, based on their Vimba SDK.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/common-interfaces/default.nix
+++ b/distros/foxy/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-common-interfaces";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/common_interfaces/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "d2e8668f3ad1bbab33ae9da3034df8c4a45dac95f1e92c92bcb8622688c7fa17";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/common_interfaces/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "7bebb396f4035e5f714f58a51f7a3ffda7a100502fbc037fbf03b1065d793113";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "9c0917f474b30a4ccf030e893c9ab545df2bd84ccdaee9d59303fa16edf9f57c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "d684bf9f752a2bb6883634da7b42a5998f7bdeb059ad94303c374b6e6bb02e93";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "31ceda0aa15c3307c7224c0b73d493725d8e80f3d7dc642a6965d0ba3270adfb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f31fd09f6cbb418bb79d5045a96778c57a01d1779803d858571c2c285dbbd49a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "ce30b80b22a9c7ae38545ab826c51cb6e0d9aff52c5498005c0ea72fdac32127";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f4416d7723aa175d4a44c92eb6c5431a016cf9ab8ea981076d6c075ffe04afcd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-msgs/default.nix
+++ b/distros/foxy/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/diagnostic_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "73736979b129074674c16914794c51923ba37aaa0cdc07176d845e8e2d953e43";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/diagnostic_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "0157e7866b3367dc441c1456f31c56cec2f169e2b461c77fc1578d2ae6420170";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.5.0-1.tar.gz";
     name = "2.5.0-1.tar.gz";
-    sha256 = "003a4af776f2fc24b0b26badf132debcb2d3bced66d26afe87b3ff334302207b";
+    sha256 = "f0a68dd33a86dcaefdea50269f6153d84bde5d8d14a1f1333be4fafa644158d4";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -150,6 +150,8 @@ self: super: {
 
  automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
 
+ avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
+
  aws-robomaker-small-warehouse-world = self.callPackage ./aws-robomaker-small-warehouse-world {};
 
  backward-ros = self.callPackage ./backward-ros {};
@@ -488,6 +490,8 @@ self: super: {
 
  grbl-ros = self.callPackage ./grbl-ros {};
 
+ grepros = self.callPackage ./grepros {};
+
  gripper-controllers = self.callPackage ./gripper-controllers {};
 
  gtest-vendor = self.callPackage ./gtest-vendor {};
@@ -678,6 +682,8 @@ self: super: {
 
  microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
 
+ microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
+
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
@@ -825,6 +831,8 @@ self: super: {
  octomap-msgs = self.callPackage ./octomap-msgs {};
 
  octomap-ros = self.callPackage ./octomap-ros {};
+
+ octomap-rviz-plugins = self.callPackage ./octomap-rviz-plugins {};
 
  octovis = self.callPackage ./octovis {};
 
@@ -1487,6 +1495,8 @@ self: super: {
  snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
  soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+
+ sol-vendor = self.callPackage ./sol-vendor {};
 
  sophus = self.callPackage ./sophus {};
 

--- a/distros/foxy/geometric-shapes/default.nix
+++ b/distros/foxy/geometric-shapes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-geometric-shapes";
-  version = "2.1.0-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6447ed798f309b35795cf9daf595f8219c9cd2ffcdb07622c8ddd4cb7882501d";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "8e657ed648fe8eefb51479e6f2939938cf51e56bf2352bbaf15a9b220676b79a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pkg-config ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
   propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 

--- a/distros/foxy/geometry-msgs/default.nix
+++ b/distros/foxy/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-geometry-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/geometry_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "ec35c19b3029f878e4b6670f033d96943510cdd5d909c6eb88d4d1de0b35914c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/geometry_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "e705e7f6da6f08ecfb2e0cde468584b15e6e2c7a39db754561d88bfcc2bd8e31";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/grepros/default.nix
+++ b/distros/foxy/grepros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, builtin-interfaces, python3Packages, pythonPackages, rclpy, rosidl-runtime-py, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-grepros";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/suurjaak/grepros-release/archive/release/foxy/grepros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "698f47b1e3da4fd7a892b4ca2eecbb8aeb326092f5e2a8e744ed5420df471f9b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ ament-cmake-pytest pythonPackages.pytest std-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces python3Packages.pyyaml rclpy rosidl-runtime-py ];
+
+  meta = {
+    description = ''grep for ROS bag files and live topics'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "df8645db8b63409e18c84b88cde8dbfd258d9e2a73bb9001fa16d0a3db5a7b05";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "091c6826f0fd87b6986a1076f7bbbcb9d9c268d03d7b3dae1f2f3abfdbe906c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-driver/default.nix
+++ b/distros/foxy/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-driver";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4915284eb98ed917871db6e30c03472e03c3180557d53e2d573ab9220f7e9d9b";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a0b687cfab991784822c3298ce72fe7f8e84720efcff768798d437fb5a799694";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-examples/default.nix
+++ b/distros/foxy/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-examples";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "211203e7307f02e28171451014999e695a287f20aea89cc38986a59543c51b48";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "cfb405c97298e48d926318ac269097d44075e416f7ed19b280cd905b52c1e6d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-msgs/default.nix
+++ b/distros/foxy/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-msgs";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e64419e830a3ffad6770456bd86094df256f97df737ac0ddf29ee03c57a00825";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "90803a5af276b8b400a03fec7aff756f206e130ed667327f4b958b83765b001f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-rqt/default.nix
+++ b/distros/foxy/microstrain-inertial-rqt/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-microstrain-inertial-rqt";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_rqt/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3b5737aadd5c7f8e4d0125cfa876d97e4885a70da2abeb9443eec4c326c46e24";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs microstrain-inertial-msgs nav-msgs rclpy rqt-gui rqt-gui-py std-msgs ];
+
+  meta = {
+    description = ''The microstrain_inertial_rqt package provides several RQT widgets to view the status of Microstrain devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/nav-msgs/default.nix
+++ b/distros/foxy/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/nav_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "224e5e6b76099ce55b66253ace982ac95f1bb39bbbab680b78aba022060bcc00";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/nav_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "3370ca9aeb5d136d71f1a5055714df946985a728fd51b2fe2bfc37035b11b526";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/octomap-rviz-plugins/default.nix
+++ b/distros/foxy/octomap-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-rendering }:
+buildRosPackage {
+  pname = "ros-foxy-octomap-rviz-plugins";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/octomap_rviz_plugins-release/archive/release/foxy/octomap_rviz_plugins/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "53ee0470b8a3a451ccb054de708759c9d45f8155d6e90783faeab49c73671be7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ octomap octomap-msgs qt5.qtbase rclcpp rviz-common rviz-default-plugins rviz-rendering ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''A set of plugins for displaying occupancy information decoded from binary octomap messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/openvslam/default.nix
+++ b/distros/foxy/openvslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, glog, libg2o, libyamlcpp, opencv3 }:
 buildRosPackage {
   pname = "ros-foxy-openvslam";
-  version = "0.2.2-r1";
+  version = "0.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/OpenVSLAM-Community/openvslam-release/archive/release/foxy/openvslam/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "b5f1c77b3aea035f4487fb7958135c37bf035698bc1e906a70dd1e2353744fcd";
+    url = "https://github.com/OpenVSLAM-Community/openvslam-release/archive/release/foxy/openvslam/0.2.4-2.tar.gz";
+    name = "0.2.4-2.tar.gz";
+    sha256 = "8e97801d84c47e9eee98d2a9b03d4f98b6dd1d383808982c043d1b47842c65a3";
   };
 
   buildType = "cmake";

--- a/distros/foxy/quaternion-operation/default.nix
+++ b/distros/foxy/quaternion-operation/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-quaternion-operation";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "0923b471cd99eb5c5dd54da8f5f2f113095ab694ebedf17bf73f00d0ba9b4b11";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "70a6617e5050ed7433cf11f60da5cdc5a540d73de9ab0a6aa2518bddda7639b1";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ouxt-lint-common ];
   propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "f684378cd33a456d8e5ae016529466bc995ae3e972a23c61e8eb63b2fddc9aa3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "600de705069247b9cfa29478740332d2c8e7aae411d056911e1e6b6a855fb731";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "5bcdcbd23030d7117b3a1b1743104cac324c3d296e23a4ac486a28a267d1d14a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "eb49f25eebd4ec1c6f802382986281b51b4e4776232e08ecaca1d94978667802";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "182f29a6830a99f947dadd6b9db5bf7067f6b0ad264d25b65aeb9b4edd6b6bca";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "b7eb5cfd64b6d4d5012fc06cb66057b98a3eff525775e38c0eefe721e848d7c1";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rtabmap-ros/default.nix
+++ b/distros/foxy/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rtabmap-ros";
-  version = "0.20.15-r2";
+  version = "0.20.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/foxy/rtabmap_ros/0.20.15-2.tar.gz";
-    name = "0.20.15-2.tar.gz";
-    sha256 = "deaff598cd3af8a157d2cbbc79673de4f03d5bc2aa53a7013b7f83b2928f2098";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/foxy/rtabmap_ros/0.20.16-2.tar.gz";
+    name = "0.20.16-2.tar.gz";
+    sha256 = "028ee4d3eb8dca7defb8227110b6a6a14f42e219e1fff7d9f1184c1edbfe2268";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sensor-msgs-py/default.nix
+++ b/distros/foxy/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-sensor-msgs-py";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs_py/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "4397d375a6d0708b78b99c4dbd3e8287e2379c97c3e39b107a3e8c919558a45d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs_py/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "06496f90d036df32d5f7d3a8178111a06ac58d4e5ab9feff8c3a3e7b7be5c23e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/sensor-msgs/default.nix
+++ b/distros/foxy/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-sensor-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "54b4f653eff8e160fc15b643105f0b6ee8d5e555298f334e237dd9fe3f7d7e84";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "020defcd9349e33e49207f8321fa119290fa233c7118aad841b68c8303d36ac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/shape-msgs/default.nix
+++ b/distros/foxy/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-shape-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/shape_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "b69e0218aa85cb169e8604dbb5993c75914f44a0a3df57e0878270457ca985c8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/shape_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "ac6bb4f5e67d9d8784978faf4b1a9f47a0e2020ea22aec32940d6b64a0c68eb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sick-safetyscanners-base/default.nix
+++ b/distros/foxy/sick-safetyscanners-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake }:
 buildRosPackage {
   pname = "ros-foxy-sick-safetyscanners-base";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/foxy/sick_safetyscanners_base/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "d6a64e72be2befd145be5f65480845a715a384fb39d2a85f9a996d584a1f3768";
+    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/foxy/sick_safetyscanners_base/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5135b0b92898039b9f24f62c96a117cf698e65df9e81d11e151a7edea81896ef";
   };
 
   buildType = "cmake";

--- a/distros/foxy/sick-safetyscanners2/default.nix
+++ b/distros/foxy/sick-safetyscanners2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, rclcpp, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
 buildRosPackage {
   pname = "ros-foxy-sick-safetyscanners2";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/foxy/sick_safetyscanners2/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "5e17224b0967885bc10abaaedc534a18068f39213fa8ec3be86243ed5a934f34";
+    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/foxy/sick_safetyscanners2/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "460a9bd31ff9d1c09b6302bbe12925d11ff0b93d778b2ecc2090746f474f0dec";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost rclcpp sensor-msgs sick-safetyscanners-base sick-safetyscanners2-interfaces ];
+  propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle sensor-msgs sick-safetyscanners-base sick-safetyscanners2-interfaces ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/sol-vendor/default.nix
+++ b/distros/foxy/sol-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ouxt-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-sol-vendor";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/sol_vendor-release/archive/release/foxy/sol_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "f609b6a2ebf599844df510d6ead990bb5558090ae7bc2335f7ef75874ecad8fb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''vendor package for the sol2 library'';
+    license = with lib.licenses; [ asl20 mit ];
+  };
+}

--- a/distros/foxy/std-msgs/default.nix
+++ b/distros/foxy/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-std-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "e3d77b3118285557c544893b84ddac21d8c490ac1098fa21c0f509c025066184";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "bb8026fdafc7fa5c6b5e7e30f53e024b26723e18951318d94c7161f8f2955070";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/std-srvs/default.nix
+++ b/distros/foxy/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-std-srvs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_srvs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "a7b2e324ece1e54527f5acdcf1cd455cd7018af07d8ab6cfeb75de4840bd8218";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_srvs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "6b4d11dee1b8698c622172cf981fa7441a70ed6ec330c1590d476d224803528a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/stereo-msgs/default.nix
+++ b/distros/foxy/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-stereo-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/stereo_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "ea4f6e7fc77c02aec34c7422c14a0cf2b13da7f921e79382eb4fa4072a30f261";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/stereo_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "ae6d8186396185a0acb15395f4ae464d32ef7417846d52a529ce111ce16788be";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-apex-test-tools/default.nix
+++ b/distros/foxy/test-apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/foxy/test_apex_test_tools/0.0.2-1/apex_test_tools-release-release-foxy-test_apex_test_tools-0.0.2-1.tar.gz";
     name = "apex_test_tools-release-release-foxy-test_apex_test_tools-0.0.2-1.tar.gz";
-    sha256 = "8f2a8281836a6ef61d778b7196cd77998aa4557285574064931e62e925832e5e";
+    sha256 = "275623d9706e2f131b95b40c5f3b082069078ece9a0bb76f2dfc3e4359cf763d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/trajectory-msgs/default.nix
+++ b/distros/foxy/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-trajectory-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/trajectory_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "fbcac90876b0a34e24cd0d2df189c7057e336518e94cfdc6a61259b982a9e5c1";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/trajectory_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "ff1eef5fb5817998de660621cbe59a3c9403e31cfc05fb351131e1046d5aa383";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.8.1-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "1dd96a196c859a7f5d569e4e7e35f12772c0f46d8596db13401ef33d23334a03";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c5c65fc11729d718ff5610ba59f3317cb5c361adb5f284ab0db3a966938d1afa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-description/default.nix
+++ b/distros/foxy/velodyne-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros, urdf, xacro }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-description";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f4da2cfab2110941bdefa94690341f3a7a9fd3941398784873e573ae0dec7185";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "9b7eac44518cc4e40dcc9d278042bb422f8571d84c0179e086b2438000fadaa9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-gazebo-plugins/default.nix
+++ b/distros/foxy/velodyne-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-ros, rclcpp, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-gazebo-plugins";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "133b902dd1174c7f3243222967bda7ed7adfceeca4d206fdc2ec9fdbafc2a26a";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "5d0a81933aff085a4f89018dfab16074d7d18b5fe88c4687670a3584666f9d44";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-simulator/default.nix
+++ b/distros/foxy/velodyne-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, velodyne-description, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-simulator";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "53fe6864147b15b56c11a80dbf079d5d71253db52b43eea7bb31dbc679b641ba";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "5a795530db06dd6f71d4cf29019e8051efc275eb67b6ea6e540e5abd88f6052a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/visualization-msgs/default.nix
+++ b/distros/foxy/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-visualization-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/visualization_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "d87b2b0738336686b05d34f205c65a425951003572793b65f03a433aae66ed8f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/visualization_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "47e0214afe3e7a94c8b2a87d3408ab69ce860663e6d02aa1c3568e10cb0fad8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, ros-environment, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-control";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "545eae5820f87119e11af60fac783c348be4a0e3d620709bfca22aa0239644da";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "31d0e32083b087bb42610140d83130b492bb3423431d6ff699a714134b8d50e4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ controller-manager hardware-interface pluginlib rclcpp webots-ros2-driver ];
+  propagatedBuildInputs = [ controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle webots-ros2-driver ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-core";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "747ec380269303483d3cb3a7b47f6b070c108aef2e73a0f7211aa05d798c7634";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "a5c1ff7def40f2ae0a7d8df75b896096f81cc4d502d1f90db8aa9da31d32e689";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-driver";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "08fa0ed0713f9cf2ed445167cce8f2f5c9044e833444780041075ddda95c9fb0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "fbbfcef080a0b42f423d7f52ab5447f05c3fdf0654d697ceb7caf0ff68f55110";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-lifecycle rclpy sensor-msgs std-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "ac10e49e9cc5ce1b7c33b619b2bbdc8f90fe94d4cbc7bd69740da93e2e3896f7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "11c21bee9da3fa5ce3f6e6229b89f4908b785b11009f9d425ab8a2096cdc7b8e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-importer/default.nix
+++ b/distros/foxy/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-importer";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "54774eaa715d7800fa1493baf0eaaf7474102408ce47648f01171d804b65f300";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "7976420d6b8b33b3853654073b37072212f43787552917a68b824afedbb66907";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-mavic";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "79299ffd127cc321e709cab254cd22d072183f710fed78da6c4d6c9a81f47632";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "4fb74a5e0fd9ebb610658a8a1de2d4e2591c092075e7a55532b748f5441a0935";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "e10bc03a9133751ac2b852bf686f03c7271e057218ec82c691fd771c728ae1c9";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "422f740735021e520aad81762e54dd9d7bb7e3e13f310d4a60a7df9a137b5722";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "d9169c7d30228f71cc24af49f1c906021d8114d641405933aa945f7d343ea424";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "23b7858d6cb5b7aa604a66b659bfa71274edf86f957eb3afe6375bb34ed6f112";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tests/default.nix
+++ b/distros/foxy/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tests";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "1c0e0168f8f751e885f7d2d674344fc28a5e32bbaaa0e6da8d5acccb373c2e4f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "ee674beb2a2829de1d73506ce0ea680cfd09f147387d4cbefbd228efd2d80217";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "4bb83c17f65508797809544cf0977a603b2844da4acfb8c63cbfe240a5232b10";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "13078f85c002824e9d8fc728561635f647caa842225c1fa465e8228d5dfc8686";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "b042f6142c4aba1c0fc83612edaa6c3113c39e371a51ffee01330021be97c52e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "10bd9a5b652f7c13449975e11e3da2418c503e2cc6872c8d95918f0f7761d42c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "8bc9795ff071d3d1a1f3a3652c5f962c4a5341fb74075326c5fd7355cca3bc6a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "5c4d935371abea3dbd58a1012a3e247cfac5421895fea09e7b58b66c22c00c0e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-core, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "1.1.3-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/1.1.3-2.tar.gz";
-    name = "1.1.3-2.tar.gz";
-    sha256 = "1efc190566ef1aa3823b03f96dab548388026ced3b6a8fe06364790dfd55ab85";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "9d419d67b1b372dcd30db52b4ba964ca695f3da4ea96d4e0316865784f7c9c0f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/chomp-motion-planner/default.nix
+++ b/distros/galactic/chomp-motion-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, rclcpp, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-chomp-motion-planner";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/chomp_motion_planner/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "aee3e8c5ecd7649a5c2f2e73d3de0ea91410ed186d4470b09ae5110c69ea39f4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core rclcpp trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''chomp_motion_planner'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-controller-interface";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "856352ede3a21bd1d609325eda685b006c6331127d7432c6d2e11b6e24a3b51b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8f8b7021de671ee198237708741f11d49e12e5ca680a1903e5f5ae4f499076d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "3b5bf8482a9e76a2365ac1b29f21a9b5d10225d1c9e8a8de22552feadfbc9344";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0848bb9a09dda6a50a834efff91a535c508719a369f6bd957e58300bc5f2552a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "eb12ca098efd1f2995759918c04d69455d0db70fe386ec8715e3e07ed3329427";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "12272b014df400223ef58491776cdcce9b098d31934679b653a873691d3a5e0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/costmap-queue/default.nix
+++ b/distros/galactic/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-costmap-queue";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "541ae20b1549cb36446773cab3fb74907e15ce17c11abb7c6e610a40f0631642";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4d18e6206e45a4d6a9e21d5abe63e9d246728c250fc58d6f9ba89a7980f664a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diff-drive-controller/default.nix
+++ b/distros/galactic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diff-drive-controller";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "667362edaad7780d4f92ddbe767acd226b057d068298420fbb0c43c73f3e3989";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a0f969b1507a129d82ba2ae7d0872107e6a4e1b29972b3c6ecee030497c830ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-core/default.nix
+++ b/distros/galactic/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-core";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "126b11f8178c1987b23a67c688cfba61885f27985f2f857ec95a1b8bde867c17";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "343c56ea4a20d6ade91653f66d6938417d7130e96c4aaec6e9d31d03efdf7506";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-critics/default.nix
+++ b/distros/galactic/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-critics";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1afa333d2286986bc6b1084c1c8038057cd2e118b90869bc853d156b8b71510f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "cb8cbe611191ffb5bfcd1252fc3b075af80751ab740066d0b77dc2771b540bdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-msgs/default.nix
+++ b/distros/galactic/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a487aff5fc8384321db9591a01f5008906e24aa9c5e7e6abc598eb785b97cc66";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f7041cbe2aee081532271dbc3e3f98c4dec1d31f095634ed8a60a60275eed764";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-plugins/default.nix
+++ b/distros/galactic/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-dwb-plugins";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "9ce9f687b15e3ed482928a353c01be0cbd16a132eb03a9350e24d621d8becc97";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ef559f61041b39fb6874608286144f43dc9871fd3bd59f53e294236ef250e827";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/effort-controllers/default.nix
+++ b/distros/galactic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-effort-controllers";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "eadb9461f808815ade13462a042b989d868da38b9eb4b285b3d086d93328202c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "13bbf94a85fa6fe45cab89b6dd12802b437bda2d4432bc1f9fa1a8ef5abc926f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/force-torque-sensor-broadcaster/default.nix
+++ b/distros/galactic/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-force-torque-sensor-broadcaster";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ac3d651e3c2b90333521f5b7c259004e1729addc598311ec3ab21d9a55eea069";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ae88f8f4f93a6280b8f46dcc88f5acfcdc99b6ec23b6a1b9a9519dd508f4d21b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/forward-command-controller/default.nix
+++ b/distros/galactic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-forward-command-controller";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "a83327b5012f2a71bfa40fd838aa45c561fcb5b293c204818a372d405710ddc9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5d014615253d64c560aad1d13d145c9f72144466e5a034199b956dbfb8ed284a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -184,6 +184,8 @@ self: super: {
 
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
+ chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
+
  class-loader = self.callPackage ./class-loader {};
 
  color-names = self.callPackage ./color-names {};
@@ -518,6 +520,12 @@ self: super: {
 
  map-msgs = self.callPackage ./map-msgs {};
 
+ mapviz = self.callPackage ./mapviz {};
+
+ mapviz-interfaces = self.callPackage ./mapviz-interfaces {};
+
+ mapviz-plugins = self.callPackage ./mapviz-plugins {};
+
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
@@ -560,21 +568,29 @@ self: super: {
 
  microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
 
+ microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
+
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
  moveit = self.callPackage ./moveit {};
 
+ moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
+
  moveit-common = self.callPackage ./moveit-common {};
 
  moveit-core = self.callPackage ./moveit-core {};
+
+ moveit-hybrid-planning = self.callPackage ./moveit-hybrid-planning {};
 
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
 
  moveit-msgs = self.callPackage ./moveit-msgs {};
 
  moveit-planners = self.callPackage ./moveit-planners {};
+
+ moveit-planners-chomp = self.callPackage ./moveit-planners-chomp {};
 
  moveit-planners-ompl = self.callPackage ./moveit-planners-ompl {};
 
@@ -591,6 +607,14 @@ self: super: {
  moveit-resources-panda-moveit-config = self.callPackage ./moveit-resources-panda-moveit-config {};
 
  moveit-resources-pr2-description = self.callPackage ./moveit-resources-pr2-description {};
+
+ moveit-resources-prbt-ikfast-manipulator-plugin = self.callPackage ./moveit-resources-prbt-ikfast-manipulator-plugin {};
+
+ moveit-resources-prbt-moveit-config = self.callPackage ./moveit-resources-prbt-moveit-config {};
+
+ moveit-resources-prbt-pg70-support = self.callPackage ./moveit-resources-prbt-pg70-support {};
+
+ moveit-resources-prbt-support = self.callPackage ./moveit-resources-prbt-support {};
 
  moveit-ros = self.callPackage ./moveit-ros {};
 
@@ -618,11 +642,15 @@ self: super: {
 
  moveit-servo = self.callPackage ./moveit-servo {};
 
+ moveit-setup-assistant = self.callPackage ./moveit-setup-assistant {};
+
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
+ multires-image = self.callPackage ./multires-image {};
 
  nao-button-sim = self.callPackage ./nao-button-sim {};
 
@@ -665,6 +693,8 @@ self: super: {
  nav2-recoveries = self.callPackage ./nav2-recoveries {};
 
  nav2-regulated-pure-pursuit-controller = self.callPackage ./nav2-regulated-pure-pursuit-controller {};
+
+ nav2-rotation-shim-controller = self.callPackage ./nav2-rotation-shim-controller {};
 
  nav2-rviz-plugins = self.callPackage ./nav2-rviz-plugins {};
 
@@ -709,6 +739,10 @@ self: super: {
  octomap = self.callPackage ./octomap {};
 
  octomap-msgs = self.callPackage ./octomap-msgs {};
+
+ octomap-ros = self.callPackage ./octomap-ros {};
+
+ octomap-rviz-plugins = self.callPackage ./octomap-rviz-plugins {};
 
  octovis = self.callPackage ./octovis {};
 
@@ -777,6 +811,10 @@ self: super: {
  phidgets-temperature = self.callPackage ./phidgets-temperature {};
 
  picknik-ament-copyright = self.callPackage ./picknik-ament-copyright {};
+
+ pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
+
+ pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
 
  plansys2-bringup = self.callPackage ./plansys2-bringup {};
 
@@ -1242,12 +1280,6 @@ self: super: {
 
  ruckig = self.callPackage ./ruckig {};
 
- run-move-group = self.callPackage ./run-move-group {};
-
- run-moveit-cpp = self.callPackage ./run-moveit-cpp {};
-
- run-ompl-constrained-planning = self.callPackage ./run-ompl-constrained-planning {};
-
  rviz2 = self.callPackage ./rviz2 {};
 
  rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
@@ -1286,6 +1318,12 @@ self: super: {
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
 
+ sick-safetyscanners2 = self.callPackage ./sick-safetyscanners2 {};
+
+ sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};
+
+ sick-safetyscanners-base = self.callPackage ./sick-safetyscanners-base {};
+
  simple-launch = self.callPackage ./simple-launch {};
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
@@ -1301,6 +1339,8 @@ self: super: {
  soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
  soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+
+ sol-vendor = self.callPackage ./sol-vendor {};
 
  spacenav = self.callPackage ./spacenav {};
 
@@ -1408,6 +1448,8 @@ self: super: {
 
  theora-image-transport = self.callPackage ./theora-image-transport {};
 
+ tile-map = self.callPackage ./tile-map {};
+
  tinyxml2-vendor = self.callPackage ./tinyxml2-vendor {};
 
  tinyxml-vendor = self.callPackage ./tinyxml-vendor {};
@@ -1514,7 +1556,11 @@ self: super: {
 
  velodyne = self.callPackage ./velodyne {};
 
+ velodyne-description = self.callPackage ./velodyne-description {};
+
  velodyne-driver = self.callPackage ./velodyne-driver {};
+
+ velodyne-gazebo-plugins = self.callPackage ./velodyne-gazebo-plugins {};
 
  velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
 
@@ -1522,9 +1568,13 @@ self: super: {
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
+ velodyne-simulator = self.callPackage ./velodyne-simulator {};
+
  vision-msgs = self.callPackage ./vision-msgs {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
+
+ visp = self.callPackage ./visp {};
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
 

--- a/distros/galactic/geometric-shapes/default.nix
+++ b/distros/galactic/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-geometric-shapes";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "e7e2b87af7bd3a814701e20285053b142a8cfa91ac1c5393d5b0978c6b46346f";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "17046796eb62521f9991f3fe32081187980b4340f8c43642ea6dc6f804780fc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gripper-controllers/default.nix
+++ b/distros/galactic/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-gripper-controllers";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ba7afb94d1ef3396520ff4600000201abdb53471da17438248180f92f65c17bb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fa86829c262273956b4af81b8ac83e8ddaf335e75f2618f46d8f6c8ba76404e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-galactic-hardware-interface";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "175ab31444041670e4ae1e6247d65bc6a310e26855d88b553737498b5c32fe46";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "4f6f8024adf7e7e86fc20ab30e7470e4346408eeb2c0a9541dedf7c22d9d2289";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-sensor-broadcaster/default.nix
+++ b/distros/galactic/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-imu-sensor-broadcaster";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "66df092cf8782ee7f8656d5b95f4ea23be83c734a7a3bc4bffa4ee24e8750568";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "dfb839801c2ffca3e38a77db0a7143114ede39f6474d9e8f2fb0fee884e0d8dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-state-broadcaster/default.nix
+++ b/distros/galactic/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-state-broadcaster";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "07a376f14fd143dcc3ccc5a11267bbc3cfc4cc2ff868349aebfdd55e3331fb7f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "133036cd403dae222c62cfa40be633da4ee346a0f0d7789d7881d33bac83f96b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-trajectory-controller/default.nix
+++ b/distros/galactic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-trajectory-controller";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ab4e53a35ba89e915e9c6d07449d2900096182eb21fd15fe701acccde2f5856b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "44b55dd9c25adbc70b8872beadb78a61fdbcd6706ba59a1231434de355ebf8b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mapviz-interfaces/default.nix
+++ b/distros/galactic/mapviz-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-mapviz-interfaces";
+  version = "2.2.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/galactic/mapviz_interfaces/2.2.0-3.tar.gz";
+    name = "2.2.0-3.tar.gz";
+    sha256 = "e3724bcf53241edc734d86500f15df59cc79cf8c5e92baee9403f472f02d21bc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ builtin-interfaces marti-common-msgs ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS interfaces used by Mapviz'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/mapviz-plugins/default.nix
+++ b/distros/galactic/mapviz-plugins/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, pluginlib, qt5, rclcpp, rclcpp-action, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-mapviz-plugins";
+  version = "2.2.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/galactic/mapviz_plugins/2.2.0-3.tar.gz";
+    name = "2.2.0-3.tar.gz";
+    sha256 = "6ab615be627a973e5b9f5d2a4701288ea0a87f2bab6f46f9c0eeb6d1ac5e0a63";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-index-cpp cv-bridge gps-msgs image-transport map-msgs mapviz marti-common-msgs marti-nav-msgs marti-sensor-msgs marti-visualization-msgs nav-msgs pluginlib qt5.qtbase rclcpp rclcpp-action sensor-msgs std-msgs stereo-msgs swri-image-util swri-math-util swri-route-util swri-transform-util tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''Common plugins for the Mapviz visualization tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/mapviz/default.nix
+++ b/distros/galactic/mapviz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, launch-xml, libyamlcpp, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg }:
+buildRosPackage {
+  pname = "ros-galactic-mapviz";
+  version = "2.2.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/galactic/mapviz/2.2.0-3.tar.gz";
+    name = "2.2.0-3.tar.gz";
+    sha256 = "9bb938c772bb47b5927327f79a86454ff4681d2081b0dcb2960ff72ef3b631bd";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ cv-bridge freeglut geometry-msgs glew image-transport launch-xml libyamlcpp mapviz-interfaces marti-common-msgs pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros xorg.libXi xorg.libXmu ];
+  nativeBuildInputs = [ ament-cmake pkg-config qt5.qtbase ];
+
+  meta = {
+    description = ''mapviz'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-driver";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6a86484b20dc12bebb29ca18109420808704b3c0156bdefebe12c273537a75d5";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e68005a93770f9ba7eb98784daa2440dfccc6228a6c9370f60425283c3a63162";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-examples";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e3c79a6503fd1a55d323666f82b7849e6db290314e53be81b5319979a1d282b9";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "b986b25b816fe368624f934b1ff5268b2e98663d5565e4680e0c41bc2906428e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-msgs";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "f38ad19922b33586f5be9162b3752b3065733a99146b67948ffbc7fc5a3e7053";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "30a60df04baf0849c3ea67a07f59986b17394d302269487faf0aa7800ff869fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-rqt/default.nix
+++ b/distros/galactic/microstrain-inertial-rqt/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-microstrain-inertial-rqt";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_rqt/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ea6d19111e06227515075a9c0cba6d227ef91fc98e59918389e896c69faeae33";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs microstrain-inertial-msgs nav-msgs rclpy rqt-gui rqt-gui-py std-msgs ];
+
+  meta = {
+    description = ''The microstrain_inertial_rqt package provides several RQT widgets to view the status of Microstrain devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/galactic/moveit-chomp-optimizer-adapter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-chomp-optimizer-adapter";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_chomp_optimizer_adapter/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "82992f9e017548a8b20d8e4d02e9a379f6d83b82a95aae2410c996355a71fe14";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''MoveIt planning request adapter utilizing chomp for solution optimization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-common/default.nix
+++ b/distros/galactic/moveit-common/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, backward-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-common";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "ce8610d297c71e3ccc3e3b8e8607ec8d1fd1768892a5b22d5a0a3100c9a4099c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "db1272768079f795cf3e23ec284c9492e937a5f1a93ec203aa2fcf8dd959b046";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ backward-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-core/default.nix
+++ b/distros/galactic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-core";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "e669ea81fbc3f4d2597b93cb406804a450bc7f5d88d41ea53f5f42f99445d80f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "cd1b8293b750df7dc1cd7595b81006abfeb3fcd13fef68c501da6261454d8bda";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-hybrid-planning/default.nix
+++ b/distros/galactic/moveit-hybrid-planning/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, pluginlib, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-hybrid-planning";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_hybrid_planning/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "86577543568787b5f69f89d1310d22465816a1b2d7493c1133a3188c2811ec9b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-planners-ompl ros-testing ];
+  propagatedBuildInputs = [ ament-index-cpp controller-manager moveit-core moveit-msgs moveit-resources-panda-moveit-config moveit-ros-planning moveit-ros-planning-interface pluginlib rclcpp rclcpp-action rclcpp-components robot-state-publisher rviz2 std-msgs std-srvs tf2-ros trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Hybrid planning components of MoveIt 2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-kinematics/default.nix
+++ b/distros/galactic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-galactic-moveit-kinematics";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "3d57602be541ef159a4756bb66e61d8d6c8cc8b253ee0cdee9d77169af7168e2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "408074ade900517739e084847612d01b7edeec055d12c41baf98153528f2c30c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners-chomp/default.nix
+++ b/distros/galactic/moveit-planners-chomp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-planners-chomp";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_chomp/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "9b425a847ee8aab034b37ad7472c098a08c3801416c8b6aa426fd964203fb4ab";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The interface for using CHOMP within MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-planners-ompl/default.nix
+++ b/distros/galactic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-ompl";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "1635bde0fb6adb34273bfc34cc26157e6a0bb4d91a4814486ce76aa3dd364237";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "65b395a378cd868ac1dc958f88e8dba96461a6a4bdc755d5eb5d8009e79a2ca2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners/default.nix
+++ b/distros/galactic/moveit-planners/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "41fcfc56c151cb3ed089a4e06b09cd42437d251614a56b1d283f3caba20a979b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "c24aa8d41298af5a6e21e44691efccec954654151a1cba18b5423a4f161e0c45";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-planners-ompl ];
+  propagatedBuildInputs = [ moveit-planners-ompl pilz-industrial-motion-planner ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-plugins/default.nix
+++ b/distros/galactic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-galactic-moveit-plugins";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "4d79ae71be92e2daee0b8268583f70d5a1a3babe7feb65bc522fe0114bcc0dcb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ee497ba4a0c0cb67e620ab1ef98cacd7ba7b849c2067553b901ef3c8be57c92f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/galactic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-prbt-ikfast-manipulator-plugin";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_ikfast_manipulator_plugin/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "20923688bf56f3b80988d6b988b74e8e1aaceb15c67c713ad57a29fd5b48a0a6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ tf2-eigen tf2-eigen-kdl ];
+  propagatedBuildInputs = [ moveit-core pluginlib rclcpp tf2-geometry-msgs tf2-kdl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The prbt_ikfast_manipulator_plugin package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/galactic/moveit-resources-prbt-moveit-config/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-prbt-moveit-config";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_moveit_config/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "d88f4da6c1abf3cfc482e75e86da4852e3cb428f410d57eb57f03ea64b859808";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher moveit-resources-prbt-ikfast-manipulator-plugin moveit-resources-prbt-support moveit-ros-move-group robot-state-publisher rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      MoveIt Resources for testing: Pilz PRBT 6
+    </p>
+    <p>
+		A project-internal configuration for testing in MoveIt.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/galactic/moveit-resources-prbt-pg70-support/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-prbt-pg70-support";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_pg70_support/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "d554b1f0081d4ffffd2ffab8cfe2ee08634c1ca3b8837c7ab100793fa7408d2a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ moveit-resources-prbt-ikfast-manipulator-plugin moveit-resources-prbt-moveit-config moveit-resources-prbt-support xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PRBT support for Schunk pg70 gripper.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/moveit-resources-prbt-support/default.nix
+++ b/distros/galactic/moveit-resources-prbt-support/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-prbt-support";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_support/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "278f6c1c0cc74159ba9c68f4936bd7565576128a37af499bac8fd22d0235ecad";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Mechanical, kinematic and visual description
+  of the Pilz light weight arm PRBT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/moveit-ros-benchmarks/default.nix
+++ b/distros/galactic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-benchmarks";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "255565e3ec512e1fe4175496630f708198bb413228a9dcdd1b70d4101bf2c095";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "8de58de891a76165d598521adfe75855e880d30d6d0eca175b92cd034e7b83b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-control-interface/default.nix
+++ b/distros/galactic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-control-interface";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "962814f2291a20860a3f95422508386e19c57e58234fec5bae74cff931f81b08";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "88283d886445b8bfce7683b000bf4700ac6b0d7be9b6a5c3480fe2002642d98e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-move-group/default.nix
+++ b/distros/galactic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-move-group";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "3c4c4b10323bb03dc78de3817c638a899608d2b648b0573df80d8c21a4017d0e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "dc6df2332d903597cdd7a9cbe20ef330946f127776f61f5f27fc6ec3f22a1ed8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-occupancy-map-monitor";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "013bf00ef24e5384962c66114f903927c7cb171f3a763379de57800899e48e33";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "952f44c063eac478297273c8a13d008b237b957bfb98f9c0b117c7b59aae3a74";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-perception/default.nix
+++ b/distros/galactic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-perception";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "01d26bdaa904d4fec0b6d52da8449dec7fcddb6b66a63c4794e375b0806e6a43";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "5811dcffed9fcf8d75281baed424168b430624362405850d4e5446f39cedb66c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning-interface/default.nix
+++ b/distros/galactic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning-interface";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "2672c269e47295de9d06e46b810f3236008da55fefa3dd780a49a48d4c74338c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "e7cc27f226968abb89a6452e47bdc2efd78d522f3ac096be590461913cef6947";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning/default.nix
+++ b/distros/galactic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "433237ef6c7258fa500b8e002a8cb11062d7a2e05d0f60f05a130e411d0df30c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "59690896abbc4741230370c092875408fc321752d27fa5352a0512d8df74f4bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-robot-interaction/default.nix
+++ b/distros/galactic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-robot-interaction";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "74cf72d6dac5714b5f05f5e36a6d6c45e3f835e2ea412b8c1f95222134c4db74";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "95221855c0df8691c8e5baa34d748fda9a3f1b9a0b8cd9c61a4af8e14e2d3bdf";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-visualization/default.nix
+++ b/distros/galactic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-visualization";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "70a5a013b869eed5c6f830de215b27d57ddb296c3b8ee793c49aa7468145f12b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "a2fd84c3c82e33cf9970b108c6ae0da0267a59fdc08989663c3b03126772f228";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-warehouse/default.nix
+++ b/distros/galactic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-warehouse";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "d7b39368b88e4102499c207844610589349d6cc6630b26c666e6406ce57ffa72";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "f39decd63bd0f7630c997cb12f7148225cac4a37551f5c97db095c4b926fc78c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros/default.nix
+++ b/distros/galactic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "00e3932121074361ad5da8f1fd76ed92c5fb7717a0454244872034f2ba8872d5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "60b7ace85867d9fca0179fb494c09bbd86a258f4d5070f0db79da4a646a4d11e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-runtime/default.nix
+++ b/distros/galactic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-runtime";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "120d3781bbdf962e1d2b3d90719e029c63c536ecfa9e1e1bc3ec2893bada3ce2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ce0857fce08c2cfdfcc15b7e09c3ad6928b50f49695fa36fe55b977480a459fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-servo/default.nix
+++ b/distros/galactic/moveit-servo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-manager, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, pluginlib, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-servo";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "d3c851259300b7055cc207dee676928ebbc9dfe776cc6051c99eb7c913b3c658";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "f63c22641782ec148568c6117d560741e23f51a130b70b5fadb37083a1748f86";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ros-testing ];
-  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager moveit-resources-panda-moveit-config ros-testing ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy moveit-core moveit-msgs moveit-ros-planning-interface pluginlib robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-setup-assistant/default.nix
+++ b/distros/galactic/moveit-setup-assistant/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, libyamlcpp, moveit-common, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, rclcpp, srdfdom, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-setup-assistant";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_setup_assistant/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "cac1109f9eeff95cb9926588fc85610a4129f0efd90eb9203bd3c86639f93a82";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ogre1_9 ompl ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
+  propagatedBuildInputs = [ ament-index-cpp libyamlcpp moveit-core moveit-ros-planning moveit-ros-visualization rclcpp srdfdom urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generates a configuration package that makes it easy to use MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-simple-controller-manager/default.nix
+++ b/distros/galactic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-galactic-moveit-simple-controller-manager";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "3ed83dc851cf10276a4ba3442f8f058329b8ebac38775bdad4bd24ee2261e13e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ed0db51aa019367bb5d7b9b359806f5dd25ca62434208aab0becdb3b9f35cf73";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit/default.nix
+++ b/distros/galactic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "6410d0d1cabdfdb4aa1e3364e7452b07ce825496e0a8dcd6f93e29f0c7825ebc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ef5a9e0cb941979f23eaa0e079c4a050257b23da602b9ef1185f5b1bfd46b1d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/multires-image/default.nix
+++ b/distros/galactic/multires-image/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, gps-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-multires-image";
+  version = "2.2.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/galactic/multires_image/2.2.0-3.tar.gz";
+    name = "2.2.0-3.tar.gz";
+    sha256 = "eb5f31714e20a21e5cbb6203f074df73be19f2cf357b9ef068b55f759bd02e53";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ cv-bridge geometry-msgs gps-msgs mapviz pluginlib qt5.qtbase rclcpp rclpy swri-math-util swri-transform-util tf2 ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''multires_image'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/nav-2d-msgs/default.nix
+++ b/distros/galactic/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "44f80572c68d54931e0d7835188492d91fd43a1f545d820de4bca9dab5888b98";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "05f16cab1259272e2deee134ea2f639f1551120237c9be5a9a653be798cc7433";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav-2d-utils/default.nix
+++ b/distros/galactic/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-utils";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "64212975a2c4fbfcbe253af5f01f1b8043a09e31f08d89290e5739705b4ae5dc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a116ec232c5e0e402a458826b6141a75fd918def35f914486b1bf425848c587c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-amcl/default.nix
+++ b/distros/galactic/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-amcl";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "470fd987afb8b7b89a6b7436bd100d77cdb17006e6410352aead9356bd38739f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "52741f51ccf7df564b0eb37b8be6e7e8b2d8ee16337c466d6c475cb294fb4306";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-behavior-tree/default.nix
+++ b/distros/galactic/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-behavior-tree";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "62aa89bbc15158d35afb0e48ae4d6fdad8ac0f9812e4c65b6ff107ea67a9c81f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "571eba2c3c71418b8f3c2362f21f37ed751517f6a957acd3a6882ffa59bca6df";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bringup/default.nix
+++ b/distros/galactic/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bringup";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "45ea86c7df2e10aa08fdc0cae49e093ea569958c2c644adafec98f5fffd39f89";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f7bfdc6242b6123e94b59ff0d0a2024cfaa24b1f46abc6cac16e7a9232b0f92c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bt-navigator/default.nix
+++ b/distros/galactic/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bt-navigator";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a0c8b12aa92bdbd37b4863bda080e56d2bbbd024b1708962699f455e0c6ea035";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3921f6bcaf09c4543955b3cbef3e67b8d0dc6b4dabb19ef69d9b05722c55184d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-common/default.nix
+++ b/distros/galactic/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-common";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b5c7e4a0a0758adaa79f0b372f73e752a200696149754002345493f8aa71d862";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b06f687cd1bba43ad3fb3dd6f8d919ba6b75dde126a4d280189ecd6b6f9a4c34";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-controller/default.nix
+++ b/distros/galactic/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-controller";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1219e279144466db73c7b1d877a358ce2221a9d417ce980ff9db8927c70be83c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "bb1ce4164d7fbf65f728abb669428af1b9684670f71b4a38e213fbd490dc2b8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-core/default.nix
+++ b/distros/galactic/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-core";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a2fa6012aa27251b3e5ab98b7d17f0a25058501126252af3173d74885fbf0ef2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8d6bfad443f6f8600747d8ff0a719293f4f4b23974b27f1002c1770e80bab929";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-costmap-2d/default.nix
+++ b/distros/galactic/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-costmap-2d";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "918e7b8f803013a38f38f7c6405c9765ba38c1493258c6429c8a30e511543a61";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "dc26b6e385625b8cf9b41847398e099c6776ff2a5f49d933c481f0548cec0ccb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-dwb-controller/default.nix
+++ b/distros/galactic/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-galactic-nav2-dwb-controller";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b3e7e1518928747c71e19c97d9696cdfc9d825b505d5d2d5f3f2b130b681126c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9ae330b3f9fbcb7f0fbf60151c48937204eb17b1d774e4b17fa34ce32b7a9879";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-gazebo-spawner/default.nix
+++ b/distros/galactic/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-gazebo-spawner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "d57c036d486adaa41ab7fa70b23850b543a83ea222a07ecadc3e7d4b09a23651";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c39156475df3d313df0e07e2b207f97d3a25eb3a44e641a7c46c07d6f2c6f919";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-lifecycle-manager/default.nix
+++ b/distros/galactic/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-lifecycle-manager";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "43201d9dc1735125a9e9f4a62357c59b0b2c6bed60d6c90ef7270fc3617b3ed3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0678d785879f8fed41038e525678308bc512fc4ab32dc18b694e9b56e57e86b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-map-server/default.nix
+++ b/distros/galactic/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-nav2-map-server";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "75b188e55038a73ab14bf294cbb5e4f404f323380375c8677468a7eee1baf697";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "597d13449dd14ffddc7c499fd9f8c524094de21a35c35d0434c208033d5130bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-msgs/default.nix
+++ b/distros/galactic/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b48a600d1567b77d40ec9e7fe14b79a863d3fb1bd0f2f462dc43667301228dce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "83eb817059d99b723f7838f3336351a7a48ef52a6f065f18b207afa8de506b17";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-navfn-planner/default.nix
+++ b/distros/galactic/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-navfn-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "32918500a35865d53cd5bec273debe6dd03b0c9e71ac4939028d5ee23400d8e5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "48e09a42db2c35079a21fc89bb87e5b0a8cf181c87469846a4b3ade07d5e756f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-planner/default.nix
+++ b/distros/galactic/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "824b39d8bc34e535b701d81f0ac2d4e1a92e8760886f3de26b9531995f52a2ce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "2a3602549d958381fe64d9cab965f7ff28db872af7bcd8df8853e38c8628d6de";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-recoveries/default.nix
+++ b/distros/galactic/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-recoveries";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0b02b1847728ee9b1a328eaa406be05c23b311502f5c562af7b219cda9ad848b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "caef9dee9228b16182fdb604dd12a51b255bfdfa5c0491985749cce533d86b49";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-regulated-pure-pursuit-controller";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "ba19334ad711048d27988e12b886ac3526e0c4940f5a3c5dbbbfab52cd790ea4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f13615c9eb011d4cb1cf6007b4898f9564ce6e214f039a96ff51a09922820d77";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rotation-shim-controller/default.nix
+++ b/distros/galactic/nav2-rotation-shim-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-nav2-rotation-shim-controller";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "852e2a3e117b6ef70ed2b4bdb958db5a4a308f0de6bf9e14989098cfb8bcba7e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common nav2-controller nav2-regulated-pure-pursuit-controller ];
+  propagatedBuildInputs = [ angles geometry-msgs nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Rotation Shim Controller'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/nav2-rviz-plugins/default.nix
+++ b/distros/galactic/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rviz-plugins";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "d876f89a392f9199520a05b4a553170af808eaddfab397235ad07ebc6cb5f457";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6a3dcbb3d8e77bbdf9fdb7336c3fe0eef9c1c9f3c8ec1012ae9343105615c197";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-simple-commander/default.nix
+++ b/distros/galactic/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-simple-commander";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "fc153e56e98c556ac57bebbb07faaba3deef55741b8ad98c24d51285a01c8922";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "24c57bae60bfd30dceb62f3685eba2b29c23da4120b4aa004bd52e16b145587b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-smac-planner/default.nix
+++ b/distros/galactic/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-smac-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "99b7144f9e96d9f26a64f61c423960ffeb6655e739c209fb0f2a37ea8d115954";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8ee8003ac342a71d0cc4c6b86afc3dfb262ad7ba278096cd54afb6ce7c6db528";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-system-tests/default.nix
+++ b/distros/galactic/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-system-tests";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "af0e973d832ccf43758ad631fb048e535bdf7736b9b51360272f20bf6d55bc49";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "5525c11d8458084fcfa2c0cdaec2075afd3a10c5480b480faee95d84827bc21a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-theta-star-planner/default.nix
+++ b/distros/galactic/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-theta-star-planner";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b691123c9d585d659206bc14356080707d22cbe66fadc8c2054048222170eed5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "eba62b8571927c432c441a86f39c42ea2eaa610af486a6a267458defe8169795";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-util/default.nix
+++ b/distros/galactic/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-util";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b1df4faec8bd0bf43b78c51324bcb8d85a802d71e93f69df2aa26c91cd46e315";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a6c599717e569696086a85db0d59d4201a2a680d3005cd422590f759eaa0fd07";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-voxel-grid/default.nix
+++ b/distros/galactic/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nav2-voxel-grid";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "3bf9e8b9007143d784c20929e1bd706865b6d6002ce22ff872973d96e0d0a20f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b07a8b6dab8bdd9bd3583cb703299564623f17285fad51cf282660b5b6a14298";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-waypoint-follower/default.nix
+++ b/distros/galactic/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-waypoint-follower";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5deddbaa934c323eadf05f72b6e2af5ef5d1a34f5f091cd5c43324d83563e5ae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4946626f3049ac302bb685978dfcdff6f45d0784d8d86be5efd0a61eed4ac4c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/navigation2/default.nix
+++ b/distros/galactic/navigation2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-galactic-navigation2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "dd1ac8a8552b178c3fbb83da9f49cabf9a7e48e5ea2cbd9c1f10852200f1ee67";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0debc66cb77c39a716184bc4b44cf824133e181bb6ea73b243a62f2dd9e8eb29";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-regulated-pure-pursuit-controller nav2-rviz-plugins nav2-smac-planner nav2-util nav2-voxel-grid nav2-waypoint-follower ];
+  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-regulated-pure-pursuit-controller nav2-rotation-shim-controller nav2-rviz-plugins nav2-smac-planner nav2-util nav2-voxel-grid nav2-waypoint-follower ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/octomap-ros/default.nix
+++ b/distros/galactic/octomap-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-octomap-ros";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/galactic/octomap_ros/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "8c4842e8369ac1c1fcc29d4347724c4630a219df1b76d3ec1e56de28757225b7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ octomap octomap-msgs sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''octomap_ros provides conversion functions between ROS and OctoMap's native types.
+    This enables a convenvient use of the octomap package in ROS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/octomap-rviz-plugins/default.nix
+++ b/distros/galactic/octomap-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-rendering }:
+buildRosPackage {
+  pname = "ros-galactic-octomap-rviz-plugins";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/octomap_rviz_plugins-release/archive/release/galactic/octomap_rviz_plugins/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "30e4acb74abded27d2a77ab223f45df9a40f49afbf480c54a74b3335ae8fda46";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ octomap octomap-msgs qt5.qtbase rclcpp rviz-common rviz-default-plugins rviz-rendering ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''A set of plugins for displaying occupancy information decoded from binary octomap messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/openvslam/default.nix
+++ b/distros/galactic/openvslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, glog, libg2o, libyamlcpp, opencv3 }:
 buildRosPackage {
   pname = "ros-galactic-openvslam";
-  version = "0.2.3-r3";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/OpenVSLAM-Community/openvslam-release/archive/release/galactic/openvslam/0.2.3-3.tar.gz";
-    name = "0.2.3-3.tar.gz";
-    sha256 = "942efc34b17b39cd4eb9051f757c00c8c5efb66b1acb09a9beae736189f9b74e";
+    url = "https://github.com/OpenVSLAM-Community/openvslam-release/archive/release/galactic/openvslam/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "f538afb090fb261f4f086249cda7a195c41375ed30453a21550de24b7a8f8be6";
   };
 
   buildType = "cmake";

--- a/distros/galactic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/galactic/pilz-industrial-motion-planner-testutils/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-galactic-pilz-industrial-motion-planner-testutils";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner_testutils/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "a994ae51f4cd474c74e12841205cfd6b6ef5d0584539ee1ff9072bd3c605c63f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common tf2-eigen ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen3-cmake-module moveit-core moveit-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''Helper scripts and functionality to test industrial motion generation'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/pilz-industrial-motion-planner/default.nix
+++ b/distros/galactic/pilz-industrial-motion-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-pilz-industrial-motion-planner";
+  version = "2.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "3080160dd7c7ffaeec5f09da3fc7a8d8cad0e185d7ce1c273d12fd3f96dc9fdb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common boost moveit-resources-panda-moveit-config moveit-resources-prbt-moveit-config moveit-resources-prbt-pg70-support moveit-resources-prbt-support pilz-industrial-motion-planner-testutils ];
+  propagatedBuildInputs = [ eigen3-cmake-module geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface orocos-kdl pluginlib rclcpp tf2 tf2-eigen tf2-eigen-kdl tf2-geometry-msgs tf2-kdl tf2-ros ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''MoveIt plugin to generate industrial trajectories PTP, LIN, CIRC and sequences thereof.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.3.0-r1";
+  version = "3.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "8ff87369227746810a8068000a5379d6369035e98df6007fedfc4929c2f3f1e2";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.3.4-1.tar.gz";
+    name = "3.3.4-1.tar.gz";
+    sha256 = "a4a9055591b9e5f42beca45b55be8a5d52ad825fe00e1c608775667882bd629c";
   };
 
   buildType = "catkin";

--- a/distros/galactic/position-controllers/default.nix
+++ b/distros/galactic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-position-controllers";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "489497b9e8702b757c452857f19a5731f613811f03567027a72797ae5912cc26";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a7b6e98ecd057b3d57851ece9765b35ae696e3995c3a8d63121655f5c8555600";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/quaternion-operation/default.nix
+++ b/distros/galactic/quaternion-operation/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-quaternion-operation";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/galactic/quaternion_operation/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "2000adee827cb2b8cdea6dd0ad31d7d4abf6fd13669da21f5ff2b2eb02e39866";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/galactic/quaternion_operation/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "0e5d07e17d6eb8299210be25f68fcb5f96b0bcd7edee11536918bd37b5b7d543";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ouxt-lint-common ];
   propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/rmw-cyclonedds-cpp/default.nix
+++ b/distros/galactic/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rmw-cyclonedds-cpp";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "2fc03f09537ea23892b56d173f50b10728f057ae6b56cccbd13848e253c89d6e";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "f86f6503f2b9cb5bac39e1582afd46867521eef1ca9266f4944922ba69c8d207";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control-test-assets";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "71cbb3533b3a9876e488871e9acb2120ef4ee5b506b09db8131bf53359e7fd05";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "d69ccc2ff88c42f88e3338efe9d139183592bcd61a5105bc11af222a3c037784";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "537000c224e9bd7e777d544be7be999a246d43f617b94e0d0577f2b5bbe55e8e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7350186da2c823a4950e143b0800c8a3c7f6cb3495c4344270bb26cdb2ae1d9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-controllers/default.nix
+++ b/distros/galactic/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-galactic-ros2-controllers";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0a0e850ad54a517684704f03527bd749419a4b8d6bb6fcc8d54b6f32083f611f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "6b6b2401381d92f219e6c714abe979341fee3f7e806742c4f4fe663056afb285";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-galactic-ros2controlcli";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "8f132b92e674ec1003f95fca10501f023fa51ce3a2e07b1809a21787dc0058fb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "31fa4dbf44a46ea0d1535a4ca86b3c33d4ad3374af24031055881d52a40d6ee6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rtabmap-ros/default.nix
+++ b/distros/galactic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rtabmap-ros";
-  version = "0.20.15-r2";
+  version = "0.20.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/galactic/rtabmap_ros/0.20.15-2.tar.gz";
-    name = "0.20.15-2.tar.gz";
-    sha256 = "6dd3c53c5bf8dacaa5c42f12e9314391648d89a0d3a0f1d6986202f73300506b";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/galactic/rtabmap_ros/0.20.16-2.tar.gz";
+    name = "0.20.16-2.tar.gz";
+    sha256 = "7889e7a44744ccef3141b82196a12fdf595fc3612727865e4a17332d104b184d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/sick-safetyscanners-base/default.nix
+++ b/distros/galactic/sick-safetyscanners-base/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake }:
+buildRosPackage {
+  pname = "ros-galactic-sick-safetyscanners-base";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/galactic/sick_safetyscanners_base/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cb34ad712a00f433ad3307ea7c1cc09621a41501fd99f6ee89b042809edda8d3";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Provides an Interface to read the sensor output of a SICK
+  Safety Scanner'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/galactic/sick-safetyscanners2-interfaces/default.nix
+++ b/distros/galactic/sick-safetyscanners2-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-sick-safetyscanners2-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners2_interfaces-release/archive/release/galactic/sick_safetyscanners2_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "745e3a59706875ad05ddb1dcb835e24bca73c9fd5831ee08030cd662c2da11bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces for the sick_safetyscanners ros2 driver'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/galactic/sick-safetyscanners2/default.nix
+++ b/distros/galactic/sick-safetyscanners2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
+buildRosPackage {
+  pname = "ros-galactic-sick-safetyscanners2";
+  version = "1.0.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/galactic/sick_safetyscanners2/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "ff786c38ed256f8d35bb40c93eee1badb70aad97525d98948f6583e50b3c955b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle sensor-msgs sick-safetyscanners-base sick-safetyscanners2-interfaces ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 Driver for the SICK safetyscanners'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/galactic/sol-vendor/default.nix
+++ b/distros/galactic/sol-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ouxt-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-sol-vendor";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/sol_vendor-release/archive/release/galactic/sol_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "99769c78a3822a4f526d248b6c9dd58a2194b0d7649c31d854f6c60a738ea92c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''vendor package for the sol2 library'';
+    license = with lib.licenses; [ asl20 mit ];
+  };
+}

--- a/distros/galactic/tile-map/default.nix
+++ b/distros/galactic/tile-map/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, libyamlcpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-tile-map";
+  version = "2.2.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/galactic/tile_map/2.2.0-3.tar.gz";
+    name = "2.2.0-3.tar.gz";
+    sha256 = "e5c953792639ada4f61da76904ecd2bd27cdacc2c3e0cace4053bc5c39d9cbc3";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ glew jsoncpp libyamlcpp mapviz pluginlib qt5.qtbase rclcpp swri-math-util swri-transform-util tf2 ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''Tile map provides a slippy map style interface for visualizing 
+     OpenStreetMap and GoogleMap tiles.  A mapviz visualization plug-in is also
+     implemented'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-galactic-transmission-interface";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6fe17a028b83308eb08eaf5314b0477685c4f7c7d013498940ed4908a3aeb3d0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "3a24d8b87edc6b3acc0f2480628bed0377d44b8b871a2affd5624786b669061c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velocity-controllers/default.nix
+++ b/distros/galactic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-velocity-controllers";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ed095bd439478ba48335b27ff8c76f90b3fe9757684a5249f4a8276a164b5903";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "179727388643ff840ab822e4a7fae7b7035f1b125607f988f50d2b3520e62df7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-description/default.nix
+++ b/distros/galactic/velodyne-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-velodyne-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "a9e8e0c59271c938648c67468aa4a9367311f9bd565d7955f0e3c4a445e99e43";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-ros urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF and meshes describing Velodyne laser scanners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/velodyne-gazebo-plugins/default.nix
+++ b/distros/galactic/velodyne-gazebo-plugins/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-ros, rclcpp, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-velodyne-gazebo-plugins";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "f111781e9bd1aa946f9ea2c1ab0fcc5a1e7f2a760e4e68a6ab5885e7f43b1c43";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-dev gazebo-msgs gazebo-ros rclcpp sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Gazebo plugin to provide simulated data from Velodyne laser scanners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/velodyne-simulator/default.nix
+++ b/distros/galactic/velodyne-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-description, velodyne-gazebo-plugins }:
+buildRosPackage {
+  pname = "ros-galactic-velodyne-simulator";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_simulator/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "f309a0d58b685d49a22aaf4cb536bcf44abea570d2d7734bfee532589c65de30";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-description velodyne-gazebo-plugins ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage allowing easy installation of Velodyne simulation components.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/visp/default.nix
+++ b/distros/galactic/visp/default.nix
@@ -1,0 +1,34 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bzip2, cmake, doxygen, eigen, libjpeg, liblapack, libpng, libv4l, libxml2, opencv3, xorg }:
+buildRosPackage {
+  pname = "ros-galactic-visp";
+  version = "3.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/lagadic/visp-release/archive/release/galactic/visp/3.4.0-2.tar.gz";
+    name = "3.4.0-2.tar.gz";
+    sha256 = "00a97b20710104bd70c17c4aec491a0511a3cd6e984e00a592baae8e28581406";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ bzip2 doxygen ];
+  propagatedBuildInputs = [ eigen libjpeg liblapack libpng libv4l libxml2 opencv3 xorg.libX11 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''ViSP standing for Visual Servoing Platform is a modular cross
+    platform library that allows prototyping and developing applications
+    using visual tracking and visual servoing technics at the heart of the
+    researches done by Inria Lagadic team. ViSP is able to compute control
+    laws that can be applied to robotic systems. It provides a set of visual
+    features that can be tracked using real time image processing or computer
+    vision algorithms. ViSP provides also simulation capabilities.
+
+    ViSP can be useful in robotics, computer vision, augmented reality
+    and computer animation.'';
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/galactic/webots-ros2-control/default.nix
+++ b/distros/galactic/webots-ros2-control/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-control";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_control/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "8839ceab3f4baab7daa3e067cef441d1e78f5ce51a9d42fcdc44ac57d914dcaf";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_control/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "bc6a6b1f4ec11278e6c3bdbef2f1b85bdc1ebf4f7c24d9697e7f831e800bf4a0";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ controller-manager hardware-interface pluginlib rclcpp webots-ros2-driver ];
+  propagatedBuildInputs = [ controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle webots-ros2-driver ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/webots-ros2-core/default.nix
+++ b/distros/galactic/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-core";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_core/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "900d07b75665a03e0e535536e98b711ce4c2ec6c90d85c3c202c930174755a05";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_core/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "5f33fe452842a7bfba069cebb6fdba441a45ea17b7e85f8ca44b07c96da8f913";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-driver/default.nix
+++ b/distros/galactic/webots-ros2-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-driver";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_driver/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "7107dd5c23d46910a57eec64b5614554d679dd98bea0418f782c5295f29877a7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_driver/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "ffb791f9b29a601ff62942371c5657ae20732a100c07b5e60fa06901756857cd";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-lifecycle rclpy sensor-msgs std-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/galactic/webots-ros2-epuck/default.nix
+++ b/distros/galactic/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-epuck";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_epuck/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "9a3a8d9b2bb0bf942e440143b84db15b196e6b6d9ecfa9feea589f13213f1b98";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_epuck/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "c99c478d2577f80e306d75abdfbd43389a5a526671cfdfe679a6b51121d4137e";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-importer/default.nix
+++ b/distros/galactic/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-importer";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_importer/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "1e174310676bad25e5353d00bdc2697a37a6d95bc9a04b10e9c134906f60327e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_importer/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "2de6ec50d2f3b682537fd71d08fe15ebe7900988f6c1dd86107ec9c13f26feff";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-mavic/default.nix
+++ b/distros/galactic/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-mavic";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_mavic/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "c3407e3244b027f96aa480ae32dae7382b055f109cfd54add8c93761b5be28da";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_mavic/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "01197293c2b1483714ff276116738676fcb25ae72a6dd9659090522737a37324";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-msgs/default.nix
+++ b/distros/galactic/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-msgs";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_msgs/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "a965f437604ab943e0309ba0dba57d3968ef86fedf003a9af1203745beba329b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_msgs/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "fc8ced284b7a3dd5ee5160e52fe79ab17e6ebedcfa590da4ac456b3ee67238cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-tesla/default.nix
+++ b/distros/galactic/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tesla";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tesla/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "9e87ebc738cdeb1aa87f80049f12ade2d60d1fae645a43a4169467ae20296e3e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tesla/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "b2781f57464a6adfcdd14671a18335fcde93fa0a62fcf66a478245227f51952c";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-tests/default.nix
+++ b/distros/galactic/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tests";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tests/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "205e0e1ab0f0db9ed9d7f71269b20be3b88913a80ea0942318e12977263b2c4b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tests/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "30cc6ff0810fce3df0d1fec414347262b42acd397efbe48322c592ce04835788";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-tiago/default.nix
+++ b/distros/galactic/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tiago";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tiago/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "46695803c0496f4efbfefc979d471084e941b8d2c20476db2e253ea1845471e0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tiago/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "8e31874f5b11f542e11b80cbcf91e7b603a32346f07e0462d66a08d9de5e0be9";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-turtlebot/default.nix
+++ b/distros/galactic/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-turtlebot";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_turtlebot/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "b7c3b25954c9b041f4b32c5106b63e6ed157c0b05c2baa224bba9824bfcb8b8b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_turtlebot/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "35a8a84da04ac74b61fac158068e04a762e3c4e53754033dcfeabb4c1cf757cc";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-universal-robot/default.nix
+++ b/distros/galactic/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-universal-robot";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_universal_robot/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "9684edce58b3dd0f4d8deb6033bfc58318abe5335620ca0aba63882cc2801849";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_universal_robot/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "8bb6dc25eb7427b1687142444683854b2a60d17eef86cdfde9515ce01f6c2ce2";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2/default.nix
+++ b/distros/galactic/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-core, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2";
-  version = "1.1.2-r2";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "10797ac0c9be45cfb68c2b1c381dcc95b875c4cf3e1f1ef9580e9133c20bdfbb";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "618ad641c643dbc1ce57cd21bccfcfa0a07ade2f7d1198ae74ac70a5f014f157";
   };
 
   buildType = "ament_python";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2110,6 +2110,8 @@ self: super: {
 
  microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
 
+ microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
+
  microstrain-mips = self.callPackage ./microstrain-mips {};
 
  mikrotik-swos-tools = self.callPackage ./mikrotik-swos-tools {};

--- a/distros/melodic/hpp-fcl/default.nix
+++ b/distros/melodic/hpp-fcl/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/1.0.1-2.tar.gz";
     name = "1.0.1-2.tar.gz";
-    sha256 = "f6c9669e0b2cf9cbc04bfc89014ae8a82b0895e65eec29d65ca557ca6d375a41";
+    sha256 = "2fdf0400d19ccdc82b6788b4715d5adf11af7e3159f8cd87f5a401ddd3fb53f5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-driver/default.nix
+++ b/distros/melodic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, mavros-msgs, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-driver";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "f83bc1d208a3ee8a01995daa804d066e3179b3ba5131b20b743399c553eae01d";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ec30eb41bae65cff1549119712d156f279a6d0a62fdb49d8de6b45ccd6e8c857";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-examples/default.nix
+++ b/distros/melodic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-examples";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "58e1591ba47af5d520d094b32bb5ca6952839810c2ffc9da74a4b1bd9720ed08";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "9b802c25cfda1b74cd821c0d63af22ecec7097ad7c59a67a38201bba75bab8d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-msgs/default.nix
+++ b/distros/melodic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-msgs";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "56922f8cb50381c8cff61218038e0abfe9dd2f5b73507c88f2448e60cbc7500d";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "fa7a85ffa88bdeb56c48bd30383d0e15704fde3565a20407c737df77cc72643d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-rqt/default.nix
+++ b/distros/melodic/microstrain-inertial-rqt/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rospy, rqt-gui, rqt-gui-py, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-microstrain-inertial-rqt";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_rqt/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "50e3fac17c6cf95016beadd913edf1ea05da93afd893f943ea5ed3d9ce4dc5c8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs microstrain-inertial-msgs nav-msgs rospy rqt-gui rqt-gui-py std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The microstrain_inertial_rqt package provides several RQT widgets to view the status of Microstrain devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/octomap-mapping/default.nix
+++ b/distros/melodic/octomap-mapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap-server }:
 buildRosPackage {
   pname = "ros-melodic-octomap-mapping";
-  version = "0.6.5-r1";
+  version = "0.6.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_mapping/0.6.5-1.tar.gz";
-    name = "0.6.5-1.tar.gz";
-    sha256 = "f1f29ddb95c6b2ff8a93fa7f3fa91cbc1fce4c0a8901bcce4bc45cb1b6eb3b0a";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_mapping/0.6.7-2.tar.gz";
+    name = "0.6.7-2.tar.gz";
+    sha256 = "da9ba92aeebe8ef2e3247256afdd9afc787e0df5c51938731444a317654556ff";
   };
 
   buildType = "catkin";

--- a/distros/melodic/octomap-rviz-plugins/default.nix
+++ b/distros/melodic/octomap-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap, octomap-msgs, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-melodic-octomap-rviz-plugins";
-  version = "0.2.2-r1";
+  version = "0.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_rviz_plugins-release/archive/release/melodic/octomap_rviz_plugins/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d1b11e67430f976ea17a6899ec116266d7b62f8e62fa579b67eb8393b72d1695";
+    url = "https://github.com/ros-gbp/octomap_rviz_plugins-release/archive/release/melodic/octomap_rviz_plugins/0.2.4-2.tar.gz";
+    name = "0.2.4-2.tar.gz";
+    sha256 = "8f5bf0f81a1734bd921fbb238890d39f32aad30f614d6b7437a42715ff8cb1b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/octomap-server/default.nix
+++ b/distros/melodic/octomap-server/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nav-msgs, nodelet, octomap, octomap-msgs, octomap-ros, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nav-msgs, nodelet, octomap, octomap-msgs, octomap-ros, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-octomap-server";
-  version = "0.6.5-r1";
+  version = "0.6.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_server/0.6.5-1.tar.gz";
-    name = "0.6.5-1.tar.gz";
-    sha256 = "160f1233069756cee1dd7109eb1f685d02f1e076fccd395e28c53ac508b5569c";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_server/0.6.7-2.tar.gz";
+    name = "0.6.7-2.tar.gz";
+    sha256 = "e3d5b8d31791cd37ab44d3e6858802b35afd4d36c7f840e83722fadf35a302df";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure nav-msgs nodelet octomap octomap-msgs octomap-ros pcl pcl-conversions pcl-ros roscpp sensor-msgs std-msgs std-srvs visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure nav-msgs nodelet octomap octomap-msgs octomap-ros pcl-conversions pcl-ros roscpp sensor-msgs std-msgs std-srvs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, fmt, geometry-msgs, message-generation, message-runtime, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, std-msgs, tinyxml-2, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "62d1cebbdde80171d4f859e4b9687390713bca5871ef3fdce9e4ab3481a20780";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "cb910c6f597bbbdaad4527f5588e17a7665cb7f4d97e2c862615523bd55f46dd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-benchmark/default.nix
+++ b/distros/melodic/rdl-benchmark/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_benchmark/3.2.0-1/rdl_release-release-melodic-rdl_benchmark-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_benchmark-3.2.0-1.tar.gz";
-    sha256 = "b3764041b76d8541b11d5acdb176bed3be086ec1b953a41aa2b56b42898d34aa";
+    sha256 = "d351794b18247cd31330fe3a9d7a84cd41c5bd8b65b3f9ed11a9abae582fed82";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-cmake/default.nix
+++ b/distros/melodic/rdl-cmake/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_cmake/3.2.0-1/rdl_release-release-melodic-rdl_cmake-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_cmake-3.2.0-1.tar.gz";
-    sha256 = "dd87bce11db76a5bd23cb7919bd886b93bb97b99df3396b824b6132619dacb7e";
+    sha256 = "30c5695aa0bb0847d991d05020be78e50d5795c51b832eeb17990da8c0488bc2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-dynamics/default.nix
+++ b/distros/melodic/rdl-dynamics/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_dynamics/3.2.0-1/rdl_release-release-melodic-rdl_dynamics-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_dynamics-3.2.0-1.tar.gz";
-    sha256 = "02996f90bf325b1c47f8b436761468a0af9662aa937ec90250cf10ecd7107fa0";
+    sha256 = "85053786c16693de1bd832d6f81307d41d63b593e2f2b54cd32d8adca0a03bf1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-msgs/default.nix
+++ b/distros/melodic/rdl-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_msgs/3.2.0-1/rdl_release-release-melodic-rdl_msgs-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_msgs-3.2.0-1.tar.gz";
-    sha256 = "338e4d203d43511f7232d2528f44364d36c739eb86f5de1b791e68ea2e9273d2";
+    sha256 = "e51406d626a0114ed044ee5e90462bc10737ed057a5abf50f808fdea52cd6ddf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-ros-tools/default.nix
+++ b/distros/melodic/rdl-ros-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_ros_tools/3.2.0-1/rdl_release-release-melodic-rdl_ros_tools-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_ros_tools-3.2.0-1.tar.gz";
-    sha256 = "3d535dc2d58a675a64d78d2b30820586f00b16e350008e146e9ac19415e0c926";
+    sha256 = "36c236da8fa738216e65211f173f73a203d2b99a582e396aabf170e26d841483";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-urdfreader/default.nix
+++ b/distros/melodic/rdl-urdfreader/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_urdfreader/3.2.0-1/rdl_release-release-melodic-rdl_urdfreader-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_urdfreader-3.2.0-1.tar.gz";
-    sha256 = "acf08d42afc98a4ffb76a16dfc67124f19f3adeb56167f886322019cb3fc83ee";
+    sha256 = "21e9d728f57fa66aa13948bb25fd1900aa5926410fe533b6e92da0f8acf00ffa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl/default.nix
+++ b/distros/melodic/rdl/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl/3.2.0-1/rdl_release-release-melodic-rdl-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl-3.2.0-1.tar.gz";
-    sha256 = "697a892941f85b37eb08270936b94605ef7745c4aa2f7788f64b1a4974b5bf46";
+    sha256 = "402f1c9db58df28b9506bff1ae06cafb299e6a076cb46a1bc44f8bfc9019436e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-babel-fish-test-msgs/default.nix
+++ b/distros/melodic/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish-test-msgs";
-  version = "0.9.0-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "038ad5070750b9751b0d6bd18052dfcf4ab5b2c0b4dd16f0051b092624d3b482";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "f13a502ad8757c7101ac8687cc3dd5771b0952ed91275872a7f2b89ab8891bce";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The ros_babel_fish_test_msgs package'';
+    description = ''Test messages for the ros_babel_fish project tests.'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/ros-babel-fish/default.nix
+++ b/distros/melodic/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, rosgraph-msgs, roslib, rostest, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish";
-  version = "0.9.0-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "a77c88ba1fbe3131cb23d79a40eda505d5243dcd2439765f3f234b3fec442283";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "394a08a9ae770f97183f60302b4a037b9ed207b4480c1937e7e5aa85e62751fb";
   };
 
   buildType = "catkin";
@@ -19,7 +19,8 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The ros_babel_fish package'';
+    description = ''A runtime message handler for ROS.
+    Allows subscription, publishing, calling of services and actions with messages known only at runtime.'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/rtabmap-ros/default.nix
+++ b/distros/melodic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rtabmap-ros";
-  version = "0.20.14-r1";
+  version = "0.20.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.14-1.tar.gz";
-    name = "0.20.14-1.tar.gz";
-    sha256 = "d9d882c91b301c548931162eac1fc0c10ad01ccbd3296fca5fa9b09a2e8f2220";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.16-1.tar.gz";
+    name = "0.20.16-1.tar.gz";
+    sha256 = "250b3e763c0c8b86070a583a5f5e27cab64cc7406f262a099eeafed19b3ebcae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/azure-iot-sdk-c/default.nix
+++ b/distros/noetic/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-azure-iot-sdk-c";
-  version = "1.7.0-r4";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.7.0-4.tar.gz";
-    name = "1.7.0-4.tar.gz";
-    sha256 = "a15053f5d1ea349991c07839eaf8c8a8eaa33fdb2c98ad7ae0fd898c1b638aa8";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "99981f9fd418f28de05e290b3dac70eaa09c3b1a0654353e51f02477fa6322bd";
   };
 
   buildType = "cmake";

--- a/distros/noetic/cob-3d-mapping-msgs/default.nix
+++ b/distros/noetic/cob-3d-mapping-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-object-detection-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-3d-mapping-msgs";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_3d_mapping_msgs/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "eb80493b8a8f0a77838bdc437a95146e3f018dd2bd74da92a99c21be3291f41d";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_3d_mapping_msgs/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "4beb7a4528d3e4f36e77ff78e2b4a24db1bf30a52fb3379378d28250a2d0ce55";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-actions/default.nix
+++ b/distros/noetic/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-actions";
-  version = "0.7.4-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "1b0afd83c6c9676136de2b9045c800eb5cfc0bef7bc8f97e60e36a746ce913a9";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "c24526eee854445bde1d739ced3151f1376038f4e40a6c23516b148e9b519228";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-controller-utils/default.nix
+++ b/distros/noetic/cob-base-controller-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, rospy, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-controller-utils";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "9dac4470da97d3a30960160e8a3081647c38807cacfdba612a0b35e89c31e61f";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "45d510270624b502ffd1da0fec23b034a82f383dd832790bf63c9e6fa3e5dd62";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-drive-chain/default.nix
+++ b/distros/noetic/cob-base-drive-chain/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-canopen-motor, cob-generic-can, cob-utilities, control-msgs, diagnostic-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-drive-chain";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "59bc5dbf5d0deb8d8b12e74960ea10a21f520b0440b413c815f287d9c1b06073";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "0e9f4a3ea5ed98f8a874a8a13323c894db17bfd25242ebe1e73d240743bbb4a4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-velocity-smoother/default.nix
+++ b/distros/noetic/cob-base-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-velocity-smoother";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "8da45623cc97be46aa093ff233717a803296eb5e84698ed39a4d42caab9eef35";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "0cab55a9bef54519eb9f0c4924ddcdeac848719b65864a0b11a4fdb3aed8e0c9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bms-driver/default.nix
+++ b/distros/noetic/cob-bms-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, pythonPackages, roscpp, rospy, socketcan-interface, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, python3Packages, roscpp, rospy, socketcan-interface, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-bms-driver";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "c3201d6c6554b524f9fce4a123bf9d064d98a4d8b8f3e141946fad09e198cd00";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "3719634d01727691f348f70915270d74df8b36de04aa0fb57badbc66ebbda67b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cob-msgs cob-srvs diagnostic-msgs diagnostic-updater pythonPackages.numpy roscpp rospy socketcan-interface std-msgs ];
+  propagatedBuildInputs = [ cob-msgs cob-srvs diagnostic-msgs diagnostic-updater python3Packages.numpy roscpp rospy socketcan-interface std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/cob-calibration-data/default.nix
+++ b/distros/noetic/cob-calibration-data/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-calibration-data";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/noetic/cob_calibration_data/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "312ab060ae878aa1af06e0474397756e2a76d06811ec7548aef197570c8ac64f";
+    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/noetic/cob_calibration_data/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "8f38e820b614d84bfc6a9f5c8f75b11db223c613a6f4f98b3fc62c0544b7a646";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cam3d-throttle/default.nix
+++ b/distros/noetic/cob-cam3d-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, nodelet, pluginlib, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-cam3d-throttle";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_cam3d_throttle/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "c5d240e7a2a77ba30ee3996586943a11f1f2a6499f4fd258c87f8ce21ba90048";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_cam3d_throttle/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "ac433834395c2d0928182e13403da1911c7c97b315c5faa7044932dc415deaa1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-canopen-motor/default.nix
+++ b/distros/noetic/cob-canopen-motor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-generic-can, cob-utilities, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-canopen-motor";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "f49516bc57aebed021aad3697864a75abdb2058356af969046b67b49ee9f3711";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "aabb0927831577e7e656b8eae07270a0bbfdbad60ec6cf1d63bfe2f58dbe509e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cartesian-controller/default.nix
+++ b/distros/noetic/cob-cartesian-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-frame-tracker, cob-script-server, cob-srvs, cob-twist-controller, geometry-msgs, message-generation, message-runtime, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, std-msgs, std-srvs, tf, topic-tools, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-cartesian-controller";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "af6c4a7445872464147f8357f8fd0be618f7145a26d342265e5c207ba0a1dce0";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "d18a2393f680bcd88e1e4780fd23b83787b2e57643d2163a6079ecc2839110e9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-monitor/default.nix
+++ b/distros/noetic/cob-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-moveit-config, moveit-ros-move-group, moveit-ros-planning, pluginlib, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-monitor";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "fa761e146d7bf956a6c75d4ba58aac655b2dcfd52876984ff6f17c655814012e";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "863695b63278cf0fbcdd2e8d2da5d7475220cced0f8e14e2f2cc5f61bd4bd1bd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-velocity-filter/default.nix
+++ b/distros/noetic/cob-collision-velocity-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-footprint-observer, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, tf, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-velocity-filter";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "ef0a9ea47c084e86dba4058f61cc762b030554412b889fd8b6e441dac66b2b39";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "27ddbfd75c50958905b50bb868d13e29b5e6525d2dab38ac578075f36e2d4cc2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-gui/default.nix
+++ b/distros/noetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, python3Packages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-gui";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "673dd9d7483f604930f9412ba498cd94e06b196d4f0542c82bb363791e20e444";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "835b398812cec0ba4730215d6ae4b1074357d074a345d50cbfd26e03c630ded5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-tools/default.nix
+++ b/distros/noetic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-tools";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "d590644c77e211ddeb11b7e7a87731e547f77378e5926a1c5c124dd1b725719a";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "16474006db239a700177721b727ee81cc896cc209bf1d7d988aa25e2dcd30261";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-common/default.nix
+++ b/distros/noetic/cob-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
 buildRosPackage {
   pname = "ros-noetic-cob-common";
-  version = "0.7.4-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "ac6244e6c38e6742878a79b4e73d49d8782421b83a12ae47f679b1958749303e";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "c6f9ef0ed9e0b363c43a81a7d091999e37e854eaa9d20dd4773bc5c07f2573fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-mode-adapter/default.nix
+++ b/distros/noetic/cob-control-mode-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-manager-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-mode-adapter";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "f96405f58618b035de03a82f1b08cf81785f0079e793c8a76433532d2c975741";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "73347837d941f7aaa1a096444e1ffeb7b13cf06c0335e7adb11c4b3e81e6ccc9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-msgs/default.nix
+++ b/distros/noetic/cob-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-msgs";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "8b53bb2fcb830b2c443f44986097666de06a7d281d57ee164b77175e3d655437";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "613c842b853d1938ab3ee14e0c29aebaa74c7492be624dd4e68c61738c538be4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control/default.nix
+++ b/distros/noetic/cob-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-controller-utils, cob-base-velocity-smoother, cob-cartesian-controller, cob-collision-velocity-filter, cob-control-mode-adapter, cob-control-msgs, cob-footprint-observer, cob-frame-tracker, cob-hardware-emulation, cob-mecanum-controller, cob-model-identifier, cob-obstacle-distance, cob-omni-drive-controller, cob-trajectory-controller, cob-tricycle-controller, cob-twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-control";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "02bd32c57301d102e1fc9456ca2e857b6a5d22ba984e39ebef2e0fa499b70e96";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "7f95b414bd49122a446a2188d4ab34c13bd9756061bea038249b893c51a6ffab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-dashboard/default.nix
+++ b/distros/noetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-noetic-cob-dashboard";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "a1e1b47a49547cbf4e0c42d6788ad8cb27c3d7e73ecc264984caff7f59503c00";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "78d1e617a3310b40b8b8e01d766443ea8878db6530f5d0a829361bcedc1bd656";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-behavior/default.nix
+++ b/distros/noetic/cob-default-robot-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-light, cob-script-server, python3Packages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-behavior";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "7e12701b80dc9c19685009dea621ab59ad9b38afd5f1530bea4d9da09b727edc";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "04a3a72c8b8ab058f179a5ce8ef80f7ef7f5d746c4783ce6273d1f1aef22ce07";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-config/default.nix
+++ b/distros/noetic/cob-default-robot-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-config";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "fe5ba87928b090b3f2c0ea5bdb884eb85e5d6134d18f5d009f5fa2cf7cf23eb0";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "7731694171bcbb7210d7ca97dc6846fa4f7eaccaaca993aae5831274deddcfe5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-description/default.nix
+++ b/distros/noetic/cob-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-description";
-  version = "0.7.4-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "ddde9202db6ddfa49950d323af70dcd6e62a065a6f10d71d38578a5c468b78ce";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "1e3bb38e77b0a1f48c596d4e78ff320cb6d63c460817a0837ebd534e396b5050";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-docker-control/default.nix
+++ b/distros/noetic/cob-docker-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-docker-control";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_docker_control/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "8f67942485c8873feca9cbafbe3981c76865896b6d0546fafc2658d786a17291";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_docker_control/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "ad5a16604e8089ac8a4b548ac74fb924de9a980ec73965f28e1e304cb0809b66";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-driver/default.nix
+++ b/distros/noetic/cob-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-drive-chain, cob-bms-driver, cob-canopen-motor, cob-elmo-homing, cob-generic-can, cob-light, cob-mimic, cob-phidgets, cob-relayboard, cob-scan-unifier, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-undercarriage-ctrl, cob-utilities, cob-voltage-control }:
 buildRosPackage {
   pname = "ros-noetic-cob-driver";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "793ba01909901e1857debfd939471ad2feb9c8a3bf1f6dc5e5d117b414135505";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "1f26c9285e6acc058bd0c5caccd59d85ca5fe6bb987591468e56546b645ebbb7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-elmo-homing/default.nix
+++ b/distros/noetic/cob-elmo-homing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-402, catkin, pluginlib, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-elmo-homing";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "a4ca4f76b31cc53e5c5bb83fc710c582465c99ac1943eed03f08e738c43b0204";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "4ff0f198fe3d5796d775b0eb0ae9a2c71e0dba1bc220cd168609613f37ad8f3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-footprint-observer/default.nix
+++ b/distros/noetic/cob-footprint-observer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-footprint-observer";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "f78185b242ffe938a5fba9d51fdb38408a9e70931c85872a06c2030299e831c4";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "aed27dede5d69c7090ac3e88256873183615ce11971c8b543423d832ae4e1022";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-frame-tracker/default.nix
+++ b/distros/noetic/cob-frame-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-srvs, control-toolbox, dynamic-reconfigure, geometry-msgs, interactive-markers, kdl-conversions, kdl-parser, message-generation, message-runtime, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-frame-tracker";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "a5ddfa408e3c04bd2cbf3870797185eed9381a43708cb6d367b3cfa60d36f3ef";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "f9598f941381418f3a06549b22daf9c14948efa4b72def3a7f9434406c06baa3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-plugins/default.nix
+++ b/distros/noetic/cob-gazebo-plugins/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-gazebo-ros-control }:
+{ lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-plugins";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_plugins/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "84ef489330cd7d586a506e789852683a67d20215c5417d86eb91f3a8d6441463";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_plugins/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "96c90d97757244d423ef5e969a25ba2ef054db9d2adf6c8068bedd4efecb4280";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cob-gazebo-ros-control ];
+  propagatedBuildInputs = [ gazebo gazebo-ros roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''cob_gazebo_plugins meta-package'';
+    description = ''Additional gazebo plugins used with Care-O-bot'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/noetic/cob-gazebo-ros-control/default.nix
+++ b/distros/noetic/cob-gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo, gazebo-ros, gazebo-ros-control, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-ros-control";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_ros_control/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "15f367fd65d13c9f016755782ed0af8ef9c78a3a34c5ce28e0b5710de9d626c7";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_ros_control/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "b2627cb7fccd19d984612a57013acafa2745bf6e7c9b5549fb360240af119add";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-generic-can/default.nix
+++ b/distros/noetic/cob-generic-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-utilities, libntcan, libpcan, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-generic-can";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "0729f0a8bfb859f8a5939bdf96acc2d6acc111dabc36428557bdc2b49f426393";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "d054777f22235d44ae04c88bb5984d66765d4a163853883ce14cc8e41c5297a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-grasp-generation/default.nix
+++ b/distros/noetic/cob-grasp-generation/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-description, geometry-msgs, message-generation, message-runtime, moveit-msgs, python3Packages, robot-state-publisher, roslib, rospy, rviz, schunk-description, sensor-msgs, std-msgs, tf, tf2-ros, trajectory-msgs, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-description, cob-manipulation-msgs, geometry-msgs, moveit-msgs, python3Packages, robot-state-publisher, roslib, rospy, rviz, schunk-description, sensor-msgs, std-msgs, tf, tf2-ros, trajectory-msgs, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-grasp-generation";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "c1370789133022dd8e6b44e11ce6f286ce08ebcdd92450304b720e5988219bb1";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "d7e681a929a37b658d340413be870f05bb558c23b69f0841c6f57515ec117554";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs cob-description geometry-msgs message-runtime moveit-msgs python3Packages.scipy python3Packages.six robot-state-publisher roslib rospy rviz schunk-description sensor-msgs std-msgs tf tf2-ros trajectory-msgs visualization-msgs xacro ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cob-description cob-manipulation-msgs geometry-msgs moveit-msgs python3Packages.scipy python3Packages.six robot-state-publisher roslib rospy rviz schunk-description sensor-msgs std-msgs tf tf2-ros trajectory-msgs visualization-msgs xacro ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/cob-hardware-config/default.nix
+++ b/distros/noetic/cob-hardware-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-calibration-data, cob-description, cob-omni-drive-controller, cob-supported-robots, costmap-2d, diagnostic-aggregator, joint-state-controller, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, laser-filters, position-controllers, raw-description, robot-state-publisher, roslaunch, rostest, rviz, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-config";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "df78f13be49ac0e4b85ff3e1e598b775f89e533365e066b41469a7e9d35f4243";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "ff9ea8ffc5394ec5cb5038fb123289b7f1a5a6e7c63923ec845cdb80a4e46bde";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-emulation/default.nix
+++ b/distros/noetic/cob-hardware-emulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, move-base-msgs, nav-msgs, roscpp, rosgraph-msgs, rospy, sensor-msgs, std-srvs, tf-conversions, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-emulation";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "df679b99bdd8c7415cd3b9c3608ebdd2a03ca112dc9baa6921db5047ec7e8934";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "e670e477879bbab4c18172e8ef9fcfd4a504bbf67bd076e47565f44e2fe403fa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-helper-tools/default.nix
+++ b/distros/noetic/cob-helper-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-helper-tools";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "d0096f06eed7696532c5626c3bbacccce4f3e3f677e43cdad635d7a0f9989787";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "f105735bc2968ab7996b7f1d7b44c48708c846a2319f3d9c247f76bd2b134925";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-image-flip/default.nix
+++ b/distros/noetic/cob-image-flip/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-perception-msgs, cv-bridge, geometry-msgs, image-transport, nodelet, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-image-flip";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_image_flip/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "a45e396e0dfe2b6ebaf9c1166833a1829b9910ae900092412bf8887214d092f7";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_image_flip/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "8ed43b175e6c293491d2e20e0a89e8a6fe9d3f0e8ce03ac1b0d344f1d41ceb63";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-interactive-teleop/default.nix
+++ b/distros/noetic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-interactive-teleop";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "8d5469c33750c15e2ba3c9babb065179010695061f29bf4c6678f02b7319c160";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "f19dcf3e8b33b8f9cc6e349143b0e245ff0b4114ea7f7ef7fd5357397f158466";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-light/default.nix
+++ b/distros/noetic/cob-light/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-light";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "b97e753fde8ddf79c926006102c65316ec44cb36e5d9f30f8883cdd448fb7b3b";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "c4b705eae5a66df0b9d1201d4ad7e8415d1c9a6ce6f41f87c5b45ab728ffa5f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-linear-nav/default.nix
+++ b/distros/noetic/cob-linear-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cob-srvs, geometry-msgs, move-base-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-linear-nav";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_linear_nav/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "11ae20b43adaabd42bc562f71e9ba2acf5c90c42fe71cb11381a92ceb25c08fd";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_linear_nav/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "c5960f0f81f66ef448f648382f5a154a915c171cf8b9eda1ec0cc76fc9be0ce0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-lookat-action/default.nix
+++ b/distros/noetic/cob-lookat-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, angles, catkin, control-msgs, geometry-msgs, kdl-conversions, kdl-parser, message-generation, message-runtime, move-base-msgs, orocos-kdl, roscpp, rospy, sensor-msgs, tf, tf-conversions, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-lookat-action";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "4c47a79bed362a244a73a62ea0aa78f5cbb1145075bccd49c58ad75a785919df";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "5db8ba80099a60b1ea42ef11ecc44b788b1fd5018ea1a29a54d6687e29d8a6d5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-manipulation-msgs/default.nix
+++ b/distros/noetic/cob-manipulation-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, moveit-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-cob-manipulation-msgs";
+  version = "0.7.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation_msgs/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "f41e5d52ca49b9b4b7bc8873311574bc23ef5e3c99bbc38e72f76f6dc84ddb25";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs message-runtime moveit-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for cob_manipulation'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cob-map-accessibility-analysis/default.nix
+++ b/distros/noetic/cob-map-accessibility-analysis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-3d-mapping-msgs, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, nav-msgs, opencv3, pcl, pcl-ros, python3Packages, roscpp, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-map-accessibility-analysis";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_map_accessibility_analysis/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "136cd24256b77bbe702c2464ec66195828d9018405bb3306fb179dd8dba7b495";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_map_accessibility_analysis/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "84f29ecb5205454a098c7ec3029f20ccced67c710f3977baa3a36d435cfc5b47";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mapping-slam/default.nix
+++ b/distros/noetic/cob-mapping-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-navigation-global, cob-supported-robots, gmapping, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-mapping-slam";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_mapping_slam/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "80fe727b8cb2ea13cf5827c085bd7b84fed59c5ba79dd9d5d1bd0dbc8f41ee0e";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_mapping_slam/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "fa9715cf6d686b08d24e9fd971251f0a01a7911b88ada1b58d31231744fcf816";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mecanum-controller/default.nix
+++ b/distros/noetic/cob-mecanum-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-mecanum-controller";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "52e62d6298d46d75a1cb278f7724b618f324cc2727e0fe15474eb057b5d5badc";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "c45c27e24a916fea170e770bccae2b94c53ce142f007905dda0de46dec951a33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mimic/default.nix
+++ b/distros/noetic/cob-mimic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, diagnostic-updater, message-generation, message-runtime, roscpp, roslib, rospy, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-mimic";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "112c9554fe2ae06b56e0ec0c83a8df5d51a3128270d43bb6fdd67dc9567ff476";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "48ec5b45f15735c5ba5290c0f1966eeadc0099240bd3d31597cd2ed5e8982035";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-model-identifier/default.nix
+++ b/distros/noetic/cob-model-identifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, geometry-msgs, kdl-parser, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-model-identifier";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "c8384829ffcd9235b5da5f4519ac911c417b449a615e2f453e95e357f28f3310";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "66377800a1fcdc5c2c106ea5269d07098fc1887d7d2c241649946c1cfa19904e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-monitoring/default.nix
+++ b/distros/noetic/cob-monitoring/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, python3Packages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-monitoring";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "9f795fc52fbefd3ccf091bfde20feee0e27f34a84d137a5cf1f33c8c305aec3e";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "f281d69403f8c7758a5e9520b3719f10c78293c04f78d7d331849f7617254194";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-bringup/default.nix
+++ b/distros/noetic/cob-moveit-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-hardware-config, cob-moveit-config, joint-state-publisher, moveit-planners-ompl, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, moveit-setup-assistant, robot-state-publisher, rviz, tf, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-bringup";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "26edc4f2824687c05a31ed7e9c892a6c0fda70a8fca376dea40585dbf7a8ddf2";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "aaba22f509827cfdd315e46cd3df66a432fec482fb0e2ddfe0d753dd390b9955";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-config/default.nix
+++ b/distros/noetic/cob-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-config";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "7a83f834e0083291ca89e0099d41b0f38a98552a593e826d7b7cb9699b8aa6c5";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "7c00139e3b54bb551daf98b7a15f08ace9bd2936c8fdff1ad74b3d3b69de4d38";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-interface/default.nix
+++ b/distros/noetic/cob-moveit-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-script-server, geometry-msgs, moveit-commander, python3Packages, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-interface";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "17170be18db61eacb68bf039a70d86e00db28e22fa82b5bb4321ade4404f3382";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "0bb73dcafe3ef02ce0678a7d883b6f38e794d6541bbc32b3abd5050615567e7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-msgs/default.nix
+++ b/distros/noetic/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-msgs";
-  version = "0.7.4-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "b561c1344e5d5bdc79cd91c873ff9aed5d67307f902fa8cdc06ba2378fce78fe";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "0e4d104ae4477f6c0e8f94c57894201b18fe9395caba4d4e334d71b2f22d47ef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-config/default.nix
+++ b/distros/noetic/cob-navigation-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-config";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_config/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "045fb465e68e0c7945f4a668f2d2734f2ae4039bd61d24e4004ed8ee8392af5f";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_config/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "75314196a7d593581b1c1705a7908bbb6a14dbf88fd5f3bfe7b9c90e6014b2c7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-global/default.nix
+++ b/distros/noetic/cob-navigation-global/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, cob-default-env-config, cob-linear-nav, cob-navigation-config, cob-scan-unifier, cob-supported-robots, dwa-local-planner, map-server, move-base, roslaunch, rviz, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-global";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_global/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "c23a2752e78f62915c2fb6227f39326bae288b2aa5282321a748150e8c96151c";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_global/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "f93dd0df9a50e8ce3a4b633487d0169f9ca168cbed6651218243e7ad68f8a257";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-local/default.nix
+++ b/distros/noetic/cob-navigation-local/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-navigation-config, cob-supported-robots, dwa-local-planner, move-base, roslaunch, rviz }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-local";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_local/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "a4ed7ae339a6f545f64bb74848494e1a8e137fe1bfd73402ac9a053197804bd8";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_local/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "571daaf3c127c4047266506731334e6e4ff8f599d0a744c559a2c70a6aa2a5fc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-slam/default.nix
+++ b/distros/noetic/cob-navigation-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-mapping-slam, cob-navigation-config, cob-navigation-global, cob-supported-robots, roslaunch, rviz }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-slam";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_slam/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "3112db28ec1b1ae6a7791c5fcd421bf53f90f6a209067e480d453358baa8b56e";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_slam/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "741e655b5e49cfe839acbe839176c238b3825bc2e11ec056374203930121516d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation/default.nix
+++ b/distros/noetic/cob-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-linear-nav, cob-map-accessibility-analysis, cob-mapping-slam, cob-navigation-config, cob-navigation-global, cob-navigation-local, cob-navigation-slam }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "a3d4b46c63018b7fc937fa0fbca23c264c9b53c9f158509d6b506231be3ab8ec";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "bb54c0664945c8fb0b011ee69a4eb5a12360276698668e4f44ec9ca134e51a8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-object-detection-msgs/default.nix
+++ b/distros/noetic/cob-object-detection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-object-detection-msgs";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_msgs/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "8f96649d7bff4f23f086d831d40e3e9ca6944b6dd1098ee1de2f286b269195a7";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_msgs/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "0220523d29b16b9c82bcee66e50b8ac983e3d57e63ad32d984a3d690e277eeca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-object-detection-visualizer/default.nix
+++ b/distros/noetic/cob-object-detection-visualizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-object-detection-msgs, cv-bridge, eigen-conversions, image-transport, message-filters, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-object-detection-visualizer";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_visualizer/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "01abde824833088eedfab80c3b21e4c240dd7eaf6f7aa4c83d8f8ee7f3f5058c";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_visualizer/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "be19c1e5964b12bcfcc6596a11b176a7eab6466a93ebe0057f6f95660c10b935";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-obstacle-distance/default.nix
+++ b/distros/noetic/cob-obstacle-distance/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cob-control-msgs, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, fcl, geometry-msgs, interactive-markers, joint-state-publisher, kdl-conversions, kdl-parser, moveit-msgs, orocos-kdl, pkg-config, robot-state-publisher, roscpp, roslib, roslint, rospy, rviz, sensor-msgs, shape-msgs, std-msgs, tf, tf-conversions, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-obstacle-distance";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "88d175b55638bc98c2073a84e6ef7b43a2f1e78f501480d4e430a9f9695f864d";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "7de7dc257ac1d212f5e784c0cdf4c02909bffe20c576532365619b5e681cdcdf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-omni-drive-controller/default.nix
+++ b/distros/noetic/cob-omni-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-omni-drive-controller";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "8b48b9f06d1fa63d5d6ad4e9b78c17b98cc0e956e3ce2a472bb38df64fad64c1";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "07c2f40bdd4e6d416f3ce2961f58a543ae75dd6b1a7653e57f3f8f65e5ffc36c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-perception-common/default.nix
+++ b/distros/noetic/cob-perception-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-3d-mapping-msgs, cob-cam3d-throttle, cob-image-flip, cob-object-detection-msgs, cob-object-detection-visualizer, cob-perception-msgs, cob-vision-utils }:
 buildRosPackage {
   pname = "ros-noetic-cob-perception-common";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_common/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "e39abf7c6b09d772a12ffef86cb664ce7d09182d075cf0a037e7895abc39351b";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_common/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "c2b674122e1ee467ca4e5b647e734ff569bc3aaebe17cb141aa614c1e0226bbb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-perception-msgs/default.nix
+++ b/distros/noetic/cob-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-perception-msgs";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_msgs/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "1e6e85a9d4ff61ce840162e0e4a6183bdc8e232f7e330b0a39121cd0392f13c2";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_msgs/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "b101f92b078465cbbe5672f6022d1d64a6150e1d8468f65d4794e7fc8f44c71f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-em-state/default.nix
+++ b/distros/noetic/cob-phidget-em-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-em-state";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "af04e771e0904b209eab08d12d0b84826611ffc013e094a5851b7328bfe9b210";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "d8a13bfe6aa3177234821b666bb9a5500cc8c30fcc04354ae936c4b38877f003";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-power-state/default.nix
+++ b/distros/noetic/cob-phidget-power-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-power-state";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "857cf86e7bc472bb333e2a598320f6f9a73e36e345e5d1f1a2b32f8fd2c688e2";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "b5aec0aa496a61038ec1a1dd6dfc79ca51a69aaa32ad56a4318cdb45ae976a49";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidgets/default.nix
+++ b/distros/noetic/cob-phidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidgets, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidgets";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "92b4e7bf93b57c3cecbfd1bb9aba68ec8ed998a0dc052a882d0c700efe9aca53";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "f3dd2a50ffd7481e8ef22830be9f39584878024c25e4c2642a3b1130fb965102";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-reflector-referencing/default.nix
+++ b/distros/noetic/cob-reflector-referencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-reflector-referencing";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_reflector_referencing/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "2688dd487f75963bb451eb924a87acd1aa91d608cfdbdf2345e77673c1426ed4";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_reflector_referencing/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "053bef87c9fbbbdc25cc44ad820aede0bf4c0ad2c1598f537aa76ce157fcba5b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-relayboard/default.nix
+++ b/distros/noetic/cob-relayboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-relayboard";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "6d175a97e2dcffca4b0e9cad768237fda90b669c929894beb5479aa37cc6536a";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "dfdd13ad2378cd8b4a3c1d6e8b43707c55486b4d96859f8a15782c7f8469a3c9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-safety-controller/default.nix
+++ b/distros/noetic/cob-safety-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-safety-controller";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_safety_controller/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "d5e0b1d61fa56e4a505a9af59e006ac52746f89c5e9d2c12a831688807935c71";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_safety_controller/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "4be7cda7abf295591cc373314f4e05f2aec6e9d7d8798a381f49fc0b36ac7d3d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-scan-unifier/default.nix
+++ b/distros/noetic/cob-scan-unifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-scan-unifier";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "6fd49355fe7922287cce557800991aba664ab2c182f111a0ff6c95cba1223776";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "edab7dd3c37f5f5f5eb183c0645c74d2adbe40051bda247ca2ba9ca599853079";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-script-server/default.nix
+++ b/distros/noetic/cob-script-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, pythonPackages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-noetic-cob-script-server";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "dfc2e2c9324f55bdfaa36da7d1ed9a3cce44571bb822fdb3b0b3d01342478d93";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "d80fb0dbac43264c414b0c8abf001a41070d573c1e5027c4bb73b281b6018e47";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs cob-actions cob-light cob-mimic cob-sound control-msgs geometry-msgs message-runtime move-base-msgs python3Packages.ipython python3Packages.pygraphviz pythonPackages.six rospy rostest std-msgs std-srvs tf trajectory-msgs urdfdom-py ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cob-actions cob-light cob-mimic cob-sound control-msgs geometry-msgs message-runtime move-base-msgs python3Packages.ipython python3Packages.pygraphviz python3Packages.six rospy rostest std-msgs std-srvs tf trajectory-msgs urdfdom-py ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/cob-sick-lms1xx/default.nix
+++ b/distros/noetic/cob-sick-lms1xx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-lms1xx";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "b0e569ff806ade40ef041fe4d3e06728df6646eda88e01bb0da8b543a0e88aae";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "1ab28c10ccae9847b44a39709c4863b8ad2af3a3e34a0bb832d648fe6e9862d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-s300/default.nix
+++ b/distros/noetic/cob-sick-s300/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-s300";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "87f2b549cc5eeee3e3a4ce6dca9a8ae5d1716638acda1caa59f3cafadc9110c4";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "66e91af7e7af9e3e58d031818b21f9ad2982adcfe9398a141aeadec481fd506f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sound/default.nix
+++ b/distros/noetic/cob-sound/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsaOss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-sound";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "e74c7890941d3497a990866d186755ef6749ee9a58ed1f005b428216c66d3b92";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "347d6370c02fe9aefd81af4dc51869b372b699ebd0f7c02087a26eb7c5b788cc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-srvs/default.nix
+++ b/distros/noetic/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-srvs";
-  version = "0.7.4-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "7470b40d37ca96291b16820378a52e9c486a0a67b8753e0b272c9d92a641dfde";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "8dc0c4c966e4763fb8d443a647069a343e3d08f9e28ece2184fe38615997187c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-substitute/default.nix
+++ b/distros/noetic/cob-substitute/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-docker-control, cob-reflector-referencing, cob-safety-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-substitute";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_substitute/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "898d8257f335760040780b96d159a28d2c6f0550a1e5af9edf8716572de010f5";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_substitute/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "9f6abb857678e7be1f7ca7870eafdb8e6c1311246d12e6a88bdb0f0c216c7e32";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-teleop/default.nix
+++ b/distros/noetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-teleop";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "817534be0ddbeed731611a5b2cf4e113f95fdb88c8731ea9ca67e3043d15e68b";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "8f6b31d68ee90bb0564bc7ec499a8ef2c264cfddc3be215224c1c5eaa2bdd3db";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-trajectory-controller/default.nix
+++ b/distros/noetic/cob-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-srvs, control-msgs, dynamic-reconfigure, roscpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-trajectory-controller";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "c327979d0443ec7724cf3efa0816f54447f5a49f77092551d31c09c38011a75c";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "fa2a6fd07b027ece5b8658aec077cf30955745f1eb6736cbbb24086f86dcbc86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-tricycle-controller/default.nix
+++ b/distros/noetic/cob-tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-tricycle-controller";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "3feaad75b3278dae7663d373998d598a8022ddbf0ff43c90c0a2b75736ce9f56";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "73a6f904572a4c299d2bb73b01cacfa95d332dac1a8133d6f240ce71d564948f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-twist-controller/default.nix
+++ b/distros/noetic/cob-twist-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-script-server, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, python3Packages, pythonPackages, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-script-server, cob-srvs, control-msgs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-twist-controller";
-  version = "0.8.13-r1";
+  version = "0.8.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.13-1.tar.gz";
-    name = "0.8.13-1.tar.gz";
-    sha256 = "24255dd823cda1fdc4d01a56d6de53f9f5a7a6d3567401bcdd739c5be063ad9c";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.17-1.tar.gz";
+    name = "0.8.17-1.tar.gz";
+    sha256 = "beb992cf7462b74803734d2365d4ef97ff1434eb5f4aa49bf19abac675050312";
   };
 
   buildType = "catkin";
   buildInputs = [ roslint ];
-  propagatedBuildInputs = [ boost cmake-modules cob-control-msgs cob-frame-tracker cob-script-server cob-srvs dynamic-reconfigure eigen eigen-conversions geometry-msgs kdl-conversions kdl-parser nav-msgs orocos-kdl pluginlib python3Packages.matplotlib pythonPackages.six robot-state-publisher roscpp rospy rviz sensor-msgs std-msgs tf tf-conversions topic-tools trajectory-msgs urdf visualization-msgs xacro ];
+  propagatedBuildInputs = [ boost cmake-modules cob-control-msgs cob-frame-tracker cob-script-server cob-srvs control-msgs dynamic-reconfigure eigen eigen-conversions geometry-msgs kdl-conversions kdl-parser nav-msgs orocos-kdl pluginlib python3Packages.matplotlib python3Packages.six robot-state-publisher roscpp rospy rviz sensor-msgs std-msgs tf tf-conversions topic-tools trajectory-msgs urdf visualization-msgs xacro ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/cob-undercarriage-ctrl/default.nix
+++ b/distros/noetic/cob-undercarriage-ctrl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-utilities, control-msgs, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-undercarriage-ctrl";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "ec724125f8a49bb67f240d305c33b2a1d552e2513bd8c5f979e8b0971f22208e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "7e9387cf4b829a20e68255c47538144219e8957629d73525537e52194e7f96c6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-utilities/default.nix
+++ b/distros/noetic/cob-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-utilities";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "74edab541520ed90b03a44f8c8b9a6c3d212ac2a08b6f1fe7771f51bfbf9669a";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "73630b8c83a6d087e134988a56d8e15314b57ea566c498d50df305d8e725a26e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-vision-utils/default.nix
+++ b/distros/noetic/cob-vision-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, roscpp, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-vision-utils";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_vision_utils/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "9b9538ccb43aeb613befe6036c209c696d86d0d391407e773052501940635d92";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_vision_utils/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "de18b314f11dc4cdd3d182874f242139503d834a0067fb8f7bebad47604dd3f9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-voltage-control/default.nix
+++ b/distros/noetic/cob-voltage-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, dynamic-reconfigure, python3Packages, pythonPackages, roscpp, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, dynamic-reconfigure, python3Packages, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-voltage-control";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "7cebe9fa0f49cbd0a270b96fb16bc0a003abe6bf1c104cecd7585fb3672820b4";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "526943b83e615389a2c6631612aba0607a724a40b988c1c17ac4735b38b2da51";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cob-msgs cob-phidgets dynamic-reconfigure python3Packages.matplotlib pythonPackages.tkinter roscpp rospy std-msgs ];
+  propagatedBuildInputs = [ cob-msgs cob-phidgets dynamic-reconfigure python3Packages.matplotlib python3Packages.tkinter roscpp rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -304,6 +304,8 @@ self: super: {
 
  cob-lookat-action = self.callPackage ./cob-lookat-action {};
 
+ cob-manipulation-msgs = self.callPackage ./cob-manipulation-msgs {};
+
  cob-map-accessibility-analysis = self.callPackage ./cob-map-accessibility-analysis {};
 
  cob-mapping-slam = self.callPackage ./cob-mapping-slam {};
@@ -984,6 +986,8 @@ self: super: {
 
  grasping-msgs = self.callPackage ./grasping-msgs {};
 
+ grepros = self.callPackage ./grepros {};
+
  grid-map = self.callPackage ./grid-map {};
 
  grid-map-core = self.callPackage ./grid-map-core {};
@@ -1013,6 +1017,8 @@ self: super: {
  grid-map-visualization = self.callPackage ./grid-map-visualization {};
 
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
+
+ grpc = self.callPackage ./grpc {};
 
  handeye = self.callPackage ./handeye {};
 
@@ -1175,6 +1181,8 @@ self: super: {
  interval-intersection = self.callPackage ./interval-intersection {};
 
  ipa-3d-fov-visualization = self.callPackage ./ipa-3d-fov-visualization {};
+
+ ipa-differential-docking = self.callPackage ./ipa-differential-docking {};
 
  ira-laser-tools = self.callPackage ./ira-laser-tools {};
 
@@ -1541,6 +1549,8 @@ self: super: {
  microstrain-inertial-examples = self.callPackage ./microstrain-inertial-examples {};
 
  microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
+
+ microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
 
  mini-maxwell = self.callPackage ./mini-maxwell {};
 

--- a/distros/noetic/generic-throttle/default.nix
+++ b/distros/noetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, python3Packages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-generic-throttle";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "66f293bb4578201cf609e4717d0bb4ca8e8235974863973ed7b0a8f5eb4300c5";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "2e31dffcbdfd53c3e00c92a1e6cbce55694458c38d5ced9c3512fd3d1890f713";
   };
 
   buildType = "catkin";

--- a/distros/noetic/grepros/default.nix
+++ b/distros/noetic/grepros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, genpy, python3Packages, rosbag, roslib, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-grepros";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/suurjaak/grepros-release/archive/release/noetic/grepros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "7fb2a6d4a13bd75df46bc29556759d563722f461490db315a97f447b942c0609";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest std-msgs ];
+  propagatedBuildInputs = [ genpy python3Packages.pyyaml rosbag roslib rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''grep for ROS bag files and live topics'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/grpc/default.nix
+++ b/distros/noetic/grpc/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, autoconf, catkin, git, libtool, rsync, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-grpc";
+  version = "0.0.10-r2";
+
+  src = fetchurl {
+    url = "https://github.com/CogRobRelease/catkin_grpc-release/archive/release/noetic/grpc/0.0.10-2.tar.gz";
+    name = "0.0.10-2.tar.gz";
+    sha256 = "96124c592e0134a9f13f0cde8f27ba14a1d0f1c76b514bbdb1cfea75ab686991";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ autoconf git libtool rsync zlib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Catkinized gRPC Package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ipa-3d-fov-visualization/default.nix
+++ b/distros/noetic/ipa-3d-fov-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ipa-3d-fov-visualization";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/ipa_3d_fov_visualization/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "27be0aa6cb8c016f969eeef634cbdc2b2683fc56567fb1cd3f577cb0c32ebf02";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/ipa_3d_fov_visualization/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "3a0784f2c54df8fe9965d0e2ea9f248b3a8b19ff9a54fe82ada73e452b45891c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ipa-differential-docking/default.nix
+++ b/distros/noetic/ipa-differential-docking/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-ipa-differential-docking";
+  version = "0.6.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/ipa_differential_docking/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "09b554178afbb3ad4f95ac879fb9f1186e7cdb5a48e3400b9483969416f74468";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is a substitute for the private implementation of ipa_differential_docking package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/laser-scan-densifier/default.nix
+++ b/distros/noetic/laser-scan-densifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-scan-densifier";
-  version = "0.7.5-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "e4b262f120abb7c4c345da1f7ac3bc0444ae5bec1ddd2e5766f1c521fa0347dc";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "9b17c6a3112f9d1b85e0794ee775d583f54ba37715ec781fabbf6dab8f72bafe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-bringup/default.nix
+++ b/distros/noetic/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-bringup";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d18999ed2a9bee6426627687f8febca9ffff7431a8a81ad2ba42501195aafa47";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "6ca51e743af6619cb577c939e3628523604032d6e1de924e27c420d46905add0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-description/default.nix
+++ b/distros/noetic/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "45d4e0728755c83bfe5cd646da3f2256d3808f46facd6b6aaba581ebeddf26c7";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "86623a8657551888b77fd654ae3ffbe0490934ddcdf1f2aee7ef9aa1329261e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-msgs, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-leo-fw";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9eed60bad8b4d0eb63316e9b3744b07e912215284174bbafc57704a2fde0262f";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5d22bf400eaa6ea3afb1ae0015e188e9f9554f61e6ac5fc3eee88a8a8541581d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-msgs/default.nix
+++ b/distros/noetic/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-leo-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "88b887f03b8ae4525fe20f43a2f31bd55b44d75062d4b73ddd010c1d275d98e0";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c76b8fb7f0a394325ecdb8dbd0a260a065872389b7d1f89127ebc692c96724f1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-robot/default.nix
+++ b/distros/noetic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-noetic-leo-robot";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "0e90aa24a09c7eecf28d57125cabd98ce8dd5e55e27c2679a25d4b6d47dbd63b";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "edf8c4db1b0c6c965b20196e180721dfb78a2207e96b5e6f9a6dc101db29af47";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-teleop/default.nix
+++ b/distros/noetic/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-noetic-leo-teleop";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "843c4268f9281ad8a9bdb4a2623b546fa849cf45ffef234a9a26da10e7fe4cde";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c4affcef4833c40698162fee458cf18a87b619515ec1fca4da4aa759b00f27ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo/default.nix
+++ b/distros/noetic/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-noetic-leo";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "6dc09bfe60d6aa84be833076fe22b287c279c58fdff7263a79e79ff525982e3b";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e425273e12ad7cd996dbe0576f757a75c01bc2fdab18b7e86841197a135766dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mapviz-plugins/default.nix
+++ b/distros/noetic/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt5, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mapviz-plugins";
-  version = "1.4.1-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz_plugins/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "2bb660906000dce2d1922deb7a30714548204c587d07ee7b9181592ff11703aa";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz_plugins/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "9725c95f637969dbcba301a892b89133500331980fd639e08efba8478d423bed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mapviz/default.nix
+++ b/distros/noetic/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, freeglut, glew, image-transport, marti-common-msgs, message-generation, message-runtime, pkg-config, pluginlib, qt5, rosapi, roscpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-transform-util, swri-yaml-util, tf, xorg }:
 buildRosPackage {
   pname = "ros-noetic-mapviz";
-  version = "1.4.1-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "9026e3ebb6759e27fcf6d9aeb4d5be214c34cfea30090bd3e1846f9d4758e8da";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "9117c574ec2db3bdec3a33e14ea06b04113e8bd3a6e0c9d7b7b3a454c256567b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, mavros-msgs, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "38806f6e30f5f66eb2c72f3e5704f44964d6c49e81a2ee1cf0a10a871ce2e20f";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "01d610f8779a8bcfa664492465ce4107ab14b2b2cb7b1f1177a065f8614cf3f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "842599e110e941288c4b9a860255023ac51685f59dea2f99b020346b327681ff";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "179506f7dd4f2e99ba049c191388fa52a30b9247cda24220ae12133bc8a8c1d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "61fc2c66dc426c9947ea02377d2ad150ccc8b7bd5bc28c103e6d34ba6359a8f7";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "c53d606378c3d80b1fac684de09eba163540a1a5f71319b99a102622342502b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-rqt/default.nix
+++ b/distros/noetic/microstrain-inertial-rqt/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rospy, rqt-gui, rqt-gui-py, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-microstrain-inertial-rqt";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "20e4fe757c575010fbda1b903dfc1f10f78228f828cdbb78bc7dcffaa18a3eb2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs microstrain-inertial-msgs nav-msgs rospy rqt-gui rqt-gui-py std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The microstrain_inertial_rqt package provides several RQT widgets to view the status of Microstrain devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/multires-image/default.nix
+++ b/distros/noetic/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gps-common, mapviz, pluginlib, qt5, roscpp, rospy, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-noetic-multires-image";
-  version = "1.4.1-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/multires_image/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "c64d7a3cb3e7b2ab4185cb3c3a7f54bced783b309d818a1ce322b435644aa39d";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/multires_image/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "cb7ef6ab42f6ad715cf1e2e7ffc02862c4b4d599ba8ed38133a02fa0c7e1116a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/octomap-mapping/default.nix
+++ b/distros/noetic/octomap-mapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap-server }:
 buildRosPackage {
   pname = "ros-noetic-octomap-mapping";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_mapping/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "def38407af47964a673eba4866068684bdfdaa2e06640e7e3d97afadad8ea5d4";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_mapping/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "ee74a243e61605b47a6e8444e0db6edcc84c5e4f4182f53fe42e555aa11ed8d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/octomap-rviz-plugins/default.nix
+++ b/distros/noetic/octomap-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap, octomap-msgs, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-octomap-rviz-plugins";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_rviz_plugins-release/archive/release/noetic/octomap_rviz_plugins/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "bdae669effd90b5b615ae9342926a27fe51116c8061d9913da5523882223caee";
+    url = "https://github.com/ros-gbp/octomap_rviz_plugins-release/archive/release/noetic/octomap_rviz_plugins/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "a4df6a9a9bc37d5722c20b8e4da89ed1c14891c825f705b43e9fb26e2dcdc7f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/octomap-server/default.nix
+++ b/distros/noetic/octomap-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nav-msgs, nodelet, octomap, octomap-msgs, octomap-ros, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-octomap-server";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_server/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "71af12549d79fa6f95ef02fc696b945b887dfcacd83db10d0d3952a14772c572";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_server/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "d85b080b98a1699bcd6423c97bc0807b9a7790d06aa745651622af0c478b2c7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/psen-scan-v2/default.nix
+++ b/distros/noetic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, fmt, geometry-msgs, message-generation, message-runtime, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, std-msgs, tinyxml-2, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-psen-scan-v2";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "649e51d059c20a671ce9e27b178b8ffa72683dc98c8020ae43d5e34bd64d6961";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "75519fa20b8f20507e9e17f83ba0cc3ca72f60165f78dce6309b65bf43712dd7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/raw-description/default.nix
+++ b/distros/noetic/raw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-raw-description";
-  version = "0.7.4-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "9fa553b6f369b6845c67875778028089c44066691724015cb9fcaadf59608ec3";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "0abf310c464787041f5a67fc91c74b1e15e451f2bc6a80fae072a587ab29d40e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-babel-fish-test-msgs/default.nix
+++ b/distros/noetic/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ros-babel-fish-test-msgs";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish_test_msgs/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "741c79ebcfdb4430e22134e95e6fec72d4c9978b557764196d49bbac1e44bf77";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish_test_msgs/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "67d20d43b351518405030c80ed6e85105980f1f974c23bb371d7144843d8113f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-babel-fish/default.nix
+++ b/distros/noetic/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, rosgraph-msgs, roslib, rostest, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ros-babel-fish";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "32967db537a618db2aa4701f35989cfe77bfc7317881537936ee29aee559705f";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "b744a0b74ee7d6073440f24092a51d614ee1ac29b1653a13d695c27dc0ece8f5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-ros/default.nix
+++ b/distros/noetic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-ros";
-  version = "0.20.14-r1";
+  version = "0.20.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.14-1.tar.gz";
-    name = "0.20.14-1.tar.gz";
-    sha256 = "3def585ea3acd32d4767c993376708b51544c4e6f027a69b5481872ea270e39d";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.16-1.tar.gz";
+    name = "0.20.16-1.tar.gz";
+    sha256 = "0c50daf55c648ca120e30890950861db40cf9e7597bb7495e62c22672fbee978";
   };
 
   buildType = "catkin";

--- a/distros/noetic/scenario-test-tools/default.nix
+++ b/distros/noetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, python3Packages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-scenario-test-tools";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "b8dc1b844fd3b82982578c01d5ccd7c67a88210be0ba8e3f7034cbce85b02c7d";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "4475f55003d72e674c73b0eb53fb3bb04c7000459b920d307cc5ff84df91bb00";
   };
 
   buildType = "catkin";

--- a/distros/noetic/service-tools/default.nix
+++ b/distros/noetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-noetic-service-tools";
-  version = "0.6.21-r1";
+  version = "0.6.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.21-1.tar.gz";
-    name = "0.6.21-1.tar.gz";
-    sha256 = "1b85114ba9ff3ce366070e7770473c8423a622880fd1b979df3913bcfc4850b8";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.26-1.tar.gz";
+    name = "0.6.26-1.tar.gz";
+    sha256 = "e2b3d12c8f99988d5c500ae9e76c5cd00aa5b3afa61f0799693cae311c1ade91";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sr-hand-detector/default.nix
+++ b/distros/noetic/sr-hand-detector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-sr-hand-detector";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "385459fd4dab5b1d61eb25e3b609f0567501c9298d04db36ba3a65948ff637c2";
+    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "354b8355e441f1149d5dc9ede3ec74a32a1120d3289c6d3d6dbe1ff5449954bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tile-map/default.nix
+++ b/distros/noetic/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, glew, jsoncpp, mapviz, pluginlib, qt5, roscpp, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-noetic-tile-map";
-  version = "1.4.1-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/tile_map/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "9f44ead5a9d4c05f30a9d75ff98900826da5a9fd5a4f56b41cec9dde75b1354d";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/tile_map/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "50c04b7b4f00b808c329d3d161ba2ada5155278071db1bafda5edec95e4559d4";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 6178a8c42f31f1a70d9fec3e68c4bfb8e1e299c0.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *actionlib-msgs 2.0.4-r1 --> 2.0.5-r1*
* *avt-vimba-camera 2001.1.0-r1*
* *common-interfaces 2.0.4-r1 --> 2.0.5-r1*
* *controller-interface 0.8.1-r1 --> 0.9.0-r1*
* *controller-manager 0.8.1-r1 --> 0.9.0-r1*
* *controller-manager-msgs 0.8.1-r1 --> 0.9.0-r1*
* *diagnostic-msgs 2.0.4-r1 --> 2.0.5-r1*
* *geometric-shapes 2.1.0-r1 --> 2.1.2-r1*
* *geometry-msgs 2.0.4-r1 --> 2.0.5-r1*
* *grepros 0.4.0-r1*
* *hardware-interface 0.8.1-r1 --> 0.9.0-r1*
* *microstrain-inertial-driver 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-examples 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-msgs 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-rqt 2.3.0-r1*
* *nav-msgs 2.0.4-r1 --> 2.0.5-r1*
* *octomap-rviz-plugins 2.0.0-r1*
* *openvslam 0.2.2-r1 --> 0.2.4-r2*
* *quaternion-operation 0.0.6-r1 --> 0.0.7-r1*
* *ros2-control 0.8.1-r1 --> 0.9.0-r1*
* *ros2-control-test-assets 0.8.1-r1 --> 0.9.0-r1*
* *ros2controlcli 0.8.1-r1 --> 0.9.0-r1*
* *rtabmap-ros 0.20.15-r2 --> 0.20.16-r2*
* *sensor-msgs 2.0.4-r1 --> 2.0.5-r1*
* *sensor-msgs-py 2.0.4-r1 --> 2.0.5-r1*
* *shape-msgs 2.0.4-r1 --> 2.0.5-r1*
* *sick-safetyscanners-base 1.0.0-r2 --> 1.0.1-r1*
* *sick-safetyscanners2 1.0.2-r1 --> 1.0.3-r1*
* *sol-vendor 0.0.3-r1*
* *std-msgs 2.0.4-r1 --> 2.0.5-r1*
* *std-srvs 2.0.4-r1 --> 2.0.5-r1*
* *stereo-msgs 2.0.4-r1 --> 2.0.5-r1*
* *trajectory-msgs 2.0.4-r1 --> 2.0.5-r1*
* *transmission-interface 0.8.1-r1 --> 0.9.0-r1*
* *velodyne-description 2.0.1-r1 --> 2.0.2-r1*
* *velodyne-gazebo-plugins 2.0.1-r1 --> 2.0.2-r1*
* *velodyne-simulator 2.0.1-r1 --> 2.0.2-r1*
* *visualization-msgs 2.0.4-r1 --> 2.0.5-r1*
* *webots-ros2 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-control 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-core 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-driver 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-epuck 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-importer 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-mavic 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-msgs 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-tesla 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-tests 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-tiago 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-turtlebot 1.1.3-r2 --> 1.2.0-r2*
* *webots-ros2-universal-robot 1.1.3-r2 --> 1.2.0-r2*

Galactic Changes:
-----------------
* *chomp-motion-planner 2.3.1-r1*
* *controller-interface 1.2.0-r1 --> 1.3.0-r1*
* *controller-manager 1.2.0-r1 --> 1.3.0-r1*
* *controller-manager-msgs 1.2.0-r1 --> 1.3.0-r1*
* *costmap-queue 1.0.7-r1 --> 1.0.8-r1*
* *diff-drive-controller 1.1.0-r1 --> 1.2.0-r1*
* *dwb-core 1.0.7-r1 --> 1.0.8-r1*
* *dwb-critics 1.0.7-r1 --> 1.0.8-r1*
* *dwb-msgs 1.0.7-r1 --> 1.0.8-r1*
* *dwb-plugins 1.0.7-r1 --> 1.0.8-r1*
* *effort-controllers 1.1.0-r1 --> 1.2.0-r1*
* *force-torque-sensor-broadcaster 1.1.0-r1 --> 1.2.0-r1*
* *forward-command-controller 1.1.0-r1 --> 1.2.0-r1*
* *geometric-shapes 2.1.1-r1 --> 2.1.2-r1*
* *gripper-controllers 1.1.0-r1 --> 1.2.0-r1*
* *hardware-interface 1.2.0-r1 --> 1.3.0-r1*
* *imu-sensor-broadcaster 1.1.0-r1 --> 1.2.0-r1*
* *joint-state-broadcaster 1.1.0-r1 --> 1.2.0-r1*
* *joint-trajectory-controller 1.1.0-r1 --> 1.2.0-r1*
* *mapviz 2.2.0-r3*
* *mapviz-interfaces 2.2.0-r3*
* *mapviz-plugins 2.2.0-r3*
* *microstrain-inertial-driver 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-examples 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-msgs 2.2.0-r1 --> 2.3.0-r1*
* *microstrain-inertial-rqt 2.3.0-r1*
* *moveit 2.3.0-r1 --> 2.3.1-r1*
* *moveit-chomp-optimizer-adapter 2.3.1-r1*
* *moveit-common 2.3.0-r1 --> 2.3.1-r1*
* *moveit-core 2.3.0-r1 --> 2.3.1-r1*
* *moveit-hybrid-planning 2.3.1-r1*
* *moveit-kinematics 2.3.0-r1 --> 2.3.1-r1*
* *moveit-planners 2.3.0-r1 --> 2.3.1-r1*
* *moveit-planners-chomp 2.3.1-r1*
* *moveit-planners-ompl 2.3.0-r1 --> 2.3.1-r1*
* *moveit-plugins 2.3.0-r1 --> 2.3.1-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.3.1-r1*
* *moveit-resources-prbt-moveit-config 2.3.1-r1*
* *moveit-resources-prbt-pg70-support 2.3.1-r1*
* *moveit-resources-prbt-support 2.3.1-r1*
* *moveit-ros 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-benchmarks 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-control-interface 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-move-group 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-occupancy-map-monitor 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-perception 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-planning 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-planning-interface 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-robot-interaction 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-visualization 2.3.0-r1 --> 2.3.1-r1*
* *moveit-ros-warehouse 2.3.0-r1 --> 2.3.1-r1*
* *moveit-runtime 2.3.0-r1 --> 2.3.1-r1*
* *moveit-servo 2.3.0-r1 --> 2.3.1-r1*
* *moveit-setup-assistant 2.3.1-r1*
* *moveit-simple-controller-manager 2.3.0-r1 --> 2.3.1-r1*
* *multires-image 2.2.0-r3*
* *nav-2d-msgs 1.0.7-r1 --> 1.0.8-r1*
* *nav-2d-utils 1.0.7-r1 --> 1.0.8-r1*
* *nav2-amcl 1.0.7-r1 --> 1.0.8-r1*
* *nav2-behavior-tree 1.0.7-r1 --> 1.0.8-r1*
* *nav2-bringup 1.0.7-r1 --> 1.0.8-r1*
* *nav2-bt-navigator 1.0.7-r1 --> 1.0.8-r1*
* *nav2-common 1.0.7-r1 --> 1.0.8-r1*
* *nav2-controller 1.0.7-r1 --> 1.0.8-r1*
* *nav2-core 1.0.7-r1 --> 1.0.8-r1*
* *nav2-costmap-2d 1.0.7-r1 --> 1.0.8-r1*
* *nav2-dwb-controller 1.0.7-r1 --> 1.0.8-r1*
* *nav2-gazebo-spawner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-lifecycle-manager 1.0.7-r1 --> 1.0.8-r1*
* *nav2-map-server 1.0.7-r1 --> 1.0.8-r1*
* *nav2-msgs 1.0.7-r1 --> 1.0.8-r1*
* *nav2-navfn-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-recoveries 1.0.7-r1 --> 1.0.8-r1*
* *nav2-regulated-pure-pursuit-controller 1.0.7-r1 --> 1.0.8-r1*
* *nav2-rotation-shim-controller 1.0.8-r1*
* *nav2-rviz-plugins 1.0.7-r1 --> 1.0.8-r1*
* *nav2-simple-commander 1.0.7-r1 --> 1.0.8-r1*
* *nav2-smac-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-system-tests 1.0.7-r1 --> 1.0.8-r1*
* *nav2-theta-star-planner 1.0.7-r1 --> 1.0.8-r1*
* *nav2-util 1.0.7-r1 --> 1.0.8-r1*
* *nav2-voxel-grid 1.0.7-r1 --> 1.0.8-r1*
* *nav2-waypoint-follower 1.0.7-r1 --> 1.0.8-r1*
* *navigation2 1.0.7-r1 --> 1.0.8-r1*
* *octomap-ros 0.4.2-r1*
* *octomap-rviz-plugins 2.0.0-r1*
* *openvslam 0.2.3-r3 --> 0.2.4-r1*
* *pilz-industrial-motion-planner 2.3.1-r1*
* *pilz-industrial-motion-planner-testutils 2.3.1-r1*
* *plotjuggler 3.3.0-r1 --> 3.3.4-r1*
* *position-controllers 1.1.0-r1 --> 1.2.0-r1*
* *quaternion-operation 0.0.6-r1 --> 0.0.7-r1*
* *rmw-cyclonedds-cpp 0.22.3-r1 --> 0.22.4-r1*
* *ros2-control 1.2.0-r1 --> 1.3.0-r1*
* *ros2-control-test-assets 1.2.0-r1 --> 1.3.0-r1*
* *ros2-controllers 1.1.0-r1 --> 1.2.0-r1*
* *ros2controlcli 1.2.0-r1 --> 1.3.0-r1*
* *rtabmap-ros 0.20.15-r2 --> 0.20.16-r2*
* *sick-safetyscanners-base 1.0.1-r1*
* *sick-safetyscanners2 1.0.3-r2*
* *sick-safetyscanners2-interfaces 1.0.0-r1*
* *sol-vendor 0.0.3-r1*
* *tile-map 2.2.0-r3*
* *transmission-interface 1.2.0-r1 --> 1.3.0-r1*
* *velocity-controllers 1.1.0-r1 --> 1.2.0-r1*
* *velodyne-description 2.0.2-r1*
* *velodyne-gazebo-plugins 2.0.2-r1*
* *velodyne-simulator 2.0.2-r1*
* *visp 3.4.0-r2*
* *webots-ros2 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-control 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-core 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-driver 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-epuck 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-importer 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-mavic 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-msgs 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-tesla 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-tests 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-tiago 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-turtlebot 1.1.2-r2 --> 1.2.0-r2*
* *webots-ros2-universal-robot 1.1.2-r2 --> 1.2.0-r2*

Melodic Changes:
----------------
* *microstrain-inertial-driver 2.2.1-r1 --> 2.3.0-r1*
* *microstrain-inertial-examples 2.2.1-r1 --> 2.3.0-r1*
* *microstrain-inertial-msgs 2.2.1-r1 --> 2.3.0-r1*
* *microstrain-inertial-rqt 2.3.0-r1*
* *octomap-mapping 0.6.5-r1 --> 0.6.7-r2*
* *octomap-rviz-plugins 0.2.2-r1 --> 0.2.4-r2*
* *octomap-server 0.6.5-r1 --> 0.6.7-r2*
* *psen-scan-v2 0.3.3-r1 --> 0.3.4-r1*
* *ros-babel-fish 0.9.0-r1 --> 0.9.2-r1*
* *ros-babel-fish-test-msgs 0.9.0-r1 --> 0.9.2-r1*
* *rtabmap-ros 0.20.14-r1 --> 0.20.16-r1*

Noetic Changes:
---------------
* *azure-iot-sdk-c 1.7.0-r4 --> 1.8.0-r1*
* *cob-3d-mapping-msgs 0.6.17-r1 --> 0.6.18-r1*
* *cob-actions 0.7.4-r1 --> 0.7.7-r1*
* *cob-base-controller-utils 0.8.13-r1 --> 0.8.17-r1*
* *cob-base-drive-chain 0.7.5-r1 --> 0.7.10-r1*
* *cob-base-velocity-smoother 0.8.13-r1 --> 0.8.17-r1*
* *cob-bms-driver 0.7.5-r1 --> 0.7.10-r1*
* *cob-calibration-data 0.6.15-r1 --> 0.6.16-r1*
* *cob-cam3d-throttle 0.6.17-r1 --> 0.6.18-r1*
* *cob-canopen-motor 0.7.5-r1 --> 0.7.10-r1*
* *cob-cartesian-controller 0.8.13-r1 --> 0.8.17-r1*
* *cob-collision-monitor 0.7.5-r1 --> 0.7.6-r1*
* *cob-collision-velocity-filter 0.8.13-r1 --> 0.8.17-r1*
* *cob-command-gui 0.6.21-r1 --> 0.6.26-r1*
* *cob-command-tools 0.6.21-r1 --> 0.6.26-r1*
* *cob-common 0.7.4-r1 --> 0.7.7-r1*
* *cob-control 0.8.13-r1 --> 0.8.17-r1*
* *cob-control-mode-adapter 0.8.13-r1 --> 0.8.17-r1*
* *cob-control-msgs 0.8.13-r1 --> 0.8.17-r1*
* *cob-dashboard 0.6.21-r1 --> 0.6.26-r1*
* *cob-default-robot-behavior 0.7.5-r1 --> 0.7.6-r1*
* *cob-default-robot-config 0.7.5-r1 --> 0.7.6-r1*
* *cob-description 0.7.4-r1 --> 0.7.7-r1*
* *cob-docker-control 0.6.10-r1 --> 0.6.11-r1*
* *cob-driver 0.7.5-r1 --> 0.7.10-r1*
* *cob-elmo-homing 0.7.5-r1 --> 0.7.10-r1*
* *cob-footprint-observer 0.8.13-r1 --> 0.8.17-r1*
* *cob-frame-tracker 0.8.13-r1 --> 0.8.17-r1*
* *cob-gazebo-plugins 0.7.5-r1 --> 0.7.6-r1*
* *cob-gazebo-ros-control 0.7.5-r1 --> 0.7.6-r1*
* *cob-generic-can 0.7.5-r1 --> 0.7.10-r1*
* *cob-grasp-generation 0.7.5-r1 --> 0.7.6-r1*
* *cob-hardware-config 0.7.5-r1 --> 0.7.6-r1*
* *cob-hardware-emulation 0.8.13-r1 --> 0.8.17-r1*
* *cob-helper-tools 0.6.21-r1 --> 0.6.26-r1*
* *cob-image-flip 0.6.17-r1 --> 0.6.18-r1*
* *cob-interactive-teleop 0.6.21-r1 --> 0.6.26-r1*
* *cob-light 0.7.5-r1 --> 0.7.10-r1*
* *cob-linear-nav 0.6.11-r1 --> 0.6.12-r1*
* *cob-lookat-action 0.7.5-r1 --> 0.7.6-r1*
* *cob-manipulation-msgs 0.7.6-r1*
* *cob-map-accessibility-analysis 0.6.11-r1 --> 0.6.12-r1*
* *cob-mapping-slam 0.6.11-r1 --> 0.6.12-r1*
* *cob-mecanum-controller 0.8.13-r1 --> 0.8.17-r1*
* *cob-mimic 0.7.5-r1 --> 0.7.10-r1*
* *cob-model-identifier 0.8.13-r1 --> 0.8.17-r1*
* *cob-monitoring 0.6.21-r1 --> 0.6.26-r1*
* *cob-moveit-bringup 0.7.5-r1 --> 0.7.6-r1*
* *cob-moveit-config 0.7.5-r1 --> 0.7.6-r1*
* *cob-moveit-interface 0.7.5-r1 --> 0.7.6-r1*
* *cob-msgs 0.7.4-r1 --> 0.7.7-r1*
* *cob-navigation 0.6.11-r1 --> 0.6.12-r1*
* *cob-navigation-config 0.6.11-r1 --> 0.6.12-r1*
* *cob-navigation-global 0.6.11-r1 --> 0.6.12-r1*
* *cob-navigation-local 0.6.11-r1 --> 0.6.12-r1*
* *cob-navigation-slam 0.6.11-r1 --> 0.6.12-r1*
* *cob-object-detection-msgs 0.6.17-r1 --> 0.6.18-r1*
* *cob-object-detection-visualizer 0.6.17-r1 --> 0.6.18-r1*
* *cob-obstacle-distance 0.8.13-r1 --> 0.8.17-r1*
* *cob-omni-drive-controller 0.8.13-r1 --> 0.8.17-r1*
* *cob-perception-common 0.6.17-r1 --> 0.6.18-r1*
* *cob-perception-msgs 0.6.17-r1 --> 0.6.18-r1*
* *cob-phidget-em-state 0.7.5-r1 --> 0.7.10-r1*
* *cob-phidget-power-state 0.7.5-r1 --> 0.7.10-r1*
* *cob-phidgets 0.7.5-r1 --> 0.7.10-r1*
* *cob-reflector-referencing 0.6.10-r1 --> 0.6.11-r1*
* *cob-relayboard 0.7.5-r1 --> 0.7.10-r1*
* *cob-safety-controller 0.6.10-r1 --> 0.6.11-r1*
* *cob-scan-unifier 0.7.5-r1 --> 0.7.10-r1*
* *cob-script-server 0.6.21-r1 --> 0.6.26-r1*
* *cob-sick-lms1xx 0.7.5-r1 --> 0.7.10-r1*
* *cob-sick-s300 0.7.5-r1 --> 0.7.10-r1*
* *cob-sound 0.7.5-r1 --> 0.7.10-r1*
* *cob-srvs 0.7.4-r1 --> 0.7.7-r1*
* *cob-substitute 0.6.10-r1 --> 0.6.11-r1*
* *cob-teleop 0.6.21-r1 --> 0.6.26-r1*
* *cob-trajectory-controller 0.8.13-r1 --> 0.8.17-r1*
* *cob-tricycle-controller 0.8.13-r1 --> 0.8.17-r1*
* *cob-twist-controller 0.8.13-r1 --> 0.8.17-r1*
* *cob-undercarriage-ctrl 0.7.5-r1 --> 0.7.10-r1*
* *cob-utilities 0.7.5-r1 --> 0.7.10-r1*
* *cob-vision-utils 0.6.17-r1 --> 0.6.18-r1*
* *cob-voltage-control 0.7.5-r1 --> 0.7.10-r1*
* *generic-throttle 0.6.21-r1 --> 0.6.26-r1*
* *grepros 0.4.0-r1*
* *grpc 0.0.10-r2*
* *ipa-3d-fov-visualization 0.6.17-r1 --> 0.6.18-r1*
* *ipa-differential-docking 0.6.11-r1*
* *laser-scan-densifier 0.7.5-r1 --> 0.7.10-r1*
* *leo 2.0.0-r1 --> 2.0.1-r1*
* *leo-bringup 2.0.0-r1 --> 2.0.1-r1*
* *leo-description 2.0.0-r1 --> 2.0.1-r1*
* *leo-fw 2.0.0-r1 --> 2.0.1-r1*
* *leo-msgs 2.0.0-r1 --> 2.0.1-r1*
* *leo-robot 2.0.0-r1 --> 2.0.1-r1*
* *leo-teleop 2.0.0-r1 --> 2.0.1-r1*
* *mapviz 1.4.1-r1 --> 1.4.1-r2*
* *mapviz-plugins 1.4.1-r1 --> 1.4.1-r2*
* *microstrain-inertial-driver 2.2.1-r1 --> 2.3.0-r1*
* *microstrain-inertial-examples 2.2.1-r1 --> 2.3.0-r1*
* *microstrain-inertial-msgs 2.2.1-r1 --> 2.3.0-r1*
* *microstrain-inertial-rqt 2.3.0-r1*
* *multires-image 1.4.1-r1 --> 1.4.1-r2*
* *octomap-mapping 0.6.6-r1 --> 0.6.7-r1*
* *octomap-rviz-plugins 0.2.3-r1 --> 0.2.4-r1*
* *octomap-server 0.6.6-r1 --> 0.6.7-r1*
* *psen-scan-v2 0.3.3-r1 --> 0.3.4-r1*
* *raw-description 0.7.4-r1 --> 0.7.7-r1*
* *ros-babel-fish 0.9.1-r1 --> 0.9.2-r1*
* *ros-babel-fish-test-msgs 0.9.1-r1 --> 0.9.2-r1*
* *rtabmap-ros 0.20.14-r1 --> 0.20.16-r1*
* *scenario-test-tools 0.6.21-r1 --> 0.6.26-r1*
* *service-tools 0.6.21-r1 --> 0.6.26-r1*
* *sr-hand-detector 0.0.8-r1 --> 0.0.9-r1*
* *tile-map 1.4.1-r1 --> 1.4.1-r2*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

