### PR TITLE
rosdistro sync, Fri Jan 14 13:27:53 2022

### DIFF
--- a/distros/foxy/chomp-motion-planner/default.nix
+++ b/distros/foxy/chomp-motion-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, rclcpp, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-chomp-motion-planner";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/chomp_motion_planner/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "73ab0c013bfcb4300a55942bad0b03b4bb493c81727742252734830683b2ed7a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core rclcpp trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''chomp_motion_planner'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/clober-msgs/default.nix
+++ b/distros/foxy/clober-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-clober-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_msgs_ros2-release/archive/release/foxy/clober_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "088b6721979a1418cbaba4d28160b1002e94f21bfc4cc92f9414d58ce04ae45b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober robot standard messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "4e42693754ccfb0f105b1591bda1538daca4561a1073e7d637d6e73bf8d1d855";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b46511bbb3bd72bee652effaa15ac7b08c0b88a14bdab9909137f031284a1cbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "333c70f402be38a68ac976aced8e5eada812f66a897a112680cbfe84898e7af3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6872d57e88a40fb00c6c2fe4b7cff8abe4e3809c2eb5842b389d0b2548f5013a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/foxy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-force-torque-sensor-broadcaster";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5cd4eefe34f18f5cffa1449dbcad04ab1c9cd440c159a6296c5c4a781fdc3da5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "bf2704ed5667aae1e8d37cbbd139b6001828561f30f8caba67d1fbaec593ff03";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "fb7795ab3f389525a5acc6c084b13360f5e15df5f10b513088483f126d6f2d11";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "83d3a727f63ffc8b95886a488dcc5a9ea12a22f1947e0e5bbec795f42cc7ea07";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -190,7 +190,11 @@ self: super: {
 
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
+ chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
+
  class-loader = self.callPackage ./class-loader {};
+
+ clober-msgs = self.callPackage ./clober-msgs {};
 
  color-names = self.callPackage ./color-names {};
 
@@ -504,6 +508,8 @@ self: super: {
 
  ifm3d-core = self.callPackage ./ifm3d-core {};
 
+ ign-ros2-control-demos = self.callPackage ./ign-ros2-control-demos {};
+
  image-common = self.callPackage ./image-common {};
 
  image-geometry = self.callPackage ./image-geometry {};
@@ -700,6 +706,8 @@ self: super: {
 
  moveit = self.callPackage ./moveit {};
 
+ moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
+
  moveit-common = self.callPackage ./moveit-common {};
 
  moveit-core = self.callPackage ./moveit-core {};
@@ -709,6 +717,8 @@ self: super: {
  moveit-msgs = self.callPackage ./moveit-msgs {};
 
  moveit-planners = self.callPackage ./moveit-planners {};
+
+ moveit-planners-chomp = self.callPackage ./moveit-planners-chomp {};
 
  moveit-planners-ompl = self.callPackage ./moveit-planners-ompl {};
 
@@ -847,8 +857,6 @@ self: super: {
  octovis = self.callPackage ./octovis {};
 
  ompl = self.callPackage ./ompl {};
-
- openvslam = self.callPackage ./openvslam {};
 
  openzen-driver = self.callPackage ./openzen-driver {};
 
@@ -1504,7 +1512,7 @@ self: super: {
 
  snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
- soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+ soccer-object-msgs = self.callPackage ./soccer-object-msgs {};
 
  sol-vendor = self.callPackage ./sol-vendor {};
 

--- a/distros/foxy/gripper-controllers/default.nix
+++ b/distros/foxy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-gripper-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "959447fe35b065e479574a725503388ff1e7508d7be4554f67bd033ca5f63696";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f2335832fb404cb238b276ed08e3dc44b771fe9c3d67294eda5213eb92f2af4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ign-ros2-control-demos/default.nix
+++ b/distros/foxy/ign-ros2-control-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-ign-gazebo, ros2controlcli, std-msgs, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-ign-ros2-control-demos";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/foxy/ign_ros2_control_demos/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "91356545bec37a898d5014244fdd0a8f6193c56b49600599fef05fb0a60ee747";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rclcpp-action ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers hardware-interface ign-ros2-control imu-sensor-broadcaster joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-ign-gazebo ros2controlcli std-msgs velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ign_ros2_control_demos'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/imu-sensor-broadcaster/default.nix
+++ b/distros/foxy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-sensor-broadcaster";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "6215c5aed3720f67d2a35d3a2b63b3acc5b53dfad1d4ac03b639ad2627ea1d4b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "941428794bc34e4853533cf314e6d13f26b3e517ce1619144f971b6f6dd5f3bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-broadcaster";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "21326858c82c50fcee6b5d2350fa12aa463a39cd701c3e81becd2109b102d13e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b8e1f593b6f78db71173a28555ee64b7ff12f5f61b134c4f2d45bef3f83825f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "40b56fa010177893f2b4f4b79c91d8479ecfe5ba4863d5492929e9f8beaad4a9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "de940f92dbc74ad5413839ae7b486ca3b52edabeb0a27fee08732ebfdf6a022d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "ae5af702242eed133b0113d231ff1f3f051e1f23f0aeed6012d08a3df2e34850";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c0a3f71883f2dd50f7cba92fab391b687413997a7a85313016746924944dba43";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-testing-ament-cmake/default.nix
+++ b/distros/foxy/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ament-cmake";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "61612d103e39c58e80e541a1da607c03aea60428015cefa72677d8c99374c667";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "d457889a8c0d4ce685748c75d92908164d548d12a9df6348832336f661962c5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-testing/default.nix
+++ b/distros/foxy/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "8679329fed9f48b2cd93c3ee518c221492689275cccec7b6268bd76b0390f1e8";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "1d328cd6a3cee5db437cead38ff365f64ff2616043688a53eb1b0b0d6adae03d";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-xml/default.nix
+++ b/distros/foxy/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-xml";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "018c546129aa1abbc630f4dc15a2cb802da981400a25211013336e1f51921a87";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "f837fdfab4c4d22d457d4e8b7ee175e6b8248ae6a069e67df15f3055748b6f35";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-yaml/default.nix
+++ b/distros/foxy/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-yaml";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "ae40846ac9279b6102fca1f57e58b165183da854821a3fb3b9fcaadd640dda38";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "986646cb49c14695273b5b87593995c6323b20e19023ecf695d3936bec7cda33";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch/default.nix
+++ b/distros/foxy/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "498b5b1e0e9aed08a72fcbdc20800999788fecb9fc6616b2ef9a8df821f786b4";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "bc1573b5f4cf66081f1dd6e86ade450df5354891779299bf0ed4695bd1875ace";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/microstrain-inertial-driver/default.nix
+++ b/distros/foxy/microstrain-inertial-driver/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_driver/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "b499d05eb384e9e73d0e201f90aab0be6d87f73056196d13499005f7a0406201";
+    sha256 = "30f6ee895802d80e89137669030a7a61216889076dda86e33a37300a56103b2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-examples/default.nix
+++ b/distros/foxy/microstrain-inertial-examples/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_examples/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "a9c3d21614df29e4c3744c0ca07e79a72e9012b71e3651761f8234ee355053aa";
+    sha256 = "c959cc5079baa437395aa5185a12d23de75a3f273a270707c8c2f1287c19d119";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-msgs/default.nix
+++ b/distros/foxy/microstrain-inertial-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_msgs/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "42d99735d6a112e470fef7b335a1812fa270635505ec5863a1af49ee7f93d43a";
+    sha256 = "19f9494b26b4d893da92fc8e2810cf99b5b2b30491f373a544695cd7fc7cfa25";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-rqt/default.nix
+++ b/distros/foxy/microstrain-inertial-rqt/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_rqt/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_rqt/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "c086707b83a7f21496abc12e3a7e77e9428cec73d9b42f18dd64d238dc7c5277";
+    sha256 = "9852bc3f449cd90ee5bcefe56149fe99ace7d84863e5c014f856fcdfb452f078";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/foxy/moveit-chomp-optimizer-adapter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-chomp-optimizer-adapter";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_chomp_optimizer_adapter/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "e115b2667935acecd4f54d8b20bc39321fa7f394246a6a372f6d9422f86dc52f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''MoveIt planning request adapter utilizing chomp for solution optimization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "35303adf34ac5e6ac500d195bf152e10afe1e762be459a683189dad256997727";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "09f5891f3ccb59e3251a45158a7afd5c014be0b9c663b3be851aa4a9725b660c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-core";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "06c3ff565271ece7e1d6ad65bbb751139095d849e067df4c9232c37f4b5582f2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "eaa14e326ffb03e88dc735f7cb1574a51854cf29dcac584dd942da08c01ee651";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "0249b9f79b0b392c7a1ea01787ec2e5a39cc52254180b6695e4e612f11bc610f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "945a1aba5e751d6f7c6f9eb1f9845eaa5cd7e372ecd31c57e7625cfc644e78b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners-chomp/default.nix
+++ b/distros/foxy/moveit-planners-chomp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-planners-chomp";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_chomp/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "4612da44d93816c551a95e295abbb1fe7115ef18acdeffbeecee8382ebae3f23";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The interface for using CHOMP within MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-planners-ompl/default.nix
+++ b/distros/foxy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners-ompl";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "7395427cb1428547cadf70aa029c4a68ecb9a7c0b620ea8fc4e420a57ef8d38f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "a26eaa86acd09f7023f172fccda3e99bb661ffad3325392000e1e2c614c585a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b5b0000f46272aab3843969f747eb745ca9df2b8347b643df13ab533d8b2dc54";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "1e771ca66e3387f428155ad274517ca50996b74ea3184115f6e73da9ecba3214";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "668a9748c983a9ecabf918ffc080f8552903f8dfdf611b47a47ab4765ded32f5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "6e84939a50bc25b2127cd9f57c2bc7a7d804b3987ae8df7f471cec61dbbb3370";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "24ffc7994309a36618dc992c89a08a0297afee3691e46e998a639e3da3e7f36a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "48c06d2ddf70a9fa6de2d98fd00e245606b775cfa5e24ad8bff4c2dfda86839e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "ac10f22cb72ef1b2f470860dca3d676e90e003dcdead035b032368d0d07fcbff";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "54203208a479cdea86656cc806112cb1949822696e5e7d6e41de856302490252";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "3e9a76eb47d1b2d513d1b346a134ed16679c6a28bc7dca5e0fb2af9d44ade812";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "e31d678dff6b2da0a7dbdcf874531cd8f4b00bd572566a6044cc361637cec253";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-perception/default.nix
+++ b/distros/foxy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-perception";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "a6c90bb96142a5ce2ac759a0ba828016631d33f692d2cdb258e50a991f441a3e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ba1884f8bfe96a25754f32f33082f945b721c28ed8d707f1d66eb7b2dee82ef1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "5f1e1319d0f3735b636d1ffdb9004431cdf73b3f6ddabdcbac28b1026c8b9021";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ca37188371f43c950d16d706337959fa067539f8114613605fff60a2cf043a69";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "fa053b5f669dcee7bde786306fba8d9e5c0cbc164f63081215728c73155ff602";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "bdb3c9502aee29ad8bb9b38ed6d3128ca81134a54e713e8c2a0a16656b35d950";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b6fe6dec1200210067c6632b533d138f6813c93b326d83fb23c72fbdea0a793e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "04d6e59b498c43899292fd11eb26da6725b7cc0cf6fc6afe00d424e98a322835";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "d427fdd7e25d63d1e06d13fc3050b6c290b37dfcd208ac9684c0c3d23926bf7c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "70527eeaebed9ee517d2f4f48a313b40a49c864d8aaa2fe723a5dd95bf3b233b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "51105f6d7b90d73bd440c3e9367b6607e4f2546fb3cda767de9e6ac44ace7967";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "6f58e99828fedb3e10624741860f64b1ba261366a5e286716c708b0a8a3616ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "5a541e9d48a4385e4c03b2bab7578862215a1265357b38555bc653f456ec26b0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "e62b170fd4d2c530db892856e23a22e7a21b12a4e1477e4776f932f84fe0ba45";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "8ea419f3f54038a728b82fde54083a69af31375a8f13231c3874fcddde006283";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "80e4048cdfc58e9334d82dd33c048100b5a7816f91701a84a6c01f650e9c4d2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "44daaeaa66f0aac439278827dd1c72ef3a3b79f142a653ef9887538c7dfed35a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "eaa39c16fb6d17aae338557b53d075799d529311ae5dbd32ec17ec7b28ac3c56";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "bbb4fcffcf9b181b949f1028208fd61b5288c4fbfd1c781edaee4f796a5319fe";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ec3eadf03ab111a3e9c45b3916c5a5d04867f8525f86362b4eef3a638b372b2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "e4924ad34713461a6a4b7738f3e17c3d352e5844bc27db66f1eb9145e0851ca1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "7379e46d8159298b5f07d71b02c450d6a66a6add7ecac0e7ca2ca02fab0998ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ntrip-client/default.nix
+++ b/distros/foxy/ntrip-client/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-ros2-release/archive/release/foxy/ntrip_client/1.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "c33d794074ab0682c8c91059bca34cc8090246183365a7a09b0489bba3649c61";
+    sha256 = "7f1b80d7344ff53499b652cb242a249f59d56140860a77cc6bda94fe41dbd66e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/osqp-vendor/default.nix
+++ b/distros/foxy/osqp-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.4-1.tar.gz";
     name = "0.0.4-1.tar.gz";
     sha256 = "826268ede5aba88290b719cbcafa55226535701b33d6afa7330c7090d6321841";
   };

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0b02720e1eb8baedf80c833f3f6e72b99964bf07620c30eab9bf98ba2e966ac7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "1a90c809ced24b38b331d77152172649dd0786a399be1323935c7a6ef35ae397";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "2d4036184a6d44bceaeda165b97428c9fe4dc414dd2500fdfcd5edeebc7cda90";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "390ba091e0396f714569ed2e8913f6e9eb6bd416af3325ddf8122ff276d3c850";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "990af5d23f730ca6252e53081955126790cbc5e2563af5ad61e7bfa41655c260";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "9c9283679849378a664eb793a45faa89507a1c6bace808ba1e1cc56215da2c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "24b31e5514646cedca412a8fbc6913639592b141f6b77df39d6b21f005b9fa33";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "4eaf91edfdaa1024450c5374d7fa8d57b7021b9f3c6a4899c1afa25b8b0eea25";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "0ed38dbf02f5db6c8903721304c67d744f113762762c916eef7129e8e21647aa";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "53ecd09290add9920ab753edd5bb0fb4a1e5de7df60698f599bd48ae91fb49ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/soccer-object-msgs/default.nix
+++ b/distros/foxy/soccer-object-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-soccer-object-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_object_msgs-release/archive/release/foxy/soccer_object_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cc7b1fa14b89d3fa44bef7cb781a0838ae7bb7933251a6e3291120ccc9401462";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing interfaces for objects in a soccer domain.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0e2d8ba3277b1c3c20892ee4a18b06dd809ec46c32c3c553785f83c0023b912e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c0b3af2e675fbdb803d67514d78d9aec50b080a1cb69c696c36a06a151c5aec3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-control";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "31d0e32083b087bb42610140d83130b492bb3423431d6ff699a714134b8d50e4";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "d259d9400c6c940490e21b0d533fe2515e0bd8843cfc16af2ab9881a6595eb33";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-core";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "a5c1ff7def40f2ae0a7d8df75b896096f81cc4d502d1f90db8aa9da31d32e689";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "6abff388e4e2ace3d6e92ea9900c32f86bfe77cec3e786f1cac88f624c58a4f5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-driver";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "fbbfcef080a0b42f423d7f52ab5447f05c3fdf0654d697ceb7caf0ff68f55110";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "fc7a54814ee88632240f9692c12a2b631c80e597904828dfde3037e4a0837fda";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "11c21bee9da3fa5ce3f6e6229b89f4908b785b11009f9d425ab8a2096cdc7b8e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "f75f24bd2ac58389bef5c389fc402d4b8242cc4221992fbc4cc134389691bf94";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-importer/default.nix
+++ b/distros/foxy/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-importer";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "7976420d6b8b33b3853654073b37072212f43787552917a68b824afedbb66907";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "602baa9f8947777a94227e2feaaa4fdb6219ebb823bdadb0345fe82cb70e5d41";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-mavic";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "4fb74a5e0fd9ebb610658a8a1de2d4e2591c092075e7a55532b748f5441a0935";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "668fc2f0236a597b8b80cd8d91ba8713e97dcabf593ab8c65df76b2236355677";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "422f740735021e520aad81762e54dd9d7bb7e3e13f310d4a60a7df9a137b5722";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "edb505cb8770b1aea706456060db69b8d93ab296346789f45554fdc68de3b3a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "23b7858d6cb5b7aa604a66b659bfa71274edf86f957eb3afe6375bb34ed6f112";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "b26ebc29ecfd8319935737f632f3c085022bead48e21766dc3bb8eabf29a2f5e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tests/default.nix
+++ b/distros/foxy/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tests";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "ee674beb2a2829de1d73506ce0ea680cfd09f147387d4cbefbd228efd2d80217";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "5bc9c33b3a883a96827c124186ed8365056b71134bbe81582c8930b6297071be";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "13078f85c002824e9d8fc728561635f647caa842225c1fa465e8228d5dfc8686";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "323aa041333ce68e94f62a487e6b6eb9a09c3a1cfdcd368437da4660d659ea0e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "10bd9a5b652f7c13449975e11e3da2418c503e2cc6872c8d95918f0f7761d42c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "9c12df4154128fcc2741c66c073c2f12afffbd0db4c7b691b8a01f24ab5f6247";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "5c4d935371abea3dbd58a1012a3e247cfac5421895fea09e7b58b66c22c00c0e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "eb9c9a7f784e0d7ef177c92ec2a9d5c1b92758c66f68c26e51c29202ff72fa15";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-core, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "9d419d67b1b372dcd30db52b4ba964ca695f3da4ea96d4e0316865784f7c9c0f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "fe3d484d956fbd4715b7d8b3b168398f19fb81e3e4428da98d407e80869a407d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/actionlib-msgs/default.nix
+++ b/distros/galactic/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-actionlib-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/actionlib_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "a59b69d5f9da1a68adedb243eca0fbee4faf1a9d8dd2856c1f9f9eb0a6456222";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/actionlib_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "5d2ce4cb8dd390e77e86ce2424071d6714ba8a743f9e50179479a683316407be";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/galactic/aws-robomaker-small-warehouse-world/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-galactic-aws-robomaker-small-warehouse-world";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/galactic/aws_robomaker_small_warehouse_world/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "846ceec0b2874b4a3af5df80f660ae65dc4d8e1fc13e2d6ea8dd9d62a437ca4d";
+    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/galactic/aws_robomaker_small_warehouse_world/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "bfbbf19db7b6fd655367553e8585662648a333bb29d2c30eed97aacd10b25418";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/common-interfaces/default.nix
+++ b/distros/galactic/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-common-interfaces";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/common_interfaces/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "c5bf580d8245e12e8dee1bac20a30c98bbb5e2e786dffa2e685c0860160e7cb0";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/common_interfaces/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "d9cfee1b1f3e1154fef1ce3a323a061c10ac84ac5d804529d03930c76177b397";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diagnostic-msgs/default.nix
+++ b/distros/galactic/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diagnostic-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/diagnostic_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "773d3303b628f790e6039b491c12af318552ba6baf013e306d29516f0aee446e";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/diagnostic_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "d6bee82d8153a12645daffd44f85f624e143dc4d2ef343798f21f29ed651a7d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diff-drive-controller/default.nix
+++ b/distros/galactic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diff-drive-controller";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a0f969b1507a129d82ba2ae7d0872107e6a4e1b29972b3c6ecee030497c830ba";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "f14ed93f682786bcad7b4baf18739540eb0e0959bbb72297b087821d3d6d3df7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/effort-controllers/default.nix
+++ b/distros/galactic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-effort-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "13bbf94a85fa6fe45cab89b6dd12802b437bda2d4432bc1f9fa1a8ef5abc926f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "a82ae2cb707c2997348682e8030031dcb7fba0139f964d4856809a04f8b10b2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/force-torque-sensor-broadcaster/default.nix
+++ b/distros/galactic/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-force-torque-sensor-broadcaster";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ae88f8f4f93a6280b8f46dcc88f5acfcdc99b6ec23b6a1b9a9519dd508f4d21b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "aa5d7db0e1ca69ce6068f766664d8570ca2343cbba0ee5ac65d946bdac950ba2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/forward-command-controller/default.nix
+++ b/distros/galactic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-forward-command-controller";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "5d014615253d64c560aad1d13d145c9f72144466e5a034199b956dbfb8ed284a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "727ac0dc733f333a5a8551b9f51df8e69cded5d6da415a1d007dcf9a1e15a0e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -506,6 +506,8 @@ self: super: {
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
+ libpointmatcher = self.callPackage ./libpointmatcher {};
+
  librealsense2 = self.callPackage ./librealsense2 {};
 
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
@@ -756,8 +758,6 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
- openvslam = self.callPackage ./openvslam {};
-
  orocos-kdl = self.callPackage ./orocos-kdl {};
 
  osqp-vendor = self.callPackage ./osqp-vendor {};
@@ -946,8 +946,6 @@ self: super: {
 
  rcpputils = self.callPackage ./rcpputils {};
 
- rcss3d-agent = self.callPackage ./rcss3d-agent {};
-
  rcutils = self.callPackage ./rcutils {};
 
  realsense2-camera = self.callPackage ./realsense2-camera {};
@@ -1134,6 +1132,8 @@ self: super: {
 
  ros-ign-interfaces = self.callPackage ./ros-ign-interfaces {};
 
+ ros-image-to-qimage = self.callPackage ./ros-image-to-qimage {};
+
  ros-testing = self.callPackage ./ros-testing {};
 
  ros-workspace = self.callPackage ./ros-workspace {};
@@ -1244,6 +1244,10 @@ self: super: {
 
  rqt-gui-py = self.callPackage ./rqt-gui-py {};
 
+ rqt-image-overlay = self.callPackage ./rqt-image-overlay {};
+
+ rqt-image-overlay-layer = self.callPackage ./rqt-image-overlay-layer {};
+
  rqt-image-view = self.callPackage ./rqt-image-view {};
 
  rqt-moveit = self.callPackage ./rqt-moveit {};
@@ -1346,7 +1350,7 @@ self: super: {
 
  soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
- soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+ soccer-object-msgs = self.callPackage ./soccer-object-msgs {};
 
  sol-vendor = self.callPackage ./sol-vendor {};
 

--- a/distros/galactic/geometry-msgs/default.nix
+++ b/distros/galactic/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-geometry-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/geometry_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "9c940bfba85ffb624b63c4e1facfd066ddefaf1d705900e0662d226d8383ad53";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/geometry_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "708f6d1292fae2e658bfbde2c3dfafe5b370e51d8c20bf405f60b5d485418e90";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gripper-controllers/default.nix
+++ b/distros/galactic/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-gripper-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "fa86829c262273956b4af81b8ac83e8ddaf335e75f2618f46d8f6c8ba76404e2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "67002322ed8742811f3fa6792614c7f0ef0280d8e20c0c0f0d035acf4d92a7fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/hash-library-vendor/default.nix
+++ b/distros/galactic/hash-library-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/hash_library_vendor-release/archive/release/galactic/hash_library_vendor/0.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/hash_library_vendor-release/archive/release/galactic/hash_library_vendor/0.1.1-1.tar.gz";
     name = "0.1.1-1.tar.gz";
     sha256 = "62bda6cb3b853dcb0394424cb1f1da97d08be3e05a5b145f912394393d4c76e9";
   };

--- a/distros/galactic/imu-sensor-broadcaster/default.nix
+++ b/distros/galactic/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-imu-sensor-broadcaster";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "dfb839801c2ffca3e38a77db0a7143114ede39f6474d9e8f2fb0fee884e0d8dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "cd4c1f73f3c9233b917b4a05cda4f969b87b8c748cbf230e2dc4b77e142e192b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-state-broadcaster/default.nix
+++ b/distros/galactic/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-state-broadcaster";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "133036cd403dae222c62cfa40be633da4ee346a0f0d7789d7881d33bac83f96b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "925ff649c26c59d3f800da31c6230eb12ee2f19501d45d12ef095db3bd91541c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-trajectory-controller/default.nix
+++ b/distros/galactic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-trajectory-controller";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "44b55dd9c25adbc70b8872beadb78a61fdbcd6706ba59a1231434de355ebf8b8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "38d8b6658829dac72dc6ae1c1f35914fe21fe4e31239c8ec0b077da2d384e6a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/libpointmatcher/default.nix
+++ b/distros/galactic/libpointmatcher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, libnabo }:
+buildRosPackage {
+  pname = "ros-galactic-libpointmatcher";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/libpointmatcher-release/archive/release/galactic/libpointmatcher/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "c7c042ff46ba25ea8b16d3091c8274e2bcd5716965b89a2a210c26e0e1722094";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost eigen libnabo ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''libpointmatcher is a modular ICP library, useful for robotics and computer vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_driver/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "f165c01ffe880ae76071e49bdff4fd13563e6ce6784c3495149df0dc8ae6444d";
+    sha256 = "2d101677955d30183c2fa08046787362361774dbb57726f98070e3c614336056";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_examples/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "635cccc7868e1b61a9eb05d7451c5a371ee1aa9e2bc908d7d42c58eb6cc38283";
+    sha256 = "8e3bcf8df8f83e987f5f9a9ede5f8c4af14c8207f6a2318c64d4d67dd723838c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_msgs/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "d03b3204b66dae05f1b0b81d36634dab768a6c9c511fe24c6509f4ae6d4cbb65";
+    sha256 = "6f95b887776a57733c1ca213d201270c61f5e8112ff2b01996d696281a0dbe8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-rqt/default.nix
+++ b/distros/galactic/microstrain-inertial-rqt/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_rqt/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_rqt/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "477a11b17beaa186fd5fe4e689f98783cc40ad6b2ca788a631aa8682b11cdd4c";
+    sha256 = "fcc402b928143240701598f3637ceaff5397ea71dbd19e7fdd9af8c30afc86fe";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav-msgs/default.nix
+++ b/distros/galactic/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/nav_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "5ae0cd4883f83b991e1c6ca565735122c75683265d833e48ecf8577dd7c5592c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/nav_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "451b488841a4a466539097249fa35f6f150971a39ecf3e841be58b9c902eca4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ntrip-client/default.nix
+++ b/distros/galactic/ntrip-client/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-ros2-release/archive/release/galactic/ntrip_client/1.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "ccc17605a247e6d1a808adda9ec0b0769e1d20fe391de7e54159b092bf9a9386";
+    sha256 = "2a56f3a461beb8cd3700cb13dc174ff2e2e43cbec730619e6c1279f9339ffb91";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/osqp-vendor/default.nix
+++ b/distros/galactic/osqp-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/galactic/osqp_vendor/0.0.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/osqp_vendor-release/archive/release/galactic/osqp_vendor/0.0.4-1.tar.gz";
     name = "0.0.4-1.tar.gz";
     sha256 = "366e082d8adb27d1206b58e830e162a5342dfc30ec076ec7f1e0ff786c90f64c";
   };

--- a/distros/galactic/position-controllers/default.nix
+++ b/distros/galactic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-position-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a7b6e98ecd057b3d57851ece9765b35ae696e3995c3a8d63121655f5c8555600";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "f03ab1617873ff19fc6aabf41362e5e8aff0ab5434fd8b266509c9e3bd57dbe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcpputils/default.nix
+++ b/distros/galactic/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-rcpputils";
-  version = "2.2.0-r2";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/galactic/rcpputils/2.2.0-2.tar.gz";
-    name = "2.2.0-2.tar.gz";
-    sha256 = "f3af21385390086e704e31d1c79c5989927ad24fa4fa5d8d8e9e307f98c87923";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/galactic/rcpputils/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "6b173721a8cdb5dcc321bc25074045c7b10155b63b9d6337b3284be15c8f867f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-image-to-qimage/default.nix
+++ b/distros/galactic/ros-image-to-qimage/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, qt5, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ros-image-to-qimage";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-sports/ros_image_to_qimage-release/archive/release/galactic/ros_image_to_qimage/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "df859dc610b2e7ef43e847b133b72289c7219d6d7d05e1ef0f7f2d3417f4b52c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge qt5.qtbase sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A package that converts a ros image msg to a qimage object'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2-controllers/default.nix
+++ b/distros/galactic/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-galactic-ros2-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6b6b2401381d92f219e6c714abe979341fee3f7e806742c4f4fe663056afb285";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1594c8a67ea69794f0bd414bccbb4be0621bc733f6a58800c92df67a99f4bef7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-image-overlay-layer/default.nix
+++ b/distros/galactic/rqt-image-overlay-layer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
+buildRosPackage {
+  pname = "ros-galactic-rqt-image-overlay-layer";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-sports/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "45f842bcefbcf76b7e39366fb17ee88fa281bf7f3e53b718a34f608363f58156";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib qt5.qtbase rclcpp rcpputils rosidl-runtime-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides an rqt_image_overlay_layer plugin interface, and a template impelementation class'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rqt-image-overlay/default.nix
+++ b/distros/galactic/rqt-image-overlay/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer }:
+buildRosPackage {
+  pname = "ros-galactic-rqt-image-overlay";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-sports/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "be7f3bfb16e7183f2491b8992cb7cd74d53790a8f680609c3cf96a6b11d69f3f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ image-transport pluginlib qt5.qtbase rclcpp ros-image-to-qimage rqt-gui-cpp rqt-image-overlay-layer ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An rqt plugin to display overlays for custom msgs on an image using plugins.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/sensor-msgs-py/default.nix
+++ b/distros/galactic/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-sensor-msgs-py";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs_py/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "88ebcc03617f6abb549243f2d533fb905d8fdcd510bbf62a3256bb71863164df";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs_py/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "c1f07b5394f0633204b3fe67b43287b591add664bd8486f2ed67c7a2734752d1";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/sensor-msgs/default.nix
+++ b/distros/galactic/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-sensor-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "cf3775ee0746b63bffab214f6ed031254b3df0b2ded88517aad857924006cdd5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "106553cbc1fc7dd5e2afd60b38d9903a977b55f35f2252c978859d6d356f10ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/shape-msgs/default.nix
+++ b/distros/galactic/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-shape-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/shape_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "ca2153e9c6d11d320a313187d6ef8cfec24baaafcd6caab1532a29db96131e7e";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/shape_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "cf37da06696fbce13ff4ec25bff0c3d5a4357ec992e0ba1045b884c18cf93382";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/soccer-marker-generation/default.nix
+++ b/distros/galactic/soccer-marker-generation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, soccer-vision-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, soccer-object-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-soccer-marker-generation";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ijnek/soccer_visualization-release/archive/release/galactic/soccer_marker_generation/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "189d3289374ddeb5078718359cd67e205eab040437466f23015f633fe821c452";
+    url = "https://github.com/ijnek/soccer_visualization-release/archive/release/galactic/soccer_marker_generation/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "1e13d7dc88344b3c411dfb4f20a184ae8404680b888aa5bcd8a7021727caa94d";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs rclcpp soccer-vision-msgs visualization-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp soccer-object-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/soccer-object-msgs/default.nix
+++ b/distros/galactic/soccer-object-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-soccer-object-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_object_msgs-release/archive/release/galactic/soccer_object_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a8655139be867e798d39895b8424fc89e9f604dbb7ea6f37d7a202e4e63e2198";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing interfaces for objects in a soccer domain.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/std-msgs/default.nix
+++ b/distros/galactic/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-std-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "166a014b5be66251f76bab39a7146cd1ace2a2877af68baaf912ae5738967794";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "5fa2de4ee95439db1b984c5f18b225cccdb4ea0daae4c9b516b06f981dcd3834";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/std-srvs/default.nix
+++ b/distros/galactic/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-std-srvs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_srvs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "da04ccd6f2e0e71676a1c02d531e2dee2942c955874f1665bda5f9823171e0a2";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_srvs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "0abc409bfdf8a76ae15722bdd5b2ebf06f0fe10bcc68cb57629f738db7440985";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/stereo-msgs/default.nix
+++ b/distros/galactic/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-stereo-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/stereo_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "0526f016130e246bdcae49d7a496f2ec26957c9c0cb86742adcf73c5b68831fe";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/stereo_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "e90e542637e89518434f180529d64776ff56e2862fa6407bd8d4b92241499c77";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/trajectory-msgs/default.nix
+++ b/distros/galactic/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-trajectory-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/trajectory_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "ff74d815dd66324c6b11aadcee3a3271ceb1b17c140026cff84b6db8357b602a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/trajectory_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "82de7d3f4c1e4d5e20b9ca29bebf18a3aad2b0bfbcad622dbd28b3e5eac0199e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velocity-controllers/default.nix
+++ b/distros/galactic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-velocity-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "179727388643ff840ab822e4a7fae7b7035f1b125607f988f50d2b3520e62df7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "59d9ae37d3bf135d883ef36b2d76b331ff40ebbdd34d1a017e3abc32ed2a2c60";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/visualization-msgs/default.nix
+++ b/distros/galactic/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-visualization-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/visualization_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "6f75b46f14a1c4cff806bb0207b7fd37dc74f8f5471e03625ee26eb179f30399";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/visualization_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "a5aae2c521469572f63d364d10687e978fbe167161ab419dcca89612d488d932";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-control/default.nix
+++ b/distros/galactic/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-control";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_control/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "bc6a6b1f4ec11278e6c3bdbef2f1b85bdc1ebf4f7c24d9697e7f831e800bf4a0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_control/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "f87fc079e2ecb09b1f2b5c4948a1a14b157cf660141d71ce1aaef40b32a96842";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-core/default.nix
+++ b/distros/galactic/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-core";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_core/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "5f33fe452842a7bfba069cebb6fdba441a45ea17b7e85f8ca44b07c96da8f913";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_core/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "098c1c462f441e117f69176804a7166d37bccc96a877a5f9af6e2960099d7499";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-driver/default.nix
+++ b/distros/galactic/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-driver";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_driver/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "ffb791f9b29a601ff62942371c5657ae20732a100c07b5e60fa06901756857cd";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_driver/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "0b55d8266b278becdd24c43cba75487aec2a03a78e1b3d4850d181174872fc95";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-epuck/default.nix
+++ b/distros/galactic/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-epuck";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_epuck/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "c99c478d2577f80e306d75abdfbd43389a5a526671cfdfe679a6b51121d4137e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_epuck/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "66a3947698fcbbd82eeadde11d6bf5afb0c16d26d96a4ec0a48fca0fb6e345ee";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-importer/default.nix
+++ b/distros/galactic/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-importer";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_importer/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "2de6ec50d2f3b682537fd71d08fe15ebe7900988f6c1dd86107ec9c13f26feff";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_importer/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "a01994f047d202b2e5158faba7417c54127ec3ad3e0a3bb6f3cb3012dca9f0d1";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-mavic/default.nix
+++ b/distros/galactic/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-mavic";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_mavic/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "01197293c2b1483714ff276116738676fcb25ae72a6dd9659090522737a37324";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_mavic/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "baad76593b3f26b25cea7cd3c668a98c37f9ad70d52251dd24dcf507633439b7";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-msgs/default.nix
+++ b/distros/galactic/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-msgs";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_msgs/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "fc8ced284b7a3dd5ee5160e52fe79ab17e6ebedcfa590da4ac456b3ee67238cf";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_msgs/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "f9dd211b8f76b88aaf929ff718a830a44d7fb2dcf7ef5cee7e66858e8409a874";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-tesla/default.nix
+++ b/distros/galactic/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tesla";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tesla/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "b2781f57464a6adfcdd14671a18335fcde93fa0a62fcf66a478245227f51952c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tesla/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "0f7ff5bfb296933f7e599011199dd728f63d582d44a43a0d5b4c58ed9f5542ff";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-tests/default.nix
+++ b/distros/galactic/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tests";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tests/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "30cc6ff0810fce3df0d1fec414347262b42acd397efbe48322c592ce04835788";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tests/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "8f67de362902444a784a43c1d57dc54df2d66466726b25b23fcd42ca3e50d2a7";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-tiago/default.nix
+++ b/distros/galactic/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tiago";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tiago/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "8e31874f5b11f542e11b80cbcf91e7b603a32346f07e0462d66a08d9de5e0be9";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tiago/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "b4f76a62510712d986ebf3edbc0c9cd47524a9c5fc72aa79f40b869e755a682f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-turtlebot/default.nix
+++ b/distros/galactic/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-turtlebot";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_turtlebot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "35a8a84da04ac74b61fac158068e04a762e3c4e53754033dcfeabb4c1cf757cc";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_turtlebot/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "1487c12108160f2e1616326cba040a371623f606e8effd2225f077b112a2726b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-universal-robot/default.nix
+++ b/distros/galactic/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-universal-robot";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_universal_robot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "8bb6dc25eb7427b1687142444683854b2a60d17eef86cdfde9515ce01f6c2ce2";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_universal_robot/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "93548926fe9d577c390331c0ecd9bdc795e78e0f76f3169bd1ba142906a9d533";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2/default.nix
+++ b/distros/galactic/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-core, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2";
-  version = "1.2.0-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "618ad641c643dbc1ce57cd21bccfcfa0a07ade2f7d1198ae74ac70a5f014f157";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "28d51a06cddbca929de9d96af859440a62953a7cce5025abd8c3a78574778145";
   };
 
   buildType = "ament_python";

--- a/distros/melodic/chomp-motion-planner/default.nix
+++ b/distros/melodic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-chomp-motion-planner";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "1eefe8cb37cde262b0e7840f03ac5a1384021c843606ee649953201df81c84c8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "b8a6e1cd04276478ab4672056b7c0a687267f3d7b678701d5257e384c9227d1a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1704,8 +1704,6 @@ self: super: {
 
  jsk-rqt-plugins = self.callPackage ./jsk-rqt-plugins {};
 
- jsk-rviz-plugins = self.callPackage ./jsk-rviz-plugins {};
-
  jsk-teleop-joy = self.callPackage ./jsk-teleop-joy {};
 
  jsk-tilt-laser = self.callPackage ./jsk-tilt-laser {};
@@ -1925,6 +1923,8 @@ self: super: {
  libphidget21 = self.callPackage ./libphidget21 {};
 
  libphidgets = self.callPackage ./libphidgets {};
+
+ libpointmatcher = self.callPackage ./libpointmatcher {};
 
  libqt-concurrent = self.callPackage ./libqt-concurrent {};
 
@@ -3720,6 +3720,8 @@ self: super: {
 
  rslidar-pointcloud = self.callPackage ./rslidar-pointcloud {};
 
+ rslidar-sdk = self.callPackage ./rslidar-sdk {};
+
  rsm-additions = self.callPackage ./rsm-additions {};
 
  rsm-core = self.callPackage ./rsm-core {};
@@ -4101,6 +4103,8 @@ self: super: {
  timestamp-tools = self.callPackage ./timestamp-tools {};
 
  topic-tools = self.callPackage ./topic-tools {};
+
+ tork-moveit-tutorial = self.callPackage ./tork-moveit-tutorial {};
 
  towr = self.callPackage ./towr {};
 

--- a/distros/melodic/image-exposure-msgs/default.nix
+++ b/distros/melodic/image-exposure-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-exposure-msgs";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/image_exposure_msgs/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "1a1518bbeb26d3e52459bc25560ad67da0c3c059fa238494d411cc1585366a9c";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/image_exposure_msgs/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "c6ba39025b456f77a855837ff900d4fa5a327054fcda320f2d2e94c219ef8ac5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive-marker/default.nix
+++ b/distros/melodic/jsk-interactive-marker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roseus, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive-marker";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_marker/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "aa813b4175c442c8130b352bbbe70c9ebb0299b9dfc63e6c74dd892ac343d991";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_marker/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "56744adac4f633df0b6c7b8f1073e5f7b3f07d8109335c370f7add394ee03b57";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive-test/default.nix
+++ b/distros/melodic/jsk-interactive-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, mk, rosbuild, rospy, rviz, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive-test";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_test/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "7e0a0fb246e712b8b7f56a170a046a771af8a4392486220ebb750aa13235c2ec";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_test/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "5c4234901ba9b98bf6b8644c7829f4ab966aa7c797987e3eb7deb2b77f7ae782";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive/default.nix
+++ b/distros/melodic/jsk-interactive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-tf-publisher, geometry-msgs, jsk-interactive-marker, mk, rosbuild, rospy, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "e70d0ac211e8eb19eec75bc00b77af7265da884a0c8a02626cfb684409b4d77f";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "5ba59c717424d8864d93e9a1bd2f8347a7532f016de3981841adf7c46cd54029";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-rqt-plugins/default.nix
+++ b/distros/melodic/jsk-rqt-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-publisher, image-view2, jsk-gui-msgs, message-generation, message-runtime, mk, pythonPackages, qt-gui-py-common, resource-retriever, rosbuild, roslaunch, rostest, rqt-gui, rqt-gui-py, rqt-image-view, rqt-plot }:
 buildRosPackage {
   pname = "ros-melodic-jsk-rqt-plugins";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rqt_plugins/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "b21d44eda2592de315538c55dac1eb0b28cf9de21ddb297afbb68cdde834afc0";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rqt_plugins/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "516b5b98d4e1aa2fdb5c7c6f1dee109b9025e544923f9a25d2f425db8b47d9c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-visualization/default.nix
+++ b/distros/melodic/jsk-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, jsk-interactive-test, jsk-rqt-plugins, jsk-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-jsk-visualization";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_visualization/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "6d8b429a38d572edddc49f424e51518dc67069ce373d7e423fb426ccdd1b8c84";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_visualization/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "7493abb6f57c227f4b59d2d26e592a0424c0a66a587fdaa85cbb441588344260";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libmavconn/default.nix
+++ b/distros/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "a3041c95add3036e7dbd4d3bedcde79be302f29e829f48418c906c20dd81be54";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "be9186517bf56c11a1233bdd9566573ad5e5000e26ba7e37b916d65b03d690be";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libpointmatcher/default.nix
+++ b/distros/melodic/libpointmatcher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, eigen, libnabo }:
+buildRosPackage {
+  pname = "ros-melodic-libpointmatcher";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/libpointmatcher-release/archive/release/melodic/libpointmatcher/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "26af003dfa5ec17281d65835377028672f83fe45b488c7923c078856fc0c3b99";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin eigen libnabo ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''libpointmatcher is a modular ICP library, useful for robotics and computer vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mavros-extras/default.nix
+++ b/distros/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "c855a9645191a0a925e5cedf89703577e48f72cf910fde471dd209ea8ec387ff";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "df6744acb7307b79f609abacf2ce2009b80253783ff67c73b2d78922edd3ddd9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-msgs/default.nix
+++ b/distros/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "ed1bcc83e700ccd70eca027e6a854cf0a95533ce376c38511f0d553bf953fc26";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "fa8f9b65e70817fffbdb9a77fa2a241f681248a4f5a5ab8ac42226e2c2ffda5c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "f37bcda0fb9eff0f84adf973c917ea96492da9c14a27c835a4afbd1a4eb31a57";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "5d7f630e1313f53975d7b03f910cbc2e871ec31a8e384c229bfdb8002603f05e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-moveit-chomp-optimizer-adapter";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a0fcb2f0f4ed4eef67a21d47e42e814e655693b5eec2b88ca21962dceac3a6ff";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "faefef3533dacce0068cd97b47a42726989b97ee4e5afd923ecf4e37590504c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-controller-manager-example/default.nix
+++ b/distros/melodic/moveit-controller-manager-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-controller-manager-example";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "7958ff6d3a19cac407e0011e6b1325b4e57a51d3dc31ad5802f4f2243008a652";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "29db84056386658a974326a447244b577071cdb94fda971a9e3c8c57fc1fbd8c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-core/default.nix
+++ b/distros/melodic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, catkin, code-coverage, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-core";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_core/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "cc1c034e5f09b20b275d49db1f94296d43da0cbae1550cc57bd2f1b9419061c0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_core/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "981e5af27f7decb864acda9283d0960fb48ed3c91dd0e09fa4f6b27d6dae7e5f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-fake-controller-manager/default.nix
+++ b/distros/melodic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-fake-controller-manager";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "0183830e48356e94ef0a8640708dcf0c0e17429f31ca53761f9868dc84e9a314";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "da64c249f0135875757379af24feac7ab7cbd49103936ba549228f5d932422bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-kinematics/default.nix
+++ b/distros/melodic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-kinematics";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "34d424f478f33d1fe4e2eaabf89d6fca4d8b4a6ed3ee345435766d7d281c0187";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "3720bf517ae0ea8d51065a9a5a59bebec0a1cafa658b7b3dd459ee3605a7bbe3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-chomp/default.nix
+++ b/distros/melodic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-chomp";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "eac99763520b1e90620a66afb24f24466f4ec5bec9f5c80becb16b956b6d3c94";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "2a199e44e95d12a89a7c6d3c2ae6e250281eb010cc8194d2fe86d70c879f32eb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-ompl/default.nix
+++ b/distros/melodic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-ompl";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "303245ef34706af1b803dbe2e7cd2f8523606cc1a25221ef139d4caaada14109";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5ba1e5c5541d484ec18493b555e5e099386e9128da534ab71147f824e6814491";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners/default.nix
+++ b/distros/melodic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "370b773039a5be90b9b8d97f0f6246d5fdbb76673d00ff564f563facdc80f010";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7bd95dab6f83fe637cb3b464697a703ec6b430f0cfb552a6ecf8a59d37ccdb16";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-plugins/default.nix
+++ b/distros/melodic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-melodic-moveit-plugins";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3ee18636379fb758cd402806886bf98ac39abaf23460e916fbd61c751dbacddd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "c24e33872f03d46a6fa658f754939c4578333316fb17d248d4929933c7cdbf3d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-fanuc-description/default.nix
+++ b/distros/melodic/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-fanuc-description";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_description/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "0a5d9ecb8548374826711eff22823fb86e6ca1b26e37d4f39a24874d7f541a11";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "46d8b567f40435fb3f0026564caf94f0b36403c39e1feeaf7d0a493d478420af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-fanuc-moveit-config";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_moveit_config/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "d11bce419df56d78db8a13f39aa93a31e9cec6d320b018238e3e2f0cd7eaf4e3";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "1252b8c2c843e7c35bc03ea29f72edf7595bad2a9bf9976e715e39c15549e4f4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-panda-description/default.nix
+++ b/distros/melodic/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-panda-description";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_description/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "11ab71e36ddcaa98661635dc5c4adc03de3efd20564106387d2f330a161fad93";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "ef4c4380e52b125a695d5dce52f4fb64157cc93870d1057399b67162cb6a8d1b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-panda-moveit-config/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, topic-tools, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, rviz, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-panda-moveit-config";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_moveit_config/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "baaf3eaeedb341f01100349341646c2c5ded56936e214d5ea991b0807b97fe11";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "8824461643a94e960c5ad7b85d65ceaac8fefc87b7c30cef810cadb8d7522e0b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-resources-panda-description robot-state-publisher topic-tools xacro ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-resources-panda-description robot-state-publisher rviz tf2-ros xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
@@ -22,7 +22,7 @@ buildRosPackage {
       MoveIt Resources for testing: Franka Emika Panda
     </p>
     <p>
-		A project-internal configuration for testing in MoveIt.
+      A project-internal configuration for testing in MoveIt.
     </p>'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/melodic/moveit-resources-pr2-description/default.nix
+++ b/distros/melodic/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-pr2-description";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_pr2_description/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "01a026146163de2a0f08186c0cbe623f69ddfa0c86b0a258d877a5a9d15a4bd3";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_pr2_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "2b5d4205ecfc223e35eb6a59d067e56a98ccb6329a92083a5f32e25b053f6244";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_ikfast_manipulator_plugin/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "84e7a9be6e81953ad3b003e2d4bde971bc0e4345c46dc89497c17713a193d4df";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_ikfast_manipulator_plugin/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "ddc3e93bd54ad9ca426ee618f5b2a4dc2128473a4b16c74d24003c3cfcfc4aae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, robot-state-publisher, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-moveit-config";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_moveit_config/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "cc1e2a2f1fef9e0a366b65158d0687aa47e40d4e24c50a1f19be9fd5b5c46dc1";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "6490af49b68db504222c288e8030b21812161ba60eb3523149adea6d9919386d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/melodic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-pg70-support";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_pg70_support/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e0828621bbed5c1cb24ce616f46987b8c58ae65facac5f7fa1869fc21e00e220";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_pg70_support/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "bb06b8de7ca0ab018cae56af743d0c98fc824e01dc66a73d46c8b7803f4e74e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-support/default.nix
+++ b/distros/melodic/moveit-resources-prbt-support/default.nix
@@ -2,21 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, robot-state-publisher, roscpp, roslaunch, roslint, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-support";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_support/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "9b377b7cdf7a37161b3c8700a69afa66c3fcfaf29da2d666cec1d96eb6584655";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_support/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "cc497fc0af21b41b5d729bff4a7bd455dde484fb0786be1a4d1fdfcb0547d691";
   };
 
   buildType = "catkin";
-  buildInputs = [ roslint sensor-msgs ];
-  checkInputs = [ cmake-modules code-coverage eigen joint-state-publisher moveit-core moveit-ros-planning roslaunch rostest rosunit rviz ];
-  propagatedBuildInputs = [ canopen-motor-node controller-manager joint-state-controller robot-state-publisher roscpp rosservice topic-tools xacro ];
+  propagatedBuildInputs = [ xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/moveit-resources/default.nix
+++ b/distros/melodic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "80247c1d9562e45f7c10e0fb3c01074c70199e712ff6c124e6322e31ddedf52c";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "3315e9198902f386e91ac925ede9548d13a7c281fd94fdb4dac37387090f8131";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-benchmarks/default.nix
+++ b/distros/melodic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-benchmarks";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "016711331970bfa96f9ad2ded8903bf7f4aa204132fdc7c9f131ddac3aad9b9c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "25dcdd54a6348f5a0a261df9279751e146b434f03273ed91f23ff1c8abd985dc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-control-interface/default.nix
+++ b/distros/melodic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-control-interface";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b6a6980834a0f4b791affba61bef5085cd38a5147b095491c826510916f3c2e3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "1a4024f9ea02b1fd5cf44d5a85f0833b06830032872fbf22073c9dc2ebba4192";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-manipulation/default.nix
+++ b/distros/melodic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-manipulation";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a22c5fb311a3f4c7cbf787f96694d8be7b675d2203f812809a8b26aa68a63dd3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0157c9ea1954d3ba5d1bbf9a859b0fdb637a963546141d023096a7d3ae6bd71c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-move-group/default.nix
+++ b/distros/melodic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-move-group";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "7b7ca396a24858254a9624316465e22983bc067284733c8b76f4380a779710e5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "375f6b60939e178cfcb1662f24fbf801b544b000d1514408342d9d0dfa646ad9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-occupancy-map-monitor";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "bfe1be2c66a45b351a9a628168777eddeca8d53bb965f82b911381a8af786724";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5961c601be710142ced99f50bba1642fa8ba900844595fa420e4b40b61c0cc7c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-perception/default.nix
+++ b/distros/melodic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, nodelet, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-perception";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "5c123b1daa18790372aa6bd1e8d4bca2e9f41b20b107996b102fb26be56ea346";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5a695f12133d2236b180157b708dde2fab7fcf91055c49fcbc9fefd17935d61d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning-interface/default.nix
+++ b/distros/melodic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigen-conversions, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning-interface";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d7d88c1313042f5e26b2a84006562ac3bf7edef25826785c8e2b9cee2e3c6b0f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "59fe2ccc91a2170322e3ac9a5b4ff304a53df4184554fa3cc609eb5993af80af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning/default.nix
+++ b/distros/melodic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d412de1b960640e88aa4aef3984f6d8677bc39b0a253da2cc7f40965e1908038";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "174ece09b8742ff6e25c45c8bf1d7e7fb52ad754e9e6741f5201008d84d3bb23";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-robot-interaction/default.nix
+++ b/distros/melodic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-robot-interaction";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "c998bacb6a047c52e03e24ca33a08242ca52ba91334b445c5fb52a20cc857df9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "3844e5d077b61e9b33c5b2d057dccc1cb7467f0c5166f30a896caa2b32e765e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-visualization/default.nix
+++ b/distros/melodic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-visualization";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "ad4f0390abe2ea4a43ae89e48bfb2f3edccdbc41cf2c1833d83a092de329e250";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0dc4e09bd1b122d9f2c92acc86544a97d7a5935586000e631e73e458b5287d7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-warehouse/default.nix
+++ b/distros/melodic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-warehouse";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3a727144ecac700858ac6d7989233b955358331370920e2cefee4cbeb92f6058";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7b5b96895482a99edcaac8cfce2fd127e6e57faa5b0b4261584c0bafd9e80ef6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros/default.nix
+++ b/distros/melodic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "57f29faad6c72a3557566dd7a339aee288cad806c8286bb36cc3734fe212ddea";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "ca1ea1bef99d4935f08e7695242006765aacdaad470924026b555f87824b7b33";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-runtime/default.nix
+++ b/distros/melodic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-runtime";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "88450045ed7478aaae509d1237189b90ef6799361d762ff78391c345b94d71d6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "280d898404b1f1aa065e7a41f28d6ff3b06818101d2dbec884783031eaee2253";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-servo/default.nix
+++ b/distros/melodic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-servo";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_servo/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a5da870e0876a50fb776b1fbd625c085d2007a2cee0c6058ac15053ddee0134e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_servo/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "dbeedb354a5a3a109f0b9e36e2d3625fdccf9007869e76ca406a41e190eb3da4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-setup-assistant/default.nix
+++ b/distros/melodic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-setup-assistant";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "123742b7e965c2ef2b2034f5fc829c44abb3daceb40d8814653ab1465ea966f3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0e023fc13c67e92da1c0ca43807e0736a28ac54cdf977a6cf46fe3449cad67c9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-simple-controller-manager/default.nix
+++ b/distros/melodic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-simple-controller-manager";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "105033bb4956c46163c3ddf377399d79bfd09ae6e91b5232bf9cfd401c5310fa";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "a3fe131162e48d591afea7f8e54df433ed3550aa2d3b28191cf27a218f08eea8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit/default.nix
+++ b/distros/melodic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-melodic-moveit";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a449da1fbaec96a89c966239ef6db53b39092a321e939363b8d54dcf4d9deb2f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "bbc58b05b24105e311d50f9690b5f09a2f939cbfc561cd11c0a740553da88fb2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/melodic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-commander, moveit-core, moveit-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion-planner-testutils";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner_testutils/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6b8242a81b56af9c66d42f774bc4e3928b8f3a2c48b76197fb02786554d72db2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner_testutils/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "603fe2048ede53337529ef90ca92e6cb7745fd9946223dac259dc12488734264";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion-planner/default.nix
+++ b/distros/melodic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, eigen-conversions, joint-limits-interface, kdl-conversions, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion-planner";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "47b9188f8807045a24572b06db3ec336ee918eccf63a121f6fed0d7307fe9153";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "f25c57870aed98bda6bed473e6877555a9bc37fb6e911a2627d71784614fecd5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pointgrey-camera-description/default.nix
+++ b/distros/melodic/pointgrey-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-pointgrey-camera-description";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_description/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "2598eda647491180bf86ca9c4ad06da2c600237482b5c817ea0375710377f2a9";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_description/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "8947475ceebb51e8a17bcf6628f885def747bb5c30e35c713694b82d1158da88";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pointgrey-camera-driver/default.nix
+++ b/distros/melodic/pointgrey-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pointgrey-camera-driver";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_driver/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "a548c8bab220b708ada9bfb8410c7ac17137e9bc1862d294a164b9cf5d733109";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_driver/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "8430fc5a117b73fad6f2bf228d3d892879b3c1cb0b1f731ee755b116c07d09d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-control/default.nix
+++ b/distros/melodic/ridgeback-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, urdf }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-control";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "6a4b2835003527236f6f60e87ba7ac8f168b701dd1d753bce8c96cb5bdbfd663";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "08547888015f3a2b37c26a66654b23adf741d755aad3efe47f88971422a1eb30";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-description/default.nix
+++ b/distros/melodic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-description";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1302bf1c13fdff3e763c4f7edc51b2b0e1a0eb36e45a834931d826b20eea6937";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "c8ebf4371f0ccd63db91fee284f6cf4aab99fe6e28bcbdbf8fbdbf2162dccdb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-msgs/default.nix
+++ b/distros/melodic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "08adb29db070e70fcee3c3821b6e6f96f384af7a9611074fd3417cb5e107d696";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "25bbaf64c4391f1d7cb16fc8217f9d47fe35895e62b1cab3128a2d77ebb629e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-navigation/default.nix
+++ b/distros/melodic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-navigation";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "0516173ca1c373695c5d9eecfc9e97ee99e26eff1f8e5d9587e2edcf486dcdf1";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "5b58af5e4a32ffe7cc45b55abf896c410c23e508ea81eb45d05e79738ece2752";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rslidar-sdk/default.nix
+++ b/distros/melodic/rslidar-sdk/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libpcap, libyamlcpp, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rslidar-sdk";
+  version = "1.3.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rslidar_sdk-release/archive/release/melodic/rslidar_sdk/1.3.0-3.tar.gz";
+    name = "1.3.0-3.tar.gz";
+    sha256 = "d8cd9cad1a9edfcc06d0c7ec8d02456f466eb384cd422d789833057f50d958ca";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ libpcap libyamlcpp pcl pcl-conversions pcl-ros roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rslidar_sdk package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/statistics-msgs/default.nix
+++ b/distros/melodic/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-statistics-msgs";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/statistics_msgs/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "db97291f1aa312ba3d199b22c2b70e0c1309200445779cf7c74f8d812a117057";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/statistics_msgs/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "eca1d76ca10b012c1a9590ebb55996bd73ad8223246637f2603b83350db0add7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/test-mavros/default.nix
+++ b/distros/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "f8955f8860c355ad00bc3a9b3918ec3f9ba698ca3bd663a0b5b6987fc894fdad";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "c4f37688b5e0a127ed0168a370a67ae7b12a48c4d9c5f235ead02a36624da98e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tork-moveit-tutorial/default.nix
+++ b/distros/melodic/tork-moveit-tutorial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, moveit-commander, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, moveit-simple-controller-manager }:
+buildRosPackage {
+  pname = "ros-melodic-tork-moveit-tutorial";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/tork_moveit_tutorial-release/archive/release/melodic/tork_moveit_tutorial/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b559d39011e7c16f709e376dc1892eb9d2bfc489388218ce37d77eadfce596d3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros moveit-commander moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface moveit-ros-visualization moveit-simple-controller-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The tork_moveit_tutorial package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/webots-ros/default.nix
+++ b/distros/melodic/webots-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, moveit-simple-controller-manager, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-webots-ros";
-  version = "4.1.0-r1";
+  version = "5.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "4c1930c9dfedcadd5d279e06072d97e04e61dea98e6dc49122923aa41d5b726e";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "eba56b3a93053246bbce5f7269abb99da3ee8d1ef5cce05a83f17651d7b66d89";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface moveit-simple-controller-manager robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/wfov-camera-msgs/default.nix
+++ b/distros/melodic/wfov-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-wfov-camera-msgs";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/wfov_camera_msgs/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "c9b9f265c88ee3687366617abbb64324044753b3ba24b8967123014a7fb51fbc";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/wfov_camera_msgs/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "6082f10c40e6051afe2fd9e75d062bc0246e99d57d607959a016d95e9a0ad22c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-controller-utils/default.nix
+++ b/distros/noetic/cob-base-controller-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, rospy, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-controller-utils";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "45d510270624b502ffd1da0fec23b034a82f383dd832790bf63c9e6fa3e5dd62";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "4fed5d1ba62fd94417d584f6b7bc4736c1760c0fa55a9573dfffbfc5cb0289ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-drive-chain/default.nix
+++ b/distros/noetic/cob-base-drive-chain/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-canopen-motor, cob-generic-can, cob-utilities, control-msgs, diagnostic-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-drive-chain";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "0e9f4a3ea5ed98f8a874a8a13323c894db17bfd25242ebe1e73d240743bbb4a4";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "5806117f4b96918ec385aa93a5e0b132c3d48772b1538d9acf94ec6c15cb11dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-velocity-smoother/default.nix
+++ b/distros/noetic/cob-base-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-velocity-smoother";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "0cab55a9bef54519eb9f0c4924ddcdeac848719b65864a0b11a4fdb3aed8e0c9";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "090f77dbfe0fabe55b0224f8ee05b64d3867876de29a2c5e82dda9afe8856458";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bms-driver/default.nix
+++ b/distros/noetic/cob-bms-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, python3Packages, roscpp, rospy, socketcan-interface, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-bms-driver";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "3719634d01727691f348f70915270d74df8b36de04aa0fb57badbc66ebbda67b";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "bf064a4a8de97141d4004ed9ca9e7493fe04f9a04140e608d2a29e1cec42b874";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-canopen-motor/default.nix
+++ b/distros/noetic/cob-canopen-motor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-generic-can, cob-utilities, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-canopen-motor";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "aabb0927831577e7e656b8eae07270a0bbfdbad60ec6cf1d63bfe2f58dbe509e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "741aa4bdf1f8a6362691ef06a77422f3cc7b327385bec855879ad6800388da4b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cartesian-controller/default.nix
+++ b/distros/noetic/cob-cartesian-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-frame-tracker, cob-script-server, cob-srvs, cob-twist-controller, geometry-msgs, message-generation, message-runtime, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, std-msgs, std-srvs, tf, topic-tools, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-cartesian-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "d18a2393f680bcd88e1e4780fd23b83787b2e57643d2163a6079ecc2839110e9";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "7150569910dba69499a9bbf1d20c951ef086bf122b4367c876c67fb1bcb3f4c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-velocity-filter/default.nix
+++ b/distros/noetic/cob-collision-velocity-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-footprint-observer, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, tf, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-velocity-filter";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "27ddbfd75c50958905b50bb868d13e29b5e6525d2dab38ac578075f36e2d4cc2";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "45891e4921ef07e04c77b650656477b19250989f6df640eff9909a3571ca4d53";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-gui/default.nix
+++ b/distros/noetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, python3Packages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-gui";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "835b398812cec0ba4730215d6ae4b1074357d074a345d50cbfd26e03c630ded5";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "5d980bb9e7d9705a200d8fd8776fdcc5b11a7155163f41e70e5854d495d01fdc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-tools/default.nix
+++ b/distros/noetic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "16474006db239a700177721b727ee81cc896cc209bf1d7d988aa25e2dcd30261";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "22088b799e92e43e54a25eeebc0cb200b1a8b549e2a3ee7b58cbe8629ed26652";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-mode-adapter/default.nix
+++ b/distros/noetic/cob-control-mode-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-manager-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-mode-adapter";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "73347837d941f7aaa1a096444e1ffeb7b13cf06c0335e7adb11c4b3e81e6ccc9";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "0b178541cf7d1bb1e7e3e95e525bce64aab6b4044f449baf906782ad810a75da";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-msgs/default.nix
+++ b/distros/noetic/cob-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-msgs";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "613c842b853d1938ab3ee14e0c29aebaa74c7492be624dd4e68c61738c538be4";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "a057d496c0a50eb5d4e126fd2aa3dadd1a556a57acb49020492b3f2dd24916ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control/default.nix
+++ b/distros/noetic/cob-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-controller-utils, cob-base-velocity-smoother, cob-cartesian-controller, cob-collision-velocity-filter, cob-control-mode-adapter, cob-control-msgs, cob-footprint-observer, cob-frame-tracker, cob-hardware-emulation, cob-mecanum-controller, cob-model-identifier, cob-obstacle-distance, cob-omni-drive-controller, cob-trajectory-controller, cob-tricycle-controller, cob-twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-control";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "7f95b414bd49122a446a2188d4ab34c13bd9756061bea038249b893c51a6ffab";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "d10c9de7c124617266c9de4b66fb2b6d66b7b40dc0bda18843e706e6e95c4beb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-dashboard/default.nix
+++ b/distros/noetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-noetic-cob-dashboard";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "78d1e617a3310b40b8b8e01d766443ea8878db6530f5d0a829361bcedc1bd656";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "ca2f1295f3daec7542e5c98229c0e5372ebab29e75c7aa0439e641bd384fa544";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-driver/default.nix
+++ b/distros/noetic/cob-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-drive-chain, cob-bms-driver, cob-canopen-motor, cob-elmo-homing, cob-generic-can, cob-light, cob-mimic, cob-phidgets, cob-relayboard, cob-scan-unifier, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-undercarriage-ctrl, cob-utilities, cob-voltage-control }:
 buildRosPackage {
   pname = "ros-noetic-cob-driver";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1f26c9285e6acc058bd0c5caccd59d85ca5fe6bb987591468e56546b645ebbb7";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "b75854778d49027b164eea5dcbebc2053d6e1f8bc7db60a2a0dfbd411dc7cc86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-elmo-homing/default.nix
+++ b/distros/noetic/cob-elmo-homing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-402, catkin, pluginlib, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-elmo-homing";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "4ff0f198fe3d5796d775b0eb0ae9a2c71e0dba1bc220cd168609613f37ad8f3e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "5d249b73bd8307623db3e0eab9915d66c61267695deb5e58023fcfa7e29592dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-footprint-observer/default.nix
+++ b/distros/noetic/cob-footprint-observer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-footprint-observer";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "aed27dede5d69c7090ac3e88256873183615ce11971c8b543423d832ae4e1022";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "16fe875891cf2a6b7ec49182cb2356a2736ce74aa9a05973d075cc92d26dd149";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-frame-tracker/default.nix
+++ b/distros/noetic/cob-frame-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-srvs, control-toolbox, dynamic-reconfigure, geometry-msgs, interactive-markers, kdl-conversions, kdl-parser, message-generation, message-runtime, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-frame-tracker";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "f9598f941381418f3a06549b22daf9c14948efa4b72def3a7f9434406c06baa3";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "b012cf74c31c3a651a60a63450a20f530071ce0ff67bd1f1f0be3113a708c875";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-generic-can/default.nix
+++ b/distros/noetic/cob-generic-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-utilities, libntcan, libpcan, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-generic-can";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "d054777f22235d44ae04c88bb5984d66765d4a163853883ce14cc8e41c5297a7";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "287ee2ad6ea34e04f1191ac4ee4199ad3baa7696fcdf92d198bd8179ab83a563";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-emulation/default.nix
+++ b/distros/noetic/cob-hardware-emulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, move-base-msgs, nav-msgs, roscpp, rosgraph-msgs, rospy, sensor-msgs, std-srvs, tf-conversions, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-emulation";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "e670e477879bbab4c18172e8ef9fcfd4a504bbf67bd076e47565f44e2fe403fa";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "7234af66f2491c9e7f360af91f62995e1157390def16f627f3fc8e86cd3a1d74";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-helper-tools/default.nix
+++ b/distros/noetic/cob-helper-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, rospy, std-srvs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, python3Packages, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-helper-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "f105735bc2968ab7996b7f1d7b44c48708c846a2319f3d9c247f76bd2b134925";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "f9b47ea1e5a6bca981b436d18d6c65fad5d8eb71d4e3eafc1c4ba1f841ee08ad";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   propagatedBuildInputs = [ cob-msgs cob-script-server diagnostic-msgs dynamic-reconfigure message-runtime rospy std-srvs tf visualization-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''Helper scripts for Care-O-bot'';

--- a/distros/noetic/cob-interactive-teleop/default.nix
+++ b/distros/noetic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-interactive-teleop";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "f19dcf3e8b33b8f9cc6e349143b0e245ff0b4114ea7f7ef7fd5357397f158466";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "ab80181672935319300567b9d5552860ce4dee4f2fbcd9a5b1b38c79ef769435";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-light/default.nix
+++ b/distros/noetic/cob-light/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-light";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "c4b705eae5a66df0b9d1201d4ad7e8415d1c9a6ce6f41f87c5b45ab728ffa5f3";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "cf60a5f96f24dc320be1f1ceeeec15d70c980f9c89e1df2517a3a2aa477628c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mecanum-controller/default.nix
+++ b/distros/noetic/cob-mecanum-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-mecanum-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "c45c27e24a916fea170e770bccae2b94c53ce142f007905dda0de46dec951a33";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "ee1df045e8e3772d7958a2ef09c253989a857427a91e7f335587ecc15ff6d3b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mimic/default.nix
+++ b/distros/noetic/cob-mimic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, diagnostic-updater, message-generation, message-runtime, roscpp, roslib, rospy, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-mimic";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "48ec5b45f15735c5ba5290c0f1966eeadc0099240bd3d31597cd2ed5e8982035";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "c83ed33cd238190508db5dd407782d03d637ff0d1d1794e938d01409563c0327";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-model-identifier/default.nix
+++ b/distros/noetic/cob-model-identifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, geometry-msgs, kdl-parser, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-model-identifier";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "66377800a1fcdc5c2c106ea5269d07098fc1887d7d2c241649946c1cfa19904e";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "fa9ac2dbc5ce0579e9b23289e1a3d315ab1a5a6fa3139df8a2e1801f4d404fb1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-monitoring/default.nix
+++ b/distros/noetic/cob-monitoring/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, python3Packages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-monitoring";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "f281d69403f8c7758a5e9520b3719f10c78293c04f78d7d331849f7617254194";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "916ec5d5c53e4b34e52a2980483caa5b873d686fc750c450fb221bb0a64ed2ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-obstacle-distance/default.nix
+++ b/distros/noetic/cob-obstacle-distance/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cob-control-msgs, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, fcl, geometry-msgs, interactive-markers, joint-state-publisher, kdl-conversions, kdl-parser, moveit-msgs, orocos-kdl, pkg-config, robot-state-publisher, roscpp, roslib, roslint, rospy, rviz, sensor-msgs, shape-msgs, std-msgs, tf, tf-conversions, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-obstacle-distance";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "7de7dc257ac1d212f5e784c0cdf4c02909bffe20c576532365619b5e681cdcdf";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "61d001ed2bdf818bc02d3db5ab62284cde5517b760509212d15ad18ae5c248c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-omni-drive-controller/default.nix
+++ b/distros/noetic/cob-omni-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-omni-drive-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "07c2f40bdd4e6d416f3ce2961f58a543ae75dd6b1a7653e57f3f8f65e5ffc36c";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "010674b5961b5ee0f348697227aa134c78e804370d3b014446e2015feeb48d93";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-em-state/default.nix
+++ b/distros/noetic/cob-phidget-em-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-em-state";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "d8a13bfe6aa3177234821b666bb9a5500cc8c30fcc04354ae936c4b38877f003";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "43929941ca3ccc40f2e2502d427b6db6e1aba8007097560e302686939e555da3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-power-state/default.nix
+++ b/distros/noetic/cob-phidget-power-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-power-state";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "b5aec0aa496a61038ec1a1dd6dfc79ca51a69aaa32ad56a4318cdb45ae976a49";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "92aa231fcda9d7af8d5b80759511ae7fc27102245ff35c400c531682ad1123f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidgets/default.nix
+++ b/distros/noetic/cob-phidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidgets, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidgets";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "f3dd2a50ffd7481e8ef22830be9f39584878024c25e4c2642a3b1130fb965102";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "0c7c881c1bf1fad1e97d015e2c70b1b8104ada7cbe317ef820b4faacab5f4704";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-relayboard/default.nix
+++ b/distros/noetic/cob-relayboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-relayboard";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "dfdd13ad2378cd8b4a3c1d6e8b43707c55486b4d96859f8a15782c7f8469a3c9";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "d12290c155c91e08399222638cd2a48b6cd9db4d8f00b9ca9245b523f2f8348d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-scan-unifier/default.nix
+++ b/distros/noetic/cob-scan-unifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-scan-unifier";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "edab7dd3c37f5f5f5eb183c0645c74d2adbe40051bda247ca2ba9ca599853079";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "e3ef09b3f86a4ba7afa8fdc962e38b426a5762a5cf8c1b18d763517f598dc51b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-script-server/default.nix
+++ b/distros/noetic/cob-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-noetic-cob-script-server";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "d80fb0dbac43264c414b0c8abf001a41070d573c1e5027c4bb73b281b6018e47";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "2fc5cf7263849b9624b997c80c203cd543125b502881e7089bb32af22105e0a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-lms1xx/default.nix
+++ b/distros/noetic/cob-sick-lms1xx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-lms1xx";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1ab28c10ccae9847b44a39709c4863b8ad2af3a3e34a0bb832d648fe6e9862d1";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "62351b707f222f4fbff516f877b71941f4ba19f0516b8de6aa47e7b5fb3478c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-s300/default.nix
+++ b/distros/noetic/cob-sick-s300/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-s300";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "66e91af7e7af9e3e58d031818b21f9ad2982adcfe9398a141aeadec481fd506f";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "3c56e17d4fcf9473d045ae51263f012391ba4dcf5dfc481f848a582b7644bd36";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sound/default.nix
+++ b/distros/noetic/cob-sound/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsaOss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-sound";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "347d6370c02fe9aefd81af4dc51869b372b699ebd0f7c02087a26eb7c5b788cc";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "78d69a1845d520b06393f6c3618c8bf0d607664c4e7e79ae2aa7311adb827795";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-teleop/default.nix
+++ b/distros/noetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-teleop";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "8f6b31d68ee90bb0564bc7ec499a8ef2c264cfddc3be215224c1c5eaa2bdd3db";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "60fc73bf5cb39dcc5be8b5c3990ee85c0eb176953bada1c1eaf753aae789a38d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-trajectory-controller/default.nix
+++ b/distros/noetic/cob-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-srvs, control-msgs, dynamic-reconfigure, roscpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-trajectory-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "fa2a6fd07b027ece5b8658aec077cf30955745f1eb6736cbbb24086f86dcbc86";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "68824e4698488025b31c1957ad9f86d5c23ec5e143d0b63703f73c029ce68215";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-tricycle-controller/default.nix
+++ b/distros/noetic/cob-tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-tricycle-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "73a6f904572a4c299d2bb73b01cacfa95d332dac1a8133d6f240ce71d564948f";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "d3c6c791150dff4d2e4c2e4be618501719e4bc09af869ba5dbe226adac7a5555";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-twist-controller/default.nix
+++ b/distros/noetic/cob-twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-script-server, cob-srvs, control-msgs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-twist-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "beb992cf7462b74803734d2365d4ef97ff1434eb5f4aa49bf19abac675050312";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "2297c4169f1fc82ee55f57d67ba550036c413bcac51e0611f905e30fd59deb62";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-undercarriage-ctrl/default.nix
+++ b/distros/noetic/cob-undercarriage-ctrl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-utilities, control-msgs, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-undercarriage-ctrl";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "7e9387cf4b829a20e68255c47538144219e8957629d73525537e52194e7f96c6";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "cef4adf5af65254263fa63c09366d041a597b2d1f0b2b3746a43dce964f1300d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-utilities/default.nix
+++ b/distros/noetic/cob-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-utilities";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "73630b8c83a6d087e134988a56d8e15314b57ea566c498d50df305d8e725a26e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "54afd36df1e32578c35b7eb559c05622a2d126697540c499d242960783c9df6d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-voltage-control/default.nix
+++ b/distros/noetic/cob-voltage-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, dynamic-reconfigure, python3Packages, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-voltage-control";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "526943b83e615389a2c6631612aba0607a724a40b988c1c17ac4735b38b2da51";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "f0097a60b2c6676a8a5b1fd8c77007002c5a331224b6fdddd8e6ba9d002ec21c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1270,8 +1270,6 @@ self: super: {
 
  jsk-rqt-plugins = self.callPackage ./jsk-rqt-plugins {};
 
- jsk-rviz-plugins = self.callPackage ./jsk-rviz-plugins {};
-
  jsk-tilt-laser = self.callPackage ./jsk-tilt-laser {};
 
  jsk-topic-tools = self.callPackage ./jsk-topic-tools {};
@@ -1407,6 +1405,8 @@ self: super: {
  libphidget22 = self.callPackage ./libphidget22 {};
 
  libphidgets = self.callPackage ./libphidgets {};
+
+ libpointmatcher = self.callPackage ./libpointmatcher {};
 
  librealsense2 = self.callPackage ./librealsense2 {};
 
@@ -2605,6 +2605,8 @@ self: super: {
  rqt-topic = self.callPackage ./rqt-topic {};
 
  rqt-web = self.callPackage ./rqt-web {};
+
+ rslidar-sdk = self.callPackage ./rslidar-sdk {};
 
  rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
 

--- a/distros/noetic/generic-throttle/default.nix
+++ b/distros/noetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, python3Packages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-generic-throttle";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "2e31dffcbdfd53c3e00c92a1e6cbce55694458c38d5ced9c3512fd3d1890f713";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "97ef0975e870870524ee365abfb050edc20e53c9b6b2e2f9b1755f1925274bf2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-exposure-msgs/default.nix
+++ b/distros/noetic/image-exposure-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-exposure-msgs";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/image_exposure_msgs/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "2b9a6a7f16a46e84d8daa950430e3b3cdbe23ab5399ab6dde4161e3509fb705a";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/image_exposure_msgs/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "405ecd3bffa5c8de1417d2e287cc1eea655c443e0e1e339a246e5dc59868cb84";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-interactive-marker/default.nix
+++ b/distros/noetic/jsk-interactive-marker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-interactive-marker";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_marker/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "d5ed235944b01bbd69328c8e4bb7c40c4fedcadfa660c1af7a08a9539a833c7f";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_marker/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "9e07b602208265e5bb46357a019f215995e3f3ebe2adb30a6ecf2223d494f4cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-interactive-test/default.nix
+++ b/distros/noetic/jsk-interactive-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, mk, rosbuild, rospy, rviz, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-interactive-test";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_test/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "8a1abd37b377327aeb95660866c9d20a4c8466a18e01731be505a38fd68c8ea5";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_test/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "72224913f0e66eff0379ca04eaf852bef3e281dd97ebd43eaa5a3c1e18d8b46a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-interactive/default.nix
+++ b/distros/noetic/jsk-interactive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-tf-publisher, geometry-msgs, jsk-interactive-marker, mk, rosbuild, rospy, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-interactive";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "5b4aa542dace05afe868182a2bb272d3c3fe5e9abb47f332f9283c4838fc5e70";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "ade9c8c7968de594d1f5ca67d8bda9adb2570635b1f35141004f5dabbe0a6eff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-rqt-plugins/default.nix
+++ b/distros/noetic/jsk-rqt-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-publisher, image-view2, jsk-gui-msgs, message-generation, message-runtime, mk, python3Packages, qt-gui-py-common, resource-retriever, rosbuild, roslaunch, rostest, rqt-gui, rqt-gui-py, rqt-image-view, rqt-plot }:
 buildRosPackage {
   pname = "ros-noetic-jsk-rqt-plugins";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_rqt_plugins/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "527e86d54828430373f1b10433e964cf60589972c532d04c35bbad93391923d8";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_rqt_plugins/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "1018fa78ab28b6366e768e7e368e4566dcf910079c9704119fda55433b414a25";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-visualization/default.nix
+++ b/distros/noetic/jsk-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, jsk-interactive-test, jsk-rqt-plugins, jsk-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-jsk-visualization";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_visualization/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "4e37a0bf2e6e2082fc282223e08aecce116746a9d22ec457c067bbe8eda518ea";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_visualization/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "a6822f98ef9339b56265c4fbf861f3b0d2bbd8d342a3f8c97180c2d72e8e50d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-scan-densifier/default.nix
+++ b/distros/noetic/laser-scan-densifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-scan-densifier";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "9b17c6a3112f9d1b85e0794ee775d583f54ba37715ec781fabbf6dab8f72bafe";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "a60a3e21ad41b4db8204cef4d0d4622f5d1aca8b1f3a55e279fec391ebfd4bda";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "52ba3dbdd2ec3b3bbf2cd62c451e6b5a98c287d842b849d3a5d754ec4162d7d0";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "2f4d67ee552dad48d28ef2a8f30737b6da891ccb308c395da628a5a78e81e34f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libpointmatcher/default.nix
+++ b/distros/noetic/libpointmatcher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, eigen, libnabo }:
+buildRosPackage {
+  pname = "ros-noetic-libpointmatcher";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/libpointmatcher-release/archive/release/noetic/libpointmatcher/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "858e42e3cbc55c43c5dae2166c9f40a6577af8fa1b0c1b03336ba8029ad99a78";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin eigen libnabo ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''libpointmatcher is a modular ICP library, useful for robotics and computer vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "99bc6a399f06787ab626008f249250fb0fc6387076330557acc80ea8e63d1801";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "fc0e550a819a55a464625952136b1d791d0394913202e44b7df59b330478ed9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "38adc5eab151d7d2c106ec9fefaabccdb6936e5ab69d25f0577d8531265f83b5";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "377d813d92ef335f80307d2758fafbf9b28f6a8bca13db24b546d498d313570f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "e36619b060668b21aeeacaf189dcdc2ea2406329540a24766e92046041748a32";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "939cb968911b8f8859dd36437d7da36d75ef46085d9731e21fe5bd5407e529a5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pointgrey-camera-description/default.nix
+++ b/distros/noetic/pointgrey-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-pointgrey-camera-description";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_description/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "0d0bd0da10b7a6f888abbac3b5f79360df4b6dac1949ace934a684f760ff1e0b";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_description/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "021f4da2c001e95309e83fa90edad0200b51fd80df3d886ca573760e8e9c5111";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pointgrey-camera-driver/default.nix
+++ b/distros/noetic/pointgrey-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pointgrey-camera-driver";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_driver/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "70339f114659294dcdcb58bd3e8db2a80eac8a1f537dc84693a94e54a672ae27";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_driver/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "5af5603bb72ac4da3259ca169526f83b47ac2d62f5ae2755983696bf1ade1a81";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-calibration-controllers/default.nix
+++ b/distros/noetic/rm-calibration-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, effort-controllers, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-calibration-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "5385f5e78f42855c490adf9d0fb9e34f50a6ba91a6bee48814cc622b1f5d702e";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "3ea9c13800fbc56e1856520da5b0254151ea1a85ffe1b97aef7f3e87e301e6a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-chassis-controllers/default.nix
+++ b/distros/noetic/rm-chassis-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, nav-msgs, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-chassis-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "16227e980135c252864c7d9c68bb442b2d32b4edfde454863129eef2bb321539";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "d94c8a2cd9048b30a08d74494769f6683376acffc6a7607b598c490691369f97";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ angles control-toolbox controller-interface effort-controllers forward-command-controller hardware-interface imu-sensor-controller pluginlib realtime-tools rm-common rm-msgs robot-localization roscpp roslint tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ angles control-toolbox controller-interface effort-controllers forward-command-controller hardware-interface imu-sensor-controller nav-msgs pluginlib realtime-tools rm-common rm-msgs robot-localization roscpp roslint tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-controllers/default.nix
+++ b/distros/noetic/rm-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-controller }:
 buildRosPackage {
   pname = "ros-noetic-rm-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "05554d86404cc251e581c2c2563028d7bd8c92e44ba8ca199de962db555ff462";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "3318a6d1d48e1490ca1fb5d7a2902198e381d3cb1767fb3dd31f3db42bd9405d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gimbal-controllers/default.nix
+++ b/distros/noetic/rm-gimbal-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-gimbal-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "612b3f33a9fe4ae93d409f43337609d09909e0eb216ce1cc94f0316106b5cdb0";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "161f683559716e9fc4120b6e54f178a3cb4068d53ff4b2305d617a4db57c5ce7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-shooter-controllers/default.nix
+++ b/distros/noetic/rm-shooter-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-shooter-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "f296625424d061e81e3794479a6b76d8e857e67555f18990c64b65c7fb3796e9";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "62bb8a6d21f988af0ddc855df146b5a2f6d8bed9953c9af5eb3a93f94f2b9801";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-state-controller/default.nix
+++ b/distros/noetic/robot-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, kdl-parser, pluginlib, realtime-tools, rm-common, roscpp, roslint, tf2-kdl, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-controller";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "141f326c9938e86964006050b4cf53b83e4377899a3851fb797ad105a160d9c7";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "bbe3ed5c9b5aa781c1f9e96cdd184a9358c0fac23a0da3807729922431b42743";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rslidar-sdk/default.nix
+++ b/distros/noetic/rslidar-sdk/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libpcap, libyamlcpp, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rslidar-sdk";
+  version = "1.3.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rslidar_sdk-release/archive/release/noetic/rslidar_sdk/1.3.0-4.tar.gz";
+    name = "1.3.0-4.tar.gz";
+    sha256 = "f19e7aff675714176889e6f190bfae965f5c047d84a25b8d20f64e445dea616b";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ libpcap libyamlcpp pcl pcl-conversions pcl-ros roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rslidar_sdk package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/scenario-test-tools/default.nix
+++ b/distros/noetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, python3Packages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-scenario-test-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "4475f55003d72e674c73b0eb53fb3bb04c7000459b920d307cc5ff84df91bb00";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "bf34e45b25fb90b29dec0b4deef92f186c47ab47f08ac4b7633975df383528d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/service-tools/default.nix
+++ b/distros/noetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-noetic-service-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "e2b3d12c8f99988d5c500ae9e76c5cd00aa5b3afa61f0799693cae311c1ade91";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "0b5656268cf34ce45f8512dbf2f1360ea6f6a980c57fe96f188ea51f34d4c61b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/statistics-msgs/default.nix
+++ b/distros/noetic/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-statistics-msgs";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/statistics_msgs/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "5eb0ddd6586f00d4ce5baf52af1eea155449e3bbbb1ddc668ccfc402a57d95c0";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/statistics_msgs/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "60160deb991195902301215019f99958f7132c20abea524d794edba6efad78f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "57d0f69717e81747632ea8a2f2032b2255bc1ce23b77f4dc3f7aae286549cefa";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "500b2a80deee89499aa6b894b4b96224422d28fd7cac5e9dc0d2200a3e1f1989";
   };
 
   buildType = "catkin";

--- a/distros/noetic/webots-ros/default.nix
+++ b/distros/noetic/webots-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, moveit-simple-controller-manager, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-webots-ros";
-  version = "4.1.0-r1";
+  version = "5.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "4175499066cf217586c057a5c6a81945abcfb491eeec7b753c72068a0f871914";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "756dc48598285ad8b9abb18577d267c8fa8c6d3318c7711728b1d7f98ba9fc57";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface moveit-simple-controller-manager robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/wfov-camera-msgs/default.nix
+++ b/distros/noetic/wfov-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-wfov-camera-msgs";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/wfov_camera_msgs/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "fa2494db9b9b17f019705378aae3e21916120d81e7b0b6ed58382186e34267fb";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/wfov_camera_msgs/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "15a433e1d9cd61751a4e471c109f2fc7ecb9bcf803ab4a7ed2e1b61d01153f1a";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit f73660a16ac2c16de51f99248d0d194ea878a519.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *chomp-motion-planner 2.2.3-r1*
* *clober-msgs 0.1.0-r1*
* *diff-drive-controller 0.5.1-r1 --> 0.6.0-r1*
* *effort-controllers 0.5.1-r1 --> 0.6.0-r1*
* *force-torque-sensor-broadcaster 0.5.1-r1 --> 0.6.0-r1*
* *forward-command-controller 0.5.1-r1 --> 0.6.0-r1*
* *gripper-controllers 0.5.1-r1 --> 0.6.0-r1*
* *ign-ros2-control-demos 0.1.1-r2*
* *imu-sensor-broadcaster 0.5.1-r1 --> 0.6.0-r1*
* *joint-state-broadcaster 0.5.1-r1 --> 0.6.0-r1*
* *joint-state-controller 0.5.1-r1 --> 0.6.0-r1*
* *joint-trajectory-controller 0.5.1-r1 --> 0.6.0-r1*
* *launch 0.10.7-r1 --> 0.10.8-r2*
* *launch-testing 0.10.7-r1 --> 0.10.8-r2*
* *launch-testing-ament-cmake 0.10.7-r1 --> 0.10.8-r2*
* *launch-xml 0.10.7-r1 --> 0.10.8-r2*
* *launch-yaml 0.10.7-r1 --> 0.10.8-r2*
* *moveit 2.2.2-r1 --> 2.2.3-r1*
* *moveit-chomp-optimizer-adapter 2.2.3-r1*
* *moveit-common 2.2.2-r1 --> 2.2.3-r1*
* *moveit-core 2.2.2-r1 --> 2.2.3-r1*
* *moveit-kinematics 2.2.2-r1 --> 2.2.3-r1*
* *moveit-planners 2.2.2-r1 --> 2.2.3-r1*
* *moveit-planners-chomp 2.2.3-r1*
* *moveit-planners-ompl 2.2.2-r1 --> 2.2.3-r1*
* *moveit-plugins 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-benchmarks 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-move-group 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-occupancy-map-monitor 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-perception 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-planning 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-planning-interface 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-robot-interaction 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-visualization 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-warehouse 2.2.2-r1 --> 2.2.3-r1*
* *moveit-runtime 2.2.2-r1 --> 2.2.3-r1*
* *moveit-servo 2.2.2-r1 --> 2.2.3-r1*
* *moveit-simple-controller-manager 2.2.2-r1 --> 2.2.3-r1*
* *position-controllers 0.5.1-r1 --> 0.6.0-r1*
* *ros2-controllers 0.5.1-r1 --> 0.6.0-r1*
* *run-move-group 2.2.2-r1 --> 2.2.3-r1*
* *run-moveit-cpp 2.2.2-r1 --> 2.2.3-r1*
* *run-ompl-constrained-planning 2.2.2-r1 --> 2.2.3-r1*
* *soccer-object-msgs 1.0.1-r1*
* *velocity-controllers 0.5.1-r1 --> 0.6.0-r1*
* *webots-ros2 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-control 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-core 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-driver 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-epuck 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-importer 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-mavic 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-msgs 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-tesla 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-tests 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-tiago 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-turtlebot 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-universal-robot 1.2.0-r2 --> 1.2.1-r3*

Galactic Changes:
-----------------
* *actionlib-msgs 2.2.3-r1 --> 2.2.4-r1*
* *aws-robomaker-small-warehouse-world 1.0.4-r1 --> 1.0.5-r1*
* *common-interfaces 2.2.3-r1 --> 2.2.4-r1*
* *diagnostic-msgs 2.2.3-r1 --> 2.2.4-r1*
* *diff-drive-controller 1.2.0-r1 --> 1.3.0-r1*
* *effort-controllers 1.2.0-r1 --> 1.3.0-r1*
* *force-torque-sensor-broadcaster 1.2.0-r1 --> 1.3.0-r1*
* *forward-command-controller 1.2.0-r1 --> 1.3.0-r1*
* *geometry-msgs 2.2.3-r1 --> 2.2.4-r1*
* *gripper-controllers 1.2.0-r1 --> 1.3.0-r1*
* *imu-sensor-broadcaster 1.2.0-r1 --> 1.3.0-r1*
* *joint-state-broadcaster 1.2.0-r1 --> 1.3.0-r1*
* *joint-trajectory-controller 1.2.0-r1 --> 1.3.0-r1*
* *libpointmatcher 1.3.1-r1*
* *nav-msgs 2.2.3-r1 --> 2.2.4-r1*
* *position-controllers 1.2.0-r1 --> 1.3.0-r1*
* *rcpputils 2.2.0-r2 --> 2.2.1-r1*
* *ros-image-to-qimage 0.0.2-r1*
* *ros2-controllers 1.2.0-r1 --> 1.3.0-r1*
* *rqt-image-overlay 0.0.1-r1*
* *rqt-image-overlay-layer 0.0.1-r1*
* *sensor-msgs 2.2.3-r1 --> 2.2.4-r1*
* *sensor-msgs-py 2.2.3-r1 --> 2.2.4-r1*
* *shape-msgs 2.2.3-r1 --> 2.2.4-r1*
* *soccer-marker-generation 0.0.1-r1 --> 0.0.2-r1*
* *soccer-object-msgs 1.0.1-r1*
* *std-msgs 2.2.3-r1 --> 2.2.4-r1*
* *std-srvs 2.2.3-r1 --> 2.2.4-r1*
* *stereo-msgs 2.2.3-r1 --> 2.2.4-r1*
* *trajectory-msgs 2.2.3-r1 --> 2.2.4-r1*
* *velocity-controllers 1.2.0-r1 --> 1.3.0-r1*
* *visualization-msgs 2.2.3-r1 --> 2.2.4-r1*
* *webots-ros2 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-control 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-core 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-driver 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-epuck 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-importer 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-mavic 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-msgs 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-tesla 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-tests 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-tiago 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-turtlebot 1.2.0-r2 --> 1.2.1-r3*
* *webots-ros2-universal-robot 1.2.0-r2 --> 1.2.1-r3*

Melodic Changes:
----------------
* *chomp-motion-planner 1.0.8-r1 --> 1.0.9-r1*
* *image-exposure-msgs 0.14.1-r1 --> 0.14.2-r1*
* *jsk-interactive 2.1.7-r2 --> 2.1.8-r1*
* *jsk-interactive-marker 2.1.7-r2 --> 2.1.8-r1*
* *jsk-interactive-test 2.1.7-r2 --> 2.1.8-r1*
* *jsk-rqt-plugins 2.1.7-r2 --> 2.1.8-r1*
* *jsk-visualization 2.1.7-r2 --> 2.1.8-r1*
* *libmavconn 1.12.2-r1 --> 1.13.0-r1*
* *libpointmatcher 1.3.1-r1*
* *mavros 1.12.2-r1 --> 1.13.0-r1*
* *mavros-extras 1.12.2-r1 --> 1.13.0-r1*
* *mavros-msgs 1.12.2-r1 --> 1.13.0-r1*
* *moveit 1.0.8-r1 --> 1.0.9-r1*
* *moveit-chomp-optimizer-adapter 1.0.8-r1 --> 1.0.9-r1*
* *moveit-controller-manager-example 1.0.8-r1 --> 1.0.9-r1*
* *moveit-core 1.0.8-r1 --> 1.0.9-r1*
* *moveit-fake-controller-manager 1.0.8-r1 --> 1.0.9-r1*
* *moveit-kinematics 1.0.8-r1 --> 1.0.9-r1*
* *moveit-planners 1.0.8-r1 --> 1.0.9-r1*
* *moveit-planners-chomp 1.0.8-r1 --> 1.0.9-r1*
* *moveit-planners-ompl 1.0.8-r1 --> 1.0.9-r1*
* *moveit-plugins 1.0.8-r1 --> 1.0.9-r1*
* *moveit-resources 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-fanuc-description 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-fanuc-moveit-config 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-panda-description 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-panda-moveit-config 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-pr2-description 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-moveit-config 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-pg70-support 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-support 0.7.3-r1 --> 0.8.2-r1*
* *moveit-ros 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-benchmarks 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-control-interface 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-manipulation 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-move-group 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-occupancy-map-monitor 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-perception 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-planning 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-planning-interface 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-robot-interaction 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-visualization 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-warehouse 1.0.8-r1 --> 1.0.9-r1*
* *moveit-runtime 1.0.8-r1 --> 1.0.9-r1*
* *moveit-servo 1.0.8-r1 --> 1.0.9-r1*
* *moveit-setup-assistant 1.0.8-r1 --> 1.0.9-r1*
* *moveit-simple-controller-manager 1.0.8-r1 --> 1.0.9-r1*
* *pilz-industrial-motion-planner 1.0.8-r1 --> 1.0.9-r1*
* *pilz-industrial-motion-planner-testutils 1.0.8-r1 --> 1.0.9-r1*
* *pointgrey-camera-description 0.14.1-r1 --> 0.14.2-r1*
* *pointgrey-camera-driver 0.14.1-r1 --> 0.14.2-r1*
* *ridgeback-control 0.3.0-r1 --> 0.3.1-r1*
* *ridgeback-description 0.3.0-r1 --> 0.3.1-r1*
* *ridgeback-msgs 0.3.0-r1 --> 0.3.1-r1*
* *ridgeback-navigation 0.3.0-r1 --> 0.3.1-r1*
* *rslidar-sdk 1.3.0-r3*
* *statistics-msgs 0.14.1-r1 --> 0.14.2-r1*
* *test-mavros 1.12.2-r1 --> 1.13.0-r1*
* *tork-moveit-tutorial 0.1.1-r1*
* *webots-ros 4.1.0-r1 --> 5.0.1-r2*
* *wfov-camera-msgs 0.14.1-r1 --> 0.14.2-r1*

Noetic Changes:
---------------
* *cob-base-controller-utils 0.8.17-r1 --> 0.8.18-r1*
* *cob-base-drive-chain 0.7.10-r1 --> 0.7.11-r1*
* *cob-base-velocity-smoother 0.8.17-r1 --> 0.8.18-r1*
* *cob-bms-driver 0.7.10-r1 --> 0.7.11-r1*
* *cob-canopen-motor 0.7.10-r1 --> 0.7.11-r1*
* *cob-cartesian-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-collision-velocity-filter 0.8.17-r1 --> 0.8.18-r1*
* *cob-command-gui 0.6.26-r1 --> 0.6.27-r1*
* *cob-command-tools 0.6.26-r1 --> 0.6.27-r1*
* *cob-control 0.8.17-r1 --> 0.8.18-r1*
* *cob-control-mode-adapter 0.8.17-r1 --> 0.8.18-r1*
* *cob-control-msgs 0.8.17-r1 --> 0.8.18-r1*
* *cob-dashboard 0.6.26-r1 --> 0.6.27-r1*
* *cob-driver 0.7.10-r1 --> 0.7.11-r1*
* *cob-elmo-homing 0.7.10-r1 --> 0.7.11-r1*
* *cob-footprint-observer 0.8.17-r1 --> 0.8.18-r1*
* *cob-frame-tracker 0.8.17-r1 --> 0.8.18-r1*
* *cob-generic-can 0.7.10-r1 --> 0.7.11-r1*
* *cob-hardware-emulation 0.8.17-r1 --> 0.8.18-r1*
* *cob-helper-tools 0.6.26-r1 --> 0.6.27-r1*
* *cob-interactive-teleop 0.6.26-r1 --> 0.6.27-r1*
* *cob-light 0.7.10-r1 --> 0.7.11-r1*
* *cob-mecanum-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-mimic 0.7.10-r1 --> 0.7.11-r1*
* *cob-model-identifier 0.8.17-r1 --> 0.8.18-r1*
* *cob-monitoring 0.6.26-r1 --> 0.6.27-r1*
* *cob-obstacle-distance 0.8.17-r1 --> 0.8.18-r1*
* *cob-omni-drive-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-phidget-em-state 0.7.10-r1 --> 0.7.11-r1*
* *cob-phidget-power-state 0.7.10-r1 --> 0.7.11-r1*
* *cob-phidgets 0.7.10-r1 --> 0.7.11-r1*
* *cob-relayboard 0.7.10-r1 --> 0.7.11-r1*
* *cob-scan-unifier 0.7.10-r1 --> 0.7.11-r1*
* *cob-script-server 0.6.26-r1 --> 0.6.27-r1*
* *cob-sick-lms1xx 0.7.10-r1 --> 0.7.11-r1*
* *cob-sick-s300 0.7.10-r1 --> 0.7.11-r1*
* *cob-sound 0.7.10-r1 --> 0.7.11-r1*
* *cob-teleop 0.6.26-r1 --> 0.6.27-r1*
* *cob-trajectory-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-tricycle-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-twist-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-undercarriage-ctrl 0.7.10-r1 --> 0.7.11-r1*
* *cob-utilities 0.7.10-r1 --> 0.7.11-r1*
* *cob-voltage-control 0.7.10-r1 --> 0.7.11-r1*
* *generic-throttle 0.6.26-r1 --> 0.6.27-r1*
* *image-exposure-msgs 0.15.0-r1 --> 0.15.1-r1*
* *jsk-interactive 2.1.7-r4 --> 2.1.8-r1*
* *jsk-interactive-marker 2.1.7-r4 --> 2.1.8-r1*
* *jsk-interactive-test 2.1.7-r4 --> 2.1.8-r1*
* *jsk-rqt-plugins 2.1.7-r4 --> 2.1.8-r1*
* *jsk-visualization 2.1.7-r4 --> 2.1.8-r1*
* *laser-scan-densifier 0.7.10-r1 --> 0.7.11-r1*
* *libmavconn 1.12.2-r2 --> 1.13.0-r1*
* *libpointmatcher 1.3.1-r1*
* *mavros 1.12.2-r2 --> 1.13.0-r1*
* *mavros-extras 1.12.2-r2 --> 1.13.0-r1*
* *mavros-msgs 1.12.2-r2 --> 1.13.0-r1*
* *pointgrey-camera-description 0.15.0-r1 --> 0.15.1-r1*
* *pointgrey-camera-driver 0.15.0-r1 --> 0.15.1-r1*
* *rm-calibration-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-chassis-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-gimbal-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-shooter-controllers 0.1.1-r3 --> 0.1.2-r1*
* *robot-state-controller 0.1.1-r3 --> 0.1.2-r1*
* *rslidar-sdk 1.3.0-r4*
* *scenario-test-tools 0.6.26-r1 --> 0.6.27-r1*
* *service-tools 0.6.26-r1 --> 0.6.27-r1*
* *statistics-msgs 0.15.0-r1 --> 0.15.1-r1*
* *test-mavros 1.12.2-r2 --> 1.13.0-r1*
* *webots-ros 4.1.0-r1 --> 5.0.1-r2*
* *wfov-camera-msgs 0.15.0-r1 --> 0.15.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] soccer_vision_msgs
 * [ ] wiimote

