### PR TITLE
rosdistro sync, Fri Jan 21 13:04:46 2022

### DIFF
--- a/distros/foxy/chomp-motion-planner/default.nix
+++ b/distros/foxy/chomp-motion-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, rclcpp, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-chomp-motion-planner";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/chomp_motion_planner/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "73ab0c013bfcb4300a55942bad0b03b4bb493c81727742252734830683b2ed7a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core rclcpp trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''chomp_motion_planner'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/clober-bringup/default.nix
+++ b/distros/foxy/clober-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-clober-bringup";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_bringup/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "e7b1900617faaacc9dbb84cd05d31604678cccc98aff82976e0bd9891f9c38fb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober bringup package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/clober-description/default.nix
+++ b/distros/foxy/clober-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, urdf }:
+buildRosPackage {
+  pname = "ros-foxy-clober-description";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_description/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "1e604d8e0847695ccbfba8bcb36ea58e146ac3a68bbf2b70e1e4a3ad799f906d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober for simulation and visualization'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/clober-msgs/default.nix
+++ b/distros/foxy/clober-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-clober-msgs";
+  version = "0.1.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_msgs_ros2-release/archive/release/foxy/clober_msgs/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "aea55a757c4d37708d7322917dc47c52733b841d045dee262be60f713181b99a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober robot standard messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/clober-navigation/default.nix
+++ b/distros/foxy/clober-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-clober-navigation";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_navigation/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "79450d3dd698c45ce63cc331f183719c5f9e5976a0a96bd08581e930781358fe";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober navigation packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/clober-serial/default.nix
+++ b/distros/foxy/clober-serial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-clober-serial";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_serial/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "b7bd6eb22d6bc23f24bd8ac1d69442d9a1e2a35ca09012f56c4710d145aa6abc";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober serial package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/clober-simulation/default.nix
+++ b/distros/foxy/clober-simulation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clober-description, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-foxy-clober-simulation";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_simulation/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "11eee45a38c1b8974775f052d296de052da8d6cf86393872cf9b9463fdb03684";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clober-description gazebo-ros-pkgs geometry-msgs nav-msgs rclcpp sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober gazebo simulation package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/clober-slam/default.nix
+++ b/distros/foxy/clober-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-clober-slam";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_slam/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "34f0fb9cb9a6590a544e1a10b227d3171705834a798d0347d2bf931ea2fa4e91";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''clober slam package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/color-names/default.nix
+++ b/distros/foxy/color-names/default.nix
@@ -2,23 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rviz2, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ouxt-lint-common, rclcpp, rviz2, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-color-names";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/color_names-release/archive/release/foxy/color_names/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "f8ea461dc0e2327076d1c4f082325a5ae4b91996d7906f15873d92e459ba7933";
+    url = "https://github.com/OUXT-Polaris/color_names-release/archive/release/foxy/color_names/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "067bb1a95abef4aa130544fed636425614ff5a8f5897c8e6f4f3b61ea5a0ff3b";
   };
 
   buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
   propagatedBuildInputs = [ rclcpp rviz2 std-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''The color_names package'';
-    license = with lib.licenses; [ mit ];
+    license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "4e42693754ccfb0f105b1591bda1538daca4561a1073e7d637d6e73bf8d1d855";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b46511bbb3bd72bee652effaa15ac7b08c0b88a14bdab9909137f031284a1cbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "333c70f402be38a68ac976aced8e5eada812f66a897a112680cbfe84898e7af3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6872d57e88a40fb00c6c2fe4b7cff8abe4e3809c2eb5842b389d0b2548f5013a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/foxy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-force-torque-sensor-broadcaster";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5cd4eefe34f18f5cffa1449dbcad04ab1c9cd440c159a6296c5c4a781fdc3da5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "bf2704ed5667aae1e8d37cbbd139b6001828561f30f8caba67d1fbaec593ff03";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "fb7795ab3f389525a5acc6c084b13360f5e15df5f10b513088483f126d6f2d11";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "83d3a727f63ffc8b95886a488dcc5a9ea12a22f1947e0e5bbec795f42cc7ea07";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -190,7 +190,23 @@ self: super: {
 
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
+ chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
+
  class-loader = self.callPackage ./class-loader {};
+
+ clober-bringup = self.callPackage ./clober-bringup {};
+
+ clober-description = self.callPackage ./clober-description {};
+
+ clober-msgs = self.callPackage ./clober-msgs {};
+
+ clober-navigation = self.callPackage ./clober-navigation {};
+
+ clober-serial = self.callPackage ./clober-serial {};
+
+ clober-simulation = self.callPackage ./clober-simulation {};
+
+ clober-slam = self.callPackage ./clober-slam {};
 
  color-names = self.callPackage ./color-names {};
 
@@ -504,6 +520,8 @@ self: super: {
 
  ifm3d-core = self.callPackage ./ifm3d-core {};
 
+ ign-ros2-control-demos = self.callPackage ./ign-ros2-control-demos {};
+
  image-common = self.callPackage ./image-common {};
 
  image-geometry = self.callPackage ./image-geometry {};
@@ -700,6 +718,8 @@ self: super: {
 
  moveit = self.callPackage ./moveit {};
 
+ moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
+
  moveit-common = self.callPackage ./moveit-common {};
 
  moveit-core = self.callPackage ./moveit-core {};
@@ -709,6 +729,8 @@ self: super: {
  moveit-msgs = self.callPackage ./moveit-msgs {};
 
  moveit-planners = self.callPackage ./moveit-planners {};
+
+ moveit-planners-chomp = self.callPackage ./moveit-planners-chomp {};
 
  moveit-planners-ompl = self.callPackage ./moveit-planners-ompl {};
 
@@ -847,8 +869,6 @@ self: super: {
  octovis = self.callPackage ./octovis {};
 
  ompl = self.callPackage ./ompl {};
-
- openvslam = self.callPackage ./openvslam {};
 
  openzen-driver = self.callPackage ./openzen-driver {};
 
@@ -1504,7 +1524,7 @@ self: super: {
 
  snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
- soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+ soccer-object-msgs = self.callPackage ./soccer-object-msgs {};
 
  sol-vendor = self.callPackage ./sol-vendor {};
 

--- a/distros/foxy/gripper-controllers/default.nix
+++ b/distros/foxy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-gripper-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "959447fe35b065e479574a725503388ff1e7508d7be4554f67bd033ca5f63696";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f2335832fb404cb238b276ed08e3dc44b771fe9c3d67294eda5213eb92f2af4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ign-ros2-control-demos/default.nix
+++ b/distros/foxy/ign-ros2-control-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-ign-gazebo, ros2controlcli, std-msgs, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-ign-ros2-control-demos";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/foxy/ign_ros2_control_demos/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "91356545bec37a898d5014244fdd0a8f6193c56b49600599fef05fb0a60ee747";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rclcpp-action ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers hardware-interface ign-ros2-control imu-sensor-broadcaster joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-ign-gazebo ros2controlcli std-msgs velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ign_ros2_control_demos'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/imu-sensor-broadcaster/default.nix
+++ b/distros/foxy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-sensor-broadcaster";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "6215c5aed3720f67d2a35d3a2b63b3acc5b53dfad1d4ac03b639ad2627ea1d4b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "941428794bc34e4853533cf314e6d13f26b3e517ce1619144f971b6f6dd5f3bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-broadcaster";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "21326858c82c50fcee6b5d2350fa12aa463a39cd701c3e81becd2109b102d13e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b8e1f593b6f78db71173a28555ee64b7ff12f5f61b134c4f2d45bef3f83825f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "40b56fa010177893f2b4f4b79c91d8479ecfe5ba4863d5492929e9f8beaad4a9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "de940f92dbc74ad5413839ae7b486ca3b52edabeb0a27fee08732ebfdf6a022d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "ae5af702242eed133b0113d231ff1f3f051e1f23f0aeed6012d08a3df2e34850";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c0a3f71883f2dd50f7cba92fab391b687413997a7a85313016746924944dba43";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-testing-ament-cmake/default.nix
+++ b/distros/foxy/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ament-cmake";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "61612d103e39c58e80e541a1da607c03aea60428015cefa72677d8c99374c667";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "d457889a8c0d4ce685748c75d92908164d548d12a9df6348832336f661962c5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-testing/default.nix
+++ b/distros/foxy/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "8679329fed9f48b2cd93c3ee518c221492689275cccec7b6268bd76b0390f1e8";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "1d328cd6a3cee5db437cead38ff365f64ff2616043688a53eb1b0b0d6adae03d";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-xml/default.nix
+++ b/distros/foxy/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-xml";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "018c546129aa1abbc630f4dc15a2cb802da981400a25211013336e1f51921a87";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "f837fdfab4c4d22d457d4e8b7ee175e6b8248ae6a069e67df15f3055748b6f35";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-yaml/default.nix
+++ b/distros/foxy/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-yaml";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "ae40846ac9279b6102fca1f57e58b165183da854821a3fb3b9fcaadd640dda38";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "986646cb49c14695273b5b87593995c6323b20e19023ecf695d3936bec7cda33";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch/default.nix
+++ b/distros/foxy/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch";
-  version = "0.10.7-r1";
+  version = "0.10.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.7-1.tar.gz";
-    name = "0.10.7-1.tar.gz";
-    sha256 = "498b5b1e0e9aed08a72fcbdc20800999788fecb9fc6616b2ef9a8df821f786b4";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.8-2.tar.gz";
+    name = "0.10.8-2.tar.gz";
+    sha256 = "bc1573b5f4cf66081f1dd6e86ade450df5354891779299bf0ed4695bd1875ace";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/microstrain-inertial-driver/default.nix
+++ b/distros/foxy/microstrain-inertial-driver/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_driver/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_driver/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "b499d05eb384e9e73d0e201f90aab0be6d87f73056196d13499005f7a0406201";
+    sha256 = "30f6ee895802d80e89137669030a7a61216889076dda86e33a37300a56103b2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-examples/default.nix
+++ b/distros/foxy/microstrain-inertial-examples/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_examples/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_examples/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "a9c3d21614df29e4c3744c0ca07e79a72e9012b71e3651761f8234ee355053aa";
+    sha256 = "c959cc5079baa437395aa5185a12d23de75a3f273a270707c8c2f1287c19d119";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-msgs/default.nix
+++ b/distros/foxy/microstrain-inertial-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_msgs/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_msgs/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "42d99735d6a112e470fef7b335a1812fa270635505ec5863a1af49ee7f93d43a";
+    sha256 = "19f9494b26b4d893da92fc8e2810cf99b5b2b30491f373a544695cd7fc7cfa25";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-rqt/default.nix
+++ b/distros/foxy/microstrain-inertial-rqt/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/foxy/microstrain_inertial_rqt/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_rqt/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "c086707b83a7f21496abc12e3a7e77e9428cec73d9b42f18dd64d238dc7c5277";
+    sha256 = "9852bc3f449cd90ee5bcefe56149fe99ace7d84863e5c014f856fcdfb452f078";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/foxy/moveit-chomp-optimizer-adapter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-chomp-optimizer-adapter";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_chomp_optimizer_adapter/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "e115b2667935acecd4f54d8b20bc39321fa7f394246a6a372f6d9422f86dc52f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''MoveIt planning request adapter utilizing chomp for solution optimization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "35303adf34ac5e6ac500d195bf152e10afe1e762be459a683189dad256997727";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "09f5891f3ccb59e3251a45158a7afd5c014be0b9c663b3be851aa4a9725b660c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-core";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "06c3ff565271ece7e1d6ad65bbb751139095d849e067df4c9232c37f4b5582f2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "eaa14e326ffb03e88dc735f7cb1574a51854cf29dcac584dd942da08c01ee651";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "0249b9f79b0b392c7a1ea01787ec2e5a39cc52254180b6695e4e612f11bc610f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "945a1aba5e751d6f7c6f9eb1f9845eaa5cd7e372ecd31c57e7625cfc644e78b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners-chomp/default.nix
+++ b/distros/foxy/moveit-planners-chomp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-planners-chomp";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_chomp/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "4612da44d93816c551a95e295abbb1fe7115ef18acdeffbeecee8382ebae3f23";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The interface for using CHOMP within MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-planners-ompl/default.nix
+++ b/distros/foxy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners-ompl";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "7395427cb1428547cadf70aa029c4a68ecb9a7c0b620ea8fc4e420a57ef8d38f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "a26eaa86acd09f7023f172fccda3e99bb661ffad3325392000e1e2c614c585a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b5b0000f46272aab3843969f747eb745ca9df2b8347b643df13ab533d8b2dc54";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "1e771ca66e3387f428155ad274517ca50996b74ea3184115f6e73da9ecba3214";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "668a9748c983a9ecabf918ffc080f8552903f8dfdf611b47a47ab4765ded32f5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "6e84939a50bc25b2127cd9f57c2bc7a7d804b3987ae8df7f471cec61dbbb3370";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "24ffc7994309a36618dc992c89a08a0297afee3691e46e998a639e3da3e7f36a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "48c06d2ddf70a9fa6de2d98fd00e245606b775cfa5e24ad8bff4c2dfda86839e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "ac10f22cb72ef1b2f470860dca3d676e90e003dcdead035b032368d0d07fcbff";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "54203208a479cdea86656cc806112cb1949822696e5e7d6e41de856302490252";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "3e9a76eb47d1b2d513d1b346a134ed16679c6a28bc7dca5e0fb2af9d44ade812";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "e31d678dff6b2da0a7dbdcf874531cd8f4b00bd572566a6044cc361637cec253";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-perception/default.nix
+++ b/distros/foxy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-perception";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "a6c90bb96142a5ce2ac759a0ba828016631d33f692d2cdb258e50a991f441a3e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ba1884f8bfe96a25754f32f33082f945b721c28ed8d707f1d66eb7b2dee82ef1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "5f1e1319d0f3735b636d1ffdb9004431cdf73b3f6ddabdcbac28b1026c8b9021";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ca37188371f43c950d16d706337959fa067539f8114613605fff60a2cf043a69";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "fa053b5f669dcee7bde786306fba8d9e5c0cbc164f63081215728c73155ff602";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "bdb3c9502aee29ad8bb9b38ed6d3128ca81134a54e713e8c2a0a16656b35d950";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b6fe6dec1200210067c6632b533d138f6813c93b326d83fb23c72fbdea0a793e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "04d6e59b498c43899292fd11eb26da6725b7cc0cf6fc6afe00d424e98a322835";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "d427fdd7e25d63d1e06d13fc3050b6c290b37dfcd208ac9684c0c3d23926bf7c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "70527eeaebed9ee517d2f4f48a313b40a49c864d8aaa2fe723a5dd95bf3b233b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "51105f6d7b90d73bd440c3e9367b6607e4f2546fb3cda767de9e6ac44ace7967";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "6f58e99828fedb3e10624741860f64b1ba261366a5e286716c708b0a8a3616ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "5a541e9d48a4385e4c03b2bab7578862215a1265357b38555bc653f456ec26b0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "e62b170fd4d2c530db892856e23a22e7a21b12a4e1477e4776f932f84fe0ba45";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "8ea419f3f54038a728b82fde54083a69af31375a8f13231c3874fcddde006283";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "80e4048cdfc58e9334d82dd33c048100b5a7816f91701a84a6c01f650e9c4d2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "44daaeaa66f0aac439278827dd1c72ef3a3b79f142a653ef9887538c7dfed35a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "eaa39c16fb6d17aae338557b53d075799d529311ae5dbd32ec17ec7b28ac3c56";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "bbb4fcffcf9b181b949f1028208fd61b5288c4fbfd1c781edaee4f796a5319fe";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ec3eadf03ab111a3e9c45b3916c5a5d04867f8525f86362b4eef3a638b372b2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "e4924ad34713461a6a4b7738f3e17c3d352e5844bc27db66f1eb9145e0851ca1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "7379e46d8159298b5f07d71b02c450d6a66a6add7ecac0e7ca2ca02fab0998ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ntrip-client/default.nix
+++ b/distros/foxy/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ntrip-client";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-ros2-release/archive/release/foxy/ntrip_client/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c33d794074ab0682c8c91059bca34cc8090246183365a7a09b0489bba3649c61";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b83ceb19296196b637207f68341785f62fa0433d242626f6f7b44e33072a3d13";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/osqp-vendor/default.nix
+++ b/distros/foxy/osqp-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.4-1.tar.gz";
     name = "0.0.4-1.tar.gz";
     sha256 = "826268ede5aba88290b719cbcafa55226535701b33d6afa7330c7090d6321841";
   };

--- a/distros/foxy/performance-test-fixture/default.nix
+++ b/distros/foxy/performance-test-fixture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-export-targets, ament-cmake-google-benchmark, ament-cmake-test, ament-lint-auto, ament-lint-common, google-benchmark-vendor, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-foxy-performance-test-fixture";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/foxy/performance_test_fixture/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "bb991825295f8847d1961b384890df1dc2060d038b8a032dd44417fb78557d1f";
+    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/foxy/performance_test_fixture/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "64cd6290440fee8c847b270ef62ff2d2827328485727b1376e2427b599e115df";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0b02720e1eb8baedf80c833f3f6e72b99964bf07620c30eab9bf98ba2e966ac7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "1a90c809ced24b38b331d77152172649dd0786a399be1323935c7a6ef35ae397";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "2d4036184a6d44bceaeda165b97428c9fe4dc414dd2500fdfcd5edeebc7cda90";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "390ba091e0396f714569ed2e8913f6e9eb6bd416af3325ddf8122ff276d3c850";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-plot/default.nix
+++ b/distros/foxy/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rqt-plot";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4657f76028513187a4cb879d3ad871a54dcf7e5b529355cc16e53535fff1edf7";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "8a275cdec0aa6e699be6052bea5d877ac1256877c54e2fc61c1329ea50ca3c69";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "990af5d23f730ca6252e53081955126790cbc5e2563af5ad61e7bfa41655c260";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "9c9283679849378a664eb793a45faa89507a1c6bace808ba1e1cc56215da2c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "24b31e5514646cedca412a8fbc6913639592b141f6b77df39d6b21f005b9fa33";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "4eaf91edfdaa1024450c5374d7fa8d57b7021b9f3c6a4899c1afa25b8b0eea25";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "0ed38dbf02f5db6c8903721304c67d744f113762762c916eef7129e8e21647aa";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "53ecd09290add9920ab753edd5bb0fb4a1e5de7df60698f599bd48ae91fb49ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/soccer-object-msgs/default.nix
+++ b/distros/foxy/soccer-object-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-soccer-object-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_object_msgs-release/archive/release/foxy/soccer_object_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cc7b1fa14b89d3fa44bef7cb781a0838ae7bb7933251a6e3291120ccc9401462";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing interfaces for objects in a soccer domain.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0e2d8ba3277b1c3c20892ee4a18b06dd809ec46c32c3c553785f83c0023b912e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c0b3af2e675fbdb803d67514d78d9aec50b080a1cb69c696c36a06a151c5aec3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-control";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "31d0e32083b087bb42610140d83130b492bb3423431d6ff699a714134b8d50e4";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "346c963e5807cb5bbd3374013c97fe51d1d214b1c02a574dc8f02bf27354e2ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-core";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "a5c1ff7def40f2ae0a7d8df75b896096f81cc4d502d1f90db8aa9da31d32e689";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "82811332fccb73c04043c82f5fca13435fae071bb9440a2e8ead224e11bda5cd";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-driver";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "fbbfcef080a0b42f423d7f52ab5447f05c3fdf0654d697ceb7caf0ff68f55110";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "ca94bf552a6d713126a38f4126ea767cdfb7e22240ca1e3493559716152d76b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "11c21bee9da3fa5ce3f6e6229b89f4908b785b11009f9d425ab8a2096cdc7b8e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "a2755dbdfa6acb7c9e7ad0bcb49ec613e7cdd9e4e8eeb8c693da5f2bf79f25d1";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-importer/default.nix
+++ b/distros/foxy/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-importer";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "7976420d6b8b33b3853654073b37072212f43787552917a68b824afedbb66907";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "0da12271f80a84606bbaef0511d6018f3e3f33ba7b9b8aa972ba62496974efcd";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-mavic";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "4fb74a5e0fd9ebb610658a8a1de2d4e2591c092075e7a55532b748f5441a0935";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "fb91a9211811c1da479161cb325cbe698533349c2c013f314ec10d5059eb4b8c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "422f740735021e520aad81762e54dd9d7bb7e3e13f310d4a60a7df9a137b5722";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "ed275dee367ed8371c3c5f0fb39bd316a4a0e3879308b5c61ca4e0be3a451d74";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "23b7858d6cb5b7aa604a66b659bfa71274edf86f957eb3afe6375bb34ed6f112";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "0a065b10e5c86271c391449b41e2b98714f2fc15df6cd8ca31898b252ba85434";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tests/default.nix
+++ b/distros/foxy/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tests";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "ee674beb2a2829de1d73506ce0ea680cfd09f147387d4cbefbd228efd2d80217";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "fe4294495eabffd309a9b7f7184da88bdadbae4126f5d23d5e9963265f3790f9";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "13078f85c002824e9d8fc728561635f647caa842225c1fa465e8228d5dfc8686";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "d7ced3020da3295c81c60cd613ae12ec04166584588e6e4fdac91fc52e51832d";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "10bd9a5b652f7c13449975e11e3da2418c503e2cc6872c8d95918f0f7761d42c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "c88209c091de023b5178a1004447c0dc92636486a995f706b8e03c01792777b5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "5c4d935371abea3dbd58a1012a3e247cfac5421895fea09e7b58b66c22c00c0e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "286ea6dd3bf5a3f0ddd7ece4e69f87711afdb2eee9d95ac3f6f337912c773182";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller moveit rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver ];
+  propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver ];
 
   meta = {
     description = ''Universal Robot ROS2 interface for Webots.'';

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-core, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "9d419d67b1b372dcd30db52b4ba964ca695f3da4ea96d4e0316865784f7c9c0f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "6add95339b331f0aa1b8b8708084afc88f0081577b865b51ab3165d6d04e70e8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/actionlib-msgs/default.nix
+++ b/distros/galactic/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-actionlib-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/actionlib_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "a59b69d5f9da1a68adedb243eca0fbee4faf1a9d8dd2856c1f9f9eb0a6456222";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/actionlib_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "5d2ce4cb8dd390e77e86ce2424071d6714ba8a743f9e50179479a683316407be";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-auto/default.nix
+++ b/distros/galactic/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-auto";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_auto/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "829d3c6c53296b7bf8fb0214b44da24a4711d8551157f8ff5a19f00e897329d5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_auto/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "7f905384399cf8e99a59b9aeda12f831f977b1c21da0ea90308a77f72d03f47b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-core/default.nix
+++ b/distros/galactic/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-core";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_core/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "4bef5d26f041e525491897a24a203631745d8d6c228e1d75f799d01614a4e3cb";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_core/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "55288d969a7ee4e9aaedc16939ef58d2bc3aedd3e5241777688d5195664a2545";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-export-definitions/default.nix
+++ b/distros/galactic/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-export-definitions";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_definitions/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "9582dad9bf9b76c16e6a018a63f6c36986a16a9579ddab400542ea8cd5d12724";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_definitions/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "f5c8df38dbae8787aa43197b6cb4de4b0097a869362dbffe36e622557aa63751";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-export-dependencies/default.nix
+++ b/distros/galactic/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-export-dependencies";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_dependencies/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "1b08f87684aa617b19254d43edaa3bdae8109dfcf13243c4a84bbe8e8931f3bc";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_dependencies/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "45df89e8a5c81535633e2e32b6568d3f29c74468e5bde480096999ebb7d5c3f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-export-include-directories/default.nix
+++ b/distros/galactic/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-export-include-directories";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_include_directories/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "a2714659930a5fdc1ae7f6475f9ebe6820adbf65e99e8ae08df9db85a7dae163";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_include_directories/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "91022216dcc2b66af5850bea9d5bd29278f195f6c8783c31dc7a562fc50024a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-export-interfaces/default.nix
+++ b/distros/galactic/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-export-interfaces";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_interfaces/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "aee37d1363d1e4fe95790c7a5119c61272954f34f6c36524b7cfe1f1ca42021c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_interfaces/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "a71e2a629195d4e0ce9516a3204df5d55438ae379c6794fc419e47a55afcb13e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-export-libraries/default.nix
+++ b/distros/galactic/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-export-libraries";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_libraries/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "b3423fb9a7cb5bcb9d32cab9c79e8fdc3ffcac4e1e9fba0389a9d95d073bea1f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_libraries/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "5bacd72181bdc1a7f7a98c93d51dba9b4c4d91c3b1d8dd135a99380d2f474ca2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-export-link-flags/default.nix
+++ b/distros/galactic/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-export-link-flags";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_link_flags/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "cf97f3bc7eef3b420d4046f4015e59cb166650ebada94cd7c1f69b284b3d171c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_link_flags/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "466b35424941d53568a3d14055e838b9b0d739aa7929c5f1079c448fd8fcb72c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-export-targets/default.nix
+++ b/distros/galactic/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-export-targets";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_targets/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "73b6f256322e7f768293a204f59ba7a1a2ee21b9b4b4785a76aa07fc25b2b360";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_export_targets/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "0b86106361f20c48124b4214d791c795d96bd8ab581d92a5ce7681ea92c2c303";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-gmock/default.nix
+++ b/distros/galactic/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-gmock";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_gmock/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "40b442c91b932e4d82bbc7fb9900b088ef134fe59fd77efd0d7457bc896831a7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_gmock/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "15c270f62b6e88181e004af781296546ea7e1bc29623d23bbe4a581871366d0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-google-benchmark/default.nix
+++ b/distros/galactic/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-google-benchmark";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_google_benchmark/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "e3ac81b9c62bc3038d9f2a41d8c69c10e735af13ef5f6ca2fb833ed8cf6f689a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_google_benchmark/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "a33710df0f70514b30e56c8f90c4752cd91786a24dfd65573f8ab8fe1829dd6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-gtest/default.nix
+++ b/distros/galactic/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-gtest";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_gtest/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "132a633643d303a8689ddd0ec71ee1d98bdd5c97ba5134a8e55bc0e8cf039f8e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_gtest/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "52393dd385addc7ff94a76aaf63659fee98d7cb206da4e5b136c45298c0ceb5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-include-directories/default.nix
+++ b/distros/galactic/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-include-directories";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_include_directories/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "29c6318cfcc404a8cc7cb6d31095ade143e4bf00eeb5ff4bc7b4101518e9de37";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_include_directories/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "e8ba619390a3a9180f4a6e6385b0ef4a23cafb7df38694f41ac14444343c45d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-libraries/default.nix
+++ b/distros/galactic/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-libraries";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_libraries/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "f7d476e048b476593ad3375d80823a95eaedc32757871a2a4642a394c0f1bb4b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_libraries/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "dad83e2d344760e360637b867cfdc660a30101be6028bd14557398e634609c46";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-nose/default.nix
+++ b/distros/galactic/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-nose";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_nose/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "f9b1973f5f4265755c3d3da9f6e1a954abb25c41fd68740572ece02d5a8deac7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_nose/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "e1edfc2111de3ca77352287d867dc669bb8fa1034ea8dca8840477084ab1c0f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-pytest/default.nix
+++ b/distros/galactic/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-pytest";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_pytest/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "035db1ebe97cf98f9aca7187761420933d3f34c21b63c56246c2f03ddb31e5e4";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_pytest/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "d53ab5abece7633dfa959b2b8f6eaea93b2c7a622b72320ad7309c61b520cbb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-python/default.nix
+++ b/distros/galactic/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-python";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_python/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "4ed745c90324d4c7935e857e9054662957dc370dcddd3fb7fd88acdc5daca757";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_python/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "a29d8bcc612cee6bad66409605327fe78839579a13327027f34f9a27df928eb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-target-dependencies/default.nix
+++ b/distros/galactic/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-target-dependencies";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_target_dependencies/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "892425d498a1e83ce5b5dad0aafcb32555955f59455e0642efb527ae317da90c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_target_dependencies/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "87e79f2a51be9cf7990ee042ce975a12ae9e7e493406f48e7da4b2c3b7c7923c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-test/default.nix
+++ b/distros/galactic/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-test";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_test/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "ec1762348ba2267388b513462193cbbdbdda9ef8b0b3be8072783658f73c2978";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_test/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "3506d1369b2c2414aae6c344f8b6b2ab74d246edd3f1be9b48991abcc8f61b16";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-version/default.nix
+++ b/distros/galactic/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-version";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_version/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "6c914530b762cb00709e6ec2c30ba7ef48a07774239ce6f79dffa8d09da228fc";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake_version/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "20730f3ce729ce7f6024e0e46f6eeba444ad472e27a12a924e7d5bf905df6b7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake/default.nix
+++ b/distros/galactic/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "6700be0ed46789df5d448613980db8a458e555865ceb64adf8c35b5753048dfd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/galactic/ament_cmake/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "ee74cd44458783df07772175caba0bbe92aad01646484a15de051a79a52d2092";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/galactic/aws-robomaker-small-warehouse-world/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-galactic-aws-robomaker-small-warehouse-world";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/galactic/aws_robomaker_small_warehouse_world/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "846ceec0b2874b4a3af5df80f660ae65dc4d8e1fc13e2d6ea8dd9d62a437ca4d";
+    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/galactic/aws_robomaker_small_warehouse_world/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "bfbbf19db7b6fd655367553e8585662648a333bb29d2c30eed97aacd10b25418";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/color-names/default.nix
+++ b/distros/galactic/color-names/default.nix
@@ -2,23 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rviz2, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ouxt-lint-common, rclcpp, rviz2, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-color-names";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/color_names-release/archive/release/galactic/color_names/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "f0eb7edaf3aa63d6beb7597d22ad05df2244f3667c61764dcc5bf504b0fd4306";
+    url = "https://github.com/OUXT-Polaris/color_names-release/archive/release/galactic/color_names/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "6e1d7f88dc431b97e80ec95d5a6a5c904e5c99f005ec79a871afa1dba6444e46";
   };
 
   buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
   propagatedBuildInputs = [ rclcpp rviz2 std-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''The color_names package'';
-    license = with lib.licenses; [ mit ];
+    license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/common-interfaces/default.nix
+++ b/distros/galactic/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-common-interfaces";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/common_interfaces/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "c5bf580d8245e12e8dee1bac20a30c98bbb5e2e786dffa2e685c0860160e7cb0";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/common_interfaces/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "d9cfee1b1f3e1154fef1ce3a323a061c10ac84ac5d804529d03930c76177b397";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diagnostic-msgs/default.nix
+++ b/distros/galactic/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diagnostic-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/diagnostic_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "773d3303b628f790e6039b491c12af318552ba6baf013e306d29516f0aee446e";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/diagnostic_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "d6bee82d8153a12645daffd44f85f624e143dc4d2ef343798f21f29ed651a7d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diff-drive-controller/default.nix
+++ b/distros/galactic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diff-drive-controller";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a0f969b1507a129d82ba2ae7d0872107e6a4e1b29972b3c6ecee030497c830ba";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "f14ed93f682786bcad7b4baf18739540eb0e0959bbb72297b087821d3d6d3df7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/effort-controllers/default.nix
+++ b/distros/galactic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-effort-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "13bbf94a85fa6fe45cab89b6dd12802b437bda2d4432bc1f9fa1a8ef5abc926f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "a82ae2cb707c2997348682e8030031dcb7fba0139f964d4856809a04f8b10b2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/force-torque-sensor-broadcaster/default.nix
+++ b/distros/galactic/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-force-torque-sensor-broadcaster";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ae88f8f4f93a6280b8f46dcc88f5acfcdc99b6ec23b6a1b9a9519dd508f4d21b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "aa5d7db0e1ca69ce6068f766664d8570ca2343cbba0ee5ac65d946bdac950ba2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/forward-command-controller/default.nix
+++ b/distros/galactic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-forward-command-controller";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "5d014615253d64c560aad1d13d145c9f72144466e5a034199b956dbfb8ed284a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "727ac0dc733f333a5a8551b9f51df8e69cded5d6da415a1d007dcf9a1e15a0e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -506,6 +506,8 @@ self: super: {
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
+ libpointmatcher = self.callPackage ./libpointmatcher {};
+
  librealsense2 = self.callPackage ./librealsense2 {};
 
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
@@ -756,8 +758,6 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
- openvslam = self.callPackage ./openvslam {};
-
  orocos-kdl = self.callPackage ./orocos-kdl {};
 
  osqp-vendor = self.callPackage ./osqp-vendor {};
@@ -946,8 +946,6 @@ self: super: {
 
  rcpputils = self.callPackage ./rcpputils {};
 
- rcss3d-agent = self.callPackage ./rcss3d-agent {};
-
  rcutils = self.callPackage ./rcutils {};
 
  realsense2-camera = self.callPackage ./realsense2-camera {};
@@ -1134,6 +1132,8 @@ self: super: {
 
  ros-ign-interfaces = self.callPackage ./ros-ign-interfaces {};
 
+ ros-image-to-qimage = self.callPackage ./ros-image-to-qimage {};
+
  ros-testing = self.callPackage ./ros-testing {};
 
  ros-workspace = self.callPackage ./ros-workspace {};
@@ -1244,6 +1244,10 @@ self: super: {
 
  rqt-gui-py = self.callPackage ./rqt-gui-py {};
 
+ rqt-image-overlay = self.callPackage ./rqt-image-overlay {};
+
+ rqt-image-overlay-layer = self.callPackage ./rqt-image-overlay-layer {};
+
  rqt-image-view = self.callPackage ./rqt-image-view {};
 
  rqt-moveit = self.callPackage ./rqt-moveit {};
@@ -1346,7 +1350,7 @@ self: super: {
 
  soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
- soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+ soccer-object-msgs = self.callPackage ./soccer-object-msgs {};
 
  sol-vendor = self.callPackage ./sol-vendor {};
 

--- a/distros/galactic/geometry-msgs/default.nix
+++ b/distros/galactic/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-geometry-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/geometry_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "9c940bfba85ffb624b63c4e1facfd066ddefaf1d705900e0662d226d8383ad53";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/geometry_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "708f6d1292fae2e658bfbde2c3dfafe5b370e51d8c20bf405f60b5d485418e90";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gripper-controllers/default.nix
+++ b/distros/galactic/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-gripper-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "fa86829c262273956b4af81b8ac83e8ddaf335e75f2618f46d8f6c8ba76404e2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "67002322ed8742811f3fa6792614c7f0ef0280d8e20c0c0f0d035acf4d92a7fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/hash-library-vendor/default.nix
+++ b/distros/galactic/hash-library-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/hash_library_vendor-release/archive/release/galactic/hash_library_vendor/0.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/hash_library_vendor-release/archive/release/galactic/hash_library_vendor/0.1.1-1.tar.gz";
     name = "0.1.1-1.tar.gz";
     sha256 = "62bda6cb3b853dcb0394424cb1f1da97d08be3e05a5b145f912394393d4c76e9";
   };

--- a/distros/galactic/imu-sensor-broadcaster/default.nix
+++ b/distros/galactic/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-imu-sensor-broadcaster";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "dfb839801c2ffca3e38a77db0a7143114ede39f6474d9e8f2fb0fee884e0d8dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "cd4c1f73f3c9233b917b4a05cda4f969b87b8c748cbf230e2dc4b77e142e192b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-state-broadcaster/default.nix
+++ b/distros/galactic/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-state-broadcaster";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "133036cd403dae222c62cfa40be633da4ee346a0f0d7789d7881d33bac83f96b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "925ff649c26c59d3f800da31c6230eb12ee2f19501d45d12ef095db3bd91541c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-trajectory-controller/default.nix
+++ b/distros/galactic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-trajectory-controller";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "44b55dd9c25adbc70b8872beadb78a61fdbcd6706ba59a1231434de355ebf8b8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "38d8b6658829dac72dc6ae1c1f35914fe21fe4e31239c8ec0b077da2d384e6a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/libpointmatcher/default.nix
+++ b/distros/galactic/libpointmatcher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, libnabo }:
+buildRosPackage {
+  pname = "ros-galactic-libpointmatcher";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/libpointmatcher-release/archive/release/galactic/libpointmatcher/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "c7c042ff46ba25ea8b16d3091c8274e2bcd5716965b89a2a210c26e0e1722094";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost eigen libnabo ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''libpointmatcher is a modular ICP library, useful for robotics and computer vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_driver/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_driver/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "f165c01ffe880ae76071e49bdff4fd13563e6ce6784c3495149df0dc8ae6444d";
+    sha256 = "2d101677955d30183c2fa08046787362361774dbb57726f98070e3c614336056";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_examples/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_examples/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "635cccc7868e1b61a9eb05d7451c5a371ee1aa9e2bc908d7d42c58eb6cc38283";
+    sha256 = "8e3bcf8df8f83e987f5f9a9ede5f8c4af14c8207f6a2318c64d4d67dd723838c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_msgs/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_msgs/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "d03b3204b66dae05f1b0b81d36634dab768a6c9c511fe24c6509f4ae6d4cbb65";
+    sha256 = "6f95b887776a57733c1ca213d201270c61f5e8112ff2b01996d696281a0dbe8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-rqt/default.nix
+++ b/distros/galactic/microstrain-inertial-rqt/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-ros2-release/archive/release/galactic/microstrain_inertial_rqt/2.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_rqt/2.4.0-1.tar.gz";
     name = "2.4.0-1.tar.gz";
-    sha256 = "477a11b17beaa186fd5fe4e689f98783cc40ad6b2ca788a631aa8682b11cdd4c";
+    sha256 = "fcc402b928143240701598f3637ceaff5397ea71dbd19e7fdd9af8c30afc86fe";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav-msgs/default.nix
+++ b/distros/galactic/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/nav_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "5ae0cd4883f83b991e1c6ca565735122c75683265d833e48ecf8577dd7c5592c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/nav_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "451b488841a4a466539097249fa35f6f150971a39ecf3e841be58b9c902eca4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ntrip-client/default.nix
+++ b/distros/galactic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ntrip-client";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-ros2-release/archive/release/galactic/ntrip_client/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ccc17605a247e6d1a808adda9ec0b0769e1d20fe391de7e54159b092bf9a9386";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "254a0fa87b29daf21daee44d56b4b672cfa5eb39099333c06ae464fcdb42943d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/osqp-vendor/default.nix
+++ b/distros/galactic/osqp-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/galactic/osqp_vendor/0.0.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/osqp_vendor-release/archive/release/galactic/osqp_vendor/0.0.4-1.tar.gz";
     name = "0.0.4-1.tar.gz";
     sha256 = "366e082d8adb27d1206b58e830e162a5342dfc30ec076ec7f1e0ff786c90f64c";
   };

--- a/distros/galactic/performance-test-fixture/default.nix
+++ b/distros/galactic/performance-test-fixture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-export-targets, ament-cmake-google-benchmark, ament-cmake-test, ament-lint-auto, ament-lint-common, google-benchmark-vendor, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-galactic-performance-test-fixture";
-  version = "0.0.7-r2";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/galactic/performance_test_fixture/0.0.7-2.tar.gz";
-    name = "0.0.7-2.tar.gz";
-    sha256 = "7efc223f59b996e797881d77bf072c9f5a7d7b428ff5af79f42a0f5c5a0f2640";
+    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/galactic/performance_test_fixture/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "9324dde4251b70c1e2d6442358e5a92ff60b1d3d9ef98f0812820de20154aaed";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/position-controllers/default.nix
+++ b/distros/galactic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-position-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a7b6e98ecd057b3d57851ece9765b35ae696e3995c3a8d63121655f5c8555600";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "f03ab1617873ff19fc6aabf41362e5e8aff0ab5434fd8b266509c9e3bd57dbe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcpputils/default.nix
+++ b/distros/galactic/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-rcpputils";
-  version = "2.2.0-r2";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/galactic/rcpputils/2.2.0-2.tar.gz";
-    name = "2.2.0-2.tar.gz";
-    sha256 = "f3af21385390086e704e31d1c79c5989927ad24fa4fa5d8d8e9e307f98c87923";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/galactic/rcpputils/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "6b173721a8cdb5dcc321bc25074045c7b10155b63b9d6337b3284be15c8f867f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-image-to-qimage/default.nix
+++ b/distros/galactic/ros-image-to-qimage/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, qt5, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ros-image-to-qimage";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-sports/ros_image_to_qimage-release/archive/release/galactic/ros_image_to_qimage/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "df859dc610b2e7ef43e847b133b72289c7219d6d7d05e1ef0f7f2d3417f4b52c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge qt5.qtbase sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A package that converts a ros image msg to a qimage object'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2-controllers/default.nix
+++ b/distros/galactic/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-galactic-ros2-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6b6b2401381d92f219e6c714abe979341fee3f7e806742c4f4fe663056afb285";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1594c8a67ea69794f0bd414bccbb4be0621bc733f6a58800c92df67a99f4bef7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-action/default.nix
+++ b/distros/galactic/rqt-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, rclpy, rqt-gui, rqt-gui-py, rqt-msg, rqt-py-common }:
 buildRosPackage {
   pname = "ros-galactic-rqt-action";
-  version = "2.0.0-r2";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_action-release/archive/release/galactic/rqt_action/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "177a7e1aa690b66331a7bd03e943922c67324b247fea20bbf4217afe4dce708a";
+    url = "https://github.com/ros2-gbp/rqt_action-release/archive/release/galactic/rqt_action/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "17354690c93e7ef1decdc43d3ccfd382e78fb3aeafb0f45cc34d7c4ac4f157d7";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-graph/default.nix
+++ b/distros/galactic/rqt-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-dotgraph, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-galactic-rqt-graph";
-  version = "1.2.0-r2";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/galactic/rqt_graph/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "7858c8de972f02a0cf13513a9f9a0d45da2bd79caca46674977eac15c208e49b";
+    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/galactic/rqt_graph/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "8ed94499f129f3934c45ef4fd9b43f49d7ad1b11cae29c674f5fd711c6517495";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-image-overlay-layer/default.nix
+++ b/distros/galactic/rqt-image-overlay-layer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
+buildRosPackage {
+  pname = "ros-galactic-rqt-image-overlay-layer";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-sports/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "45f842bcefbcf76b7e39366fb17ee88fa281bf7f3e53b718a34f608363f58156";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib qt5.qtbase rclcpp rcpputils rosidl-runtime-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides an rqt_image_overlay_layer plugin interface, and a template impelementation class'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rqt-image-overlay/default.nix
+++ b/distros/galactic/rqt-image-overlay/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer }:
+buildRosPackage {
+  pname = "ros-galactic-rqt-image-overlay";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-sports/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "be7f3bfb16e7183f2491b8992cb7cd74d53790a8f680609c3cf96a6b11d69f3f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ image-transport pluginlib qt5.qtbase rclcpp ros-image-to-qimage rqt-gui-cpp rqt-image-overlay-layer ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An rqt plugin to display overlays for custom msgs on an image using plugins.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rqt-plot/default.nix
+++ b/distros/galactic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rqt-plot";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/galactic/rqt_plot/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "62e816285327a8eb886b9d5cc7c4159aa584185c1a54b78bf5a2c31a9ccdd467";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/galactic/rqt_plot/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "660c263d99ad23b8a68f25ecd9d490b7e37323913dd8d848d8978bb888334e7c";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/sensor-msgs-py/default.nix
+++ b/distros/galactic/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-sensor-msgs-py";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs_py/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "88ebcc03617f6abb549243f2d533fb905d8fdcd510bbf62a3256bb71863164df";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs_py/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "c1f07b5394f0633204b3fe67b43287b591add664bd8486f2ed67c7a2734752d1";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/sensor-msgs/default.nix
+++ b/distros/galactic/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-sensor-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "cf3775ee0746b63bffab214f6ed031254b3df0b2ded88517aad857924006cdd5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/sensor_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "106553cbc1fc7dd5e2afd60b38d9903a977b55f35f2252c978859d6d356f10ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/shape-msgs/default.nix
+++ b/distros/galactic/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-shape-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/shape_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "ca2153e9c6d11d320a313187d6ef8cfec24baaafcd6caab1532a29db96131e7e";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/shape_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "cf37da06696fbce13ff4ec25bff0c3d5a4357ec992e0ba1045b884c18cf93382";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/soccer-marker-generation/default.nix
+++ b/distros/galactic/soccer-marker-generation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, soccer-vision-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, soccer-object-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-soccer-marker-generation";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ijnek/soccer_visualization-release/archive/release/galactic/soccer_marker_generation/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "189d3289374ddeb5078718359cd67e205eab040437466f23015f633fe821c452";
+    url = "https://github.com/ijnek/soccer_visualization-release/archive/release/galactic/soccer_marker_generation/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "1e13d7dc88344b3c411dfb4f20a184ae8404680b888aa5bcd8a7021727caa94d";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs rclcpp soccer-vision-msgs visualization-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp soccer-object-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/soccer-object-msgs/default.nix
+++ b/distros/galactic/soccer-object-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-soccer-object-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_object_msgs-release/archive/release/galactic/soccer_object_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a8655139be867e798d39895b8424fc89e9f604dbb7ea6f37d7a202e4e63e2198";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing interfaces for objects in a soccer domain.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/sros2-cmake/default.nix
+++ b/distros/galactic/sros2-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-test, ament-lint-auto, ament-lint-common, ros2cli, sros2 }:
 buildRosPackage {
   pname = "ros-galactic-sros2-cmake";
-  version = "0.10.2-r2";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/galactic/sros2_cmake/0.10.2-2.tar.gz";
-    name = "0.10.2-2.tar.gz";
-    sha256 = "3401bc19a94faea516f31400d82d6b386892443a30c54b2e47d338aab5eabcb3";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/galactic/sros2_cmake/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "3c46164870aa9209546438c151ddfef2f1109bc49b58ea667c053bded8e407b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/sros2/default.nix
+++ b/distros/galactic/sros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-sros2";
-  version = "0.10.2-r2";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/galactic/sros2/0.10.2-2.tar.gz";
-    name = "0.10.2-2.tar.gz";
-    sha256 = "e2a5da1776045744622be952d57f3c6cd63e5b13c70b84a0b055eb2f5d425baf";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/galactic/sros2/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "602dfec0a3a9a51251d5f316e702ff4bfc6fa9faffad789917e954d970055881";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/std-msgs/default.nix
+++ b/distros/galactic/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-std-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "166a014b5be66251f76bab39a7146cd1ace2a2877af68baaf912ae5738967794";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "5fa2de4ee95439db1b984c5f18b225cccdb4ea0daae4c9b516b06f981dcd3834";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/std-srvs/default.nix
+++ b/distros/galactic/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-std-srvs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_srvs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "da04ccd6f2e0e71676a1c02d531e2dee2942c955874f1665bda5f9823171e0a2";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/std_srvs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "0abc409bfdf8a76ae15722bdd5b2ebf06f0fe10bcc68cb57629f738db7440985";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/stereo-msgs/default.nix
+++ b/distros/galactic/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-stereo-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/stereo_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "0526f016130e246bdcae49d7a496f2ec26957c9c0cb86742adcf73c5b68831fe";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/stereo_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "e90e542637e89518434f180529d64776ff56e2862fa6407bd8d4b92241499c77";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/trajectory-msgs/default.nix
+++ b/distros/galactic/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-trajectory-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/trajectory_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "ff74d815dd66324c6b11aadcee3a3271ceb1b17c140026cff84b6db8357b602a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/trajectory_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "82de7d3f4c1e4d5e20b9ca29bebf18a3aad2b0bfbcad622dbd28b3e5eac0199e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velocity-controllers/default.nix
+++ b/distros/galactic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-velocity-controllers";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "179727388643ff840ab822e4a7fae7b7035f1b125607f988f50d2b3520e62df7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "59d9ae37d3bf135d883ef36b2d76b331ff40ebbdd34d1a017e3abc32ed2a2c60";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/visualization-msgs/default.nix
+++ b/distros/galactic/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-visualization-msgs";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/visualization_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "6f75b46f14a1c4cff806bb0207b7fd37dc74f8f5471e03625ee26eb179f30399";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/galactic/visualization_msgs/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "a5aae2c521469572f63d364d10687e978fbe167161ab419dcca89612d488d932";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-control/default.nix
+++ b/distros/galactic/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-control";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_control/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "bc6a6b1f4ec11278e6c3bdbef2f1b85bdc1ebf4f7c24d9697e7f831e800bf4a0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_control/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "1dfc8bfd82441783e9d79930ec41c6e1e9ae5baecb79d2b22a11d6f518b6bc02";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-core/default.nix
+++ b/distros/galactic/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-core";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_core/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "5f33fe452842a7bfba069cebb6fdba441a45ea17b7e85f8ca44b07c96da8f913";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_core/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "53c247f2c64a7f3aa30f3ac3b24c8574500279a6e51baf6b375e8a3d670d30b6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-driver/default.nix
+++ b/distros/galactic/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-driver";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_driver/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "ffb791f9b29a601ff62942371c5657ae20732a100c07b5e60fa06901756857cd";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_driver/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "f7349d0623a3c32a4aafb0a6062514afb45c418cee528846fc206995efceead3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-epuck/default.nix
+++ b/distros/galactic/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-epuck";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_epuck/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "c99c478d2577f80e306d75abdfbd43389a5a526671cfdfe679a6b51121d4137e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_epuck/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "38b38181fb532b8a22628f020fde704fd0c5cb789bc949233a155db8fc5f6c8b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-importer/default.nix
+++ b/distros/galactic/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-importer";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_importer/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "2de6ec50d2f3b682537fd71d08fe15ebe7900988f6c1dd86107ec9c13f26feff";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_importer/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "63067a44d21eaa132cbadc77495305b28034611e57b043c8b967acccf31ab8e8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-mavic/default.nix
+++ b/distros/galactic/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-mavic";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_mavic/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "01197293c2b1483714ff276116738676fcb25ae72a6dd9659090522737a37324";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_mavic/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "b110f2f2ae30482618588f8e3c9911f9a553da7dd5529c413cb6d3069b2926b1";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-msgs/default.nix
+++ b/distros/galactic/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-msgs";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_msgs/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "fc8ced284b7a3dd5ee5160e52fe79ab17e6ebedcfa590da4ac456b3ee67238cf";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e6575bfeeac782bacd921f69ea5adac20c1b5ae7d4e8353c1fca6a54f7735cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/webots-ros2-tesla/default.nix
+++ b/distros/galactic/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tesla";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tesla/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "b2781f57464a6adfcdd14671a18335fcde93fa0a62fcf66a478245227f51952c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tesla/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "a578e5ac2a16a1008740308ee231c96f029b2fd3c38a2ea651f1bf620d65ba70";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-tests/default.nix
+++ b/distros/galactic/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tests";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tests/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "30cc6ff0810fce3df0d1fec414347262b42acd397efbe48322c592ce04835788";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tests/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "73ae23ff7b69e40114f1eed9c4fd5b4f545977eedd33be034a06b6c7cbb473fc";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-tiago/default.nix
+++ b/distros/galactic/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-tiago";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tiago/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "8e31874f5b11f542e11b80cbcf91e7b603a32346f07e0462d66a08d9de5e0be9";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_tiago/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "4965df8ccfaf34d1bd8bf338e53b99a24f1ccb2ba595920412ce3f376e9d434d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-turtlebot/default.nix
+++ b/distros/galactic/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-turtlebot";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_turtlebot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "35a8a84da04ac74b61fac158068e04a762e3c4e53754033dcfeabb4c1cf757cc";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_turtlebot/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "f2cf7a6cc0fc5bf5f18642df5bba7fd95e7b2a0d28ebbe093d774b3a0dfdfe86";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/webots-ros2-universal-robot/default.nix
+++ b/distros/galactic/webots-ros2-universal-robot/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, moveit, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2-universal-robot";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_universal_robot/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "8bb6dc25eb7427b1687142444683854b2a60d17eef86cdfde9515ce01f6c2ce2";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2_universal_robot/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e870c497323071187e2e419de3b47ca3676eb0248d452eefc034f1e0ac90cc14";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller moveit rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver ];
+  propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver ];
 
   meta = {
     description = ''Universal Robot ROS2 interface for Webots.'';

--- a/distros/galactic/webots-ros2/default.nix
+++ b/distros/galactic/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-core, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-galactic-webots-ros2";
-  version = "1.2.0-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "618ad641c643dbc1ce57cd21bccfcfa0a07ade2f7d1198ae74ac70a5f014f157";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/galactic/webots_ros2/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "dfda7ec827e4a1b7b4064e9848b859823471ac414dfaef14b45b38bfb9421b46";
   };
 
   buildType = "ament_python";

--- a/distros/melodic/chomp-motion-planner/default.nix
+++ b/distros/melodic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-chomp-motion-planner";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "1eefe8cb37cde262b0e7840f03ac5a1384021c843606ee649953201df81c84c8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "b8a6e1cd04276478ab4672056b7c0a687267f3d7b678701d5257e384c9227d1a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.9-r2";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.9-2.tar.gz";
-    name = "0.1.9-2.tar.gz";
-    sha256 = "8729ac9bb598c995a6a01e228a209c00e166fa08d516202dad6cbc308b982db2";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "671675984156c172450732e1cf53dd4c477b2e7df3280ef2b9c7e682f4c95eb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.9-r2";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.9-2.tar.gz";
-    name = "0.1.9-2.tar.gz";
-    sha256 = "476fe53fb38033437fd450852107c6f910cf693bba7b43fefe9e0c28eab3d32a";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "79b3e3015c6819d91db0000f8ff3877731b111b9245e304fafb69f27bcb034f5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-desktop/default.nix
+++ b/distros/melodic/dingo-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dingo-msgs, dingo-viz }:
 buildRosPackage {
   pname = "ros-melodic-dingo-desktop";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/melodic/dingo_desktop/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "db4ea8291d9ba30cbf19fd72a473dc9c047bcd16e2b6c97ddb73ea464a02dd75";
+    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/melodic/dingo_desktop/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "783a5da55c27e4175f547cbe6894001f3792040759fcbbc4e9d56f65b801d4ca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-gazebo/default.nix
+++ b/distros/melodic/dingo-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dingo-control, dingo-description, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, ridgeback-gazebo-plugins, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-gazebo";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/melodic/dingo_gazebo/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "08c7a47b951b9afc7aa08afcf83741088a69c8ec4e746384204aeedcd569e630";
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/melodic/dingo_gazebo/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "fa86b9d84e6fdf5acd6654b58e57c061f661b15038eeeb79d5f4a2890064f39f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.9-r2";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.9-2.tar.gz";
-    name = "0.1.9-2.tar.gz";
-    sha256 = "149b26e9f04cae21c9f3e5947a908cada8d0be81e71d76881e2a259429b81155";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "e4822a65d81656b3e248a1eaf98204a9d03cf4d7d0d56b61c962e41366050022";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.9-r2";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.9-2.tar.gz";
-    name = "0.1.9-2.tar.gz";
-    sha256 = "c9c7acc5177110ea5ee6ef69241bb8e2dc42d1131a02de8d4166ac352add1f38";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "a4e94d20963dd88256b78523d8570f0409ebb333f3aefee0bb203e1a56825c1d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-simulator/default.nix
+++ b/distros/melodic/dingo-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dingo-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-dingo-simulator";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/melodic/dingo_simulator/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "1563b72dfc24bafcdd8c9a879fdce5bd45fabdc58db6bb0ed9eae07f7f4a385f";
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/melodic/dingo_simulator/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "a00831f9eb08f30fdb5f6ab2d00952cd89454fce024dff8b9ab58888fcfe1ed5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-viz/default.nix
+++ b/distros/melodic/dingo-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dingo-description, joint-state-publisher-gui, roslaunch, rviz }:
+{ lib, buildRosPackage, fetchurl, catkin, dingo-description, joint-state-publisher-gui, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz }:
 buildRosPackage {
   pname = "ros-melodic-dingo-viz";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/melodic/dingo_viz/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f25fb2be9a06afe7fb48e34b67b7eab22f75bc876090501ac2c918efd8940c0c";
+    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/melodic/dingo_viz/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "e9b4282d6e944beda9b5be7a53f385c0b8a4ce0b0c8f1ae1c08ff6a5544eebcb";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ dingo-description joint-state-publisher-gui rviz ];
+  propagatedBuildInputs = [ dingo-description joint-state-publisher-gui rqt-console rqt-gui rqt-robot-monitor rviz ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1704,8 +1704,6 @@ self: super: {
 
  jsk-rqt-plugins = self.callPackage ./jsk-rqt-plugins {};
 
- jsk-rviz-plugins = self.callPackage ./jsk-rviz-plugins {};
-
  jsk-teleop-joy = self.callPackage ./jsk-teleop-joy {};
 
  jsk-tilt-laser = self.callPackage ./jsk-tilt-laser {};
@@ -1925,6 +1923,8 @@ self: super: {
  libphidget21 = self.callPackage ./libphidget21 {};
 
  libphidgets = self.callPackage ./libphidgets {};
+
+ libpointmatcher = self.callPackage ./libpointmatcher {};
 
  libqt-concurrent = self.callPackage ./libqt-concurrent {};
 
@@ -3720,6 +3720,8 @@ self: super: {
 
  rslidar-pointcloud = self.callPackage ./rslidar-pointcloud {};
 
+ rslidar-sdk = self.callPackage ./rslidar-sdk {};
+
  rsm-additions = self.callPackage ./rsm-additions {};
 
  rsm-core = self.callPackage ./rsm-core {};
@@ -4101,6 +4103,8 @@ self: super: {
  timestamp-tools = self.callPackage ./timestamp-tools {};
 
  topic-tools = self.callPackage ./topic-tools {};
+
+ tork-moveit-tutorial = self.callPackage ./tork-moveit-tutorial {};
 
  towr = self.callPackage ./towr {};
 

--- a/distros/melodic/husky-base/default.nix
+++ b/distros/melodic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-husky-base";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "dc77e8ea9b79913b0d79f4640e0b1833e72be611f2f759796ac425c16ca31904";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "fd664cedb3242fdebf24200d0ab31ff6beb7864920a7ed2dfb50c1ee93cd83a9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-bringup/default.nix
+++ b/distros/melodic/husky-bringup/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, realsense2-camera, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7, velodyne-pointcloud }:
+{ lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, realsense2-camera, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7, urg-node, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-melodic-husky-bringup";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "46bad79d296bc55882200607ea60f6e9b7f025a9826a394314a6f72ba72d0b55";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "3297a2f584935bc59074af9d6977e81e25bb6d87a940b0e1270fe2c9ed2b7014";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ husky-base husky-control husky-description imu-filter-madgwick imu-transformer lms1xx microstrain-3dmgx2-imu microstrain-mips nmea-comms nmea-navsat-driver pythonPackages.scipy realsense2-camera robot-localization robot-upstart tf tf2-ros um6 um7 velodyne-pointcloud ];
+  propagatedBuildInputs = [ husky-base husky-control husky-description imu-filter-madgwick imu-transformer lms1xx microstrain-3dmgx2-imu microstrain-mips nmea-comms nmea-navsat-driver pythonPackages.scipy realsense2-camera robot-localization robot-upstart tf tf2-ros um6 um7 urg-node velodyne-pointcloud ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/husky-control/default.nix
+++ b/distros/melodic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-husky-control";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "c5c5813986a35fb0068e2e450ef1c30f2d95839933a992f9913d855c5e12020b";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "bfbb7174d467d83651c0c76c896aedf0661b41417f578c8aa36af27630559050";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-description/default.nix
+++ b/distros/melodic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-husky-description";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "ed1b31abad1d0184c6b4ebeef0a4c4130d5190e4113d8b2743f9ba889f160251";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "c0db369219ffaf76f9a8ff9e0743da2d7911f8732423f22bac95fbe984657960";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-desktop/default.nix
+++ b/distros/melodic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-melodic-husky-desktop";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "3805d7f4f820955e23429335d4ddfe6fd4e565d277f8c4aa4c011d04022bb0e1";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "3a8d05a037c43365b77ee3f278f39955b442389dbcd3a6a88c54995884b93722";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-gazebo/default.nix
+++ b/distros/melodic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-husky-gazebo";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "42b5cd143ee7d44aab60c380172a3e2f635ae0687af64bd28613ef54f7606194";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "929efdbc684ec337362372f6ed014533ba41c6a6de587a9be7ede71070ab022e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-msgs/default.nix
+++ b/distros/melodic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-husky-msgs";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "c32e1a1b78bb2bfce1bd122c01669fcf09dcc43d005885266aad4345acd9f240";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "a879789fb44a9396d3aa2dad8b432358fc7edaea6db698b94d2b0beca023de20";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-navigation/default.nix
+++ b/distros/melodic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-husky-navigation";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "02427a982d0723d543215e63a7998533cf3360f0a6c9f092da64554fb9bfcd0a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "bce28f39ba0768aadb409e6d335cd31d3c8dccd4c2a9c1b93b6f036b00e88d29";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-robot/default.nix
+++ b/distros/melodic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-melodic-husky-robot";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "ca4b293cdcc7046b3e8914f663d525a65a98af8b5bcf1dc0115d0b6d8b5a667a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "cdf96a1bacd675ad790c0a14e3ac121e208a721c298e3da351604b8ba207f9fc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-simulator/default.nix
+++ b/distros/melodic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-husky-simulator";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "b38959be7e5874e7dc7b699e231b1781252d551303fea791f8faf83cb66890b7";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "ab8ab8efcfa5a429a83407e9bad34e1fd34802c479e4d3462f502c1cc8db0efc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-viz/default.nix
+++ b/distros/melodic/husky-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
+{ lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-husky-viz";
-  version = "0.4.10-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "2d6cef1ceed85bb50de7f008fdacf8785b04a8609f9c53d721fba4c5873fe9f8";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "853e0802e4f91894130add6337f19ec926be51e48be9a3b9b0889a16befc6d7f";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ husky-description joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz rviz-imu-plugin ];
+  propagatedBuildInputs = [ husky-description joint-state-publisher joint-state-publisher-gui robot-state-publisher rqt-console rqt-gui rqt-robot-monitor rviz rviz-imu-plugin ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/image-exposure-msgs/default.nix
+++ b/distros/melodic/image-exposure-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-exposure-msgs";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/image_exposure_msgs/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "1a1518bbeb26d3e52459bc25560ad67da0c3c059fa238494d411cc1585366a9c";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/image_exposure_msgs/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "c6ba39025b456f77a855837ff900d4fa5a327054fcda320f2d2e94c219ef8ac5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-control/default.nix
+++ b/distros/melodic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-jackal-control";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "fd09c26650d3f79df023c270c34b393b5ee16a8da622efe3f2926d6016c0137d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "1b9b235a034db914f87e24fbc7c2f1380e0d582992d5e37a8e4d573c8eaea198";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-description/default.nix
+++ b/distros/melodic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-description";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "0c3b2b89bac7988a33517390b85aebe7c17108c68428ba42fdf5386e8b7e65af";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "7cc7ce82831529fe3dbfc36161b47490f2bcd26105851daec8764ea024850c99";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-desktop/default.nix
+++ b/distros/melodic/jackal-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jackal-msgs, jackal-viz }:
 buildRosPackage {
   pname = "ros-melodic-jackal-desktop";
-  version = "0.3.2-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_desktop-release/archive/release/melodic/jackal_desktop/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "75057128589c98a64195ceccf02f1fa7595d11b7536fe69c0187b42f5ae3829c";
+    url = "https://github.com/clearpath-gbp/jackal_desktop-release/archive/release/melodic/jackal_desktop/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "72c94376d4b6d0af285c61998eee8da28ca5e08e172f3a9826a7e8f2b4ed7dee";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-msgs/default.nix
+++ b/distros/melodic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jackal-msgs";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "c951675a95eb8d978a900fca445e435062dbe20e75479f7274b26b7bb90abc12";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "de0f164f4a5563fa2b8a113e456d1933d5080c67c4b4825193d7e749f3a3e217";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-navigation/default.nix
+++ b/distros/melodic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-navigation";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "e866dcee4e81fed58cdf6124fe3605b09c5178a8818cd325400ff7cc6f13b6dd";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "d722054cec54ab540df895646e88c4157f1040647d8934f3ab2dd10db888b884";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-tutorials/default.nix
+++ b/distros/melodic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-melodic-jackal-tutorials";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "c486e6a59c096ea2947610a84f1c5670cabbdfee198fc6b9dbad90a296c7f9b2";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "c406b696e44dd2f1a39fea9ae9b800db0b4b24b8174bfe5e3253cc2685fe6710";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-viz/default.nix
+++ b/distros/melodic/jackal-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, jackal-description, joint-state-publisher, roslaunch, rviz }:
+{ lib, buildRosPackage, fetchurl, catkin, jackal-description, joint-state-publisher, joint-state-publisher-gui, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz }:
 buildRosPackage {
   pname = "ros-melodic-jackal-viz";
-  version = "0.3.2-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_desktop-release/archive/release/melodic/jackal_viz/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "7849a0a3491f501d697a8146a432808113bcb48663d3b43651a109385602be6f";
+    url = "https://github.com/clearpath-gbp/jackal_desktop-release/archive/release/melodic/jackal_viz/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "aa7216c1a1982b0289692e673b80eb160a0daed28f15c5ac5fdf2362ca28ba97";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ jackal-description joint-state-publisher rviz ];
+  propagatedBuildInputs = [ jackal-description joint-state-publisher joint-state-publisher-gui rqt-console rqt-gui rqt-robot-monitor rviz ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/jsk-interactive-marker/default.nix
+++ b/distros/melodic/jsk-interactive-marker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roseus, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive-marker";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_marker/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "aa813b4175c442c8130b352bbbe70c9ebb0299b9dfc63e6c74dd892ac343d991";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_marker/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "56744adac4f633df0b6c7b8f1073e5f7b3f07d8109335c370f7add394ee03b57";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive-test/default.nix
+++ b/distros/melodic/jsk-interactive-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, mk, rosbuild, rospy, rviz, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive-test";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_test/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "7e0a0fb246e712b8b7f56a170a046a771af8a4392486220ebb750aa13235c2ec";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_test/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "5c4234901ba9b98bf6b8644c7829f4ab966aa7c797987e3eb7deb2b77f7ae782";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive/default.nix
+++ b/distros/melodic/jsk-interactive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-tf-publisher, geometry-msgs, jsk-interactive-marker, mk, rosbuild, rospy, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "e70d0ac211e8eb19eec75bc00b77af7265da884a0c8a02626cfb684409b4d77f";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "5ba59c717424d8864d93e9a1bd2f8347a7532f016de3981841adf7c46cd54029";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-rqt-plugins/default.nix
+++ b/distros/melodic/jsk-rqt-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-publisher, image-view2, jsk-gui-msgs, message-generation, message-runtime, mk, pythonPackages, qt-gui-py-common, resource-retriever, rosbuild, roslaunch, rostest, rqt-gui, rqt-gui-py, rqt-image-view, rqt-plot }:
 buildRosPackage {
   pname = "ros-melodic-jsk-rqt-plugins";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rqt_plugins/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "b21d44eda2592de315538c55dac1eb0b28cf9de21ddb297afbb68cdde834afc0";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rqt_plugins/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "516b5b98d4e1aa2fdb5c7c6f1dee109b9025e544923f9a25d2f425db8b47d9c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-visualization/default.nix
+++ b/distros/melodic/jsk-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, jsk-interactive-test, jsk-rqt-plugins, jsk-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-jsk-visualization";
-  version = "2.1.7-r2";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_visualization/2.1.7-2.tar.gz";
-    name = "2.1.7-2.tar.gz";
-    sha256 = "6d8b429a38d572edddc49f424e51518dc67069ce373d7e423fb426ccdd1b8c84";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_visualization/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "7493abb6f57c227f4b59d2d26e592a0424c0a66a587fdaa85cbb441588344260";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libmavconn/default.nix
+++ b/distros/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "a3041c95add3036e7dbd4d3bedcde79be302f29e829f48418c906c20dd81be54";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "be9186517bf56c11a1233bdd9566573ad5e5000e26ba7e37b916d65b03d690be";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libpointmatcher/default.nix
+++ b/distros/melodic/libpointmatcher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, eigen, libnabo }:
+buildRosPackage {
+  pname = "ros-melodic-libpointmatcher";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/libpointmatcher-release/archive/release/melodic/libpointmatcher/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "26af003dfa5ec17281d65835377028672f83fe45b488c7923c078856fc0c3b99";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin eigen libnabo ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''libpointmatcher is a modular ICP library, useful for robotics and computer vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/marti-can-msgs/default.nix
+++ b/distros/melodic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-can-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "f68e8194a14c01ac2fedd55efb803f78a27c1c7d7fc966910c94dc6bac13d95e";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "b6450f1cc6b5efad8ec970461249180c2ed668459ed2015ddfb8e3756aeaa009";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-common-msgs/default.nix
+++ b/distros/melodic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-common-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "f02b5cc31a17570231e8e10b2d55c5791ed8cbed8510cd40347d6ecc06f25316";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "2b71a0d94ad970b6926032586facedd0df0026c3ca9ca5cc11f31531041bbbc7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-dbw-msgs/default.nix
+++ b/distros/melodic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-dbw-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "c220e3f20ba487235ee2bd09d847bc936592ed2bcc596ffbe146d16943122035";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "83c3ee9c15967c011c8d0e8df55d630b8fdaac1ff1b7963136805521f926805f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-nav-msgs/default.nix
+++ b/distros/melodic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-nav-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "e02bad17b082c27c390410be00958fbe30e9d861af6678b0c0eec56ff317522b";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "68eb07c92aa1502639be1bd7e4212b5372d08db9269bf263addf510a6a9119c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-perception-msgs/default.nix
+++ b/distros/melodic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-perception-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "a460597ba5de6f799b64e95f158a367a4e16bc032150cb7b0627caa6ef50000a";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "91113e28b14b3c9635313969df9660cd5c8154b5839736e1540405d17b22b204";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-sensor-msgs/default.nix
+++ b/distros/melodic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-sensor-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "f67e116de61763b26fba3c3971f443cf89efa11812303b06d6c303ef688ed9e2";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "572beda2b36523772af99c1f7beb4f16a5008c7fa66fa19390b35ba77b959ad3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-status-msgs/default.nix
+++ b/distros/melodic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-status-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "56c8dd1217e86e01705211990c154d90d3a94095ff0b42439d7934673567fcd8";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "445f3a4f31c7907f32701b1061eb355fa825c54803c4d6c567e491bce5ab8fe0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-visualization-msgs/default.nix
+++ b/distros/melodic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-visualization-msgs";
-  version = "0.10.0-r2";
+  version = "0.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.10.0-2.tar.gz";
-    name = "0.10.0-2.tar.gz";
-    sha256 = "10db790551687d6618942216d11f049cf36281c3951153b98b5c4ba1ecdd87cf";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.10.0-3.tar.gz";
+    name = "0.10.0-3.tar.gz";
+    sha256 = "4335c670a2f171fd62259d7aaf3d4df23f29b4ba0c175fa5b2995c1874afbf02";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-extras/default.nix
+++ b/distros/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "c855a9645191a0a925e5cedf89703577e48f72cf910fde471dd209ea8ec387ff";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "df6744acb7307b79f609abacf2ce2009b80253783ff67c73b2d78922edd3ddd9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-msgs/default.nix
+++ b/distros/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "ed1bcc83e700ccd70eca027e6a854cf0a95533ce376c38511f0d553bf953fc26";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "fa8f9b65e70817fffbdb9a77fa2a241f681248a4f5a5ab8ac42226e2c2ffda5c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "f37bcda0fb9eff0f84adf973c917ea96492da9c14a27c835a4afbd1a4eb31a57";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "5d7f630e1313f53975d7b03f910cbc2e871ec31a8e384c229bfdb8002603f05e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mocap-optitrack/default.nix
+++ b/distros/melodic/mocap-optitrack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-melodic-mocap-optitrack";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/melodic/mocap_optitrack/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "b24b882c77e1041170f376a619acdcef1fa07239bd2f669562b873cb5f551113";
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/melodic/mocap_optitrack/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "7b2f61f2be3055952bd3d33826704a4fe6cd3e34188a98926d23fd91c23ecf07";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-moveit-chomp-optimizer-adapter";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a0fcb2f0f4ed4eef67a21d47e42e814e655693b5eec2b88ca21962dceac3a6ff";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "faefef3533dacce0068cd97b47a42726989b97ee4e5afd923ecf4e37590504c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-controller-manager-example/default.nix
+++ b/distros/melodic/moveit-controller-manager-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-controller-manager-example";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "7958ff6d3a19cac407e0011e6b1325b4e57a51d3dc31ad5802f4f2243008a652";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "29db84056386658a974326a447244b577071cdb94fda971a9e3c8c57fc1fbd8c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-core/default.nix
+++ b/distros/melodic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, catkin, code-coverage, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-core";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_core/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "cc1c034e5f09b20b275d49db1f94296d43da0cbae1550cc57bd2f1b9419061c0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_core/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "981e5af27f7decb864acda9283d0960fb48ed3c91dd0e09fa4f6b27d6dae7e5f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-fake-controller-manager/default.nix
+++ b/distros/melodic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-fake-controller-manager";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "0183830e48356e94ef0a8640708dcf0c0e17429f31ca53761f9868dc84e9a314";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "da64c249f0135875757379af24feac7ab7cbd49103936ba549228f5d932422bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-kinematics/default.nix
+++ b/distros/melodic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-kinematics";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "34d424f478f33d1fe4e2eaabf89d6fca4d8b4a6ed3ee345435766d7d281c0187";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "3720bf517ae0ea8d51065a9a5a59bebec0a1cafa658b7b3dd459ee3605a7bbe3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-chomp/default.nix
+++ b/distros/melodic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-chomp";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "eac99763520b1e90620a66afb24f24466f4ec5bec9f5c80becb16b956b6d3c94";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "2a199e44e95d12a89a7c6d3c2ae6e250281eb010cc8194d2fe86d70c879f32eb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-ompl/default.nix
+++ b/distros/melodic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-ompl";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "303245ef34706af1b803dbe2e7cd2f8523606cc1a25221ef139d4caaada14109";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5ba1e5c5541d484ec18493b555e5e099386e9128da534ab71147f824e6814491";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners/default.nix
+++ b/distros/melodic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "370b773039a5be90b9b8d97f0f6246d5fdbb76673d00ff564f563facdc80f010";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7bd95dab6f83fe637cb3b464697a703ec6b430f0cfb552a6ecf8a59d37ccdb16";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-plugins/default.nix
+++ b/distros/melodic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-melodic-moveit-plugins";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3ee18636379fb758cd402806886bf98ac39abaf23460e916fbd61c751dbacddd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "c24e33872f03d46a6fa658f754939c4578333316fb17d248d4929933c7cdbf3d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-fanuc-description/default.nix
+++ b/distros/melodic/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-fanuc-description";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_description/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "0a5d9ecb8548374826711eff22823fb86e6ca1b26e37d4f39a24874d7f541a11";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "46d8b567f40435fb3f0026564caf94f0b36403c39e1feeaf7d0a493d478420af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-fanuc-moveit-config";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_moveit_config/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "d11bce419df56d78db8a13f39aa93a31e9cec6d320b018238e3e2f0cd7eaf4e3";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "1252b8c2c843e7c35bc03ea29f72edf7595bad2a9bf9976e715e39c15549e4f4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-panda-description/default.nix
+++ b/distros/melodic/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-panda-description";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_description/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "11ab71e36ddcaa98661635dc5c4adc03de3efd20564106387d2f330a161fad93";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "ef4c4380e52b125a695d5dce52f4fb64157cc93870d1057399b67162cb6a8d1b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-panda-moveit-config/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, topic-tools, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, rviz, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-panda-moveit-config";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_moveit_config/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "baaf3eaeedb341f01100349341646c2c5ded56936e214d5ea991b0807b97fe11";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "8824461643a94e960c5ad7b85d65ceaac8fefc87b7c30cef810cadb8d7522e0b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-resources-panda-description robot-state-publisher topic-tools xacro ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-resources-panda-description robot-state-publisher rviz tf2-ros xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
@@ -22,7 +22,7 @@ buildRosPackage {
       MoveIt Resources for testing: Franka Emika Panda
     </p>
     <p>
-		A project-internal configuration for testing in MoveIt.
+      A project-internal configuration for testing in MoveIt.
     </p>'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/melodic/moveit-resources-pr2-description/default.nix
+++ b/distros/melodic/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-pr2-description";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_pr2_description/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "01a026146163de2a0f08186c0cbe623f69ddfa0c86b0a258d877a5a9d15a4bd3";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_pr2_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "2b5d4205ecfc223e35eb6a59d067e56a98ccb6329a92083a5f32e25b053f6244";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_ikfast_manipulator_plugin/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "84e7a9be6e81953ad3b003e2d4bde971bc0e4345c46dc89497c17713a193d4df";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_ikfast_manipulator_plugin/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "ddc3e93bd54ad9ca426ee618f5b2a4dc2128473a4b16c74d24003c3cfcfc4aae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, robot-state-publisher, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-moveit-config";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_moveit_config/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "cc1e2a2f1fef9e0a366b65158d0687aa47e40d4e24c50a1f19be9fd5b5c46dc1";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_moveit_config/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "6490af49b68db504222c288e8030b21812161ba60eb3523149adea6d9919386d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/melodic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-pg70-support";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_pg70_support/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e0828621bbed5c1cb24ce616f46987b8c58ae65facac5f7fa1869fc21e00e220";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_pg70_support/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "bb06b8de7ca0ab018cae56af743d0c98fc824e01dc66a73d46c8b7803f4e74e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-support/default.nix
+++ b/distros/melodic/moveit-resources-prbt-support/default.nix
@@ -2,21 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, robot-state-publisher, roscpp, roslaunch, roslint, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-support";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_support/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "9b377b7cdf7a37161b3c8700a69afa66c3fcfaf29da2d666cec1d96eb6584655";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_support/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "cc497fc0af21b41b5d729bff4a7bd455dde484fb0786be1a4d1fdfcb0547d691";
   };
 
   buildType = "catkin";
-  buildInputs = [ roslint sensor-msgs ];
-  checkInputs = [ cmake-modules code-coverage eigen joint-state-publisher moveit-core moveit-ros-planning roslaunch rostest rosunit rviz ];
-  propagatedBuildInputs = [ canopen-motor-node controller-manager joint-state-controller robot-state-publisher roscpp rosservice topic-tools xacro ];
+  propagatedBuildInputs = [ xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/moveit-resources/default.nix
+++ b/distros/melodic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources";
-  version = "0.7.3-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "80247c1d9562e45f7c10e0fb3c01074c70199e712ff6c124e6322e31ddedf52c";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "3315e9198902f386e91ac925ede9548d13a7c281fd94fdb4dac37387090f8131";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-benchmarks/default.nix
+++ b/distros/melodic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-benchmarks";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "016711331970bfa96f9ad2ded8903bf7f4aa204132fdc7c9f131ddac3aad9b9c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "25dcdd54a6348f5a0a261df9279751e146b434f03273ed91f23ff1c8abd985dc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-control-interface/default.nix
+++ b/distros/melodic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-control-interface";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b6a6980834a0f4b791affba61bef5085cd38a5147b095491c826510916f3c2e3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "1a4024f9ea02b1fd5cf44d5a85f0833b06830032872fbf22073c9dc2ebba4192";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-manipulation/default.nix
+++ b/distros/melodic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-manipulation";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a22c5fb311a3f4c7cbf787f96694d8be7b675d2203f812809a8b26aa68a63dd3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0157c9ea1954d3ba5d1bbf9a859b0fdb637a963546141d023096a7d3ae6bd71c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-move-group/default.nix
+++ b/distros/melodic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-move-group";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "7b7ca396a24858254a9624316465e22983bc067284733c8b76f4380a779710e5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "375f6b60939e178cfcb1662f24fbf801b544b000d1514408342d9d0dfa646ad9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-occupancy-map-monitor";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "bfe1be2c66a45b351a9a628168777eddeca8d53bb965f82b911381a8af786724";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5961c601be710142ced99f50bba1642fa8ba900844595fa420e4b40b61c0cc7c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-perception/default.nix
+++ b/distros/melodic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, nodelet, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-perception";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "5c123b1daa18790372aa6bd1e8d4bca2e9f41b20b107996b102fb26be56ea346";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5a695f12133d2236b180157b708dde2fab7fcf91055c49fcbc9fefd17935d61d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning-interface/default.nix
+++ b/distros/melodic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigen-conversions, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning-interface";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d7d88c1313042f5e26b2a84006562ac3bf7edef25826785c8e2b9cee2e3c6b0f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "59fe2ccc91a2170322e3ac9a5b4ff304a53df4184554fa3cc609eb5993af80af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning/default.nix
+++ b/distros/melodic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d412de1b960640e88aa4aef3984f6d8677bc39b0a253da2cc7f40965e1908038";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "174ece09b8742ff6e25c45c8bf1d7e7fb52ad754e9e6741f5201008d84d3bb23";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-robot-interaction/default.nix
+++ b/distros/melodic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-robot-interaction";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "c998bacb6a047c52e03e24ca33a08242ca52ba91334b445c5fb52a20cc857df9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "3844e5d077b61e9b33c5b2d057dccc1cb7467f0c5166f30a896caa2b32e765e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-visualization/default.nix
+++ b/distros/melodic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-visualization";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "ad4f0390abe2ea4a43ae89e48bfb2f3edccdbc41cf2c1833d83a092de329e250";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0dc4e09bd1b122d9f2c92acc86544a97d7a5935586000e631e73e458b5287d7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-warehouse/default.nix
+++ b/distros/melodic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-warehouse";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3a727144ecac700858ac6d7989233b955358331370920e2cefee4cbeb92f6058";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7b5b96895482a99edcaac8cfce2fd127e6e57faa5b0b4261584c0bafd9e80ef6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros/default.nix
+++ b/distros/melodic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "57f29faad6c72a3557566dd7a339aee288cad806c8286bb36cc3734fe212ddea";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "ca1ea1bef99d4935f08e7695242006765aacdaad470924026b555f87824b7b33";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-runtime/default.nix
+++ b/distros/melodic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-runtime";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "88450045ed7478aaae509d1237189b90ef6799361d762ff78391c345b94d71d6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "280d898404b1f1aa065e7a41f28d6ff3b06818101d2dbec884783031eaee2253";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-servo/default.nix
+++ b/distros/melodic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-servo";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_servo/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a5da870e0876a50fb776b1fbd625c085d2007a2cee0c6058ac15053ddee0134e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_servo/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "dbeedb354a5a3a109f0b9e36e2d3625fdccf9007869e76ca406a41e190eb3da4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-setup-assistant/default.nix
+++ b/distros/melodic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-setup-assistant";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "123742b7e965c2ef2b2034f5fc829c44abb3daceb40d8814653ab1465ea966f3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0e023fc13c67e92da1c0ca43807e0736a28ac54cdf977a6cf46fe3449cad67c9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-simple-controller-manager/default.nix
+++ b/distros/melodic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-simple-controller-manager";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "105033bb4956c46163c3ddf377399d79bfd09ae6e91b5232bf9cfd401c5310fa";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "a3fe131162e48d591afea7f8e54df433ed3550aa2d3b28191cf27a218f08eea8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit/default.nix
+++ b/distros/melodic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-melodic-moveit";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a449da1fbaec96a89c966239ef6db53b39092a321e939363b8d54dcf4d9deb2f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "bbc58b05b24105e311d50f9690b5f09a2f939cbfc561cd11c0a740553da88fb2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/melodic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-commander, moveit-core, moveit-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion-planner-testutils";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner_testutils/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6b8242a81b56af9c66d42f774bc4e3928b8f3a2c48b76197fb02786554d72db2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner_testutils/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "603fe2048ede53337529ef90ca92e6cb7745fd9946223dac259dc12488734264";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion-planner/default.nix
+++ b/distros/melodic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, eigen-conversions, joint-limits-interface, kdl-conversions, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion-planner";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "47b9188f8807045a24572b06db3ec336ee918eccf63a121f6fed0d7307fe9153";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "f25c57870aed98bda6bed473e6877555a9bc37fb6e911a2627d71784614fecd5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pointgrey-camera-description/default.nix
+++ b/distros/melodic/pointgrey-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-pointgrey-camera-description";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_description/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "2598eda647491180bf86ca9c4ad06da2c600237482b5c817ea0375710377f2a9";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_description/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "8947475ceebb51e8a17bcf6628f885def747bb5c30e35c713694b82d1158da88";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pointgrey-camera-driver/default.nix
+++ b/distros/melodic/pointgrey-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pointgrey-camera-driver";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_driver/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "a548c8bab220b708ada9bfb8410c7ac17137e9bc1862d294a164b9cf5d733109";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_driver/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "8430fc5a117b73fad6f2bf228d3d892879b3c1cb0b1f731ee755b116c07d09d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, fmt, geometry-msgs, message-generation, message-runtime, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, std-msgs, tinyxml-2, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.3.4-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "cb910c6f597bbbdaad4527f5588e17a7665cb7f4d97e2c862615523bd55f46dd";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "b317f1026f39a7a411c5f15d5262f1daa0968b9016f1807a452a7cb22d6550c7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-control/default.nix
+++ b/distros/melodic/ridgeback-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, urdf }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-control";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "6a4b2835003527236f6f60e87ba7ac8f168b701dd1d753bce8c96cb5bdbfd663";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "08547888015f3a2b37c26a66654b23adf741d755aad3efe47f88971422a1eb30";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-description/default.nix
+++ b/distros/melodic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-description";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1302bf1c13fdff3e763c4f7edc51b2b0e1a0eb36e45a834931d826b20eea6937";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "c8ebf4371f0ccd63db91fee284f6cf4aab99fe6e28bcbdbf8fbdbf2162dccdb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-desktop/default.nix
+++ b/distros/melodic/ridgeback-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ridgeback-msgs, ridgeback-viz }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-desktop";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_desktop/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "5c7eeeaf0246b33c3f906ea00a4a525686eade472f858b50e81cf0cfcb111b5f";
+    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_desktop/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "373a75ac21b797cac2276f52e99c391d9da32553373cf4f407ab8fc4bfc940fd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-msgs/default.nix
+++ b/distros/melodic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "08adb29db070e70fcee3c3821b6e6f96f384af7a9611074fd3417cb5e107d696";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "25bbaf64c4391f1d7cb16fc8217f9d47fe35895e62b1cab3128a2d77ebb629e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-navigation/default.nix
+++ b/distros/melodic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-navigation";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "0516173ca1c373695c5d9eecfc9e97ee99e26eff1f8e5d9587e2edcf486dcdf1";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "5b58af5e4a32ffe7cc45b55abf896c410c23e508ea81eb45d05e79738ece2752";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-viz/default.nix
+++ b/distros/melodic/ridgeback-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, ridgeback-description, roslaunch, rviz }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, ridgeback-description, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-viz";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_viz/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "bbeb69b326c060ceb4aca963b3e28511c57803b188f2b33c0836fb0dca66db07";
+    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_viz/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "475858d5eeeb3bfd11319044e2768307aba08fcb411925b754b89831dd3710db";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui ridgeback-description rviz ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui ridgeback-description rqt-console rqt-gui rqt-robot-monitor rviz ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rslidar-sdk/default.nix
+++ b/distros/melodic/rslidar-sdk/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libpcap, libyamlcpp, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rslidar-sdk";
+  version = "1.3.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rslidar_sdk-release/archive/release/melodic/rslidar_sdk/1.3.0-3.tar.gz";
+    name = "1.3.0-3.tar.gz";
+    sha256 = "d8cd9cad1a9edfcc06d0c7ec8d02456f466eb384cd422d789833057f50d958ca";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ libpcap libyamlcpp pcl pcl-conversions pcl-ros roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rslidar_sdk package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/statistics-msgs/default.nix
+++ b/distros/melodic/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-statistics-msgs";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/statistics_msgs/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "db97291f1aa312ba3d199b22c2b70e0c1309200445779cf7c74f8d812a117057";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/statistics_msgs/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "eca1d76ca10b012c1a9590ebb55996bd73ad8223246637f2603b83350db0add7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/test-mavros/default.nix
+++ b/distros/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "1.12.2-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.12.2-1.tar.gz";
-    name = "1.12.2-1.tar.gz";
-    sha256 = "f8955f8860c355ad00bc3a9b3918ec3f9ba698ca3bd663a0b5b6987fc894fdad";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "c4f37688b5e0a127ed0168a370a67ae7b12a48c4d9c5f235ead02a36624da98e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tork-moveit-tutorial/default.nix
+++ b/distros/melodic/tork-moveit-tutorial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, moveit-commander, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, moveit-simple-controller-manager }:
+buildRosPackage {
+  pname = "ros-melodic-tork-moveit-tutorial";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/tork_moveit_tutorial-release/archive/release/melodic/tork_moveit_tutorial/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b559d39011e7c16f709e376dc1892eb9d2bfc489388218ce37d77eadfce596d3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros moveit-commander moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface moveit-ros-visualization moveit-simple-controller-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The tork_moveit_tutorial package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/warthog-control/default.nix
+++ b/distros/melodic/warthog-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-warthog-control";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_control/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "e15ff240c247e0733b5f319f25e7847d83c99d7807143b26261c1bc3a1af69fc";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_control/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "57f23805ee7fe02e49a667344fc9d83c9da862f0d5ca656cfe07aa2499a9fb2e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-description/default.nix
+++ b/distros/melodic/warthog-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-warthog-description";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_description/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "980542ca1871b6455b04b5b65038126f5c8441a9415fe2432852f8391b96b3df";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_description/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "4c6b2233e81e8a3fd83af6f9cf2815dcfff21edaa579a2ce39ad5c1aa3f1d473";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-desktop/default.nix
+++ b/distros/melodic/warthog-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, warthog-msgs, warthog-viz }:
 buildRosPackage {
   pname = "ros-melodic-warthog-desktop";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog_desktop-release/archive/release/melodic/warthog_desktop/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "dd9cb05569510461e865eb51fb6dda99cdf8a2a4a9536d67804ba94575100b6a";
+    url = "https://github.com/clearpath-gbp/warthog_desktop-release/archive/release/melodic/warthog_desktop/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "67791be4dee0cd2f12e04c840c20146a589fb2bf3dcc009f6376ea2899062807";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-gazebo/default.nix
+++ b/distros/melodic/warthog-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, joint-state-publisher, roscpp, roslaunch, warthog-control, warthog-description }:
 buildRosPackage {
   pname = "ros-melodic-warthog-gazebo";
-  version = "0.2.1-r1";
+  version = "0.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog_simulator-release/archive/release/melodic/warthog_gazebo/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "31abcb4928145948bffd645a6f87394cd1868586d0ad00df4dafa09ba01790f5";
+    url = "https://github.com/clearpath-gbp/warthog_simulator-release/archive/release/melodic/warthog_gazebo/0.2.2-2.tar.gz";
+    name = "0.2.2-2.tar.gz";
+    sha256 = "8440194957dc342739f264bfc6c722aade6e49bcadc6d2e64506b2378e9bab59";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-msgs/default.nix
+++ b/distros/melodic/warthog-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-warthog-msgs";
-  version = "0.1.4-r2";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_msgs/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "3df0ba916742d200c6f69b1abd42bf3d5f258783b25df029bb6aba3a41b7f76f";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "625e326f76ef82103595d8a059df3413afc9d829eca8c4a434655b2b5407ccba";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-simulator/default.nix
+++ b/distros/melodic/warthog-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, warthog-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-warthog-simulator";
-  version = "0.2.1-r1";
+  version = "0.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog_simulator-release/archive/release/melodic/warthog_simulator/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "74906c172ae52e51327685dd41f026da754359b26db911a68c7ddfe9fe79f096";
+    url = "https://github.com/clearpath-gbp/warthog_simulator-release/archive/release/melodic/warthog_simulator/0.2.2-2.tar.gz";
+    name = "0.2.2-2.tar.gz";
+    sha256 = "be0d98e29d052f06df7da430fa0363812a499e4ac58cd1d47ba30f960c487f26";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-viz/default.nix
+++ b/distros/melodic/warthog-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, roslaunch, rviz, warthog-description }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz, warthog-description }:
 buildRosPackage {
   pname = "ros-melodic-warthog-viz";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog_desktop-release/archive/release/melodic/warthog_viz/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "2f960a1ab14f68a3c7fa56d4f343176d4f1499372203c6114657d90610d8df76";
+    url = "https://github.com/clearpath-gbp/warthog_desktop-release/archive/release/melodic/warthog_viz/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "0b8051c8bb18f3e0bbfcaaa6a3659dd27644f40512e07a0a9b8dcc41af1d477c";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui rviz warthog-description ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui rqt-console rqt-gui rqt-robot-monitor rviz warthog-description ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/webots-ros/default.nix
+++ b/distros/melodic/webots-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, moveit-simple-controller-manager, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-webots-ros";
-  version = "4.1.0-r1";
+  version = "5.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "4c1930c9dfedcadd5d279e06072d97e04e61dea98e6dc49122923aa41d5b726e";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "eba56b3a93053246bbce5f7269abb99da3ee8d1ef5cce05a83f17651d7b66d89";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface moveit-simple-controller-manager robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/wfov-camera-msgs/default.nix
+++ b/distros/melodic/wfov-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-wfov-camera-msgs";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/wfov_camera_msgs/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "c9b9f265c88ee3687366617abbb64324044753b3ba24b8967123014a7fb51fbc";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/wfov_camera_msgs/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "6082f10c40e6051afe2fd9e75d062bc0246e99d57d607959a016d95e9a0ad22c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.14-r1";
+  version = "1.13.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.14-1.tar.gz";
-    name = "1.13.14-1.tar.gz";
-    sha256 = "73b5aa3e0251b99b527e9bc8e2f8e298a29f50fe738b106ab0be40641c37700b";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.15-1.tar.gz";
+    name = "1.13.15-1.tar.gz";
+    sha256 = "0f01804df71628567ea2ff5bbec1adeba929552ab70a6e2a09d4a1c6086825b1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-controller-utils/default.nix
+++ b/distros/noetic/cob-base-controller-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, rospy, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-controller-utils";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "45d510270624b502ffd1da0fec23b034a82f383dd832790bf63c9e6fa3e5dd62";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "4fed5d1ba62fd94417d584f6b7bc4736c1760c0fa55a9573dfffbfc5cb0289ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-drive-chain/default.nix
+++ b/distros/noetic/cob-base-drive-chain/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-canopen-motor, cob-generic-can, cob-utilities, control-msgs, diagnostic-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-drive-chain";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "0e9f4a3ea5ed98f8a874a8a13323c894db17bfd25242ebe1e73d240743bbb4a4";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "5806117f4b96918ec385aa93a5e0b132c3d48772b1538d9acf94ec6c15cb11dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-velocity-smoother/default.nix
+++ b/distros/noetic/cob-base-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-velocity-smoother";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "0cab55a9bef54519eb9f0c4924ddcdeac848719b65864a0b11a4fdb3aed8e0c9";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "090f77dbfe0fabe55b0224f8ee05b64d3867876de29a2c5e82dda9afe8856458";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bms-driver/default.nix
+++ b/distros/noetic/cob-bms-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, python3Packages, roscpp, rospy, socketcan-interface, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-bms-driver";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "3719634d01727691f348f70915270d74df8b36de04aa0fb57badbc66ebbda67b";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "bf064a4a8de97141d4004ed9ca9e7493fe04f9a04140e608d2a29e1cec42b874";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-canopen-motor/default.nix
+++ b/distros/noetic/cob-canopen-motor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-generic-can, cob-utilities, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-canopen-motor";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "aabb0927831577e7e656b8eae07270a0bbfdbad60ec6cf1d63bfe2f58dbe509e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "741aa4bdf1f8a6362691ef06a77422f3cc7b327385bec855879ad6800388da4b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cartesian-controller/default.nix
+++ b/distros/noetic/cob-cartesian-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-frame-tracker, cob-script-server, cob-srvs, cob-twist-controller, geometry-msgs, message-generation, message-runtime, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, std-msgs, std-srvs, tf, topic-tools, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-cartesian-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "d18a2393f680bcd88e1e4780fd23b83787b2e57643d2163a6079ecc2839110e9";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "7150569910dba69499a9bbf1d20c951ef086bf122b4367c876c67fb1bcb3f4c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-velocity-filter/default.nix
+++ b/distros/noetic/cob-collision-velocity-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-footprint-observer, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, tf, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-velocity-filter";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "27ddbfd75c50958905b50bb868d13e29b5e6525d2dab38ac578075f36e2d4cc2";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "45891e4921ef07e04c77b650656477b19250989f6df640eff9909a3571ca4d53";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-gui/default.nix
+++ b/distros/noetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, python3Packages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-gui";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "835b398812cec0ba4730215d6ae4b1074357d074a345d50cbfd26e03c630ded5";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "5d980bb9e7d9705a200d8fd8776fdcc5b11a7155163f41e70e5854d495d01fdc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-tools/default.nix
+++ b/distros/noetic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "16474006db239a700177721b727ee81cc896cc209bf1d7d988aa25e2dcd30261";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "22088b799e92e43e54a25eeebc0cb200b1a8b549e2a3ee7b58cbe8629ed26652";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-mode-adapter/default.nix
+++ b/distros/noetic/cob-control-mode-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-manager-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-mode-adapter";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "73347837d941f7aaa1a096444e1ffeb7b13cf06c0335e7adb11c4b3e81e6ccc9";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "0b178541cf7d1bb1e7e3e95e525bce64aab6b4044f449baf906782ad810a75da";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-msgs/default.nix
+++ b/distros/noetic/cob-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-msgs";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "613c842b853d1938ab3ee14e0c29aebaa74c7492be624dd4e68c61738c538be4";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "a057d496c0a50eb5d4e126fd2aa3dadd1a556a57acb49020492b3f2dd24916ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control/default.nix
+++ b/distros/noetic/cob-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-controller-utils, cob-base-velocity-smoother, cob-cartesian-controller, cob-collision-velocity-filter, cob-control-mode-adapter, cob-control-msgs, cob-footprint-observer, cob-frame-tracker, cob-hardware-emulation, cob-mecanum-controller, cob-model-identifier, cob-obstacle-distance, cob-omni-drive-controller, cob-trajectory-controller, cob-tricycle-controller, cob-twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-control";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "7f95b414bd49122a446a2188d4ab34c13bd9756061bea038249b893c51a6ffab";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "d10c9de7c124617266c9de4b66fb2b6d66b7b40dc0bda18843e706e6e95c4beb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-dashboard/default.nix
+++ b/distros/noetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-noetic-cob-dashboard";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "78d1e617a3310b40b8b8e01d766443ea8878db6530f5d0a829361bcedc1bd656";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "ca2f1295f3daec7542e5c98229c0e5372ebab29e75c7aa0439e641bd384fa544";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-driver/default.nix
+++ b/distros/noetic/cob-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-drive-chain, cob-bms-driver, cob-canopen-motor, cob-elmo-homing, cob-generic-can, cob-light, cob-mimic, cob-phidgets, cob-relayboard, cob-scan-unifier, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-undercarriage-ctrl, cob-utilities, cob-voltage-control }:
 buildRosPackage {
   pname = "ros-noetic-cob-driver";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1f26c9285e6acc058bd0c5caccd59d85ca5fe6bb987591468e56546b645ebbb7";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "b75854778d49027b164eea5dcbebc2053d6e1f8bc7db60a2a0dfbd411dc7cc86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-elmo-homing/default.nix
+++ b/distros/noetic/cob-elmo-homing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-402, catkin, pluginlib, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-elmo-homing";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "4ff0f198fe3d5796d775b0eb0ae9a2c71e0dba1bc220cd168609613f37ad8f3e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "5d249b73bd8307623db3e0eab9915d66c61267695deb5e58023fcfa7e29592dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-footprint-observer/default.nix
+++ b/distros/noetic/cob-footprint-observer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-footprint-observer";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "aed27dede5d69c7090ac3e88256873183615ce11971c8b543423d832ae4e1022";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "16fe875891cf2a6b7ec49182cb2356a2736ce74aa9a05973d075cc92d26dd149";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-frame-tracker/default.nix
+++ b/distros/noetic/cob-frame-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-srvs, control-toolbox, dynamic-reconfigure, geometry-msgs, interactive-markers, kdl-conversions, kdl-parser, message-generation, message-runtime, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-frame-tracker";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "f9598f941381418f3a06549b22daf9c14948efa4b72def3a7f9434406c06baa3";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "b012cf74c31c3a651a60a63450a20f530071ce0ff67bd1f1f0be3113a708c875";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-generic-can/default.nix
+++ b/distros/noetic/cob-generic-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-utilities, libntcan, libpcan, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-generic-can";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "d054777f22235d44ae04c88bb5984d66765d4a163853883ce14cc8e41c5297a7";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "287ee2ad6ea34e04f1191ac4ee4199ad3baa7696fcdf92d198bd8179ab83a563";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-emulation/default.nix
+++ b/distros/noetic/cob-hardware-emulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, move-base-msgs, nav-msgs, roscpp, rosgraph-msgs, rospy, sensor-msgs, std-srvs, tf-conversions, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-emulation";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "e670e477879bbab4c18172e8ef9fcfd4a504bbf67bd076e47565f44e2fe403fa";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "7234af66f2491c9e7f360af91f62995e1157390def16f627f3fc8e86cd3a1d74";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-helper-tools/default.nix
+++ b/distros/noetic/cob-helper-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, rospy, std-srvs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, python3Packages, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-helper-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "f105735bc2968ab7996b7f1d7b44c48708c846a2319f3d9c247f76bd2b134925";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "f9b47ea1e5a6bca981b436d18d6c65fad5d8eb71d4e3eafc1c4ba1f841ee08ad";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   propagatedBuildInputs = [ cob-msgs cob-script-server diagnostic-msgs dynamic-reconfigure message-runtime rospy std-srvs tf visualization-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''Helper scripts for Care-O-bot'';

--- a/distros/noetic/cob-interactive-teleop/default.nix
+++ b/distros/noetic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-interactive-teleop";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "f19dcf3e8b33b8f9cc6e349143b0e245ff0b4114ea7f7ef7fd5357397f158466";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "ab80181672935319300567b9d5552860ce4dee4f2fbcd9a5b1b38c79ef769435";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-light/default.nix
+++ b/distros/noetic/cob-light/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-light";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "c4b705eae5a66df0b9d1201d4ad7e8415d1c9a6ce6f41f87c5b45ab728ffa5f3";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "cf60a5f96f24dc320be1f1ceeeec15d70c980f9c89e1df2517a3a2aa477628c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mecanum-controller/default.nix
+++ b/distros/noetic/cob-mecanum-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-mecanum-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "c45c27e24a916fea170e770bccae2b94c53ce142f007905dda0de46dec951a33";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "ee1df045e8e3772d7958a2ef09c253989a857427a91e7f335587ecc15ff6d3b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mimic/default.nix
+++ b/distros/noetic/cob-mimic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, diagnostic-updater, message-generation, message-runtime, roscpp, roslib, rospy, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-mimic";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "48ec5b45f15735c5ba5290c0f1966eeadc0099240bd3d31597cd2ed5e8982035";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "c83ed33cd238190508db5dd407782d03d637ff0d1d1794e938d01409563c0327";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-model-identifier/default.nix
+++ b/distros/noetic/cob-model-identifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, geometry-msgs, kdl-parser, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-model-identifier";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "66377800a1fcdc5c2c106ea5269d07098fc1887d7d2c241649946c1cfa19904e";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "fa9ac2dbc5ce0579e9b23289e1a3d315ab1a5a6fa3139df8a2e1801f4d404fb1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-monitoring/default.nix
+++ b/distros/noetic/cob-monitoring/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, python3Packages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-monitoring";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "f281d69403f8c7758a5e9520b3719f10c78293c04f78d7d331849f7617254194";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "916ec5d5c53e4b34e52a2980483caa5b873d686fc750c450fb221bb0a64ed2ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-obstacle-distance/default.nix
+++ b/distros/noetic/cob-obstacle-distance/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cob-control-msgs, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, fcl, geometry-msgs, interactive-markers, joint-state-publisher, kdl-conversions, kdl-parser, moveit-msgs, orocos-kdl, pkg-config, robot-state-publisher, roscpp, roslib, roslint, rospy, rviz, sensor-msgs, shape-msgs, std-msgs, tf, tf-conversions, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-obstacle-distance";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "7de7dc257ac1d212f5e784c0cdf4c02909bffe20c576532365619b5e681cdcdf";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "61d001ed2bdf818bc02d3db5ab62284cde5517b760509212d15ad18ae5c248c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-omni-drive-controller/default.nix
+++ b/distros/noetic/cob-omni-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-omni-drive-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "07c2f40bdd4e6d416f3ce2961f58a543ae75dd6b1a7653e57f3f8f65e5ffc36c";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "010674b5961b5ee0f348697227aa134c78e804370d3b014446e2015feeb48d93";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-em-state/default.nix
+++ b/distros/noetic/cob-phidget-em-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-em-state";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "d8a13bfe6aa3177234821b666bb9a5500cc8c30fcc04354ae936c4b38877f003";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "43929941ca3ccc40f2e2502d427b6db6e1aba8007097560e302686939e555da3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-power-state/default.nix
+++ b/distros/noetic/cob-phidget-power-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-power-state";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "b5aec0aa496a61038ec1a1dd6dfc79ca51a69aaa32ad56a4318cdb45ae976a49";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "92aa231fcda9d7af8d5b80759511ae7fc27102245ff35c400c531682ad1123f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidgets/default.nix
+++ b/distros/noetic/cob-phidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidgets, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidgets";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "f3dd2a50ffd7481e8ef22830be9f39584878024c25e4c2642a3b1130fb965102";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "0c7c881c1bf1fad1e97d015e2c70b1b8104ada7cbe317ef820b4faacab5f4704";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-relayboard/default.nix
+++ b/distros/noetic/cob-relayboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-relayboard";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "dfdd13ad2378cd8b4a3c1d6e8b43707c55486b4d96859f8a15782c7f8469a3c9";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "d12290c155c91e08399222638cd2a48b6cd9db4d8f00b9ca9245b523f2f8348d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-scan-unifier/default.nix
+++ b/distros/noetic/cob-scan-unifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-scan-unifier";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "edab7dd3c37f5f5f5eb183c0645c74d2adbe40051bda247ca2ba9ca599853079";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "e3ef09b3f86a4ba7afa8fdc962e38b426a5762a5cf8c1b18d763517f598dc51b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-script-server/default.nix
+++ b/distros/noetic/cob-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-noetic-cob-script-server";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "d80fb0dbac43264c414b0c8abf001a41070d573c1e5027c4bb73b281b6018e47";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "2fc5cf7263849b9624b997c80c203cd543125b502881e7089bb32af22105e0a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-lms1xx/default.nix
+++ b/distros/noetic/cob-sick-lms1xx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-lms1xx";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1ab28c10ccae9847b44a39709c4863b8ad2af3a3e34a0bb832d648fe6e9862d1";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "62351b707f222f4fbff516f877b71941f4ba19f0516b8de6aa47e7b5fb3478c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-s300/default.nix
+++ b/distros/noetic/cob-sick-s300/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-s300";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "66e91af7e7af9e3e58d031818b21f9ad2982adcfe9398a141aeadec481fd506f";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "3c56e17d4fcf9473d045ae51263f012391ba4dcf5dfc481f848a582b7644bd36";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sound/default.nix
+++ b/distros/noetic/cob-sound/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsaOss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-sound";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "347d6370c02fe9aefd81af4dc51869b372b699ebd0f7c02087a26eb7c5b788cc";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "78d69a1845d520b06393f6c3618c8bf0d607664c4e7e79ae2aa7311adb827795";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-teleop/default.nix
+++ b/distros/noetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-teleop";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "8f6b31d68ee90bb0564bc7ec499a8ef2c264cfddc3be215224c1c5eaa2bdd3db";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "60fc73bf5cb39dcc5be8b5c3990ee85c0eb176953bada1c1eaf753aae789a38d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-trajectory-controller/default.nix
+++ b/distros/noetic/cob-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-srvs, control-msgs, dynamic-reconfigure, roscpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-trajectory-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "fa2a6fd07b027ece5b8658aec077cf30955745f1eb6736cbbb24086f86dcbc86";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "68824e4698488025b31c1957ad9f86d5c23ec5e143d0b63703f73c029ce68215";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-tricycle-controller/default.nix
+++ b/distros/noetic/cob-tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-tricycle-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "73a6f904572a4c299d2bb73b01cacfa95d332dac1a8133d6f240ce71d564948f";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "d3c6c791150dff4d2e4c2e4be618501719e4bc09af869ba5dbe226adac7a5555";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-twist-controller/default.nix
+++ b/distros/noetic/cob-twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-script-server, cob-srvs, control-msgs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-twist-controller";
-  version = "0.8.17-r1";
+  version = "0.8.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.17-1.tar.gz";
-    name = "0.8.17-1.tar.gz";
-    sha256 = "beb992cf7462b74803734d2365d4ef97ff1434eb5f4aa49bf19abac675050312";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.18-1.tar.gz";
+    name = "0.8.18-1.tar.gz";
+    sha256 = "2297c4169f1fc82ee55f57d67ba550036c413bcac51e0611f905e30fd59deb62";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-undercarriage-ctrl/default.nix
+++ b/distros/noetic/cob-undercarriage-ctrl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-utilities, control-msgs, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-undercarriage-ctrl";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "7e9387cf4b829a20e68255c47538144219e8957629d73525537e52194e7f96c6";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "cef4adf5af65254263fa63c09366d041a597b2d1f0b2b3746a43dce964f1300d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-utilities/default.nix
+++ b/distros/noetic/cob-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-utilities";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "73630b8c83a6d087e134988a56d8e15314b57ea566c498d50df305d8e725a26e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "54afd36df1e32578c35b7eb559c05622a2d126697540c499d242960783c9df6d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-voltage-control/default.nix
+++ b/distros/noetic/cob-voltage-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, dynamic-reconfigure, python3Packages, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-voltage-control";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "526943b83e615389a2c6631612aba0607a724a40b988c1c17ac4735b38b2da51";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "f0097a60b2c6676a8a5b1fd8c77007002c5a331224b6fdddd8e6ba9d002ec21c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-control/default.nix
+++ b/distros/noetic/dingo-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-control";
+  version = "0.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_control/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "ae91661023806bc792e86d488f8ddd8c00d55006d1852e4db9984f998052e01b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller interactive-marker-twist-server joint-state-controller joy ridgeback-control robot-localization teleop-twist-joy topic-tools twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Controllers for Dingo'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dingo-description/default.nix
+++ b/distros/noetic/dingo-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, velodyne-description, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-description";
+  version = "0.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_description/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "eb637f155b3fa298f51b222a45fc004cdab9aaeb07b1dd7fdac189f661c7526f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lms1xx realsense2-description robot-state-publisher urdf velodyne-description xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The dingo_description package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dingo-msgs/default.nix
+++ b/distros/noetic/dingo-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-msgs";
+  version = "0.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_msgs/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "77207a4237d66a8d28664153ca26a5156a20806fcd751a9a6ed08567faa1fd6a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages exclusive to Dingo, especially for representing low-level motor commands and sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dingo-navigation/default.nix
+++ b/distros/noetic/dingo-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-navigation";
+  version = "0.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_navigation/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "dd6a1b2bc08b2ddf50c9f17c1d45e7cd5728efc65962315aaa0f54aa24f6957d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ amcl gmapping map-server move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files and code for autonomous navigation of the Dingo'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -542,6 +542,14 @@ self: super: {
 
  dijkstra-mesh-planner = self.callPackage ./dijkstra-mesh-planner {};
 
+ dingo-control = self.callPackage ./dingo-control {};
+
+ dingo-description = self.callPackage ./dingo-description {};
+
+ dingo-msgs = self.callPackage ./dingo-msgs {};
+
+ dingo-navigation = self.callPackage ./dingo-navigation {};
+
  dlux-global-planner = self.callPackage ./dlux-global-planner {};
 
  dlux-plugins = self.callPackage ./dlux-plugins {};
@@ -1184,6 +1192,8 @@ self: super: {
 
  ipa-differential-docking = self.callPackage ./ipa-differential-docking {};
 
+ ipcamera-driver = self.callPackage ./ipcamera-driver {};
+
  ira-laser-tools = self.callPackage ./ira-laser-tools {};
 
  iris-lama = self.callPackage ./iris-lama {};
@@ -1269,8 +1279,6 @@ self: super: {
  jsk-roseus = self.callPackage ./jsk-roseus {};
 
  jsk-rqt-plugins = self.callPackage ./jsk-rqt-plugins {};
-
- jsk-rviz-plugins = self.callPackage ./jsk-rviz-plugins {};
 
  jsk-tilt-laser = self.callPackage ./jsk-tilt-laser {};
 
@@ -1407,6 +1415,8 @@ self: super: {
  libphidget22 = self.callPackage ./libphidget22 {};
 
  libphidgets = self.callPackage ./libphidgets {};
+
+ libpointmatcher = self.callPackage ./libpointmatcher {};
 
  librealsense2 = self.callPackage ./librealsense2 {};
 
@@ -2224,6 +2234,14 @@ self: super: {
 
  rgbd-launch = self.callPackage ./rgbd-launch {};
 
+ ridgeback-control = self.callPackage ./ridgeback-control {};
+
+ ridgeback-description = self.callPackage ./ridgeback-description {};
+
+ ridgeback-msgs = self.callPackage ./ridgeback-msgs {};
+
+ ridgeback-navigation = self.callPackage ./ridgeback-navigation {};
+
  rm-calibration-controllers = self.callPackage ./rm-calibration-controllers {};
 
  rm-chassis-controllers = self.callPackage ./rm-chassis-controllers {};
@@ -2605,6 +2623,8 @@ self: super: {
  rqt-topic = self.callPackage ./rqt-topic {};
 
  rqt-web = self.callPackage ./rqt-web {};
+
+ rslidar-sdk = self.callPackage ./rslidar-sdk {};
 
  rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
 

--- a/distros/noetic/generic-throttle/default.nix
+++ b/distros/noetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, python3Packages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-generic-throttle";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "2e31dffcbdfd53c3e00c92a1e6cbce55694458c38d5ced9c3512fd3d1890f713";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "97ef0975e870870524ee365abfb050edc20e53c9b6b2e2f9b1755f1925274bf2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-exposure-msgs/default.nix
+++ b/distros/noetic/image-exposure-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-exposure-msgs";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/image_exposure_msgs/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "2b9a6a7f16a46e84d8daa950430e3b3cdbe23ab5399ab6dde4161e3509fb705a";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/image_exposure_msgs/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "405ecd3bffa5c8de1417d2e287cc1eea655c443e0e1e339a246e5dc59868cb84";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ipcamera-driver/default.nix
+++ b/distros/noetic/ipcamera-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ipcamera-driver";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/alireza-hosseini/ipcamera_driver-release/archive/release/noetic/ipcamera_driver/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "a1b25abd5b024972c806f46fa24f8abad5f3ec0e072baa282277ef354fb9fb57";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ camera-info-manager cv-bridge dynamic-reconfigure image-transport roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple node to publish regular IP camera video streams to a ros topic.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/jsk-interactive-marker/default.nix
+++ b/distros/noetic/jsk-interactive-marker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-interactive-marker";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_marker/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "d5ed235944b01bbd69328c8e4bb7c40c4fedcadfa660c1af7a08a9539a833c7f";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_marker/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "9e07b602208265e5bb46357a019f215995e3f3ebe2adb30a6ecf2223d494f4cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-interactive-test/default.nix
+++ b/distros/noetic/jsk-interactive-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, mk, rosbuild, rospy, rviz, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-interactive-test";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_test/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "8a1abd37b377327aeb95660866c9d20a4c8466a18e01731be505a38fd68c8ea5";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_test/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "72224913f0e66eff0379ca04eaf852bef3e281dd97ebd43eaa5a3c1e18d8b46a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-interactive/default.nix
+++ b/distros/noetic/jsk-interactive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-tf-publisher, geometry-msgs, jsk-interactive-marker, mk, rosbuild, rospy, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-interactive";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "5b4aa542dace05afe868182a2bb272d3c3fe5e9abb47f332f9283c4838fc5e70";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "ade9c8c7968de594d1f5ca67d8bda9adb2570635b1f35141004f5dabbe0a6eff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-rqt-plugins/default.nix
+++ b/distros/noetic/jsk-rqt-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-publisher, image-view2, jsk-gui-msgs, message-generation, message-runtime, mk, python3Packages, qt-gui-py-common, resource-retriever, rosbuild, roslaunch, rostest, rqt-gui, rqt-gui-py, rqt-image-view, rqt-plot }:
 buildRosPackage {
   pname = "ros-noetic-jsk-rqt-plugins";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_rqt_plugins/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "527e86d54828430373f1b10433e964cf60589972c532d04c35bbad93391923d8";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_rqt_plugins/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "1018fa78ab28b6366e768e7e368e4566dcf910079c9704119fda55433b414a25";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-visualization/default.nix
+++ b/distros/noetic/jsk-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, jsk-interactive-test, jsk-rqt-plugins, jsk-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-jsk-visualization";
-  version = "2.1.7-r4";
+  version = "2.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_visualization/2.1.7-4.tar.gz";
-    name = "2.1.7-4.tar.gz";
-    sha256 = "4e37a0bf2e6e2082fc282223e08aecce116746a9d22ec457c067bbe8eda518ea";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_visualization/2.1.8-1.tar.gz";
+    name = "2.1.8-1.tar.gz";
+    sha256 = "a6822f98ef9339b56265c4fbf861f3b0d2bbd8d342a3f8c97180c2d72e8e50d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-scan-densifier/default.nix
+++ b/distros/noetic/laser-scan-densifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-scan-densifier";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "9b17c6a3112f9d1b85e0794ee775d583f54ba37715ec781fabbf6dab8f72bafe";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "a60a3e21ad41b4db8204cef4d0d4622f5d1aca8b1f3a55e279fec391ebfd4bda";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-bringup/default.nix
+++ b/distros/noetic/leo-bringup/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-bringup";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e0833867cf5bd60ad339a6df5eafbdfba0b340e739ad722291eebd2695ae0f7f";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "b6688572cd6e6d6f077c2600a3d9ef4ad551fdcfd9f3488132575a8e34fd7193";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs leo-description leo-fw robot-state-publisher rosbridge-server rosserial-python sensor-msgs web-video-server xacro ];
+  propagatedBuildInputs = [ geometry-msgs leo-description leo-fw robot-state-publisher rosapi rosbridge-server rosserial-python sensor-msgs web-video-server xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-msgs, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-leo-fw";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "b437d8aca0b68e315a4a2045ea2bad21de0f8baf00b91c206aea6d9c011a4f4b";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "e2b093da980a6f30d82cd4fe98fe3ed3615ec759f0ed6070c352bea85788f250";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-robot/default.nix
+++ b/distros/noetic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-noetic-leo-robot";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "b977f2723ef59327c1011888bda7e06c4e0c01750bfd588d02423604a71e1b71";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "648a0d7d096a61441577f3d24de3e51ae11457e50bba14ae087cfed8cdb6c87c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "52ba3dbdd2ec3b3bbf2cd62c451e6b5a98c287d842b849d3a5d754ec4162d7d0";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "2f4d67ee552dad48d28ef2a8f30737b6da891ccb308c395da628a5a78e81e34f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libpointmatcher/default.nix
+++ b/distros/noetic/libpointmatcher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, eigen, libnabo }:
+buildRosPackage {
+  pname = "ros-noetic-libpointmatcher";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/libpointmatcher-release/archive/release/noetic/libpointmatcher/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "858e42e3cbc55c43c5dae2166c9f40a6577af8fa1b0c1b03336ba8029ad99a78";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin eigen libnabo ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''libpointmatcher is a modular ICP library, useful for robotics and computer vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "99bc6a399f06787ab626008f249250fb0fc6387076330557acc80ea8e63d1801";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "fc0e550a819a55a464625952136b1d791d0394913202e44b7df59b330478ed9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "38adc5eab151d7d2c106ec9fefaabccdb6936e5ab69d25f0577d8531265f83b5";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "377d813d92ef335f80307d2758fafbf9b28f6a8bca13db24b546d498d313570f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "e36619b060668b21aeeacaf189dcdc2ea2406329540a24766e92046041748a32";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "939cb968911b8f8859dd36437d7da36d75ef46085d9731e21fe5bd5407e529a5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mocap-optitrack/default.nix
+++ b/distros/noetic/mocap-optitrack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-mocap-optitrack";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/noetic/mocap_optitrack/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "f716b1b8ee1eb54407d3105c99823da87bb1a8dacc9ee18069e21e0e60084ea7";
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/noetic/mocap_optitrack/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "da97430ade87f439925a50f94cf6b2e2df0617396fb058c8d732c0b2dee8eab0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pointgrey-camera-description/default.nix
+++ b/distros/noetic/pointgrey-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-pointgrey-camera-description";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_description/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "0d0bd0da10b7a6f888abbac3b5f79360df4b6dac1949ace934a684f760ff1e0b";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_description/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "021f4da2c001e95309e83fa90edad0200b51fd80df3d886ca573760e8e9c5111";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pointgrey-camera-driver/default.nix
+++ b/distros/noetic/pointgrey-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pointgrey-camera-driver";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_driver/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "70339f114659294dcdcb58bd3e8db2a80eac8a1f537dc84693a94e54a672ae27";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_driver/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "5af5603bb72ac4da3259ca169526f83b47ac2d62f5ae2755983696bf1ade1a81";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-control/default.nix
+++ b/distros/noetic/ridgeback-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-ridgeback-control";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_control/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "0332e62492bba9f6db8b7fa9b17800917d9cc147939a3af1a56d3d575c0cee99";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-interface controller-manager interactive-marker-twist-server joint-state-controller joy nav-msgs realtime-tools robot-localization teleop-twist-joy tf topic-tools urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Controllers for Ridgeback'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ridgeback-description/default.nix
+++ b/distros/noetic/ridgeback-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-ridgeback-description";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_description/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "9eb55c5e1e4795b357cab278cfe06e6f50d291deb60e0743a4fe5eb80f0b0c4e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ lms1xx robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF robot description for Ridgeback'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ridgeback-msgs/default.nix
+++ b/distros/noetic/ridgeback-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ridgeback-msgs";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "84cd40f1bb1832e3b4a13409873904ea749c6743b30aac8aeabcec818d658ff1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages exclusive to Ridgeback, especially for representing low-level motor commands and sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ridgeback-navigation/default.nix
+++ b/distros/noetic/ridgeback-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-ridgeback-navigation";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_navigation/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "54aac94db8046adba7fd59dad20125a637eca2dacc3604b379ceb20a49238b95";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ amcl gmapping map-server move-base urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files and code for autonomous navigation of the Ridgeback'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-calibration-controllers/default.nix
+++ b/distros/noetic/rm-calibration-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, effort-controllers, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-calibration-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "5385f5e78f42855c490adf9d0fb9e34f50a6ba91a6bee48814cc622b1f5d702e";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "3ea9c13800fbc56e1856520da5b0254151ea1a85ffe1b97aef7f3e87e301e6a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-chassis-controllers/default.nix
+++ b/distros/noetic/rm-chassis-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, nav-msgs, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-chassis-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "16227e980135c252864c7d9c68bb442b2d32b4edfde454863129eef2bb321539";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "d94c8a2cd9048b30a08d74494769f6683376acffc6a7607b598c490691369f97";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ angles control-toolbox controller-interface effort-controllers forward-command-controller hardware-interface imu-sensor-controller pluginlib realtime-tools rm-common rm-msgs robot-localization roscpp roslint tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ angles control-toolbox controller-interface effort-controllers forward-command-controller hardware-interface imu-sensor-controller nav-msgs pluginlib realtime-tools rm-common rm-msgs robot-localization roscpp roslint tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-controllers/default.nix
+++ b/distros/noetic/rm-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-controller }:
 buildRosPackage {
   pname = "ros-noetic-rm-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "05554d86404cc251e581c2c2563028d7bd8c92e44ba8ca199de962db555ff462";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "3318a6d1d48e1490ca1fb5d7a2902198e381d3cb1767fb3dd31f3db42bd9405d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gimbal-controllers/default.nix
+++ b/distros/noetic/rm-gimbal-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-gimbal-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "612b3f33a9fe4ae93d409f43337609d09909e0eb216ce1cc94f0316106b5cdb0";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "161f683559716e9fc4120b6e54f178a3cb4068d53ff4b2305d617a4db57c5ce7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-shooter-controllers/default.nix
+++ b/distros/noetic/rm-shooter-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-shooter-controllers";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "f296625424d061e81e3794479a6b76d8e857e67555f18990c64b65c7fb3796e9";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "62bb8a6d21f988af0ddc855df146b5a2f6d8bed9953c9af5eb3a93f94f2b9801";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-state-controller/default.nix
+++ b/distros/noetic/robot-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, kdl-parser, pluginlib, realtime-tools, rm-common, roscpp, roslint, tf2-kdl, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-controller";
-  version = "0.1.1-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.1-3.tar.gz";
-    name = "0.1.1-3.tar.gz";
-    sha256 = "141f326c9938e86964006050b4cf53b83e4377899a3851fb797ad105a160d9c7";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "bbe3ed5c9b5aa781c1f9e96cdd184a9358c0fac23a0da3807729922431b42743";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rslidar-sdk/default.nix
+++ b/distros/noetic/rslidar-sdk/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libpcap, libyamlcpp, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rslidar-sdk";
+  version = "1.3.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rslidar_sdk-release/archive/release/noetic/rslidar_sdk/1.3.0-4.tar.gz";
+    name = "1.3.0-4.tar.gz";
+    sha256 = "f19e7aff675714176889e6f190bfae965f5c047d84a25b8d20f64e445dea616b";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ libpcap libyamlcpp pcl pcl-conversions pcl-ros roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rslidar_sdk package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/scenario-test-tools/default.nix
+++ b/distros/noetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, python3Packages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-scenario-test-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "4475f55003d72e674c73b0eb53fb3bb04c7000459b920d307cc5ff84df91bb00";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "bf34e45b25fb90b29dec0b4deef92f186c47ab47f08ac4b7633975df383528d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/service-tools/default.nix
+++ b/distros/noetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-noetic-service-tools";
-  version = "0.6.26-r1";
+  version = "0.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.26-1.tar.gz";
-    name = "0.6.26-1.tar.gz";
-    sha256 = "e2b3d12c8f99988d5c500ae9e76c5cd00aa5b3afa61f0799693cae311c1ade91";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.27-1.tar.gz";
+    name = "0.6.27-1.tar.gz";
+    sha256 = "0b5656268cf34ce45f8512dbf2f1360ea6f6a980c57fe96f188ea51f34d4c61b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/statistics-msgs/default.nix
+++ b/distros/noetic/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-statistics-msgs";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/statistics_msgs/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "5eb0ddd6586f00d4ce5baf52af1eea155449e3bbbb1ddc668ccfc402a57d95c0";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/statistics_msgs/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "60160deb991195902301215019f99958f7132c20abea524d794edba6efad78f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.12.2-r2";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.12.2-2.tar.gz";
-    name = "1.12.2-2.tar.gz";
-    sha256 = "57d0f69717e81747632ea8a2f2032b2255bc1ce23b77f4dc3f7aae286549cefa";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "500b2a80deee89499aa6b894b4b96224422d28fd7cac5e9dc0d2200a3e1f1989";
   };
 
   buildType = "catkin";

--- a/distros/noetic/webots-ros/default.nix
+++ b/distros/noetic/webots-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, moveit-simple-controller-manager, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-webots-ros";
-  version = "4.1.0-r1";
+  version = "5.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "4175499066cf217586c057a5c6a81945abcfb491eeec7b753c72068a0f871914";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/5.0.1-2.tar.gz";
+    name = "5.0.1-2.tar.gz";
+    sha256 = "756dc48598285ad8b9abb18577d267c8fa8c6d3318c7711728b1d7f98ba9fc57";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface moveit-simple-controller-manager robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/wfov-camera-msgs/default.nix
+++ b/distros/noetic/wfov-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-wfov-camera-msgs";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/wfov_camera_msgs/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "fa2494db9b9b17f019705378aae3e21916120d81e7b0b6ed58382186e34267fb";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/wfov_camera_msgs/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "15a433e1d9cd61751a4e471c109f2fc7ecb9bcf803ab4a7ed2e1b61d01153f1a";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit f73660a16ac2c16de51f99248d0d194ea878a519.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *chomp-motion-planner 2.2.3-r1*
* *clober-bringup 0.1.0-r1*
* *clober-description 0.1.0-r1*
* *clober-msgs 0.1.0-r3*
* *clober-navigation 0.1.0-r1*
* *clober-serial 0.1.0-r1*
* *clober-simulation 0.1.0-r1*
* *clober-slam 0.1.0-r1*
* *color-names 0.0.2-r1 --> 0.0.3-r1*
* *diff-drive-controller 0.5.1-r1 --> 0.6.0-r1*
* *effort-controllers 0.5.1-r1 --> 0.6.0-r1*
* *force-torque-sensor-broadcaster 0.5.1-r1 --> 0.6.0-r1*
* *forward-command-controller 0.5.1-r1 --> 0.6.0-r1*
* *gripper-controllers 0.5.1-r1 --> 0.6.0-r1*
* *ign-ros2-control-demos 0.1.1-r2*
* *imu-sensor-broadcaster 0.5.1-r1 --> 0.6.0-r1*
* *joint-state-broadcaster 0.5.1-r1 --> 0.6.0-r1*
* *joint-state-controller 0.5.1-r1 --> 0.6.0-r1*
* *joint-trajectory-controller 0.5.1-r1 --> 0.6.0-r1*
* *launch 0.10.7-r1 --> 0.10.8-r2*
* *launch-testing 0.10.7-r1 --> 0.10.8-r2*
* *launch-testing-ament-cmake 0.10.7-r1 --> 0.10.8-r2*
* *launch-xml 0.10.7-r1 --> 0.10.8-r2*
* *launch-yaml 0.10.7-r1 --> 0.10.8-r2*
* *moveit 2.2.2-r1 --> 2.2.3-r1*
* *moveit-chomp-optimizer-adapter 2.2.3-r1*
* *moveit-common 2.2.2-r1 --> 2.2.3-r1*
* *moveit-core 2.2.2-r1 --> 2.2.3-r1*
* *moveit-kinematics 2.2.2-r1 --> 2.2.3-r1*
* *moveit-planners 2.2.2-r1 --> 2.2.3-r1*
* *moveit-planners-chomp 2.2.3-r1*
* *moveit-planners-ompl 2.2.2-r1 --> 2.2.3-r1*
* *moveit-plugins 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-benchmarks 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-move-group 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-occupancy-map-monitor 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-perception 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-planning 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-planning-interface 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-robot-interaction 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-visualization 2.2.2-r1 --> 2.2.3-r1*
* *moveit-ros-warehouse 2.2.2-r1 --> 2.2.3-r1*
* *moveit-runtime 2.2.2-r1 --> 2.2.3-r1*
* *moveit-servo 2.2.2-r1 --> 2.2.3-r1*
* *moveit-simple-controller-manager 2.2.2-r1 --> 2.2.3-r1*
* *ntrip-client 1.0.0-r1 --> 1.0.1-r1*
* *performance-test-fixture 0.0.6-r1 --> 0.0.8-r1*
* *position-controllers 0.5.1-r1 --> 0.6.0-r1*
* *ros2-controllers 0.5.1-r1 --> 0.6.0-r1*
* *rqt-plot 1.1.0-r1 --> 1.1.1-r1*
* *run-move-group 2.2.2-r1 --> 2.2.3-r1*
* *run-moveit-cpp 2.2.2-r1 --> 2.2.3-r1*
* *run-ompl-constrained-planning 2.2.2-r1 --> 2.2.3-r1*
* *soccer-object-msgs 1.0.1-r1*
* *velocity-controllers 0.5.1-r1 --> 0.6.0-r1*
* *webots-ros2 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-control 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-core 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-driver 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-epuck 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-importer 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-mavic 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-msgs 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-tesla 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-tests 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-tiago 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-turtlebot 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-universal-robot 1.2.0-r2 --> 1.2.2-r1*

Galactic Changes:
-----------------
* *actionlib-msgs 2.2.3-r1 --> 2.2.4-r1*
* *ament-cmake 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-auto 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-core 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-export-definitions 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-export-dependencies 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-export-include-directories 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-export-interfaces 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-export-libraries 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-export-link-flags 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-export-targets 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-gmock 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-google-benchmark 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-gtest 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-include-directories 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-libraries 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-nose 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-pytest 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-python 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-target-dependencies 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-test 1.1.4-r1 --> 1.1.5-r1*
* *ament-cmake-version 1.1.4-r1 --> 1.1.5-r1*
* *aws-robomaker-small-warehouse-world 1.0.4-r1 --> 1.0.5-r1*
* *color-names 0.0.2-r1 --> 0.0.3-r1*
* *common-interfaces 2.2.3-r1 --> 2.2.4-r1*
* *diagnostic-msgs 2.2.3-r1 --> 2.2.4-r1*
* *diff-drive-controller 1.2.0-r1 --> 1.3.0-r1*
* *effort-controllers 1.2.0-r1 --> 1.3.0-r1*
* *force-torque-sensor-broadcaster 1.2.0-r1 --> 1.3.0-r1*
* *forward-command-controller 1.2.0-r1 --> 1.3.0-r1*
* *geometry-msgs 2.2.3-r1 --> 2.2.4-r1*
* *gripper-controllers 1.2.0-r1 --> 1.3.0-r1*
* *imu-sensor-broadcaster 1.2.0-r1 --> 1.3.0-r1*
* *joint-state-broadcaster 1.2.0-r1 --> 1.3.0-r1*
* *joint-trajectory-controller 1.2.0-r1 --> 1.3.0-r1*
* *libpointmatcher 1.3.1-r1*
* *nav-msgs 2.2.3-r1 --> 2.2.4-r1*
* *ntrip-client 1.0.0-r1 --> 1.0.1-r1*
* *performance-test-fixture 0.0.7-r2 --> 0.0.8-r1*
* *position-controllers 1.2.0-r1 --> 1.3.0-r1*
* *rcpputils 2.2.0-r2 --> 2.2.1-r1*
* *ros-image-to-qimage 0.0.2-r1*
* *ros2-controllers 1.2.0-r1 --> 1.3.0-r1*
* *rqt-action 2.0.0-r2 --> 2.0.1-r1*
* *rqt-graph 1.2.0-r2 --> 1.2.1-r1*
* *rqt-image-overlay 0.0.1-r1*
* *rqt-image-overlay-layer 0.0.1-r1*
* *rqt-plot 1.1.0-r1 --> 1.1.1-r1*
* *sensor-msgs 2.2.3-r1 --> 2.2.4-r1*
* *sensor-msgs-py 2.2.3-r1 --> 2.2.4-r1*
* *shape-msgs 2.2.3-r1 --> 2.2.4-r1*
* *soccer-marker-generation 0.0.1-r1 --> 0.0.2-r1*
* *soccer-object-msgs 1.0.1-r1*
* *sros2 0.10.2-r2 --> 0.10.3-r1*
* *sros2-cmake 0.10.2-r2 --> 0.10.3-r1*
* *std-msgs 2.2.3-r1 --> 2.2.4-r1*
* *std-srvs 2.2.3-r1 --> 2.2.4-r1*
* *stereo-msgs 2.2.3-r1 --> 2.2.4-r1*
* *trajectory-msgs 2.2.3-r1 --> 2.2.4-r1*
* *velocity-controllers 1.2.0-r1 --> 1.3.0-r1*
* *visualization-msgs 2.2.3-r1 --> 2.2.4-r1*
* *webots-ros2 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-control 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-core 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-driver 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-epuck 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-importer 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-mavic 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-msgs 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-tesla 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-tests 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-tiago 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-turtlebot 1.2.0-r2 --> 1.2.2-r1*
* *webots-ros2-universal-robot 1.2.0-r2 --> 1.2.2-r1*

Melodic Changes:
----------------
* *chomp-motion-planner 1.0.8-r1 --> 1.0.9-r1*
* *dingo-control 0.1.9-r2 --> 0.1.10-r1*
* *dingo-description 0.1.9-r2 --> 0.1.10-r1*
* *dingo-desktop 0.1.0-r1 --> 0.1.1-r1*
* *dingo-gazebo 0.1.0-r1 --> 0.1.1-r1*
* *dingo-msgs 0.1.9-r2 --> 0.1.10-r1*
* *dingo-navigation 0.1.9-r2 --> 0.1.10-r1*
* *dingo-simulator 0.1.0-r1 --> 0.1.1-r1*
* *dingo-viz 0.1.0-r1 --> 0.1.1-r1*
* *husky-base 0.4.10-r1 --> 0.4.12-r1*
* *husky-bringup 0.4.10-r1 --> 0.4.12-r1*
* *husky-control 0.4.10-r1 --> 0.4.12-r1*
* *husky-description 0.4.10-r1 --> 0.4.12-r1*
* *husky-desktop 0.4.10-r1 --> 0.4.12-r1*
* *husky-gazebo 0.4.10-r1 --> 0.4.12-r1*
* *husky-msgs 0.4.10-r1 --> 0.4.12-r1*
* *husky-navigation 0.4.10-r1 --> 0.4.12-r1*
* *husky-robot 0.4.10-r1 --> 0.4.12-r1*
* *husky-simulator 0.4.10-r1 --> 0.4.12-r1*
* *husky-viz 0.4.10-r1 --> 0.4.12-r1*
* *image-exposure-msgs 0.14.1-r1 --> 0.14.2-r1*
* *jackal-control 0.7.7-r1 --> 0.7.8-r1*
* *jackal-description 0.7.7-r1 --> 0.7.8-r1*
* *jackal-desktop 0.3.2-r1 --> 0.4.1-r1*
* *jackal-msgs 0.7.7-r1 --> 0.7.8-r1*
* *jackal-navigation 0.7.7-r1 --> 0.7.8-r1*
* *jackal-tutorials 0.7.7-r1 --> 0.7.8-r1*
* *jackal-viz 0.3.2-r1 --> 0.4.1-r1*
* *jsk-interactive 2.1.7-r2 --> 2.1.8-r1*
* *jsk-interactive-marker 2.1.7-r2 --> 2.1.8-r1*
* *jsk-interactive-test 2.1.7-r2 --> 2.1.8-r1*
* *jsk-rqt-plugins 2.1.7-r2 --> 2.1.8-r1*
* *jsk-visualization 2.1.7-r2 --> 2.1.8-r1*
* *libmavconn 1.12.2-r1 --> 1.13.0-r1*
* *libpointmatcher 1.3.1-r1*
* *marti-can-msgs 0.10.0-r2 --> 0.10.0-r3*
* *marti-common-msgs 0.10.0-r2 --> 0.10.0-r3*
* *marti-dbw-msgs 0.10.0-r2 --> 0.10.0-r3*
* *marti-nav-msgs 0.10.0-r2 --> 0.10.0-r3*
* *marti-perception-msgs 0.10.0-r2 --> 0.10.0-r3*
* *marti-sensor-msgs 0.10.0-r2 --> 0.10.0-r3*
* *marti-status-msgs 0.10.0-r2 --> 0.10.0-r3*
* *marti-visualization-msgs 0.10.0-r2 --> 0.10.0-r3*
* *mavros 1.12.2-r1 --> 1.13.0-r1*
* *mavros-extras 1.12.2-r1 --> 1.13.0-r1*
* *mavros-msgs 1.12.2-r1 --> 1.13.0-r1*
* *mocap-optitrack 0.1.3-r1 --> 0.1.4-r1*
* *moveit 1.0.8-r1 --> 1.0.9-r1*
* *moveit-chomp-optimizer-adapter 1.0.8-r1 --> 1.0.9-r1*
* *moveit-controller-manager-example 1.0.8-r1 --> 1.0.9-r1*
* *moveit-core 1.0.8-r1 --> 1.0.9-r1*
* *moveit-fake-controller-manager 1.0.8-r1 --> 1.0.9-r1*
* *moveit-kinematics 1.0.8-r1 --> 1.0.9-r1*
* *moveit-planners 1.0.8-r1 --> 1.0.9-r1*
* *moveit-planners-chomp 1.0.8-r1 --> 1.0.9-r1*
* *moveit-planners-ompl 1.0.8-r1 --> 1.0.9-r1*
* *moveit-plugins 1.0.8-r1 --> 1.0.9-r1*
* *moveit-resources 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-fanuc-description 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-fanuc-moveit-config 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-panda-description 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-panda-moveit-config 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-pr2-description 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-moveit-config 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-pg70-support 0.7.3-r1 --> 0.8.2-r1*
* *moveit-resources-prbt-support 0.7.3-r1 --> 0.8.2-r1*
* *moveit-ros 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-benchmarks 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-control-interface 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-manipulation 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-move-group 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-occupancy-map-monitor 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-perception 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-planning 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-planning-interface 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-robot-interaction 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-visualization 1.0.8-r1 --> 1.0.9-r1*
* *moveit-ros-warehouse 1.0.8-r1 --> 1.0.9-r1*
* *moveit-runtime 1.0.8-r1 --> 1.0.9-r1*
* *moveit-servo 1.0.8-r1 --> 1.0.9-r1*
* *moveit-setup-assistant 1.0.8-r1 --> 1.0.9-r1*
* *moveit-simple-controller-manager 1.0.8-r1 --> 1.0.9-r1*
* *pilz-industrial-motion-planner 1.0.8-r1 --> 1.0.9-r1*
* *pilz-industrial-motion-planner-testutils 1.0.8-r1 --> 1.0.9-r1*
* *pointgrey-camera-description 0.14.1-r1 --> 0.14.2-r1*
* *pointgrey-camera-driver 0.14.1-r1 --> 0.14.2-r1*
* *psen-scan-v2 0.3.4-r1 --> 0.10.0-r1*
* *ridgeback-control 0.3.0-r1 --> 0.3.1-r1*
* *ridgeback-description 0.3.0-r1 --> 0.3.1-r1*
* *ridgeback-desktop 0.1.2-r1 --> 0.1.3-r1*
* *ridgeback-msgs 0.3.0-r1 --> 0.3.1-r1*
* *ridgeback-navigation 0.3.0-r1 --> 0.3.1-r1*
* *ridgeback-viz 0.1.2-r1 --> 0.1.3-r1*
* *rslidar-sdk 1.3.0-r3*
* *statistics-msgs 0.14.1-r1 --> 0.14.2-r1*
* *test-mavros 1.12.2-r1 --> 1.13.0-r1*
* *tork-moveit-tutorial 0.1.1-r1*
* *warthog-control 0.1.4-r2 --> 0.1.5-r1*
* *warthog-description 0.1.4-r2 --> 0.1.5-r1*
* *warthog-desktop 0.1.0-r1 --> 0.1.1-r1*
* *warthog-gazebo 0.2.1-r1 --> 0.2.2-r2*
* *warthog-msgs 0.1.4-r2 --> 0.1.5-r1*
* *warthog-simulator 0.2.1-r1 --> 0.2.2-r2*
* *warthog-viz 0.1.0-r1 --> 0.1.1-r1*
* *webots-ros 4.1.0-r1 --> 5.0.1-r2*
* *wfov-camera-msgs 0.14.1-r1 --> 0.14.2-r1*
* *xacro 1.13.14-r1 --> 1.13.15-r1*

Noetic Changes:
---------------
* *cob-base-controller-utils 0.8.17-r1 --> 0.8.18-r1*
* *cob-base-drive-chain 0.7.10-r1 --> 0.7.11-r1*
* *cob-base-velocity-smoother 0.8.17-r1 --> 0.8.18-r1*
* *cob-bms-driver 0.7.10-r1 --> 0.7.11-r1*
* *cob-canopen-motor 0.7.10-r1 --> 0.7.11-r1*
* *cob-cartesian-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-collision-velocity-filter 0.8.17-r1 --> 0.8.18-r1*
* *cob-command-gui 0.6.26-r1 --> 0.6.27-r1*
* *cob-command-tools 0.6.26-r1 --> 0.6.27-r1*
* *cob-control 0.8.17-r1 --> 0.8.18-r1*
* *cob-control-mode-adapter 0.8.17-r1 --> 0.8.18-r1*
* *cob-control-msgs 0.8.17-r1 --> 0.8.18-r1*
* *cob-dashboard 0.6.26-r1 --> 0.6.27-r1*
* *cob-driver 0.7.10-r1 --> 0.7.11-r1*
* *cob-elmo-homing 0.7.10-r1 --> 0.7.11-r1*
* *cob-footprint-observer 0.8.17-r1 --> 0.8.18-r1*
* *cob-frame-tracker 0.8.17-r1 --> 0.8.18-r1*
* *cob-generic-can 0.7.10-r1 --> 0.7.11-r1*
* *cob-hardware-emulation 0.8.17-r1 --> 0.8.18-r1*
* *cob-helper-tools 0.6.26-r1 --> 0.6.27-r1*
* *cob-interactive-teleop 0.6.26-r1 --> 0.6.27-r1*
* *cob-light 0.7.10-r1 --> 0.7.11-r1*
* *cob-mecanum-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-mimic 0.7.10-r1 --> 0.7.11-r1*
* *cob-model-identifier 0.8.17-r1 --> 0.8.18-r1*
* *cob-monitoring 0.6.26-r1 --> 0.6.27-r1*
* *cob-obstacle-distance 0.8.17-r1 --> 0.8.18-r1*
* *cob-omni-drive-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-phidget-em-state 0.7.10-r1 --> 0.7.11-r1*
* *cob-phidget-power-state 0.7.10-r1 --> 0.7.11-r1*
* *cob-phidgets 0.7.10-r1 --> 0.7.11-r1*
* *cob-relayboard 0.7.10-r1 --> 0.7.11-r1*
* *cob-scan-unifier 0.7.10-r1 --> 0.7.11-r1*
* *cob-script-server 0.6.26-r1 --> 0.6.27-r1*
* *cob-sick-lms1xx 0.7.10-r1 --> 0.7.11-r1*
* *cob-sick-s300 0.7.10-r1 --> 0.7.11-r1*
* *cob-sound 0.7.10-r1 --> 0.7.11-r1*
* *cob-teleop 0.6.26-r1 --> 0.6.27-r1*
* *cob-trajectory-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-tricycle-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-twist-controller 0.8.17-r1 --> 0.8.18-r1*
* *cob-undercarriage-ctrl 0.7.10-r1 --> 0.7.11-r1*
* *cob-utilities 0.7.10-r1 --> 0.7.11-r1*
* *cob-voltage-control 0.7.10-r1 --> 0.7.11-r1*
* *dingo-control 0.1.10-r1*
* *dingo-description 0.1.10-r1*
* *dingo-msgs 0.1.10-r1*
* *dingo-navigation 0.1.10-r1*
* *generic-throttle 0.6.26-r1 --> 0.6.27-r1*
* *image-exposure-msgs 0.15.0-r1 --> 0.15.1-r1*
* *ipcamera-driver 0.1.1-r1*
* *jsk-interactive 2.1.7-r4 --> 2.1.8-r1*
* *jsk-interactive-marker 2.1.7-r4 --> 2.1.8-r1*
* *jsk-interactive-test 2.1.7-r4 --> 2.1.8-r1*
* *jsk-rqt-plugins 2.1.7-r4 --> 2.1.8-r1*
* *jsk-visualization 2.1.7-r4 --> 2.1.8-r1*
* *laser-scan-densifier 0.7.10-r1 --> 0.7.11-r1*
* *leo-bringup 2.0.2-r1 --> 2.0.3-r1*
* *leo-fw 2.0.2-r1 --> 2.0.3-r1*
* *leo-robot 2.0.2-r1 --> 2.0.3-r1*
* *libmavconn 1.12.2-r2 --> 1.13.0-r1*
* *libpointmatcher 1.3.1-r1*
* *mavros 1.12.2-r2 --> 1.13.0-r1*
* *mavros-extras 1.12.2-r2 --> 1.13.0-r1*
* *mavros-msgs 1.12.2-r2 --> 1.13.0-r1*
* *mocap-optitrack 0.1.3-r1 --> 0.1.4-r1*
* *pointgrey-camera-description 0.15.0-r1 --> 0.15.1-r1*
* *pointgrey-camera-driver 0.15.0-r1 --> 0.15.1-r1*
* *ridgeback-control 0.3.1-r1*
* *ridgeback-description 0.3.1-r1*
* *ridgeback-msgs 0.3.1-r1*
* *ridgeback-navigation 0.3.1-r1*
* *rm-calibration-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-chassis-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-gimbal-controllers 0.1.1-r3 --> 0.1.2-r1*
* *rm-shooter-controllers 0.1.1-r3 --> 0.1.2-r1*
* *robot-state-controller 0.1.1-r3 --> 0.1.2-r1*
* *rslidar-sdk 1.3.0-r4*
* *scenario-test-tools 0.6.26-r1 --> 0.6.27-r1*
* *service-tools 0.6.26-r1 --> 0.6.27-r1*
* *statistics-msgs 0.15.0-r1 --> 0.15.1-r1*
* *test-mavros 1.12.2-r2 --> 1.13.0-r1*
* *webots-ros 4.1.0-r1 --> 5.0.1-r2*
* *wfov-camera-msgs 0.15.0-r1 --> 0.15.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] soccer_vision_msgs
 * [ ] wiimote

