### PR TITLE
rosdistro sync, Fri Feb 11 13:25:09 2022

### DIFF
--- a/distros/foxy/bag-recorder-nodes/default.nix
+++ b/distros/foxy/bag-recorder-nodes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-bag-recorder-nodes";
+  version = "0.3.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/bag_recorder_nodes/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "f0632d4811553c36a304c5da7202b47c3f0c3c9caa69fc66b13a82ef873c4097";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ example-interfaces rclcpp rosbag2-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Sample nodes demonstrating how to write bags programmatically'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/dataspeed-can-msg-filters/default.nix
+++ b/distros/foxy/dataspeed-can-msg-filters/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-foxy-dataspeed-can-msg-filters";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/foxy/dataspeed_can_msg_filters/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "82eea65813f5f8033f7d1a42c88e43610e05f080622300a1427987fbd9ae5a61";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Time synchronize multiple CAN messages to get a single callback'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/dataspeed-can-usb/default.nix
+++ b/distros/foxy/dataspeed-can-usb/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, lusb, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-dataspeed-can-usb";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/foxy/dataspeed_can_usb/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "251aea36db8f3e5714fdca9e73cf90500bf65feef530bef8612278cc9d8ae70c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs lusb rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Driver to interface with the Dataspeed Inc. USB CAN Tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/dataspeed-can/default.nix
+++ b/distros/foxy/dataspeed-can/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-can-msg-filters, dataspeed-can-usb }:
+buildRosPackage {
+  pname = "ros-foxy-dataspeed-can";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/foxy/dataspeed_can/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4b8d8aa8a6d9fe9be2390e844e49b3f136581d14eaf566a91286d1a115b5cdca";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ dataspeed-can-msg-filters dataspeed-can-usb ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CAN bus tools using Dataspeed hardware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.6.10-r1";
+  version = "2.6.10-r3";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.10-1.tar.gz";
-    name = "2.6.10-1.tar.gz";
-    sha256 = "c6fa49a8ee49445f6cf2173f22d7e9577fa44b25d515d5b8543149f143540684";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.10-3.tar.gz";
+    name = "2.6.10-3.tar.gz";
+    sha256 = "e7d63e79cc0ee6fe27218e70722464eabfd762a5724c771cac1f5d888c8a0fac";
   };
 
   buildType = "cmake";

--- a/distros/foxy/foonathan-memory-vendor/default.nix
+++ b/distros/foxy/foonathan-memory-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, git }:
 buildRosPackage {
   pname = "ros-foxy-foonathan-memory-vendor";
-  version = "1.0.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/foxy/foonathan_memory_vendor/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "64487af73cf438cf39c3de29d20646bf7c410894dad634b9cac087625402f88b";
+    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/foxy/foonathan_memory_vendor/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "72237602a3dedee05aafe1ce726a97754debd386bada768617a3e6c90184f283";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -156,6 +156,8 @@ self: super: {
 
  backward-ros = self.callPackage ./backward-ros {};
 
+ bag-recorder-nodes = self.callPackage ./bag-recorder-nodes {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  bno055 = self.callPackage ./bno055 {};
@@ -241,6 +243,12 @@ self: super: {
  cv-bridge = self.callPackage ./cv-bridge {};
 
  cyclonedds = self.callPackage ./cyclonedds {};
+
+ dataspeed-can = self.callPackage ./dataspeed-can {};
+
+ dataspeed-can-msg-filters = self.callPackage ./dataspeed-can-msg-filters {};
+
+ dataspeed-can-usb = self.callPackage ./dataspeed-can-usb {};
 
  delphi-esr-msgs = self.callPackage ./delphi-esr-msgs {};
 
@@ -651,6 +659,8 @@ self: super: {
  logging-demo = self.callPackage ./logging-demo {};
 
  lua-vendor = self.callPackage ./lua-vendor {};
+
+ lusb = self.callPackage ./lusb {};
 
  map-msgs = self.callPackage ./map-msgs {};
 

--- a/distros/foxy/lusb/default.nix
+++ b/distros/foxy/lusb/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, pkg-config }:
+buildRosPackage {
+  pname = "ros-foxy-lusb";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/lusb-release/archive/release/foxy/lusb/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "98b476cc1d755f1dcad7090affaec5cbf5594e917af57c11e1c0796fb6e1d4f5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pkg-config ];
+  propagatedBuildInputs = [ libusb1 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Library for interfacing to USB devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ntrip-client/default.nix
+++ b/distros/foxy/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ntrip-client";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "b83ceb19296196b637207f68341785f62fa0433d242626f6f7b44e33072a3d13";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "daac58e9448b27b4626a603a2b39635ea6f23c81be00e7f780e54fb43ea9c140";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "3f0e4834cc67a69e393a0e67733d58e66793b81f9887b4a93c055e3d3ce2f97b";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "92290aceeecbf6353e6a49711cc6ddd10abe8ba9d1edbb831818630cd819a930";
   };
 
   buildType = "catkin";

--- a/distros/foxy/python-qt-binding/default.nix
+++ b/distros/foxy/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-python-qt-binding";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/foxy/python_qt_binding/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "f914e6d0b4c6c2e79ce000cd4d98117f08567a781e1a542d9d551f2c455f8132";
+    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/foxy/python_qt_binding/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "677afe0d5db221190285bf5a62827ce95442d3d2b2bdbeb296c3bd512748feab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/quaternion-operation/default.nix
+++ b/distros/foxy/quaternion-operation/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-quaternion-operation";
-  version = "0.0.7-r1";
+  version = "0.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "70a6617e5050ed7433cf11f60da5cdc5a540d73de9ab0a6aa2518bddda7639b1";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "8ce497e6156de01072993ba627ce8916bec87bd00b1d9b181dee6ef7c3091699";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ouxt-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ouxt-lint-common ];
   propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/rc-reason-clients/default.nix
+++ b/distros/foxy/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rc-reason-clients";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_clients/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "ad033a9a070702944c878c8dc5eb20c8c2f958321bb1516728edb3d808b18d42";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_clients/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9f6fc761497712168142296354efd49a180780f3d80f72e65996a016cdcdf672";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rc-reason-msgs/default.nix
+++ b/distros/foxy/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rc-reason-msgs";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "c68518a81511c0433c59d01e84d443dbbcea14493fcec54b64ba3bd945af62d2";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "196d7862660b4c44b1c9729b3de31baadfe103442d0a87e7878c2607324588eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "cfff99792c386e25604e8136d085fffbfe64e462a9bd7aa781ca68bcff187d22";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "655751eb402fe9ec39a89ea1ed6fd6b869989fbf90452e90625e827a894c3d2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "b7af7bb193191ddbaf0d74908a23caa44e28e84e26e22bbcb6fd9308366fa059";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "5610196b8f65a5f00b0760cfe6b4b1024b428a20aa1f93d35812f0f5864d8c78";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "643d915a072baa0130e798eb780df2f6c58e686ac0b7ee02828b5d4da4abe6c8";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "0d0c0be72a6b88ef4f341bf4ac2a045995d087c4c675c57b9cf4ee1138324e15";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "ca70c2367f151aa670fc55cd0ff61077edd05eab5e6597523013afc2e378da73";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "7a7ae8c98022818f109284ae97323e9e3f0facb88106222fd9ade5c89abc76df";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/foxy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-cyclonedds-cpp";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "f23bf035b9f92094af5c3e1815bc84aef40e6013cb7ad267596449ef45dce17a";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "d513e3bb0794179fbf86f255631023c05e495f5903483d4da3d3712462868111";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-socketcan/default.nix
+++ b/distros/foxy/ros2-socketcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, can-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-ros2-socketcan";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/autowarefoundation/ros2_socketcan-release/archive/release/foxy/ros2_socketcan/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "da4596e101c9cc6bb3096723c50152e3997d85c664df4380296ec1a78bade10f";
+    url = "https://github.com/ros2-gbp/ros2_socketcan-release/archive/release/foxy/ros2_socketcan/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0e1d360e58b44ddfa46158a568d646042a0738513f9e42e801de5f73a3eabecb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2bag/default.nix
+++ b/distros/foxy/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, ros2cli, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-foxy-ros2bag";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "314d56fc958c8a3d4340d89e95148955722bae77e146f1952ad44c22f74d4231";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "da2c068ff21189869581513abe6724ea4fe7ba914a2f1b595c060d94fc19c423";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosbag2-compression/default.nix
+++ b/distros/foxy/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-compression";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "2cad09b9bde49dad3031f280746729213f9f3facc0da10efaa4f8ef32ef3e53c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "4a6ab0de150dae4704a44edc72ea9f34337037e423598989ea7b5054972da84a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-converter-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-converter-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rmw, rmw-fastrtps-cpp, rosbag2-cpp, rosbag2-test-common, rosidl-runtime-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-converter-default-plugins";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "20bfa740b28fb280ceed092eb2ac7079131e570dc5fa6f78fa8ad93d2384ccbd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "c8fa7cdc58299965760ef0b3d95e886672fd5a9c24345b48ec18fd783850448a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-cpp/default.nix
+++ b/distros/foxy/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-cpp";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "129df1f3b7f0f0628a7962411c73deef20b571ad9d8238ce6a1fe19c4f43fb8a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "0623fda4007032007e753aaf713e1fd7c863d607ab2d47b8730e92ade6696063";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage-default-plugins";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "9d479aae173b6e6b4f2a203b76df720d1e10d575b901932e9c9868a687b62ef6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "b7fe3b35448b47d2250b11cd67c8e2774c8c230027b86be539d7c2d0639a609b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage/default.nix
+++ b/distros/foxy/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "531c1a385e67cd6cbd54188f0b2b844b4552e687b9a82c317ca4e704dea56315";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "cb85ffbfb4c7f56a33536846a4e01b041d2e18230da1e8f49700e06b6358ed55";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-test-common/default.nix
+++ b/distros/foxy/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-test-common";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "15520db6ed09c3a231ac1317443a372e079aa13b0144dc63016ff1904e73352c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "850916cd7ec0395ddb5935524e8391047eeb9ac5effc8617fd26ce976a00eb29";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-tests/default.nix
+++ b/distros/foxy/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-tests";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "811ded9fac8a0bad80e6bd6135031e7d3b67925bd40576cbb837db7332fcdab6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "26edda1d351eb0e390784de7a1da1935b14e0a7bee407a28b441ec945b4d7e47";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-transport/default.nix
+++ b/distros/foxy/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, rpyutils, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-transport";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "68d7c95ab20930794b4263eaf21e1bdc9f0c1ecac8ba02b0067ab744d1632a8d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "f186303cdb48a31c21a681cfe94b5ab4d4f27da07d266e6a1cecb8ae5eba558f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2/default.nix
+++ b/distros/foxy/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "b21e5dfa6fb8ce2016f930ea8e444585bc55141f04171a904a466111f60beed9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "15d386a2a8e6324ca3bafe766b9ea2b11e5004fd2334fd86b33ed3220ab67a63";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "3cb31ef6684f4871f9eac4e2fb23dd7fe3690da73f0cf206659a473173399fad";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "aa2dc94b3a6787f6e0480fee0b1be18e50200e565e0a01b4ae9fda0547188961";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "ecbce1ad75ee15c9f6f2ac49405cd13d7a210cce5b0dded7da8ebb5d5e917426";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "76bef3ca0a079aa54df30eec48c1ab6275fa50eb02fae60aa55cb940cdfb9121";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "1d98a593a6b6dbdb506b10fb4945b40ee41bd3a2086f942f17e71f36da2f7fc4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "3d21b50cd9db4fe02b7fd5f4781f12eb03764baf286e03a9f5b97168c02391cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "57122c9197708e6c77a0173628e145b5d2a6451d0cc78a9197140988886d701a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "ed3627b16b71c8db18622c2cf9c5eea3bed4dd5d18ddc0191ed058c4a220d9b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "cc043b924372dfcbf1e64e40e5826ce4b698c5849ac17d5062c69ce3fcb8fd91";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "fdaa8783fff6da4abd3d44fa9729b1dde6fb89c93f9843804f51d8784ba785bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "24e8ccb0bca945f16455e7c7d325fbfb6e9ffb8e64a2bbddf9e0ffdbf9bb8a7e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "f518bf85f7fd1c77c2cad35313cf03aa2fa2dec233b0b44240ac55ea1a11784e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "fc0a8727c0d7dcf5b6862fc33a83ce31d0fbd794740529d624b37797b9b07e06";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "0ddb0418b80e5407c09567d5e19ff865a8b57f53dd72adc388001134cbef16d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "55587f11823cf9524b0977756b8ce51549ff36574957abb3732f450d690dd58e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "64294136536477bb01d764871e0a5227819b2b6da040c8144c9fb587cc71d756";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/shared-queues-vendor/default.nix
+++ b/distros/foxy/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-shared-queues-vendor";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "97e124a84c70bc9af3a73480702e81cd3a742724c049761a9aeaf4b4fddd058f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "e1551c0c9907346a1bb4e1b06b08f9bfbddeb999d9b5839486a5393557f3c598";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sqlite3-vendor/default.nix
+++ b/distros/foxy/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-foxy-sqlite3-vendor";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "747946eb57d96eefa6f3322ee3392470bcdd0a848538285e730469d2e7e429ab";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "cf2a0488809b957a0bd612a3d7116d68193e70d4eaf1eb99bbb37cf0464e2329";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tango-icons-vendor/default.nix
+++ b/distros/foxy/tango-icons-vendor/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-foxy-tango-icons-vendor";
-  version = "0.0.1-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/foxy/tango_icons_vendor/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "90d9bbe7a9e1ad18345098ec72b7b24aec9ef6b4d7b21dbf7da0d62756e15132";
+    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/foxy/tango_icons_vendor/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "4b446b64501c6b98c051963c3902d4e6a282ecb44b0290ee0cd47a923cb643c2";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ tango-icon-theme ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/tvm-vendor/default.nix
+++ b/distros/foxy/tvm-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/autowarefoundation/tvm_vendor-release/archive/release/foxy/tvm_vendor/0.7.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/foxy/tvm_vendor/0.7.3-1.tar.gz";
     name = "0.7.3-1.tar.gz";
     sha256 = "f799eb570d317864b80b56aaeb82abf92fcd67a814894d5ceaee7fca8946ff49";
   };

--- a/distros/foxy/velodyne-description/default.nix
+++ b/distros/foxy/velodyne-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "9b7eac44518cc4e40dcc9d278042bb422f8571d84c0179e086b2438000fadaa9";
   };

--- a/distros/foxy/velodyne-driver/default.nix
+++ b/distros/foxy/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-driver";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "dcd53879bfe59dab8a75aed0854e30897a8f5cc073a9e92332ff267a28c64117";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_driver/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "9b53724abc6976b2fa6ea09db9adc0144c1b6ad398045e772a8f622a091c2d0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-gazebo-plugins/default.nix
+++ b/distros/foxy/velodyne-gazebo-plugins/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "5d0a81933aff085a4f89018dfab16074d7d18b5fe88c4687670a3584666f9d44";
   };

--- a/distros/foxy/velodyne-laserscan/default.nix
+++ b/distros/foxy/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-laserscan";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_laserscan/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "1384f7a87a0541b0300293ca5c8a46758f57451f96f5560adf04eaf483f9fd64";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_laserscan/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "6c8e5434b0d44c53c2239ec6d48f612e526e073d4ce925189c75036ba50290af";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-msgs/default.nix
+++ b/distros/foxy/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ca34811a64993988832d77a9dfed728a9d6c6785e10d90820edae0dd700eab41";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "0e1988c6ca72a6ba237845af37bfbd41d46f10a0404ebf2c68202524d46ef857";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-pointcloud/default.nix
+++ b/distros/foxy/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-pointcloud";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_pointcloud/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "cb9c8876d8f8f603c5cfcbc23c3370b044b6126285e5551c57c073fc1bb8a5d6";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_pointcloud/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "c50a8b5c5affd431ec85665ce710532bf81a0d0f85d8fc4548d8c9c9e726c879";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-simulator/default.nix
+++ b/distros/foxy/velodyne-simulator/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "5a795530db06dd6f71d4cf29019e8051efc275eb67b6ea6e540e5abd88f6052a";
   };

--- a/distros/foxy/velodyne/default.nix
+++ b/distros/foxy/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-foxy-velodyne";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6af955d9a5f27ae867bd15ecdbe93f53a6ec881bba3b80c06e5f31e747641c15";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "7b8eea45da04784f481634bfeb2fd0c41990b24a69ea4ca412b329d2a90b187e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/vision-msgs/default.nix
+++ b/distros/foxy/vision-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/Kukanani/vision_msgs-release/archive/release/foxy/vision_msgs/2.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/vision_msgs-release/archive/release/foxy/vision_msgs/2.0.0-1.tar.gz";
     name = "2.0.0-1.tar.gz";
     sha256 = "3f6e7fde4e470ccb2cbdc0235753a772bb7e2ad1f7f2c6a625a51a2d42f15894";
   };

--- a/distros/foxy/zstd-vendor/default.nix
+++ b/distros/foxy/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, zstd }:
 buildRosPackage {
   pname = "ros-foxy-zstd-vendor";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "894765acd5f917266e4702d03d6eb765454e5e01f635072e4858de71700ec60e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "188b22156f065f15c39e25d30b11b002ab5c01396a6819965dfe14ebb29db13e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/chomp-motion-planner/default.nix
+++ b/distros/galactic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, rclcpp, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-chomp-motion-planner";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/chomp_motion_planner/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "470ead804b7b04a0ec991dbc1137a41b6cf9f976a244f166c9723171b6b7e7ec";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/chomp_motion_planner/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "c98639ad50ae4bb8eab40b3ac7c09ced9516f908b8d8b265d650594cd453b5f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/foonathan-memory-vendor/default.nix
+++ b/distros/galactic/foonathan-memory-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, git }:
 buildRosPackage {
   pname = "ros-galactic-foonathan-memory-vendor";
-  version = "1.0.0-r3";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/galactic/foonathan_memory_vendor/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "624c8dff568b167d7c4707efc5b172312349947241b0aab663cf0ee7be365ad9";
+    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/galactic/foonathan_memory_vendor/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "753733941d76b2f208aaf6418f9a4fb70efbec005c2c2ae7b4045a7da98bce92";
   };
 
   buildType = "cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -590,6 +590,8 @@ self: super: {
 
  moveit-common = self.callPackage ./moveit-common {};
 
+ moveit-configs-utils = self.callPackage ./moveit-configs-utils {};
+
  moveit-core = self.callPackage ./moveit-core {};
 
  moveit-hybrid-planning = self.callPackage ./moveit-hybrid-planning {};
@@ -1559,6 +1561,8 @@ self: super: {
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
+
+ ur-client-library = self.callPackage ./ur-client-library {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/galactic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/galactic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-galactic-moveit-chomp-optimizer-adapter";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_chomp_optimizer_adapter/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "3fc5eaf64a6fa1a1137b61df4bf02ee021afc9b75b88adfd0036985e452ee3d3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_chomp_optimizer_adapter/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "661a6686035bd43bdda5ee07430193872ceeee9922b4ef9a993ff6680b40eb38";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-common/default.nix
+++ b/distros/galactic/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, backward-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-common";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "0dc7987a8a652628585514d5deaa685cad2d0f2890160b55915ca3d0e9b8f9de";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "363e76c772e53e51e5ac1efe079fffbdd021f4ab65c09880ca52fae03af1b818";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-configs-utils/default.nix
+++ b/distros/galactic/moveit-configs-utils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, launch-param-builder }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-configs-utils";
+  version = "2.3.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_configs_utils/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "ec8844e1d8ba9345cd32e26dfd7429e4e3be4125dacb7de87524a1a8d699bbb4";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python launch-param-builder ];
+
+  meta = {
+    description = ''Python library for loading moveit config parameters in launch files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-core/default.nix
+++ b/distros/galactic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-core";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "89c67a04f954c693fcb524a8c75fe880cd7eab1bba407cae19342918dae2a94f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "e4a8851a6010a2e29847110694fbba093cc75d1129ee69066a671bc78b5c7177";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-hybrid-planning/default.nix
+++ b/distros/galactic/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, pluginlib, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-hybrid-planning";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_hybrid_planning/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "c3b8e4f9be962bc6321ceda50fad0f728b6b6606fe58591e82a03a175c52a23b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_hybrid_planning/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "706da66907af5351fc015130d026c7e24da72d64698971f3f6592d592507d371";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-kinematics/default.nix
+++ b/distros/galactic/moveit-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-galactic-moveit-kinematics";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "f9b7af777f61b562071b48f59c93d87da22b2b47facca43c9bde5deb81f53149";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "83872949a43e86655d7c377f1f06b0480e8c2b54fa242efa76b0ec85d5133886";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-param-builder moveit-configs-utils moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
   propagatedBuildInputs = [ class-loader eigen moveit-core moveit-msgs orocos-kdl pluginlib pythonPackages.lxml tf2 tf2-kdl urdfdom ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/moveit-planners-chomp/default.nix
+++ b/distros/galactic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-chomp";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_chomp/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "9ec610286384020dc5903d04f1b3227a0738257a517edb00864e0d55630ab9d3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_chomp/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "946ce1da6061975d25633f082418a9af0bbd7ca2cf0bc8d987aa118558a0a739";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners-ompl/default.nix
+++ b/distros/galactic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-ompl";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cd2351f77d55c3ef789502a121f5f399f7bfc87c8fbfc933c24470a2e03701cd";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "7433ae177fc534e73886d8c806cd2d62692efb696846dbe3eb19e9287df067ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners/default.nix
+++ b/distros/galactic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "c1913e540533950f65b9cdefaebd2ea52dc9e1111d9fee78707b9b6e54232bac";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "3d642f85c002a86bb7305139535d8cbff0e769cb251de33355ac8c45f749a224";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-plugins/default.nix
+++ b/distros/galactic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-galactic-moveit-plugins";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "eee939c39f925027026d33edb821786b9e878986548c89174b4526125d90e4cc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "8a78a78ede18cc5083fa8ad0f66a7f6dbc7f15b18b6cc35d762ab762f495a6f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/galactic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_ikfast_manipulator_plugin/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "fa0b48ddcac47b467580b8fe84b3dfda619e1497780016c9d28d5858dd20f3fb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_ikfast_manipulator_plugin/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b7a8a317eda9b3961d1bd8169ba0e23df396f25ad8ff0204d51b31b4c1f1a88e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/galactic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-moveit-config";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_moveit_config/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cb6621edd7d3a5e2154c4131896126430fe8a19c6dfa25189819a6214dc2bb1c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_moveit_config/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "8705cf71d51bb9716015754f862c6868d22fd94c2d4e8d4f64c4951ed3844550";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/galactic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-pg70-support";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_pg70_support/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "893f947cbef7f83f0eada2b8c80754448aae6d49ce347cec2729be108a19931a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_pg70_support/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "7a5459712b1dd5a62eaca244c617f25a13969d2e9a1ebf6737d95570723be8d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-support/default.nix
+++ b/distros/galactic/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-support";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_support/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "14bd279e06cca24ed2376ff454a67c7a1cd5847c357e4ed925b0c416984b46df";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_support/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "f6b01994d43bd6caa7ecc5b7d0ca5c52cebdcc7d9cd9bbdb112554ca9244889e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-benchmarks/default.nix
+++ b/distros/galactic/moveit-ros-benchmarks/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-benchmarks";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cb8d31f7be581d09fdfaf545243ee7e659fee01bf40356b892118c2a050f469a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "6affa2715ef517048661ed3d1b3726079929e2bde62a100086fe863ac7918689";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost moveit-ros-planning moveit-ros-warehouse pluginlib rclcpp tf2-eigen ];
+  propagatedBuildInputs = [ boost launch-param-builder moveit-configs-utils moveit-ros-planning moveit-ros-warehouse pluginlib rclcpp tf2-eigen ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-ros-control-interface/default.nix
+++ b/distros/galactic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-control-interface";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "fa6eee8c50f65f360cb9d65928f06cd65607801c99b4413a12cd144fda87422b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "4f03bdae2c8aad5c1c112b854081c315be49db208e1b22e04a915ae24e590a35";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-move-group/default.nix
+++ b/distros/galactic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-move-group";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "93b45d986bcb706fd8f8da826275f4cd5f9e2cd70b6ef09291a7b705ed6294ec";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "a887e3fe8433eaea1f1616fa609adcb5aa866ab6bec79c07b26f91368e256a5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-occupancy-map-monitor";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "e739005de6505578dc3f50514738fb4ce03ed9a771ee084c69ad6434d55adf71";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b09757c26166e7ab45dc305f9ca20318a3a5c067d84677afaf228ed60fa14a33";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-perception/default.nix
+++ b/distros/galactic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-perception";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "8d347e8e26e4b7a535bb398dfa5268b5bb7afe19e7fd87f1267cacc3184e6745";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "d03f2f4927e255f98084b8f843a10e01b9253739fc9e5f3031fa4ec9d478acfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning-interface/default.nix
+++ b/distros/galactic/moveit-ros-planning-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning-interface";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "5b7d3b53fe01b23961b8a0be92c03c01420c7c14e106507e67bba6b11bce87c6";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "cac52977ba1c390474a2c14fb008d524ec8f12b787fab541c8dd00c00dd12b24";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ eigen moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto moveit-configs-utils moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
   propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/moveit-ros-planning/default.nix
+++ b/distros/galactic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, ros-testing, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "f7157b88b7b1d7924abaff7c66e63fe114b497d168c4bc650cf2550464d71f8a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "348e796c66657b52c49aafdda629a0c41318d43e94c2d8bc5ad42a014f99e15a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-robot-interaction/default.nix
+++ b/distros/galactic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-robot-interaction";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "6a5288421081e4d4efeab2a2688e837b3cd3d5c4945187b4d6c27601b9eb692b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "ef4f58c64b657471ed73cda6f8cdccd6ad46513eee7aa911bd8bd785ef2c8e91";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-visualization/default.nix
+++ b/distros/galactic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-visualization";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "b98db371931384398cc8210ba9f3233498e930e25fc5e11e8f5e100b34539bdb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "fc719a62961d33366a1df9592cf780903fe734baa5cd7e48c648afc4f0fb3c93";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-warehouse/default.nix
+++ b/distros/galactic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-warehouse";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cb74ddfd633f1c9cab6dcdd967ac854dd3c5b8d7ae428cf2b52675c969642c71";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "4ced5fff43e035e137d06abe89efc0fecdd614d9f327c8d4cc117cc85bb16187";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros/default.nix
+++ b/distros/galactic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "7f8a666c087ef7049831fb8a302834a9e9fb1af18787928047d5b872e5f2102e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "22d169494a89b6ef8ac766c9c10b0639dcdb233eded0c412404d8d9b86991908";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-runtime/default.nix
+++ b/distros/galactic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-runtime";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "93404e8be0ecc58b3ae5897529e9e71e786d0093c1c0d649c541cb58a2a79553";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "0d113aa2c88829c173db2227bea83aa3b574f61c8b826b0370ba6c2bc0a9c752";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-servo/default.nix
+++ b/distros/galactic/moveit-servo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-manager, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, pluginlib, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-manager, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, pluginlib, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-servo";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "9b6a2464e732b4f6e0b8a97474647e4db6dc5fa79186aca15cc23b2caf70a3ca";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b8f3ee2c54c130501dc81a5625b0bc97d0cb851a577f3ef425677a8380c4176d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager moveit-resources-panda-moveit-config ros-testing ];
-  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy moveit-core moveit-msgs moveit-ros-planning-interface pluginlib robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy launch-param-builder moveit-configs-utils moveit-core moveit-msgs moveit-ros-planning-interface pluginlib robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-setup-assistant/default.nix
+++ b/distros/galactic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, libyamlcpp, moveit-common, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, rclcpp, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-setup-assistant";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_setup_assistant/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "132bee5b1c92fb0cc89bb0aec3f74c446f3883ea1bb1272f7279f33a48dd68e3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_setup_assistant/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "f169bb8e35ad2acbbeb55a1a41d3a1a9af984a68cf76b1b1661ec54f818fa931";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-simple-controller-manager/default.nix
+++ b/distros/galactic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-galactic-moveit-simple-controller-manager";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "c64e3cfe654a3fff73836d47321c731fc2e67b263f9d74f65d75dfe20ee2ef5d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "61d69ab608e8fbda5091e86a3c765e30a3d5ee7eefd433603139040d29edf0ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit/default.nix
+++ b/distros/galactic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "3143df967db307192081b3c654759321540436b6d929c3a6571a973685660a27";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "a99bba34aaab181b4f257f6f744e7f12cbe4cf6eb77f87a33d71800bcc835139";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nao-lola/default.nix
+++ b/distros/galactic/nao-lola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nao-lola";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ijnek/nao_lola-release/archive/release/galactic/nao_lola/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "c61ff7eb66fc2a791f130688ab751f11b8170dadf57d7a7a0788988db1e97a87";
+    url = "https://github.com/ijnek/nao_lola-release/archive/release/galactic/nao_lola/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "e6fa466bf82175af43aad3397b46c25977b6e414525c046f07d87fcd159be3fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ntrip-client/default.nix
+++ b/distros/galactic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ntrip-client";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "254a0fa87b29daf21daee44d56b4b672cfa5eb39099333c06ae464fcdb42943d";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "0f3ec60933148b818edcd25890ff9025decefe67ec8d9ea494da14fd345a9a28";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/galactic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-pilz-industrial-motion-planner-testutils";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner_testutils/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "13c6f41e9fdd442b6902f7c75928360ed7ca60052132caa34f518afbf5e3114a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner_testutils/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "d1527fe7bd867725e8c0a301e42278e4f6e166416ab96d48cf65d2781fa2ca04";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/pilz-industrial-motion-planner/default.nix
+++ b/distros/galactic/pilz-industrial-motion-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-pilz-industrial-motion-planner";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "bf7c5239e00a2efefc3b972c941ea425e6bd93a84e3b9529457aedbb63a1e3e0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "17fa2fb4089d6f50f86c3d8393d8c1b7a13f19bd17c879d61f0c5bb96dc98920";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common boost moveit-resources-panda-moveit-config moveit-resources-prbt-moveit-config moveit-resources-prbt-pg70-support moveit-resources-prbt-support pilz-industrial-motion-planner-testutils ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common boost moveit-resources-panda-moveit-config moveit-resources-prbt-moveit-config moveit-resources-prbt-pg70-support moveit-resources-prbt-support pilz-industrial-motion-planner-testutils ros-testing ];
   propagatedBuildInputs = [ eigen3-cmake-module geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface orocos-kdl pluginlib rclcpp tf2 tf2-eigen tf2-eigen-kdl tf2-geometry-msgs tf2-kdl tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/plansys2-bringup/default.nix
+++ b/distros/galactic/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bringup";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "f27337bd6f14fe943c27eb4e9981601aecff9cd8ff3a49bf1669cb195946e8a2";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "570a0835dc87b3265b21ebec7afdf75740a2122c54c16ba93c7ddc0b2ccc0f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-bt-actions/default.nix
+++ b/distros/galactic/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bt-actions";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "064682f8cbe19b1d1465b8cd8eebb052143da0cff3393258ec30a20b132a3fd3";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "fb1c1520a6d88e1d270de2d31df2802139274cbee2292c5144b1aeda9c78d49b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-core/default.nix
+++ b/distros/galactic/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-core";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "8fab0723c02c0a4834eaaac9eb1b5f96dc114ff7ec2ffe42086ce9e16cd6852e";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "c4725cb608eee1b2def71c343c1645feb5b52577c51eebd9eda51c0851136e7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-domain-expert/default.nix
+++ b/distros/galactic/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-domain-expert";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "cbc3f9de79636e7f4b436ce6a439aa929d31d94ad3b5e01c05e0fad27add4388";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "a5dd7d002571c5070a88ae662cc0f7d16fd0ac312e45bb53d743ed9401bf92d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-executor/default.nix
+++ b/distros/galactic/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-executor";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "da697a96a162902d34ca1d95ec6ef0a83e0411858eecd4019b1ab49e1cad0238";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "a3a9e981c0b690cd60e9dfb8cfa33b0fad16c7d47380d8ac54e74057c349d572";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-lifecycle-manager/default.nix
+++ b/distros/galactic/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-lifecycle-manager";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "734bbc926c1c482c8b60b4dd7867143f3ee7b13a5266bdb7b3a667704a67e5e9";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "cd2e7aab5f6c54b14a5db4bddf7ddb0fef029cdfc5e98487bb0af1855e0a0fcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-msgs/default.nix
+++ b/distros/galactic/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-msgs";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "6018ae43d84ee057bb4baa1335d83cf74154b31ccb763ef3d6d2412131b10105";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "df7293e4a536542b9a255ef6a9f87c9c8c308895904154fd3296676924911906";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-pddl-parser/default.nix
+++ b/distros/galactic/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-pddl-parser";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "5b8173f01fbf026a608db04c72fb166a4028bada383c4ef4f961c3761722df2d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "3441ffa0121b3d29187032ae8c8001b898a81e6d4ffec30667c8acf7a8185705";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-planner/default.nix
+++ b/distros/galactic/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-planner";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "4057270815e06cb5dbd99e31fc9c87d7d6eaa64a9b12bbc948c3dae03318345e";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "da3097b12deb5ce38008ede6036e90e478d25222a4c1485c6d79a7327c94e1e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-popf-plan-solver/default.nix
+++ b/distros/galactic/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-popf-plan-solver";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "e92ce6b8dcae208e040038120cf38a9f2b7e5674922ce1d25424493df48563f0";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "e746cba7018b9c81cc72ec5d0f3484b648ba715100319c5894af53c4c298b923";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-problem-expert/default.nix
+++ b/distros/galactic/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-problem-expert";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "3eee9d8f027ee60b44f393578bd3df16586508eb6cd279e62be2bb1001408d48";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "943ec906da4502a7edbce2e532d1ef437140fd4db413777f25aa9dcd99efe91b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-terminal/default.nix
+++ b/distros/galactic/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-terminal";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "c4129ea8a5db8b1522f560b3289404088b9fa9935040fcfc73760ad1edc4e26a";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "e8defbc2e94d2a4aa0b65e4558adcf2daba402c0e73a906c093ea6653d904e44";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/quaternion-operation/default.nix
+++ b/distros/galactic/quaternion-operation/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-quaternion-operation";
-  version = "0.0.7-r1";
+  version = "0.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/galactic/quaternion_operation/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "0e5d07e17d6eb8299210be25f68fcb5f96b0bcd7edee11536918bd37b5b7d543";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/galactic/quaternion_operation/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "f4c8ae99597b9118dcfa12fc166dcd203c0e83512f019861925ce13e503cc50e";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ouxt-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ouxt-lint-common ];
   propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/rc-reason-clients/default.nix
+++ b/distros/galactic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rc-reason-clients";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_clients/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "d2e59341adf62d93e74e63fb8aecb2514d6b7da07f7c6c327a7fe91c8ec1079e";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_clients/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3825ba19925bfd8373d590e7d9f9954bb1b0d9bd0d5acd9addd07166ba8add02";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rc-reason-msgs/default.nix
+++ b/distros/galactic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rc-reason-msgs";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "44ed59b880e13f073571177f633a592488ef8d409766f299e35d034328bdf7d8";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "8377b453dc88baf021f4dd6871e7993ff9c05ad7f6de786a3f46be32f4d93be2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-ign-interfaces/default.nix
+++ b/distros/galactic/ros-ign-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros-ign-interfaces";
-  version = "0.233.3-r1";
+  version = "0.233.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign_interfaces/0.233.3-1.tar.gz";
-    name = "0.233.3-1.tar.gz";
-    sha256 = "1b1a48d3b863b10f18e5444fc1d95ae874c99b251cb96e5f5e1c8c104ea0e02f";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign_interfaces/0.233.4-1.tar.gz";
+    name = "0.233.4-1.tar.gz";
+    sha256 = "4787706d92b1bb6599ac170efdd55b03c698e921fa805a973b0a1c0eeb20bd80";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-ign/default.nix
+++ b/distros/galactic/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-galactic-ros-ign";
-  version = "0.233.3-r1";
+  version = "0.233.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign/0.233.3-1.tar.gz";
-    name = "0.233.3-1.tar.gz";
-    sha256 = "0a3c939993c2039383a7b7562567b4c1f2c8a8d527f30c3060b7de48b6de6ff2";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign/0.233.4-1.tar.gz";
+    name = "0.233.4-1.tar.gz";
+    sha256 = "6cbe901531cc54df4389383e648d6f2de9d7ae40834bd5bf551d3784adc42347";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-socketcan/default.nix
+++ b/distros/galactic/ros2-socketcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, can-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-ros2-socketcan";
-  version = "1.0.0-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_socketcan-release/archive/release/galactic/ros2_socketcan/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "e2e2d2660aade3568096dbe1b02545a8a8bd468aec6a11ae9ecb52ca0e80a49b";
+    url = "https://github.com/ros2-gbp/ros2_socketcan-release/archive/release/galactic/ros2_socketcan/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "edce29fa94d22e4a69d10986c4a70773a8aaad4c3adb3985444ccc3843ecb271";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-bag-plugins/default.nix
+++ b/distros/galactic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rqt-bag-plugins";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag_plugins/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "d12acd475eec014cad84da64eca891b186592d67369d39ee4af20742129c5853";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag_plugins/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "b6bfdfb96caafef9f46d7094d0480e88924a732896143a68e7d7c0143c3380c6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-bag/default.nix
+++ b/distros/galactic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-galactic-rqt-bag";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "3492f0a933c5187de62d33f8d48a2f6129c3fd580db4e29bb85d9fa15fa0c4ca";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "6cfc07c51560bb4ac31b3f2cca712901ff9791c635f637d5e1468a3b88940b12";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/tvm-vendor/default.nix
+++ b/distros/galactic/tvm-vendor/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/autowarefoundation/tvm_vendor-release/archive/release/galactic/tvm_vendor/0.7.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/galactic/tvm_vendor/0.7.3-1.tar.gz";
     name = "0.7.3-1.tar.gz";
     sha256 = "b0fb82c63fe0dcf47a26f531e4bf88fbbbb1b03b2af5c7b5c5e193309678c4bc";
   };

--- a/distros/galactic/ur-client-library/default.nix
+++ b/distros/galactic/ur-client-library/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, console-bridge }:
+buildRosPackage {
+  pname = "ros-galactic-ur-client-library";
+  version = "1.0.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/galactic/ur_client_library/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "b3378b1cfc4478adc8dc336d75c18d547d8ded7fbea268d013e9741e73d01f35";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ ament-cmake console-bridge ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.'';
+    license = with lib.licenses; [ asl20 bsd2 "Zlib" mit ];
+  };
+}

--- a/distros/galactic/velodyne-description/default.nix
+++ b/distros/galactic/velodyne-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_description/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/galactic/velodyne_description/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "a9e8e0c59271c938648c67468aa4a9367311f9bd565d7955f0e3c4a445e99e43";
   };

--- a/distros/galactic/velodyne-driver/default.nix
+++ b/distros/galactic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-driver";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "213f03d4cfa040a071ebd4505d57b10fdaec05efab704f28f4b2c6a8784b5985";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "63b305d7113d4ec7f977da66faba82f3427cfa4453da6993709bbb50a43402de";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-gazebo-plugins/default.nix
+++ b/distros/galactic/velodyne-gazebo-plugins/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/galactic/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "f111781e9bd1aa946f9ea2c1ab0fcc5a1e7f2a760e4e68a6ab5885e7f43b1c43";
   };

--- a/distros/galactic/velodyne-laserscan/default.nix
+++ b/distros/galactic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-laserscan";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "3515176c9763bd0abb07f81b59117dc95c0e5d8eec2c3d0f323176bebd6fde36";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "409d3a53c5b4a6c7164b3f85d7e9a4635119751820fd22c7c46b8730b3ee1794";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-msgs/default.nix
+++ b/distros/galactic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-msgs";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "c19e94b5596816f2871b05eb2a9d5533e41d9e250dc14ecceae066bcffc21f3f";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5557887b891ea9c9b3ac06a8aae9129c7c78badbba97b18a145055c1c72fc4fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-pointcloud/default.nix
+++ b/distros/galactic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-pointcloud";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "5b3ef4c7a62a21e3f98bbf1aef48b7b59f688c62fde5d5125cdbfd116269faab";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "14336818e211d7231a126ab5e45762cd4170f4f9472f1af3e505d67e8c6e2796";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-simulator/default.nix
+++ b/distros/galactic/velodyne-simulator/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_simulator/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/galactic/velodyne_simulator/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "f309a0d58b685d49a22aaf4cb536bcf44abea570d2d7734bfee532589c65de30";
   };

--- a/distros/galactic/velodyne/default.nix
+++ b/distros/galactic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-galactic-velodyne";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "d4e276529592ef296e5022eb18ca3d2203b3b291581646fdafd1215b0067fb47";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "838f82656dfefc285648931d87839ae27b2dfcf13ad7c7d81803012b1ff3b6c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.9-r1";
+  version = "2.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "07ad3559467602369b9a5f49f1e91536451b13c6981379905211a48152694876";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.10-1.tar.gz";
+    name = "2.6.10-1.tar.gz";
+    sha256 = "8712716a3329c801296de538d2347558fada0cbb202b114a43d5e353d8f7c35c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/euslisp/default.nix
+++ b/distros/melodic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-melodic-euslisp";
-  version = "9.27.0-r1";
+  version = "9.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.27.0-1.tar.gz";
-    name = "9.27.0-1.tar.gz";
-    sha256 = "6afe4048c28c7c5d1b94a85be4c774797eac4f43835fa20511e841eac47f5907";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.29.0-1.tar.gz";
+    name = "9.29.0-1.tar.gz";
+    sha256 = "b37d14d6e5177c35d13b36cd3ee3108e9d1d474e2be768eab959d3bbaf77aabc";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3136,8 +3136,6 @@ self: super: {
 
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
 
- rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
-
  rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
 
  rc-tagdetect-client = self.callPackage ./rc-tagdetect-client {};

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2022.1.5-r1";
+  version = "2022.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.1.5-1.tar.gz";
-    name = "2022.1.5-1.tar.gz";
-    sha256 = "680dd8d9c37c088ec4ffe32941cd6370e4d0dd85f7b8dd8e8827c2552298a6ad";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.2.2-1.tar.gz";
+    name = "2022.2.2-1.tar.gz";
+    sha256 = "1aaa955279437353c8111c7d6aa8e1a052721861da7f0a091f2ad2c3433fb28e";
   };
 
   buildType = "cmake";

--- a/distros/melodic/ntrip-client/default.nix
+++ b/distros/melodic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ntrip-client";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "fbcea3209e67715ce474f01810f73ab5179b80b60344f81352d7a664ffe00232";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "bd8fa6101b2348b83714b27576dfea851faea7194fc89910a59060912b387220";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pcl-conversions/default.nix
+++ b/distros/melodic/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, pcl, pcl-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pcl-conversions";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_conversions/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "c39fde1d353721e726cb1f09337098545dc97ba9eb3d2360497c429e03d6c0a1";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_conversions/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "802d6bc106aac351f44e40da87ccab4e8c48c710c80123181e3f3399fbc93a5c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pcl-ros/default.nix
+++ b/distros/melodic/pcl-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen, geometry-msgs, message-filters, nodelet, nodelet-topic-tools, pcl, pcl-conversions, pcl-msgs, pluginlib, rosbag, rosconsole, roscpp, roslib, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, message-filters, nodelet, nodelet-topic-tools, pcl, pcl-conversions, pcl-msgs, pluginlib, rosbag, rosconsole, roscpp, roslib, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pcl-ros";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_ros/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "f7377e1788ce4ac31b1aea62601b40be17ecbd982869526fff7d6bdc77c02313";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_ros/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "81c8f34db4e676394e91982470aaf3e88b0e23f955a4f5b49efbddbe812dada8";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules rosconsole roslib ];
+  buildInputs = [ rosconsole roslib ];
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ dynamic-reconfigure eigen geometry-msgs message-filters nodelet nodelet-topic-tools pcl pcl-conversions pcl-msgs pluginlib rosbag roscpp sensor-msgs std-msgs tf tf2 tf2-eigen tf2-ros ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/perception-pcl/default.nix
+++ b/distros/melodic/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-melodic-perception-pcl";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/perception_pcl/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "503b98798df94bcbce84828d6f07a175a87f4e9719eb3a56198dc97792378359";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/perception_pcl/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "2599983e343b30b490122b261c020ce74a17328ab748cbe840007753e9579608";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "1581461ad87fa7b2cac9f968bba2f50c6d1035e0d1d19028732b7b193d2e6e19";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "95ec593f36377331be10b64ada9d335931ebe09457be83aa7af9ca452019c08c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/melodic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rc-hand-eye-calibration-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "1ec1067c217bdef0a3c5e30b3bde1dbc415cb3c531853d593273aabef2edeb9a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "28a9e136b7b771c3e45a08f9124c3ea050e91df384d56cffad6572bbef29a9e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-pick-client/default.nix
+++ b/distros/melodic/rc-pick-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-pick-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "8e4b3c36d1fd8c068236e6390631a69a297d9f9ecc8d5b1f9666cd2b45c4e63a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b039f18e7f474e9f5fb2eec1f1ace65facca17dc31754f1753cd6e7fadcb8d4f";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ curl dynamic-reconfigure geometry-msgs message-runtime rc-common-msgs rcdiscover roscpp shape-msgs std-srvs tf tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ curl dynamic-reconfigure geometry-msgs message-runtime rc-common-msgs rcdiscover roscpp std-srvs tf tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rc-reason-clients/default.nix
+++ b/distros/melodic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, pythonPackages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-clients";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "773d5496e448df0f049a9c7280153920e3040461070b2b9cb5a131bcfcec71a5";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "5680aca20acb26716ada6a8fb89a11b099535eab0eea9976e07cb35e2379feb9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-msgs/default.nix
+++ b/distros/melodic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-msgs";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "ff54aa120cbcc25182a8b936b4528ea8f7e2ad0cc174a8bdd0f83d9090508fb7";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "ed41aa1d94c1f1f73d7b36a780e835adebd9fb42dbcce24e1be957b952f6e684";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-silhouettematch-client/default.nix
+++ b/distros/melodic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-silhouettematch-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "60b0b638e9e7dd2916e95f4dafdac396665ba00a4da4e1d2c542130c73e639d3";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "9d0c7d8cb5051a7a60da5b414bf8db02a4dacf7ec7e340a37d32860bfc817bc7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-tagdetect-client/default.nix
+++ b/distros/melodic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-tagdetect-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "a8bf4f7f7f185ee22adaa73df2f53ebdd6a74eadb385784cb16a5840bc905433";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "1e05e9ee50122d94fbc654cab6de61861d62585272500861a718c9b3da626886";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-description/default.nix
+++ b/distros/melodic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-description";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "621d2975c45002d2114671c16b9781934a274675019e26c0ec7594bbf8ca37bb";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "06e14260580313d2a6dbe4fa67afff2a56d1b78b4e81bf0b6e968fc43124390e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-driver/default.nix
+++ b/distros/melodic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-driver";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "6a0ca88bd27602bdf4f5fff8470f91f1bcf0fa6479aca677e4c41d9faac380b4";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "6dbe6edfa1132c3aade3347f98a0dd430bed1a822c611e91e2c3468f9c848207";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard/default.nix
+++ b/distros/melodic/rc-visard/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
+{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "686f98970cd7ea2cab688a10ab7f819b0db8da05e3f84c4cb26844751958e81b";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "05579726c188abb8e4801fa04e5761d035e40bd1136d6c5590965519ed3ca2e1";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-roi-manager-gui rc-silhouettematch-client rc-tagdetect-client rc-visard-description rc-visard-driver ];
+  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-silhouettematch-client rc-tagdetect-client rc-visard-description rc-visard-driver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dingo-gazebo/default.nix
+++ b/distros/noetic/dingo-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dingo-control, dingo-description, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, ridgeback-gazebo-plugins, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-gazebo";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_gazebo/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "7b35e2a11f815c324bb1b6c9cbd9fab92f97c6f13602c1350080683b489b90c3";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dingo-control dingo-description gazebo-plugins gazebo-ros gazebo-ros-control hector-gazebo-plugins ridgeback-gazebo-plugins ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launchfiles to use Dingo in Gazebo.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dingo-simulator/default.nix
+++ b/distros/noetic/dingo-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dingo-gazebo }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-simulator";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_simulator/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "09094dfe9128e2ce280c7c62ba092c9ac08630d405ce6639df972304f50b5394";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dingo-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Packages for simulating Dingo.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.9-r1";
+  version = "2.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "9449ffa6a473d13b3f73a3fa96b1ab6cf45ec6a14caaeb7fbf17afefcc037342";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.10-1.tar.gz";
+    name = "2.6.10-1.tar.gz";
+    sha256 = "9b36e533876ad0228e73157bb4f036092174ae382192fc7c61b51b85d22eb79d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -548,9 +548,13 @@ self: super: {
 
  dingo-desktop = self.callPackage ./dingo-desktop {};
 
+ dingo-gazebo = self.callPackage ./dingo-gazebo {};
+
  dingo-msgs = self.callPackage ./dingo-msgs {};
 
  dingo-navigation = self.callPackage ./dingo-navigation {};
+
+ dingo-simulator = self.callPackage ./dingo-simulator {};
 
  dingo-viz = self.callPackage ./dingo-viz {};
 

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2022.1.5-r1";
+  version = "2022.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.1.5-1.tar.gz";
-    name = "2022.1.5-1.tar.gz";
-    sha256 = "6ff80173db17b9b162d3b6529c09bf8a9733402c10583fc6c59925bdd890ad3f";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.2.2-1.tar.gz";
+    name = "2022.2.2-1.tar.gz";
+    sha256 = "631d98097760a71fc92d2d06020c15d5a3250d96aeb3b366988108ef97f2faf5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mia-hand-bringup/default.nix
+++ b/distros/noetic/mia-hand-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mia-hand-description, mia-hand-driver, mia-hand-gazebo, mia-hand-ros-control }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-bringup";
-  version = "1.0.0-r13";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_bringup/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "54ea4beba19456237a3ca82d07a4e120f5af1553f3075bdd89db35962da5d955";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_bringup/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f3286d2ada593a3467748add5bd5df73c9ef9fc3331f6cdfc07ae940720a2e54";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-description/default.nix
+++ b/distros/noetic/mia-hand-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-limits-interface, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roscpp, rostime, rviz, sensor-msgs, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-description";
-  version = "1.0.0-r13";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_description/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "eb7181d71b31e2949accf0af96bdf8eedb9164c1a514d3cd739214e17b8963a1";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2f71045e658e66e667d4472e6748433a1c2c10c654978743a926fa2e730b66ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-gazebo/default.nix
+++ b/distros/noetic/mia-hand-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-manager, gazebo-ros-control, hardware-interface, joint-limits-interface, mia-hand-description, mia-hand-ros-control, pluginlib, roscpp, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-gazebo";
-  version = "1.0.0-r13";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_gazebo/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "d6c0d9e445c9924203c1d902c8e1dd4b548e5a09b7d0c1b289a65bfa792894f7";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_gazebo/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "fbd84cc011b2c1cd0ef8b74edf9912d30e3b2721c25523b9541567abd18280ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-moveit-config/default.nix
+++ b/distros/noetic/mia-hand-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, mia-hand-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-moveit-config";
-  version = "1.0.0-r13";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_moveit_config/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "60a66c548e9d3b6c3d51b8dae65ff26fb17f6bb4407385428e5a6f63bc3e0644";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_moveit_config/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5c55cbfd6d6e8e0b43840ab7d8f9f7127a7a41ed266ef8d72db61605f788f902";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-msgs/default.nix
+++ b/distros/noetic/mia-hand-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-msgs";
-  version = "1.0.0-r13";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_msgs/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "79bbde4295d3ab46307fabc372618919142f7ab82ee17de8b9f04340c5a8d6d1";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8d47875fc678bcfa21756ccda33ae484d4a400336f909ef27b16f732c19ac6f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-ros-control/default.nix
+++ b/distros/noetic/mia-hand-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-manager, hardware-interface, joint-limits-interface, mia-hand-description, mia-hand-driver, pluginlib, ros-controllers, roscpp, rqt-joint-trajectory-controller, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-ros-control";
-  version = "1.0.0-r13";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_control/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "3bb26cf31e64e8b7c4aa3e95787dbd80788af7266903ac712b79eec0363469cb";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_control/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "76c42b9e8248068f77ce1dd77ff21b7071d88dfc68f9d1358edc2bc8a4ce76eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-ros-pkgs/default.nix
+++ b/distros/noetic/mia-hand-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mia-hand-bringup, mia-hand-description, mia-hand-driver, mia-hand-gazebo, mia-hand-moveit-config, mia-hand-msgs, mia-hand-ros-control }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-ros-pkgs";
-  version = "1.0.0-r13";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_pkgs/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "4b6fbbffe891c2277bf148c60d2277e1c69328ed925bf5257edead7fb9e23edb";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_pkgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "426bb700a89216e43d02b4ff4a06276fa5378a9d6033c87ef4b79d6a448e8f32";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ntrip-client/default.nix
+++ b/distros/noetic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ntrip-client";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f4de7fad28471c2f4d1307e157b3cf4ff6f953133f241ac801b5b5a2e221fb81";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cf1cf0459dbbd26305989ef21308f7a52c57e6842ab07e651530c8096148fefc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "0bf81812bb0126f18b7b63246cbb7eab86fbef63896dba3eae517126f0460a85";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "8e83d749e670ab6ea129512f7470856a5ebc3c7a424ded9b783e8e6d16689198";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit d28a39debdb152610b21a9b432c817b2f74bdec1.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *bag-recorder-nodes 0.3.9-r1*
* *dataspeed-can 2.0.1-r1*
* *dataspeed-can-msg-filters 2.0.1-r1*
* *dataspeed-can-usb 2.0.1-r1*
* *eigenpy 2.6.10-r1 --> 2.6.10-r3*
* *foonathan-memory-vendor 1.0.0-r1 --> 1.2.0-r1*
* *lusb 2.0.1-r1*
* *ntrip-client 1.0.1-r1 --> 1.0.2-r1*
* *plotjuggler 3.4.0-r1 --> 3.4.1-r1*
* *python-qt-binding 1.0.5-r1 --> 1.0.6-r2*
* *quaternion-operation 0.0.7-r1 --> 0.0.11-r1*
* *rc-reason-clients 0.2.1-r1 --> 0.3.0-r1*
* *rc-reason-msgs 0.2.1-r1 --> 0.3.0-r1*
* *rcl 1.1.12-r1 --> 1.1.13-r1*
* *rcl-action 1.1.12-r1 --> 1.1.13-r1*
* *rcl-lifecycle 1.1.12-r1 --> 1.1.13-r1*
* *rcl-yaml-param-parser 1.1.12-r1 --> 1.1.13-r1*
* *rmw-cyclonedds-cpp 0.7.7-r1 --> 0.7.8-r1*
* *ros2-socketcan 1.0.0-r1 --> 1.1.0-r1*
* *ros2bag 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-compression 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-converter-default-plugins 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-cpp 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-storage 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-storage-default-plugins 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-test-common 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-tests 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-transport 0.3.8-r1 --> 0.3.9-r1*
* *rviz-assimp-vendor 8.2.5-r1 --> 8.2.6-r1*
* *rviz-common 8.2.5-r1 --> 8.2.6-r1*
* *rviz-default-plugins 8.2.5-r1 --> 8.2.6-r1*
* *rviz-ogre-vendor 8.2.5-r1 --> 8.2.6-r1*
* *rviz-rendering 8.2.5-r1 --> 8.2.6-r1*
* *rviz-rendering-tests 8.2.5-r1 --> 8.2.6-r1*
* *rviz-visual-testing-framework 8.2.5-r1 --> 8.2.6-r1*
* *rviz2 8.2.5-r1 --> 8.2.6-r1*
* *shared-queues-vendor 0.3.8-r1 --> 0.3.9-r1*
* *sqlite3-vendor 0.3.8-r1 --> 0.3.9-r1*
* *tango-icons-vendor 0.0.1-r1 --> 0.1.0-r1*
* *velodyne 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-driver 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-laserscan 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-msgs 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-pointcloud 2.1.0-r1 --> 2.1.1-r1*
* *zstd-vendor 0.3.8-r1 --> 0.3.9-r1*

Galactic Changes:
-----------------
* *chomp-motion-planner 2.3.3-r1 --> 2.3.4-r1*
* *foonathan-memory-vendor 1.0.0-r3 --> 1.2.0-r1*
* *moveit 2.3.3-r1 --> 2.3.4-r1*
* *moveit-chomp-optimizer-adapter 2.3.3-r1 --> 2.3.4-r1*
* *moveit-common 2.3.3-r1 --> 2.3.4-r1*
* *moveit-configs-utils 2.3.4-r1*
* *moveit-core 2.3.3-r1 --> 2.3.4-r1*
* *moveit-hybrid-planning 2.3.3-r1 --> 2.3.4-r1*
* *moveit-kinematics 2.3.3-r1 --> 2.3.4-r1*
* *moveit-planners 2.3.3-r1 --> 2.3.4-r1*
* *moveit-planners-chomp 2.3.3-r1 --> 2.3.4-r1*
* *moveit-planners-ompl 2.3.3-r1 --> 2.3.4-r1*
* *moveit-plugins 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-moveit-config 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-pg70-support 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-support 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-benchmarks 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-control-interface 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-move-group 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-occupancy-map-monitor 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-perception 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-planning 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-planning-interface 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-robot-interaction 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-visualization 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-warehouse 2.3.3-r1 --> 2.3.4-r1*
* *moveit-runtime 2.3.3-r1 --> 2.3.4-r1*
* *moveit-servo 2.3.3-r1 --> 2.3.4-r1*
* *moveit-setup-assistant 2.3.3-r1 --> 2.3.4-r1*
* *moveit-simple-controller-manager 2.3.3-r1 --> 2.3.4-r1*
* *nao-lola 0.0.3-r1 --> 0.0.4-r1*
* *ntrip-client 1.0.1-r1 --> 1.0.2-r1*
* *pilz-industrial-motion-planner 2.3.3-r1 --> 2.3.4-r1*
* *pilz-industrial-motion-planner-testutils 2.3.3-r1 --> 2.3.4-r1*
* *plansys2-bringup 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-bt-actions 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-core 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-domain-expert 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-executor 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-lifecycle-manager 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-msgs 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-pddl-parser 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-planner 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-popf-plan-solver 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-problem-expert 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-terminal 2.0.0-r3 --> 2.0.1-r3*
* *quaternion-operation 0.0.7-r1 --> 0.0.11-r1*
* *rc-reason-clients 0.2.1-r1 --> 0.3.0-r1*
* *rc-reason-msgs 0.2.1-r1 --> 0.3.0-r1*
* *ros-ign 0.233.3-r1 --> 0.233.4-r1*
* *ros-ign-interfaces 0.233.3-r1 --> 0.233.4-r1*
* *ros2-socketcan 1.0.0-r2 --> 1.1.0-r1*
* *rqt-bag 1.1.1-r2 --> 1.1.2-r1*
* *rqt-bag-plugins 1.1.1-r2 --> 1.1.2-r1*
* *ur-client-library 1.0.0-r3*
* *velodyne 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-driver 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-laserscan 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-msgs 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-pointcloud 2.1.1-r2 --> 2.2.0-r1*

Melodic Changes:
----------------
* *eigenpy 2.6.9-r1 --> 2.6.10-r1*
* *euslisp 9.27.0-r1 --> 9.29.0-r1*
* *mavlink 2022.1.5-r1 --> 2022.2.2-r1*
* *ntrip-client 1.0.0-r1 --> 1.0.1-r1*
* *pcl-conversions 1.7.3-r1 --> 1.7.4-r1*
* *pcl-ros 1.7.3-r1 --> 1.7.4-r1*
* *perception-pcl 1.7.3-r1 --> 1.7.4-r1*
* *plotjuggler 3.4.0-r1 --> 3.4.1-r1*
* *rc-hand-eye-calibration-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-pick-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-reason-clients 0.2.1-r1 --> 0.3.0-r1*
* *rc-reason-msgs 0.2.1-r1 --> 0.3.0-r1*
* *rc-silhouettematch-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-tagdetect-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard-description 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard-driver 3.2.4-r1 --> 3.3.0-r1*

Noetic Changes:
---------------
* *dingo-gazebo 0.1.1-r1*
* *dingo-simulator 0.1.1-r1*
* *eigenpy 2.6.9-r1 --> 2.6.10-r1*
* *mavlink 2022.1.5-r1 --> 2022.2.2-r1*
* *mia-hand-bringup 1.0.0-r13 --> 1.0.1-r1*
* *mia-hand-description 1.0.0-r13 --> 1.0.1-r1*
* *mia-hand-gazebo 1.0.0-r13 --> 1.0.1-r1*
* *mia-hand-moveit-config 1.0.0-r13 --> 1.0.1-r1*
* *mia-hand-msgs 1.0.0-r13 --> 1.0.1-r1*
* *mia-hand-ros-control 1.0.0-r13 --> 1.0.1-r1*
* *mia-hand-ros-pkgs 1.0.0-r13 --> 1.0.1-r1*
* *ntrip-client 1.0.0-r1 --> 1.0.1-r1*
* *plotjuggler 3.4.0-r1 --> 3.4.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

