### PR TITLE
rosdistro sync, Fri Feb 18 13:30:03 2022

### DIFF
--- a/distros/foxy/bag-recorder-nodes/default.nix
+++ b/distros/foxy/bag-recorder-nodes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-bag-recorder-nodes";
+  version = "0.3.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/bag_recorder_nodes/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "f0632d4811553c36a304c5da7202b47c3f0c3c9caa69fc66b13a82ef873c4097";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ example-interfaces rclcpp rosbag2-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Sample nodes demonstrating how to write bags programmatically'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/bosch-locator-bridge/default.nix
+++ b/distros/foxy/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-bosch-locator-bridge";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "30f50681eab385883a1c97061a3227d9f98d103e1c060fd0a5989e6e13c22a7c";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "7ae93cb2e8794182ef5015f639e4a20461c824e1cc8e7a5f5c2f45ad569fa387";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dataspeed-can-msg-filters/default.nix
+++ b/distros/foxy/dataspeed-can-msg-filters/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-foxy-dataspeed-can-msg-filters";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/foxy/dataspeed_can_msg_filters/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "82eea65813f5f8033f7d1a42c88e43610e05f080622300a1427987fbd9ae5a61";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Time synchronize multiple CAN messages to get a single callback'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/dataspeed-can-usb/default.nix
+++ b/distros/foxy/dataspeed-can-usb/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, lusb, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-dataspeed-can-usb";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/foxy/dataspeed_can_usb/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "251aea36db8f3e5714fdca9e73cf90500bf65feef530bef8612278cc9d8ae70c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs lusb rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Driver to interface with the Dataspeed Inc. USB CAN Tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/dataspeed-can/default.nix
+++ b/distros/foxy/dataspeed-can/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-can-msg-filters, dataspeed-can-usb }:
+buildRosPackage {
+  pname = "ros-foxy-dataspeed-can";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/foxy/dataspeed_can/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4b8d8aa8a6d9fe9be2390e844e49b3f136581d14eaf566a91286d1a115b5cdca";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ dataspeed-can-msg-filters dataspeed-can-usb ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CAN bus tools using Dataspeed hardware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.6.10-r1";
+  version = "2.6.10-r3";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.10-1.tar.gz";
-    name = "2.6.10-1.tar.gz";
-    sha256 = "c6fa49a8ee49445f6cf2173f22d7e9577fa44b25d515d5b8543149f143540684";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.10-3.tar.gz";
+    name = "2.6.10-3.tar.gz";
+    sha256 = "e7d63e79cc0ee6fe27218e70722464eabfd762a5724c771cac1f5d888c8a0fac";
   };
 
   buildType = "cmake";

--- a/distros/foxy/foonathan-memory-vendor/default.nix
+++ b/distros/foxy/foonathan-memory-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, git }:
 buildRosPackage {
   pname = "ros-foxy-foonathan-memory-vendor";
-  version = "1.0.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/foxy/foonathan_memory_vendor/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "64487af73cf438cf39c3de29d20646bf7c410894dad634b9cac087625402f88b";
+    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/foxy/foonathan_memory_vendor/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "72237602a3dedee05aafe1ce726a97754debd386bada768617a3e6c90184f283";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -156,6 +156,8 @@ self: super: {
 
  backward-ros = self.callPackage ./backward-ros {};
 
+ bag-recorder-nodes = self.callPackage ./bag-recorder-nodes {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  bno055 = self.callPackage ./bno055 {};
@@ -241,6 +243,12 @@ self: super: {
  cv-bridge = self.callPackage ./cv-bridge {};
 
  cyclonedds = self.callPackage ./cyclonedds {};
+
+ dataspeed-can = self.callPackage ./dataspeed-can {};
+
+ dataspeed-can-msg-filters = self.callPackage ./dataspeed-can-msg-filters {};
+
+ dataspeed-can-usb = self.callPackage ./dataspeed-can-usb {};
 
  delphi-esr-msgs = self.callPackage ./delphi-esr-msgs {};
 
@@ -510,6 +518,8 @@ self: super: {
 
  gripper-controllers = self.callPackage ./gripper-controllers {};
 
+ gscam = self.callPackage ./gscam {};
+
  gtest-vendor = self.callPackage ./gtest-vendor {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
@@ -651,6 +661,8 @@ self: super: {
  logging-demo = self.callPackage ./logging-demo {};
 
  lua-vendor = self.callPackage ./lua-vendor {};
+
+ lusb = self.callPackage ./lusb {};
 
  map-msgs = self.callPackage ./map-msgs {};
 
@@ -1229,6 +1241,8 @@ self: super: {
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
+
+ robot-upstart = self.callPackage ./robot-upstart {};
 
  ros1-bridge = self.callPackage ./ros1-bridge {};
 

--- a/distros/foxy/gscam/default.nix
+++ b/distros/foxy/gscam/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, class-loader, cv-bridge, gst_all_1, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-gscam";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gscam-release/archive/release/foxy/gscam/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "09cd4e9b8487bc99bf4a2d6268ff6a9773fdaec31a90b62efeae3134f65ee70e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ camera-calibration-parsers camera-info-manager class-loader cv-bridge gst_all_1.gst-plugins-base gst_all_1.gstreamer image-transport rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A ROS camera driver that uses gstreamer to connect to
+    devices such as webcams.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/libphidget22/default.nix
+++ b/distros/foxy/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-foxy-libphidget22";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/libphidget22/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "c5928f41449bdcacee44aa1184b21001e838254d51a20ebed809ca7692611f91";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/libphidget22/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ea4aeece6ab2abe32b65ff08ae275ce3b70c2491951c42b9d70c827347cdce29";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/lusb/default.nix
+++ b/distros/foxy/lusb/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, pkg-config }:
+buildRosPackage {
+  pname = "ros-foxy-lusb";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/lusb-release/archive/release/foxy/lusb/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "98b476cc1d755f1dcad7090affaec5cbf5594e917af57c11e1c0796fb6e1d4f5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pkg-config ];
+  propagatedBuildInputs = [ libusb1 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Library for interfacing to USB devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/microstrain-inertial-driver/default.nix
+++ b/distros/foxy/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-driver";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_driver/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "b0543069b3251a18a7f9ef76d881efc9eb11b807c14bc7471c2615c44bb9932f";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_driver/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "234ac5b329b1a2d5a23f9a3679f8facac7fd239223783106ac9105810e88e31d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-examples/default.nix
+++ b/distros/foxy/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-examples";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_examples/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "b2255cb7431c55638aed51cada3a54a35d52e4d53384f38995363c7100b40983";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_examples/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "e6a2310f0f5842d5d2b966fc883c638ff5c51a3d4598b8a057ea6323d8a681b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-msgs/default.nix
+++ b/distros/foxy/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-msgs";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_msgs/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "44a5ac05cace56813da7eb8e9422296739827389d58d60b09aefd4e9ab1b0748";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_msgs/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "5d79a5d4eac9fa37b59adf0fe11beb833b215d5b529b5774a2ddd51ffbf8989b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/microstrain-inertial-rqt/default.nix
+++ b/distros/foxy/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-microstrain-inertial-rqt";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_rqt/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "f4c017d0809072faeec32d3e76d84033c7a37dc8f6f36589d3ecee66ee90feee";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/foxy/microstrain_inertial_rqt/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "72b3b25628d2f9b7fe3340a286aeed7b0014f0f127efaf990dee5068c09b4503";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/nmea-hardware-interface/default.nix
+++ b/distros/foxy/nmea-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, controller-interface, geographic-msgs, gtk3, hardware-interface, nmea-msgs, ouxt-lint-common, pkg-config, pluginlib, quaternion-operation, rclcpp, rclcpp-components, realtime-tools, ros2-control, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, controller-interface, diagnostic-msgs, geographic-msgs, gtk3, hardware-interface, nmea-msgs, ouxt-lint-common, pkg-config, pluginlib, quaternion-operation, rclcpp, rclcpp-components, realtime-tools, ros2-control, rviz2 }:
 buildRosPackage {
   pname = "ros-foxy-nmea-hardware-interface";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/nmea_hardware_interface-release/archive/release/foxy/nmea_hardware_interface/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "be58795522259dee54ab7ec82b123d36a74440e0b86bc987cafbf525e67ab9a7";
+    url = "https://github.com/OUXT-Polaris/nmea_hardware_interface-release/archive/release/foxy/nmea_hardware_interface/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "ffe94d9324cdca94875615be905d2efce8a43fd8943b11cb9485c7d94d647068";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ouxt-lint-common ];
-  propagatedBuildInputs = [ boost controller-interface geographic-msgs gtk3 hardware-interface nmea-msgs pkg-config pluginlib quaternion-operation rclcpp rclcpp-components realtime-tools ros2-control rviz2 ];
+  propagatedBuildInputs = [ boost controller-interface diagnostic-msgs geographic-msgs gtk3 hardware-interface nmea-msgs pkg-config pluginlib quaternion-operation rclcpp rclcpp-components realtime-tools ros2-control rviz2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/ntrip-client/default.nix
+++ b/distros/foxy/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ntrip-client";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "b83ceb19296196b637207f68341785f62fa0433d242626f6f7b44e33072a3d13";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "daac58e9448b27b4626a603a2b39635ea6f23c81be00e7f780e54fb43ea9c140";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/phidgets-accelerometer/default.nix
+++ b/distros/foxy/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-accelerometer";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_accelerometer/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "b00e4de3dd27b97daee8644337520d64883c53d92d4fe700c71103e332ade285";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_accelerometer/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a962e77c9136467ad8127e90f65e1abec50cd212a98cb99f031b5a1cacb42ae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-analog-inputs/default.nix
+++ b/distros/foxy/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-analog-inputs";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_analog_inputs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "1ebecd07e774348a61d5dc9050e6f5657c58eb27581e0eea20b850f237e4b1d9";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_analog_inputs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "7ab4c69e38d29306d8a678a2d815791d8b3e298f90fbf171d9982ff0906e8a18";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-api/default.nix
+++ b/distros/foxy/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-api";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_api/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "3a2f290bbc698da7ca3c462af52fcb4db3f5111dcf954583215052b470c4cd97";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_api/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ef33bfcb1e4046fce79ef924fe748cbf307a7e55a127fc0f98370305147b6660";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-digital-inputs/default.nix
+++ b/distros/foxy/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-digital-inputs";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_inputs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "59c1d032441ca98a1adbd947a201f8996d825b919f3688af43af08ed43815b72";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_inputs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "58519a24ad3905484650e77d2124bda79f4366a2be254bbd8d33af9dbc468878";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-digital-outputs/default.nix
+++ b/distros/foxy/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-digital-outputs";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_outputs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "68491dae73c9415d41ae11f2d41a900aac912a4c5315424bf9f93907137e4cb3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_outputs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "536cc54b9af1e0fc389e8fa446017326c97da12e359901b59e6f95c741a6948d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-drivers/default.nix
+++ b/distros/foxy/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-drivers";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_drivers/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "526d4ae729ab6189be7c6fc7ea3e5dd009e1c4bf33d3cdedcc9bf84b0d339aaf";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_drivers/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ffe7ad2720db74835fc2a70362be9d52907fb304637c8aebc92c4532cd15466d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-gyroscope/default.nix
+++ b/distros/foxy/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-gyroscope";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_gyroscope/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "b21fd666f53b410f0d8b0cf94aa749c6abff1a7e0a3937021d4624514b703c5b";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_gyroscope/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "7b0e237bd95bc729d79eafca5ea0a52e8b32d86edeb01e7cc053609dfe9e72c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-high-speed-encoder/default.nix
+++ b/distros/foxy/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-high-speed-encoder";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_high_speed_encoder/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "176d4a4404c64ebf11d34fcd0de48ae0bed946b4df947ab823899d671b0c9ffa";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_high_speed_encoder/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3f2e7f3de2fe94afc8c0a511cb29b717433c1094c798cf2da9d02aa58c8112f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-ik/default.nix
+++ b/distros/foxy/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-ik";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_ik/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "5178308119afb77e39fce121240d0032dedaf9d1ac61e49f1c11c977388f5b10";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_ik/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "524deb70a8b4ab74b58c2a4928711a8abdaf2ec61011ce04280aa193334713d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-magnetometer/default.nix
+++ b/distros/foxy/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-magnetometer";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_magnetometer/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "8a9534b09a0b8d536ece27ea634254dc2ffd7d0fd7cfd0a4b7c96309c3363399";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_magnetometer/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "9b826b1e41109b9a42310dfbbb0fe9d8dfb21928899b5072f961aa5ea0035ea1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-motors/default.nix
+++ b/distros/foxy/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-motors";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_motors/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "9240a1cc7e6c862fd002acbefef4fd7b6ac6575e80561d77900217ee62b7505d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_motors/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "88078bee5be0729eec6cf4d313d9188f6ed913690081a4cff05b9ca7bbbc01b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-msgs/default.nix
+++ b/distros/foxy/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-msgs";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_msgs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "032277cc6f355ff7b2ed98b62d0b64f8d82be0980439921ce3e733e2a4a09ca7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "acd3a36aada61d45437e9d1e55d203268a3914ef3ccc1c247ba0b3da3eebcee6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-spatial/default.nix
+++ b/distros/foxy/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-spatial";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_spatial/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "33c8dbd3490c7321dded0f33bbb32958e3a9a0b9022e81bbea23524c1d204a8b";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_spatial/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "43b2fb8b2dea4de62f6f33b667c6656edbde5a83e271e721c3cf12f87e2a14bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-temperature/default.nix
+++ b/distros/foxy/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-temperature";
-  version = "2.0.2-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_temperature/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "9b7646ba800f43e078678b7aaa5cf4df7d0dca5706c31d9d3f1f1751e088cf24";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_temperature/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "4eca76e80249050cc615fc6285a1601a8b5cabda73b1170a6b916e1de74615fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.6.2-r1";
+  version = "1.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "6c668508000d06a3274d79cae605ce96df80dc52f33fc832a0e0ece041161749";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.7.2-1.tar.gz";
+    name = "1.7.2-1.tar.gz";
+    sha256 = "b9ccd0527820889123388af70c416c86717b779845ff11a7c486e3280f85974f";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.4.0-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "3f0e4834cc67a69e393a0e67733d58e66793b81f9887b4a93c055e3d3ce2f97b";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "4a322a505075e35205ae44b3ee0781c3ed50165b8b1f590dc8f4de724f5eb4a9";
   };
 
   buildType = "catkin";

--- a/distros/foxy/python-qt-binding/default.nix
+++ b/distros/foxy/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-python-qt-binding";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/foxy/python_qt_binding/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "f914e6d0b4c6c2e79ce000cd4d98117f08567a781e1a542d9d551f2c455f8132";
+    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/foxy/python_qt_binding/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "677afe0d5db221190285bf5a62827ce95442d3d2b2bdbeb296c3bd512748feab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/quaternion-operation/default.nix
+++ b/distros/foxy/quaternion-operation/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-quaternion-operation";
-  version = "0.0.7-r1";
+  version = "0.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "70a6617e5050ed7433cf11f60da5cdc5a540d73de9ab0a6aa2518bddda7639b1";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "8ce497e6156de01072993ba627ce8916bec87bd00b1d9b181dee6ef7c3091699";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ouxt-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ouxt-lint-common ];
   propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/rc-reason-clients/default.nix
+++ b/distros/foxy/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rc-reason-clients";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_clients/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "ad033a9a070702944c878c8dc5eb20c8c2f958321bb1516728edb3d808b18d42";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_clients/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9f6fc761497712168142296354efd49a180780f3d80f72e65996a016cdcdf672";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rc-reason-msgs/default.nix
+++ b/distros/foxy/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rc-reason-msgs";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "c68518a81511c0433c59d01e84d443dbbcea14493fcec54b64ba3bd945af62d2";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/foxy/rc_reason_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "196d7862660b4c44b1c9729b3de31baadfe103442d0a87e7878c2607324588eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "cfff99792c386e25604e8136d085fffbfe64e462a9bd7aa781ca68bcff187d22";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "655751eb402fe9ec39a89ea1ed6fd6b869989fbf90452e90625e827a894c3d2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "b7af7bb193191ddbaf0d74908a23caa44e28e84e26e22bbcb6fd9308366fa059";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "5610196b8f65a5f00b0760cfe6b4b1024b428a20aa1f93d35812f0f5864d8c78";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "643d915a072baa0130e798eb780df2f6c58e686ac0b7ee02828b5d4da4abe6c8";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "0d0c0be72a6b88ef4f341bf4ac2a045995d087c4c675c57b9cf4ee1138324e15";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.12-r1";
+  version = "1.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "ca70c2367f151aa670fc55cd0ff61077edd05eab5e6597523013afc2e378da73";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.13-1.tar.gz";
+    name = "1.1.13-1.tar.gz";
+    sha256 = "7a7ae8c98022818f109284ae97323e9e3f0facb88106222fd9ade5c89abc76df";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense-hardware-interface/default.nix
+++ b/distros/foxy/realsense-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, controller-interface, cv-bridge, hardware-interface, image-transport, librealsense2, nav-msgs, pluginlib, poco, quaternion-operation, rclcpp, rclcpp-components, realtime-tools, ros2-control, rviz2, sensor-msgs, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, controller-interface, cv-bridge, diagnostic-msgs, gtk3, hardware-interface, image-transport, librealsense2, libusb1, nav-msgs, openssl, ouxt-lint-common, pkg-config, pluginlib, poco, rclcpp, rclcpp-components, realtime-tools, ros2-control, rviz2, sensor-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense-hardware-interface";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/realsense_hardware_interface-release/archive/release/foxy/realsense_hardware_interface/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "3119bf7e88139e500a4bd18dcf79db6296723057fb1b8c0406799f37aa0834c3";
+    url = "https://github.com/OUXT-Polaris/realsense_hardware_interface-release/archive/release/foxy/realsense_hardware_interface/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "0d46b3c3c50593eb21c18e552069bf067aa944d3354f783e3dd034940e5d8a21";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-clang-format ament-cmake-copyright ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ controller-interface cv-bridge hardware-interface image-transport librealsense2 nav-msgs pluginlib poco quaternion-operation rclcpp rclcpp-components realtime-tools ros2-control rviz2 sensor-msgs tf2-msgs ];
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  propagatedBuildInputs = [ controller-interface cv-bridge diagnostic-msgs gtk3 hardware-interface image-transport librealsense2 libusb1 nav-msgs openssl pkg-config pluginlib poco rclcpp rclcpp-components realtime-tools ros2-control rviz2 sensor-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/foxy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-cyclonedds-cpp";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "f23bf035b9f92094af5c3e1815bc84aef40e6013cb7ad267596449ef45dce17a";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "d513e3bb0794179fbf86f255631023c05e495f5903483d4da3d3712462868111";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/robot-upstart/default.nix
+++ b/distros/foxy/robot-upstart/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-foxy-robot-upstart";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/foxy/robot_upstart/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "714def52f4fa3531267624ce03b54de412e18d35a7f098a4184bff1f3242f595";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+
+  meta = {
+    description = ''The robot_upstart package provides scripts which may be used to install
+    and uninstall Ubuntu Linux upstart jobs which launch groups of roslaunch files.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ros2-socketcan/default.nix
+++ b/distros/foxy/ros2-socketcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, can-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-ros2-socketcan";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/autowarefoundation/ros2_socketcan-release/archive/release/foxy/ros2_socketcan/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "da4596e101c9cc6bb3096723c50152e3997d85c664df4380296ec1a78bade10f";
+    url = "https://github.com/ros2-gbp/ros2_socketcan-release/archive/release/foxy/ros2_socketcan/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0e1d360e58b44ddfa46158a568d646042a0738513f9e42e801de5f73a3eabecb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2bag/default.nix
+++ b/distros/foxy/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, ros2cli, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-foxy-ros2bag";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "314d56fc958c8a3d4340d89e95148955722bae77e146f1952ad44c22f74d4231";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "da2c068ff21189869581513abe6724ea4fe7ba914a2f1b595c060d94fc19c423";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosbag2-compression/default.nix
+++ b/distros/foxy/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-compression";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "2cad09b9bde49dad3031f280746729213f9f3facc0da10efaa4f8ef32ef3e53c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "4a6ab0de150dae4704a44edc72ea9f34337037e423598989ea7b5054972da84a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-converter-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-converter-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rmw, rmw-fastrtps-cpp, rosbag2-cpp, rosbag2-test-common, rosidl-runtime-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-converter-default-plugins";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "20bfa740b28fb280ceed092eb2ac7079131e570dc5fa6f78fa8ad93d2384ccbd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "c8fa7cdc58299965760ef0b3d95e886672fd5a9c24345b48ec18fd783850448a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-cpp/default.nix
+++ b/distros/foxy/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-cpp";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "129df1f3b7f0f0628a7962411c73deef20b571ad9d8238ce6a1fe19c4f43fb8a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "0623fda4007032007e753aaf713e1fd7c863d607ab2d47b8730e92ade6696063";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage-default-plugins";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "9d479aae173b6e6b4f2a203b76df720d1e10d575b901932e9c9868a687b62ef6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "b7fe3b35448b47d2250b11cd67c8e2774c8c230027b86be539d7c2d0639a609b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage/default.nix
+++ b/distros/foxy/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "531c1a385e67cd6cbd54188f0b2b844b4552e687b9a82c317ca4e704dea56315";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "cb85ffbfb4c7f56a33536846a4e01b041d2e18230da1e8f49700e06b6358ed55";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-test-common/default.nix
+++ b/distros/foxy/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-test-common";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "15520db6ed09c3a231ac1317443a372e079aa13b0144dc63016ff1904e73352c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "850916cd7ec0395ddb5935524e8391047eeb9ac5effc8617fd26ce976a00eb29";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-tests/default.nix
+++ b/distros/foxy/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-tests";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "811ded9fac8a0bad80e6bd6135031e7d3b67925bd40576cbb837db7332fcdab6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "26edda1d351eb0e390784de7a1da1935b14e0a7bee407a28b441ec945b4d7e47";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-transport/default.nix
+++ b/distros/foxy/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, rpyutils, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-transport";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "68d7c95ab20930794b4263eaf21e1bdc9f0c1ecac8ba02b0067ab744d1632a8d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "f186303cdb48a31c21a681cfe94b5ab4d4f27da07d266e6a1cecb8ae5eba558f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2/default.nix
+++ b/distros/foxy/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "b21e5dfa6fb8ce2016f930ea8e444585bc55141f04171a904a466111f60beed9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "15d386a2a8e6324ca3bafe766b9ea2b11e5004fd2334fd86b33ed3220ab67a63";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "3cb31ef6684f4871f9eac4e2fb23dd7fe3690da73f0cf206659a473173399fad";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "aa2dc94b3a6787f6e0480fee0b1be18e50200e565e0a01b4ae9fda0547188961";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "ecbce1ad75ee15c9f6f2ac49405cd13d7a210cce5b0dded7da8ebb5d5e917426";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "76bef3ca0a079aa54df30eec48c1ab6275fa50eb02fae60aa55cb940cdfb9121";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "1d98a593a6b6dbdb506b10fb4945b40ee41bd3a2086f942f17e71f36da2f7fc4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "3d21b50cd9db4fe02b7fd5f4781f12eb03764baf286e03a9f5b97168c02391cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "57122c9197708e6c77a0173628e145b5d2a6451d0cc78a9197140988886d701a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "ed3627b16b71c8db18622c2cf9c5eea3bed4dd5d18ddc0191ed058c4a220d9b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "cc043b924372dfcbf1e64e40e5826ce4b698c5849ac17d5062c69ce3fcb8fd91";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "fdaa8783fff6da4abd3d44fa9729b1dde6fb89c93f9843804f51d8784ba785bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "24e8ccb0bca945f16455e7c7d325fbfb6e9ffb8e64a2bbddf9e0ffdbf9bb8a7e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "f518bf85f7fd1c77c2cad35313cf03aa2fa2dec233b0b44240ac55ea1a11784e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "fc0a8727c0d7dcf5b6862fc33a83ce31d0fbd794740529d624b37797b9b07e06";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "0ddb0418b80e5407c09567d5e19ff865a8b57f53dd72adc388001134cbef16d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.2.5-r1";
+  version = "8.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.5-1.tar.gz";
-    name = "8.2.5-1.tar.gz";
-    sha256 = "55587f11823cf9524b0977756b8ce51549ff36574957abb3732f450d690dd58e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.6-1.tar.gz";
+    name = "8.2.6-1.tar.gz";
+    sha256 = "64294136536477bb01d764871e0a5227819b2b6da040c8144c9fb587cc71d756";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/shared-queues-vendor/default.nix
+++ b/distros/foxy/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-shared-queues-vendor";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "97e124a84c70bc9af3a73480702e81cd3a742724c049761a9aeaf4b4fddd058f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "e1551c0c9907346a1bb4e1b06b08f9bfbddeb999d9b5839486a5393557f3c598";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sqlite3-vendor/default.nix
+++ b/distros/foxy/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-foxy-sqlite3-vendor";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "747946eb57d96eefa6f3322ee3392470bcdd0a848538285e730469d2e7e429ab";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "cf2a0488809b957a0bd612a3d7116d68193e70d4eaf1eb99bbb37cf0464e2329";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tango-icons-vendor/default.nix
+++ b/distros/foxy/tango-icons-vendor/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-foxy-tango-icons-vendor";
-  version = "0.0.1-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/foxy/tango_icons_vendor/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "90d9bbe7a9e1ad18345098ec72b7b24aec9ef6b4d7b21dbf7da0d62756e15132";
+    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/foxy/tango_icons_vendor/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "4b446b64501c6b98c051963c3902d4e6a282ecb44b0290ee0cd47a923cb643c2";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ tango-icon-theme ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/tvm-vendor/default.nix
+++ b/distros/foxy/tvm-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, libxml2, openblas, ros-environment, spirv-headers, spirv-tools, vulkan-loader }:
 buildRosPackage {
   pname = "ros-foxy-tvm-vendor";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/autowarefoundation/tvm_vendor-release/archive/release/foxy/tvm_vendor/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "f799eb570d317864b80b56aaeb82abf92fcd67a814894d5ceaee7fca8946ff49";
+    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/foxy/tvm_vendor/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "60f57740a85c06ac445b2a97b0601e634ee9f6a3b27577f411d79660ccde8e8e";
   };
 
   buildType = "catkin";

--- a/distros/foxy/velodyne-description/default.nix
+++ b/distros/foxy/velodyne-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "9b7eac44518cc4e40dcc9d278042bb422f8571d84c0179e086b2438000fadaa9";
   };

--- a/distros/foxy/velodyne-driver/default.nix
+++ b/distros/foxy/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-driver";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "dcd53879bfe59dab8a75aed0854e30897a8f5cc073a9e92332ff267a28c64117";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_driver/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "9b53724abc6976b2fa6ea09db9adc0144c1b6ad398045e772a8f622a091c2d0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-gazebo-plugins/default.nix
+++ b/distros/foxy/velodyne-gazebo-plugins/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "5d0a81933aff085a4f89018dfab16074d7d18b5fe88c4687670a3584666f9d44";
   };

--- a/distros/foxy/velodyne-laserscan/default.nix
+++ b/distros/foxy/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-laserscan";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_laserscan/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "1384f7a87a0541b0300293ca5c8a46758f57451f96f5560adf04eaf483f9fd64";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_laserscan/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "6c8e5434b0d44c53c2239ec6d48f612e526e073d4ce925189c75036ba50290af";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-msgs/default.nix
+++ b/distros/foxy/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ca34811a64993988832d77a9dfed728a9d6c6785e10d90820edae0dd700eab41";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "0e1988c6ca72a6ba237845af37bfbd41d46f10a0404ebf2c68202524d46ef857";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-pointcloud/default.nix
+++ b/distros/foxy/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-foxy-velodyne-pointcloud";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_pointcloud/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "cb9c8876d8f8f603c5cfcbc23c3370b044b6126285e5551c57c073fc1bb8a5d6";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_pointcloud/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "c50a8b5c5affd431ec85665ce710532bf81a0d0f85d8fc4548d8c9c9e726c879";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-simulator/default.nix
+++ b/distros/foxy/velodyne-simulator/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "5a795530db06dd6f71d4cf29019e8051efc275eb67b6ea6e540e5abd88f6052a";
   };

--- a/distros/foxy/velodyne/default.nix
+++ b/distros/foxy/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-foxy-velodyne";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6af955d9a5f27ae867bd15ecdbe93f53a6ec881bba3b80c06e5f31e747641c15";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "7b8eea45da04784f481634bfeb2fd0c41990b24a69ea4ca412b329d2a90b187e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/vision-msgs/default.nix
+++ b/distros/foxy/vision-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/Kukanani/vision_msgs-release/archive/release/foxy/vision_msgs/2.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/vision_msgs-release/archive/release/foxy/vision_msgs/2.0.0-1.tar.gz";
     name = "2.0.0-1.tar.gz";
     sha256 = "3f6e7fde4e470ccb2cbdc0235753a772bb7e2ad1f7f2c6a625a51a2d42f15894";
   };

--- a/distros/foxy/zstd-vendor/default.nix
+++ b/distros/foxy/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, zstd }:
 buildRosPackage {
   pname = "ros-foxy-zstd-vendor";
-  version = "0.3.8-r1";
+  version = "0.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.8-1.tar.gz";
-    name = "0.3.8-1.tar.gz";
-    sha256 = "894765acd5f917266e4702d03d6eb765454e5e01f635072e4858de71700ec60e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.9-1.tar.gz";
+    name = "0.3.9-1.tar.gz";
+    sha256 = "188b22156f065f15c39e25d30b11b002ab5c01396a6819965dfe14ebb29db13e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/chomp-motion-planner/default.nix
+++ b/distros/galactic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, rclcpp, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-chomp-motion-planner";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/chomp_motion_planner/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "470ead804b7b04a0ec991dbc1137a41b6cf9f976a244f166c9723171b6b7e7ec";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/chomp_motion_planner/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "c98639ad50ae4bb8eab40b3ac7c09ced9516f908b8d8b265d650594cd453b5f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-controller-interface";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "8f8b7021de671ee198237708741f11d49e12e5ca680a1903e5f5ae4f499076d5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "0e7d5b9bcd4dd5f407f6a762784b8267d16aa3fb3ccb2e996df75bfb595c18fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "0848bb9a09dda6a50a834efff91a535c508719a369f6bd957e58300bc5f2552a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "90c9901e61c07e7e229314510fada811f374a4ea41681e176d75b5acea021815";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "12272b014df400223ef58491776cdcce9b098d31934679b653a873691d3a5e0d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c72d0162bcea201c8054b93f0543ef74dfac615f4e41bb3c7f4f5158302e5436";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/foonathan-memory-vendor/default.nix
+++ b/distros/galactic/foonathan-memory-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, git }:
 buildRosPackage {
   pname = "ros-galactic-foonathan-memory-vendor";
-  version = "1.0.0-r3";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/galactic/foonathan_memory_vendor/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "624c8dff568b167d7c4707efc5b172312349947241b0aab663cf0ee7be365ad9";
+    url = "https://github.com/ros2-gbp/foonathan_memory_vendor-release/archive/release/galactic/foonathan_memory_vendor/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "753733941d76b2f208aaf6418f9a4fb70efbec005c2c2ae7b4045a7da98bce92";
   };
 
   buildType = "cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -394,6 +394,8 @@ self: super: {
 
  gripper-controllers = self.callPackage ./gripper-controllers {};
 
+ gscam = self.callPackage ./gscam {};
+
  gtest-vendor = self.callPackage ./gtest-vendor {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
@@ -590,6 +592,8 @@ self: super: {
 
  moveit-common = self.callPackage ./moveit-common {};
 
+ moveit-configs-utils = self.callPackage ./moveit-configs-utils {};
+
  moveit-core = self.callPackage ./moveit-core {};
 
  moveit-hybrid-planning = self.callPackage ./moveit-hybrid-planning {};
@@ -661,8 +665,6 @@ self: super: {
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
  multires-image = self.callPackage ./multires-image {};
-
- nao-button-sim = self.callPackage ./nao-button-sim {};
 
  nao-command-msgs = self.callPackage ./nao-command-msgs {};
 
@@ -1559,6 +1561,8 @@ self: super: {
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
+
+ ur-client-library = self.callPackage ./ur-client-library {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/galactic/gscam/default.nix
+++ b/distros/galactic/gscam/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, class-loader, cv-bridge, gst_all_1, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-gscam";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gscam-release/archive/release/galactic/gscam/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d38faf4ca581daac146630bd806b3ad68ebc81a052ae4a4518bdd4a86a988c43";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ camera-calibration-parsers camera-info-manager class-loader cv-bridge gst_all_1.gst-plugins-base gst_all_1.gstreamer image-transport rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A ROS camera driver that uses gstreamer to connect to
+    devices such as webcams.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-galactic-hardware-interface";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "4f6f8024adf7e7e86fc20ab30e7470e4346408eeb2c0a9541dedf7c22d9d2289";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "597b7524a397dd58ee4e4210e8e75ce41e1619004dd49e800f4f06955dd5c2e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/libphidget22/default.nix
+++ b/distros/galactic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-galactic-libphidget22";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/libphidget22/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "8f8ee29321775752a5053b28770844bb68c7ce2820652ab3bae4e549a8d0ace7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/libphidget22/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "46dc58a7b8e145a772b6c26892bdd082775c3b2d62515eca39264845d329d813";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-driver/default.nix
+++ b/distros/galactic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-driver";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_driver/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "233438a0284f48323a16dd09b3b75ff22dc639c57d82d2cd7d1c983a6441c428";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_driver/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "9f9aabdb08509623ff3e4edbc05d39c520f0f6c07f56de4c6c015c1ad58e47ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-examples/default.nix
+++ b/distros/galactic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-examples";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_examples/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "26ce78c49c060ab5dd62cf09e9e69acde7d38d19b6f8bc401255348852a1eba1";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_examples/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "61e3d60002c22c7119a22085718e14836a16e17c25b884efb62649742f28e138";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-msgs/default.nix
+++ b/distros/galactic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-msgs";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_msgs/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "489c7a8a95bdabb26afbaa5c48be1f2bd3809f8e507ddf89611ca96679128899";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_msgs/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "a592938f4ed14d8a90988bb0498a16217ffb08532f9501c7d5000d5bef3427ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/microstrain-inertial-rqt/default.nix
+++ b/distros/galactic/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-microstrain-inertial-rqt";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_rqt/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "f71e7ad3a3e75aa6c4313166dfcff12ebb4d823b80a545ea9c42fcddadd3257a";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/galactic/microstrain_inertial_rqt/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "5d74f741403218dae44ff5ade3d225c0db326150d51827ca02c39238c2994269";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/galactic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-galactic-moveit-chomp-optimizer-adapter";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_chomp_optimizer_adapter/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "3fc5eaf64a6fa1a1137b61df4bf02ee021afc9b75b88adfd0036985e452ee3d3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_chomp_optimizer_adapter/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "661a6686035bd43bdda5ee07430193872ceeee9922b4ef9a993ff6680b40eb38";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-common/default.nix
+++ b/distros/galactic/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, backward-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-common";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "0dc7987a8a652628585514d5deaa685cad2d0f2890160b55915ca3d0e9b8f9de";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "363e76c772e53e51e5ac1efe079fffbdd021f4ab65c09880ca52fae03af1b818";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-configs-utils/default.nix
+++ b/distros/galactic/moveit-configs-utils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, launch-param-builder }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-configs-utils";
+  version = "2.3.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_configs_utils/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "ec8844e1d8ba9345cd32e26dfd7429e4e3be4125dacb7de87524a1a8d699bbb4";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python launch-param-builder ];
+
+  meta = {
+    description = ''Python library for loading moveit config parameters in launch files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-core/default.nix
+++ b/distros/galactic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-core";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "89c67a04f954c693fcb524a8c75fe880cd7eab1bba407cae19342918dae2a94f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "e4a8851a6010a2e29847110694fbba093cc75d1129ee69066a671bc78b5c7177";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-hybrid-planning/default.nix
+++ b/distros/galactic/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, pluginlib, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-hybrid-planning";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_hybrid_planning/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "c3b8e4f9be962bc6321ceda50fad0f728b6b6606fe58591e82a03a175c52a23b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_hybrid_planning/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "706da66907af5351fc015130d026c7e24da72d64698971f3f6592d592507d371";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-kinematics/default.nix
+++ b/distros/galactic/moveit-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-galactic-moveit-kinematics";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "f9b7af777f61b562071b48f59c93d87da22b2b47facca43c9bde5deb81f53149";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "83872949a43e86655d7c377f1f06b0480e8c2b54fa242efa76b0ec85d5133886";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-param-builder moveit-configs-utils moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
   propagatedBuildInputs = [ class-loader eigen moveit-core moveit-msgs orocos-kdl pluginlib pythonPackages.lxml tf2 tf2-kdl urdfdom ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/moveit-planners-chomp/default.nix
+++ b/distros/galactic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-chomp";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_chomp/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "9ec610286384020dc5903d04f1b3227a0738257a517edb00864e0d55630ab9d3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_chomp/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "946ce1da6061975d25633f082418a9af0bbd7ca2cf0bc8d987aa118558a0a739";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners-ompl/default.nix
+++ b/distros/galactic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-ompl";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cd2351f77d55c3ef789502a121f5f399f7bfc87c8fbfc933c24470a2e03701cd";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "7433ae177fc534e73886d8c806cd2d62692efb696846dbe3eb19e9287df067ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners/default.nix
+++ b/distros/galactic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "c1913e540533950f65b9cdefaebd2ea52dc9e1111d9fee78707b9b6e54232bac";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "3d642f85c002a86bb7305139535d8cbff0e769cb251de33355ac8c45f749a224";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-plugins/default.nix
+++ b/distros/galactic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-galactic-moveit-plugins";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "eee939c39f925027026d33edb821786b9e878986548c89174b4526125d90e4cc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "8a78a78ede18cc5083fa8ad0f66a7f6dbc7f15b18b6cc35d762ab762f495a6f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/galactic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_ikfast_manipulator_plugin/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "fa0b48ddcac47b467580b8fe84b3dfda619e1497780016c9d28d5858dd20f3fb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_ikfast_manipulator_plugin/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b7a8a317eda9b3961d1bd8169ba0e23df396f25ad8ff0204d51b31b4c1f1a88e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/galactic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-moveit-config";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_moveit_config/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cb6621edd7d3a5e2154c4131896126430fe8a19c6dfa25189819a6214dc2bb1c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_moveit_config/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "8705cf71d51bb9716015754f862c6868d22fd94c2d4e8d4f64c4951ed3844550";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/galactic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-pg70-support";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_pg70_support/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "893f947cbef7f83f0eada2b8c80754448aae6d49ce347cec2729be108a19931a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_pg70_support/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "7a5459712b1dd5a62eaca244c617f25a13969d2e9a1ebf6737d95570723be8d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-resources-prbt-support/default.nix
+++ b/distros/galactic/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-resources-prbt-support";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_support/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "14bd279e06cca24ed2376ff454a67c7a1cd5847c357e4ed925b0c416984b46df";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_resources_prbt_support/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "f6b01994d43bd6caa7ecc5b7d0ca5c52cebdcc7d9cd9bbdb112554ca9244889e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-benchmarks/default.nix
+++ b/distros/galactic/moveit-ros-benchmarks/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-benchmarks";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cb8d31f7be581d09fdfaf545243ee7e659fee01bf40356b892118c2a050f469a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "6affa2715ef517048661ed3d1b3726079929e2bde62a100086fe863ac7918689";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost moveit-ros-planning moveit-ros-warehouse pluginlib rclcpp tf2-eigen ];
+  propagatedBuildInputs = [ boost launch-param-builder moveit-configs-utils moveit-ros-planning moveit-ros-warehouse pluginlib rclcpp tf2-eigen ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-ros-control-interface/default.nix
+++ b/distros/galactic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-control-interface";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "fa6eee8c50f65f360cb9d65928f06cd65607801c99b4413a12cd144fda87422b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "4f03bdae2c8aad5c1c112b854081c315be49db208e1b22e04a915ae24e590a35";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-move-group/default.nix
+++ b/distros/galactic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-move-group";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "93b45d986bcb706fd8f8da826275f4cd5f9e2cd70b6ef09291a7b705ed6294ec";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "a887e3fe8433eaea1f1616fa609adcb5aa866ab6bec79c07b26f91368e256a5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-occupancy-map-monitor";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "e739005de6505578dc3f50514738fb4ce03ed9a771ee084c69ad6434d55adf71";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b09757c26166e7ab45dc305f9ca20318a3a5c067d84677afaf228ed60fa14a33";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-perception/default.nix
+++ b/distros/galactic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-perception";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "8d347e8e26e4b7a535bb398dfa5268b5bb7afe19e7fd87f1267cacc3184e6745";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "d03f2f4927e255f98084b8f843a10e01b9253739fc9e5f3031fa4ec9d478acfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning-interface/default.nix
+++ b/distros/galactic/moveit-ros-planning-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning-interface";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "5b7d3b53fe01b23961b8a0be92c03c01420c7c14e106507e67bba6b11bce87c6";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "cac52977ba1c390474a2c14fb008d524ec8f12b787fab541c8dd00c00dd12b24";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ eigen moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto moveit-configs-utils moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
   propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/moveit-ros-planning/default.nix
+++ b/distros/galactic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, ros-testing, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "f7157b88b7b1d7924abaff7c66e63fe114b497d168c4bc650cf2550464d71f8a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "348e796c66657b52c49aafdda629a0c41318d43e94c2d8bc5ad42a014f99e15a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-robot-interaction/default.nix
+++ b/distros/galactic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-robot-interaction";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "6a5288421081e4d4efeab2a2688e837b3cd3d5c4945187b4d6c27601b9eb692b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "ef4f58c64b657471ed73cda6f8cdccd6ad46513eee7aa911bd8bd785ef2c8e91";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-visualization/default.nix
+++ b/distros/galactic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-visualization";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "b98db371931384398cc8210ba9f3233498e930e25fc5e11e8f5e100b34539bdb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "fc719a62961d33366a1df9592cf780903fe734baa5cd7e48c648afc4f0fb3c93";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-warehouse/default.nix
+++ b/distros/galactic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-warehouse";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "cb74ddfd633f1c9cab6dcdd967ac854dd3c5b8d7ae428cf2b52675c969642c71";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "4ced5fff43e035e137d06abe89efc0fecdd614d9f327c8d4cc117cc85bb16187";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros/default.nix
+++ b/distros/galactic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "7f8a666c087ef7049831fb8a302834a9e9fb1af18787928047d5b872e5f2102e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "22d169494a89b6ef8ac766c9c10b0639dcdb233eded0c412404d8d9b86991908";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-runtime/default.nix
+++ b/distros/galactic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-runtime";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "93404e8be0ecc58b3ae5897529e9e71e786d0093c1c0d649c541cb58a2a79553";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "0d113aa2c88829c173db2227bea83aa3b574f61c8b826b0370ba6c2bc0a9c752";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-servo/default.nix
+++ b/distros/galactic/moveit-servo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-manager, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, pluginlib, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-manager, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, pluginlib, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-servo";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "9b6a2464e732b4f6e0b8a97474647e4db6dc5fa79186aca15cc23b2caf70a3ca";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b8f3ee2c54c130501dc81a5625b0bc97d0cb851a577f3ef425677a8380c4176d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager moveit-resources-panda-moveit-config ros-testing ];
-  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy moveit-core moveit-msgs moveit-ros-planning-interface pluginlib robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy launch-param-builder moveit-configs-utils moveit-core moveit-msgs moveit-ros-planning-interface pluginlib robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-setup-assistant/default.nix
+++ b/distros/galactic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, libyamlcpp, moveit-common, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, rclcpp, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-galactic-moveit-setup-assistant";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_setup_assistant/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "132bee5b1c92fb0cc89bb0aec3f74c446f3883ea1bb1272f7279f33a48dd68e3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_setup_assistant/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "f169bb8e35ad2acbbeb55a1a41d3a1a9af984a68cf76b1b1661ec54f818fa931";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-simple-controller-manager/default.nix
+++ b/distros/galactic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-galactic-moveit-simple-controller-manager";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "c64e3cfe654a3fff73836d47321c731fc2e67b263f9d74f65d75dfe20ee2ef5d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "61d69ab608e8fbda5091e86a3c765e30a3d5ee7eefd433603139040d29edf0ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit/default.nix
+++ b/distros/galactic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "3143df967db307192081b3c654759321540436b6d929c3a6571a973685660a27";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "a99bba34aaab181b4f257f6f744e7f12cbe4cf6eb77f87a33d71800bcc835139";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nao-lola/default.nix
+++ b/distros/galactic/nao-lola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nao-lola";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ijnek/nao_lola-release/archive/release/galactic/nao_lola/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "c61ff7eb66fc2a791f130688ab751f11b8170dadf57d7a7a0788988db1e97a87";
+    url = "https://github.com/ijnek/nao_lola-release/archive/release/galactic/nao_lola/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "e6fa466bf82175af43aad3397b46c25977b6e414525c046f07d87fcd159be3fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nmea-hardware-interface/default.nix
+++ b/distros/galactic/nmea-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, controller-interface, geographic-msgs, gtk3, hardware-interface, nmea-msgs, ouxt-lint-common, pkg-config, pluginlib, quaternion-operation, rclcpp, rclcpp-components, realtime-tools, ros2-control, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, controller-interface, diagnostic-msgs, geographic-msgs, gtk3, hardware-interface, nmea-msgs, ouxt-lint-common, pkg-config, pluginlib, quaternion-operation, rclcpp, rclcpp-components, realtime-tools, ros2-control, rviz2 }:
 buildRosPackage {
   pname = "ros-galactic-nmea-hardware-interface";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/nmea_hardware_interface-release/archive/release/galactic/nmea_hardware_interface/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "3f3696c72788adfe62f782739db2798499c07e3887d0b7271a669612fcd991e8";
+    url = "https://github.com/OUXT-Polaris/nmea_hardware_interface-release/archive/release/galactic/nmea_hardware_interface/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "aa12e194f677655d07f5319b5433691371c9867eb6e426eda9c8885be7cc090a";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ouxt-lint-common ];
-  propagatedBuildInputs = [ boost controller-interface geographic-msgs gtk3 hardware-interface nmea-msgs pkg-config pluginlib quaternion-operation rclcpp rclcpp-components realtime-tools ros2-control rviz2 ];
+  propagatedBuildInputs = [ boost controller-interface diagnostic-msgs geographic-msgs gtk3 hardware-interface nmea-msgs pkg-config pluginlib quaternion-operation rclcpp rclcpp-components realtime-tools ros2-control rviz2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/ntrip-client/default.nix
+++ b/distros/galactic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ntrip-client";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "254a0fa87b29daf21daee44d56b4b672cfa5eb39099333c06ae464fcdb42943d";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "0f3ec60933148b818edcd25890ff9025decefe67ec8d9ea494da14fd345a9a28";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/phidgets-accelerometer/default.nix
+++ b/distros/galactic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-accelerometer";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_accelerometer/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "7719bd584b0d7a8e1e827aaf859198a27cb6857852ec2b172c8399638e1ee07e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_accelerometer/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "3552109fe2aba6f22c01da260b65ea790007f88558067211037f0cce47d82b4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-analog-inputs/default.nix
+++ b/distros/galactic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-analog-inputs";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_analog_inputs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "3eb96e768e7d4bc6379e38600a9c818b80cc3a8133e1f52c42a2db9461a47946";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_analog_inputs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "4c1d526cc93d436b3e72679b83336b9a61b404ba86b1d256b9ff452674bebf37";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-api/default.nix
+++ b/distros/galactic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-api";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_api/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "2aa42b9ddbdbf95550722a7032943cad7319a9170e284133359b2b503e69c4de";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_api/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "ed76b730aed3c954b83fc4c9ab9e53edb48d19deaaff81dcd1def5c40893c709";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-digital-inputs/default.nix
+++ b/distros/galactic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-digital-inputs";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_inputs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "2360d0df777522513aa3746f02ee74a803e10157f59a2cd7e1629c7b8f61c4ee";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_inputs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "a9dca4591b281eb8897ee9cf6694c09ddf7d5c0f80b6f9ce72c6aae0d32349e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-digital-outputs/default.nix
+++ b/distros/galactic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-digital-outputs";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_outputs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "96f686b37d6765153991b900204a3e545b4f78c13ed51d51d7bd6efed2841f75";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_outputs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "4ce5efa8eaf008f9ff3305d84ed7fe8fcf16c8f41d294fad3d22a37ea856863f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-drivers/default.nix
+++ b/distros/galactic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-drivers";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_drivers/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "c065f41350a72f2c24d853f9990b5bda4fde2e0c43d302926d3dbe59f835decb";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_drivers/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "bc1d57e7db3949cb63f598314f9cbd3d327e00e4ae4260c1c81e56dcd6a5b26e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-gyroscope/default.nix
+++ b/distros/galactic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-gyroscope";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_gyroscope/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "3a69f6739a74c52e8d4f62ef09a972625a00347640158580ee0b0979a41cf473";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_gyroscope/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "b612146ee61ce866b53f375f2aae0a48de18eeacbb372108e3fb531d269b04d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-high-speed-encoder/default.nix
+++ b/distros/galactic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-high-speed-encoder";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_high_speed_encoder/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "b34fb8948fca836dec78b1b7ef46011e32e168ac7e0ad8cfe7fbff0581840a63";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_high_speed_encoder/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "3beb416be7b352d97a470388d8c2c4e5f20633bc14b883a40bd042d64378f21d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-ik/default.nix
+++ b/distros/galactic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-ik";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_ik/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "9f9ac59d39b5d5c6a30e2b6112c673b865180d1231d1157e05e3fe1b33869be8";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_ik/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "fbef84b727378fe2651f54d67545727ffb9eccd668115dcd61560062ff13eb18";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-magnetometer/default.nix
+++ b/distros/galactic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-magnetometer";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_magnetometer/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "58725896a43537cc2e322bf1c47a06ac696106611a6d063c4b716076240eed03";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_magnetometer/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "0f27e5bcc85fc78996bf6273b5459c194fce2e92d074ef72516d24004e6f845c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-motors/default.nix
+++ b/distros/galactic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-motors";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_motors/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "7706b1f736d8fa2056f4f5158d68357f8aa520a90613a652139bd445d388b13f";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_motors/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "43abee1dda1ba2df130645ca50a842b7f5065ecca9aa5a789c1973d5f4e2f659";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-msgs/default.nix
+++ b/distros/galactic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-msgs";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_msgs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "8b514cbb4815b072df8208cf07cda9ace0e2a576d844b5ac3357d5fd1411e646";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_msgs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "8ea44817055d6f636245c2f196e7e4216099e301ff16df229778f8d3aca91f65";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-spatial/default.nix
+++ b/distros/galactic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-spatial";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_spatial/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "c4f94483c2b62da8f65ef9e4d6d4e7ff7f8d8a60fe02f1d88004eca366fa8618";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_spatial/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "e0ec470bc2ae39c43f3b6d18a129840a3d46ace5b8ec4f330a964a6b3e81eacb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-temperature/default.nix
+++ b/distros/galactic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-temperature";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_temperature/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "0afa3df6ea213b0baf1ccfa3b502efd0ab1ef65115bafcce8cf2a84ed5398a4d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_temperature/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "ccfcae3ba0509c7465fa62f9eec74dd685a3c4ea438163a9733c54edcca284af";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/galactic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-pilz-industrial-motion-planner-testutils";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner_testutils/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "13c6f41e9fdd442b6902f7c75928360ed7ca60052132caa34f518afbf5e3114a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner_testutils/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "d1527fe7bd867725e8c0a301e42278e4f6e166416ab96d48cf65d2781fa2ca04";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/pilz-industrial-motion-planner/default.nix
+++ b/distros/galactic/pilz-industrial-motion-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-pilz-industrial-motion-planner";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "bf7c5239e00a2efefc3b972c941ea425e6bd93a84e3b9529457aedbb63a1e3e0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/pilz_industrial_motion_planner/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "17fa2fb4089d6f50f86c3d8393d8c1b7a13f19bd17c879d61f0c5bb96dc98920";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common boost moveit-resources-panda-moveit-config moveit-resources-prbt-moveit-config moveit-resources-prbt-pg70-support moveit-resources-prbt-support pilz-industrial-motion-planner-testutils ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common boost moveit-resources-panda-moveit-config moveit-resources-prbt-moveit-config moveit-resources-prbt-pg70-support moveit-resources-prbt-support pilz-industrial-motion-planner-testutils ros-testing ];
   propagatedBuildInputs = [ eigen3-cmake-module geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface orocos-kdl pluginlib rclcpp tf2 tf2-eigen tf2-eigen-kdl tf2-geometry-msgs tf2-kdl tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/plansys2-bringup/default.nix
+++ b/distros/galactic/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bringup";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "f27337bd6f14fe943c27eb4e9981601aecff9cd8ff3a49bf1669cb195946e8a2";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "570a0835dc87b3265b21ebec7afdf75740a2122c54c16ba93c7ddc0b2ccc0f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-bt-actions/default.nix
+++ b/distros/galactic/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bt-actions";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "064682f8cbe19b1d1465b8cd8eebb052143da0cff3393258ec30a20b132a3fd3";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "fb1c1520a6d88e1d270de2d31df2802139274cbee2292c5144b1aeda9c78d49b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-core/default.nix
+++ b/distros/galactic/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-core";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "8fab0723c02c0a4834eaaac9eb1b5f96dc114ff7ec2ffe42086ce9e16cd6852e";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "c4725cb608eee1b2def71c343c1645feb5b52577c51eebd9eda51c0851136e7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-domain-expert/default.nix
+++ b/distros/galactic/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-domain-expert";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "cbc3f9de79636e7f4b436ce6a439aa929d31d94ad3b5e01c05e0fad27add4388";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "a5dd7d002571c5070a88ae662cc0f7d16fd0ac312e45bb53d743ed9401bf92d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-executor/default.nix
+++ b/distros/galactic/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-executor";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "da697a96a162902d34ca1d95ec6ef0a83e0411858eecd4019b1ab49e1cad0238";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "a3a9e981c0b690cd60e9dfb8cfa33b0fad16c7d47380d8ac54e74057c349d572";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-lifecycle-manager/default.nix
+++ b/distros/galactic/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-lifecycle-manager";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "734bbc926c1c482c8b60b4dd7867143f3ee7b13a5266bdb7b3a667704a67e5e9";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "cd2e7aab5f6c54b14a5db4bddf7ddb0fef029cdfc5e98487bb0af1855e0a0fcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-msgs/default.nix
+++ b/distros/galactic/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-msgs";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "6018ae43d84ee057bb4baa1335d83cf74154b31ccb763ef3d6d2412131b10105";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "df7293e4a536542b9a255ef6a9f87c9c8c308895904154fd3296676924911906";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-pddl-parser/default.nix
+++ b/distros/galactic/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-pddl-parser";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "5b8173f01fbf026a608db04c72fb166a4028bada383c4ef4f961c3761722df2d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "3441ffa0121b3d29187032ae8c8001b898a81e6d4ffec30667c8acf7a8185705";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-planner/default.nix
+++ b/distros/galactic/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-planner";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "4057270815e06cb5dbd99e31fc9c87d7d6eaa64a9b12bbc948c3dae03318345e";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "da3097b12deb5ce38008ede6036e90e478d25222a4c1485c6d79a7327c94e1e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-popf-plan-solver/default.nix
+++ b/distros/galactic/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-popf-plan-solver";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "e92ce6b8dcae208e040038120cf38a9f2b7e5674922ce1d25424493df48563f0";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "e746cba7018b9c81cc72ec5d0f3484b648ba715100319c5894af53c4c298b923";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-problem-expert/default.nix
+++ b/distros/galactic/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-problem-expert";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "3eee9d8f027ee60b44f393578bd3df16586508eb6cd279e62be2bb1001408d48";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "943ec906da4502a7edbce2e532d1ef437140fd4db413777f25aa9dcd99efe91b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-terminal/default.nix
+++ b/distros/galactic/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-terminal";
-  version = "2.0.0-r3";
+  version = "2.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "c4129ea8a5db8b1522f560b3289404088b9fa9935040fcfc73760ad1edc4e26a";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.1-3.tar.gz";
+    name = "2.0.1-3.tar.gz";
+    sha256 = "e8defbc2e94d2a4aa0b65e4558adcf2daba402c0e73a906c093ea6653d904e44";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plotjuggler-ros/default.nix
+++ b/distros/galactic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler-ros";
-  version = "1.5.1-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/galactic/plotjuggler_ros/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "be0bcdd99993ddd30072c1a8150db442141a53ae5d2fc39fb17d6bcd7b054640";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/galactic/plotjuggler_ros/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "fe0e12fd2161ed6100846ebcfe160f37a20e410060f82cda8718d812a5b630cb";
   };
 
   buildType = "catkin";

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.3.4-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.3.4-1.tar.gz";
-    name = "3.3.4-1.tar.gz";
-    sha256 = "a4a9055591b9e5f42beca45b55be8a5d52ad825fe00e1c608775667882bd629c";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "917322dd3b9ef735c0db860c71ff7f3ce09f47cc9dad98b8ddbf4f5d583a223f";
   };
 
   buildType = "catkin";

--- a/distros/galactic/quaternion-operation/default.nix
+++ b/distros/galactic/quaternion-operation/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, eigen, geometry-msgs, ouxt-lint-common, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-quaternion-operation";
-  version = "0.0.7-r1";
+  version = "0.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/galactic/quaternion_operation/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "0e5d07e17d6eb8299210be25f68fcb5f96b0bcd7edee11536918bd37b5b7d543";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/galactic/quaternion_operation/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "f4c8ae99597b9118dcfa12fc166dcd203c0e83512f019861925ce13e503cc50e";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ouxt-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ouxt-lint-common ];
   propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/rc-reason-clients/default.nix
+++ b/distros/galactic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rc-reason-clients";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_clients/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "d2e59341adf62d93e74e63fb8aecb2514d6b7da07f7c6c327a7fe91c8ec1079e";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_clients/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3825ba19925bfd8373d590e7d9f9954bb1b0d9bd0d5acd9addd07166ba8add02";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rc-reason-msgs/default.nix
+++ b/distros/galactic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rc-reason-msgs";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "44ed59b880e13f073571177f633a592488ef8d409766f299e35d034328bdf7d8";
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "8377b453dc88baf021f4dd6871e7993ff9c05ad7f6de786a3f46be32f4d93be2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/robot-state-publisher/default.nix
+++ b/distros/galactic/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-galactic-robot-state-publisher";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/galactic/robot_state_publisher/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "6799396fb3c289819c0aad41caad0c52cd32308bb785be496c2f0d969f98ef13";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/galactic/robot_state_publisher/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "7632aac8c3c71e0efa84468499625ec1bb002f0d119316e30c3f929d226463be";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-ign-interfaces/default.nix
+++ b/distros/galactic/ros-ign-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros-ign-interfaces";
-  version = "0.233.3-r1";
+  version = "0.233.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign_interfaces/0.233.3-1.tar.gz";
-    name = "0.233.3-1.tar.gz";
-    sha256 = "1b1a48d3b863b10f18e5444fc1d95ae874c99b251cb96e5f5e1c8c104ea0e02f";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign_interfaces/0.233.4-1.tar.gz";
+    name = "0.233.4-1.tar.gz";
+    sha256 = "4787706d92b1bb6599ac170efdd55b03c698e921fa805a973b0a1c0eeb20bd80";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-ign/default.nix
+++ b/distros/galactic/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-galactic-ros-ign";
-  version = "0.233.3-r1";
+  version = "0.233.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign/0.233.3-1.tar.gz";
-    name = "0.233.3-1.tar.gz";
-    sha256 = "0a3c939993c2039383a7b7562567b4c1f2c8a8d527f30c3060b7de48b6de6ff2";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign/0.233.4-1.tar.gz";
+    name = "0.233.4-1.tar.gz";
+    sha256 = "6cbe901531cc54df4389383e648d6f2de9d7ae40834bd5bf551d3784adc42347";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control-test-assets";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "d69ccc2ff88c42f88e3338efe9d139183592bcd61a5105bc11af222a3c037784";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "fe146bb001f59c8bf9f00d0020476e734a302a0553712c9d033768e3ec96d42e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "7350186da2c823a4950e143b0800c8a3c7f6cb3495c4344270bb26cdb2ae1d9a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "103a4ef57243483d76b6441e06b411563e716dcba599db96f2af5295fec95487";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-socketcan/default.nix
+++ b/distros/galactic/ros2-socketcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, can-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-ros2-socketcan";
-  version = "1.0.0-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_socketcan-release/archive/release/galactic/ros2_socketcan/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "e2e2d2660aade3568096dbe1b02545a8a8bd468aec6a11ae9ecb52ca0e80a49b";
+    url = "https://github.com/ros2-gbp/ros2_socketcan-release/archive/release/galactic/ros2_socketcan/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "edce29fa94d22e4a69d10986c4a70773a8aaad4c3adb3985444ccc3843ecb271";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-galactic-ros2controlcli";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "31fa4dbf44a46ea0d1535a4ca86b3c33d4ad3374af24031055881d52a40d6ee6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "422603a6a081026518aa8725626b81d2b8d424ac6d5bdfc4c3caf152585c5bce";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-bag-plugins/default.nix
+++ b/distros/galactic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rqt-bag-plugins";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag_plugins/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "d12acd475eec014cad84da64eca891b186592d67369d39ee4af20742129c5853";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag_plugins/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "b6bfdfb96caafef9f46d7094d0480e88924a732896143a68e7d7c0143c3380c6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-bag/default.nix
+++ b/distros/galactic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-galactic-rqt-bag";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "3492f0a933c5187de62d33f8d48a2f6129c3fd580db4e29bb85d9fa15fa0c4ca";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/galactic/rqt_bag/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "6cfc07c51560bb4ac31b3f2cca712901ff9791c635f637d5e1468a3b88940b12";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-galactic-transmission-interface";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "3a24d8b87edc6b3acc0f2480628bed0377d44b8b871a2affd5624786b669061c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2e8da6385659ea712ca0cfcbecc44dd54afb0c79d513070722f3c9f1882ad757";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tvm-vendor/default.nix
+++ b/distros/galactic/tvm-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, libxml2, openblas, ros-environment, spirv-headers, spirv-tools, vulkan-loader }:
 buildRosPackage {
   pname = "ros-galactic-tvm-vendor";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/autowarefoundation/tvm_vendor-release/archive/release/galactic/tvm_vendor/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "b0fb82c63fe0dcf47a26f531e4bf88fbbbb1b03b2af5c7b5c5e193309678c4bc";
+    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/galactic/tvm_vendor/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "b42ffb4f9599de069dba6659c059602069adbe36ac4a1ac356b1f013120328be";
   };
 
   buildType = "catkin";

--- a/distros/galactic/ur-client-library/default.nix
+++ b/distros/galactic/ur-client-library/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, console-bridge }:
+buildRosPackage {
+  pname = "ros-galactic-ur-client-library";
+  version = "1.0.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/galactic/ur_client_library/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "b3378b1cfc4478adc8dc336d75c18d547d8ded7fbea268d013e9741e73d01f35";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ ament-cmake console-bridge ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.'';
+    license = with lib.licenses; [ asl20 bsd2 "Zlib" mit ];
+  };
+}

--- a/distros/galactic/velodyne-description/default.nix
+++ b/distros/galactic/velodyne-description/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_description/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/galactic/velodyne_description/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "a9e8e0c59271c938648c67468aa4a9367311f9bd565d7955f0e3c4a445e99e43";
   };

--- a/distros/galactic/velodyne-driver/default.nix
+++ b/distros/galactic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-driver";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "213f03d4cfa040a071ebd4505d57b10fdaec05efab704f28f4b2c6a8784b5985";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "63b305d7113d4ec7f977da66faba82f3427cfa4453da6993709bbb50a43402de";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-gazebo-plugins/default.nix
+++ b/distros/galactic/velodyne-gazebo-plugins/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/galactic/velodyne_gazebo_plugins/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "f111781e9bd1aa946f9ea2c1ab0fcc5a1e7f2a760e4e68a6ab5885e7f43b1c43";
   };

--- a/distros/galactic/velodyne-laserscan/default.nix
+++ b/distros/galactic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-laserscan";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "3515176c9763bd0abb07f81b59117dc95c0e5d8eec2c3d0f323176bebd6fde36";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "409d3a53c5b4a6c7164b3f85d7e9a4635119751820fd22c7c46b8730b3ee1794";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-msgs/default.nix
+++ b/distros/galactic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-msgs";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "c19e94b5596816f2871b05eb2a9d5533e41d9e250dc14ecceae066bcffc21f3f";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5557887b891ea9c9b3ac06a8aae9129c7c78badbba97b18a145055c1c72fc4fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-pointcloud/default.nix
+++ b/distros/galactic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-pointcloud";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "5b3ef4c7a62a21e3f98bbf1aef48b7b59f688c62fde5d5125cdbfd116269faab";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "14336818e211d7231a126ab5e45762cd4170f4f9472f1af3e505d67e8c6e2796";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-simulator/default.nix
+++ b/distros/galactic/velodyne-simulator/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/galactic/velodyne_simulator/2.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/galactic/velodyne_simulator/2.0.2-1.tar.gz";
     name = "2.0.2-1.tar.gz";
     sha256 = "f309a0d58b685d49a22aaf4cb536bcf44abea570d2d7734bfee532589c65de30";
   };

--- a/distros/galactic/velodyne/default.nix
+++ b/distros/galactic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-galactic-velodyne";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "d4e276529592ef296e5022eb18ca3d2203b3b291581646fdafd1215b0067fb47";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "838f82656dfefc285648931d87839ae27b2dfcf13ad7c7d81803012b1ff3b6c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/visp/default.nix
+++ b/distros/galactic/visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bzip2, cmake, doxygen, eigen, libjpeg, liblapack, libpng, libv4l, libxml2, opencv3, xorg }:
 buildRosPackage {
   pname = "ros-galactic-visp";
-  version = "3.4.0-r2";
+  version = "3.5.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/visp-release/archive/release/galactic/visp/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "00a97b20710104bd70c17c4aec491a0511a3cd6e984e00a592baae8e28581406";
+    url = "https://github.com/lagadic/visp-release/archive/release/galactic/visp/3.5.0-3.tar.gz";
+    name = "3.5.0-3.tar.gz";
+    sha256 = "597822d5c324767ca87da01c15bd73dac45fb69dc79ddc19919f3e6c9a928a04";
   };
 
   buildType = "cmake";

--- a/distros/melodic/avt-vimba-camera/default.nix
+++ b/distros/melodic/avt-vimba-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-proc, image-transport, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-avt-vimba-camera";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "13e807526426a15d481207dd213bfeb3683ead4e188353da61ead6b0f70a9a3d";
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3e91999ce02aa63045feae3ec63bbf82f1badc08c3553ded70decc109967548d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/aws-common/default.nix
+++ b/distros/melodic/aws-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, curl, gtest, openssl, ros-environment, util-linux, zlib }:
 buildRosPackage {
   pname = "ros-melodic-aws-common";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_common-release/archive/release/melodic/aws_common/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "ca6b356a24bbfc7851da14716f3f90cdc751ce5d7620f5eda2401cdfebdddbfe";
+    url = "https://github.com/aws-gbp/aws_common-release/archive/release/melodic/aws_common/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d432e283db309fa929373f84ea3aa48ce7919caa608ebc5b033b0b55336e8d19";
   };
 
   buildType = "cmake";

--- a/distros/melodic/aws-ros1-common/default.nix
+++ b/distros/melodic/aws-ros1-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, gtest, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-aws-ros1-common";
-  version = "2.0.1-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/melodic/aws_ros1_common/2.0.1-2.tar.gz";
-    name = "2.0.1-2.tar.gz";
-    sha256 = "6ce3c5da6d51c25b2c8453af0a780dbeaa94561baf086346a2fdc2b3ed27caac";
+    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/melodic/aws_ros1_common/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "24a738e160ad02cdb48e5ff6334739193edc14583b90bce7d77c9f735b00864e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-logger/default.nix
+++ b/distros/melodic/cloudwatch-logger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-logs-common, gtest, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logger";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/melodic/cloudwatch_logger/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "b76d61d2863ba0edb061c39e0b0722df5a54f62d0f215dc7f5152fe4850fc871";
+    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/melodic/cloudwatch_logger/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "a8557c5581e22ba30088f76043c42a5f22e4b7045af5e1ea2b707387c536db1f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-logs-common/default.nix
+++ b/distros/melodic/cloudwatch-logs-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logs-common";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_logs_common/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "34f60d17cd9747fc6f691ab0da37a5ae48f19d60e03e21fdf9e30582f625199c";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_logs_common/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "01b8d478fca24e0c34b62c0c8fdb429081380c4ed368af59f7f2a71b9f6710c7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/cloudwatch-metrics-collector/default.nix
+++ b/distros/melodic/cloudwatch-metrics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-collector";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "1c8d20e04ea8096f94cf510c3624385a2b1f8effc03276fe4a0fcd6f6b3fb3f8";
+    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "825b38181077ca024fe497525ec5dd69e3e7eedd662a65bba98c0521e9f5c3c3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-metrics-common/default.nix
+++ b/distros/melodic/cloudwatch-metrics-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-common";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_metrics_common/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "5bf53ce407e01c6461fb30d1cbb09721c2e452f52751c7bbf3fb0e80f6e10ed7";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_metrics_common/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "ffe43bbe3567d57586e1cee957002b8123d07a3d70508081d4e783fccf801d8c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/dataflow-lite/default.nix
+++ b/distros/melodic/dataflow-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, gtest }:
 buildRosPackage {
   pname = "ros-melodic-dataflow-lite";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/dataflow_lite/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "6bd3d571380bb06623afd09ae46e1a0d95368ccafe14416a323fd79ac84e2bed";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/dataflow_lite/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "48eee6c7e4843e4e73a2b800d5b59214e15bcfc87157012e79bca5ca968af806";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.9-r1";
+  version = "2.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "07ad3559467602369b9a5f49f1e91536451b13c6981379905211a48152694876";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.10-1.tar.gz";
+    name = "2.6.10-1.tar.gz";
+    sha256 = "8712716a3329c801296de538d2347558fada0cbb202b114a43d5e353d8f7c35c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/euslisp/default.nix
+++ b/distros/melodic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-melodic-euslisp";
-  version = "9.27.0-r1";
+  version = "9.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.27.0-1.tar.gz";
-    name = "9.27.0-1.tar.gz";
-    sha256 = "6afe4048c28c7c5d1b94a85be4c774797eac4f43835fa20511e841eac47f5907";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.29.0-1.tar.gz";
+    name = "9.29.0-1.tar.gz";
+    sha256 = "b37d14d6e5177c35d13b36cd3ee3108e9d1d474e2be768eab959d3bbaf77aabc";
   };
 
   buildType = "cmake";

--- a/distros/melodic/file-management/default.nix
+++ b/distros/melodic/file-management/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, dataflow-lite, gtest }:
 buildRosPackage {
   pname = "ros-melodic-file-management";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/file_management/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "ba98a28f68f31e1a51a1fb3de6afc22b8797f88ddeb0416a1d85fdbbc863e51d";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/file_management/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "56eb2cea0667a774bc0205104fedbdd3f935968d941ec70a051d52ad7f3cd048";
   };
 
   buildType = "cmake";

--- a/distros/melodic/file-uploader-msgs/default.nix
+++ b/distros/melodic/file-uploader-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-file-uploader-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/file_uploader_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "09cb1bb3bd826bc012b149ae435bf76f4d1b9f9dc6efda04fbb57baf476ae2c7";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/file_uploader_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "acb003c039995c7b1500acb18f5274fa2aaccb0805141931c5138cedbc731193";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3136,8 +3136,6 @@ self: super: {
 
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
 
- rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
-
  rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
 
  rc-tagdetect-client = self.callPackage ./rc-tagdetect-client {};

--- a/distros/melodic/h264-encoder-core/default.nix
+++ b/distros/melodic/h264-encoder-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, ffmpeg, gtest }:
 buildRosPackage {
   pname = "ros-melodic-h264-encoder-core";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/h264_encoder_core-release/archive/release/melodic/h264_encoder_core/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "19f31cb9992ac20374ee457efcac78772598992ad832d31da4c9c23f02029dad";
+    url = "https://github.com/aws-gbp/h264_encoder_core-release/archive/release/melodic/h264_encoder_core/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "bdcf55d6442de34b56bb1e23bbeb4d12f29aaa46a25ac2899ef38b326fc03e6a";
   };
 
   buildType = "cmake";

--- a/distros/melodic/health-metric-collector/default.nix
+++ b/distros/melodic/health-metric-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, message-generation, message-runtime, ros-monitoring-msgs, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-health-metric-collector";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/melodic/health_metric_collector/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "de3cceb8580f9dea5b9dc921ff1364c6486c89e217ae42ebf5349d67f8668c0c";
+    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/melodic/health_metric_collector/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "7bc8f10d1e168870282670c9da976844f48cf49699b064b8b701a1b09da9ef4e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kinesis-manager/default.nix
+++ b/distros/melodic/kinesis-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, curl, gtest, log4cplus, openssl, pkg-config }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-manager";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_manager-release/archive/release/melodic/kinesis_manager/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "6db7c90ac6fb345ff10ec737c2f37f5cc6a0f6a6aebf038c852375afd2fb40e2";
+    url = "https://github.com/aws-gbp/kinesis_manager-release/archive/release/melodic/kinesis_manager/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "6f22911e08025ecc3b5f01cb5ae4fe7acd7c9ae49a7470299cb72892ca8b9b08";
   };
 
   buildType = "cmake";

--- a/distros/melodic/kinesis-video-msgs/default.nix
+++ b/distros/melodic/kinesis-video-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-video-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "d3116f1e9c9aea3eeda1de9c5a49056834699356ebdf058f713112425306ca09";
+    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "e857e438116f810e6523c5124130522aae0efb005c5eb615943d0a129554bdaf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kinesis-video-streamer/default.nix
+++ b/distros/melodic/kinesis-video-streamer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, image-transport, kinesis-manager, kinesis-video-msgs, roscpp, rostest, rostopic, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-video-streamer";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_streamer/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "c9d21edf29f27e1896e428ecabe75be86a821ecb7caa07ff4fd3ffd45c4c1385";
+    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_streamer/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "a64bdfb44fd7078a6fd38b5b311f37132db8339445c11f414d7d9358992b86e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lex-common-msgs/default.nix
+++ b/distros/melodic/lex-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lex-common-msgs";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_common_msgs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "ca665d382b0694fc69c410c9b474bffebf278025ac46ac6554488870e94b23c8";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_common_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "185e910bba5ebe7d74453e9c843063c4238cec97dc442617ca47da8ad138372e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lex-common/default.nix
+++ b/distros/melodic/lex-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, gtest, ros-environment }:
 buildRosPackage {
   pname = "ros-melodic-lex-common";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_common-release/archive/release/melodic/lex_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "69a222e4226dfcaf24a2a5c923b70f37b411c95a51ae870b97a6734178cd8536";
+    url = "https://github.com/aws-gbp/lex_common-release/archive/release/melodic/lex_common/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c19408145479820b1c6aac9421d65161786b8e17b679ae4fd6db36a003d3ab52";
   };
 
   buildType = "cmake";

--- a/distros/melodic/lex-node/default.nix
+++ b/distros/melodic/lex-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, lex-common, lex-common-msgs, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lex-node";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_node/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "24375a02bbf5b57fa1fb9765d43c4cbcf76f7c14e3f250369a738f023ab773e6";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_node/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "e7ef63cc1fb0b85d1c3e4c69d8feb4866ba240937ad8e639c7afd8ddf5253a81";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2022.1.5-r1";
+  version = "2022.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.1.5-1.tar.gz";
-    name = "2022.1.5-1.tar.gz";
-    sha256 = "680dd8d9c37c088ec4ffe32941cd6370e4d0dd85f7b8dd8e8827c2552298a6ad";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.2.2-1.tar.gz";
+    name = "2022.2.2-1.tar.gz";
+    sha256 = "1aaa955279437353c8111c7d6aa8e1a052721861da7f0a091f2ad2c3433fb28e";
   };
 
   buildType = "cmake";

--- a/distros/melodic/microstrain-inertial-driver/default.nix
+++ b/distros/melodic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, mavros-msgs, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-driver";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "47717696f4e505bdee19207971a16f90afad7adc4e822018e7341a5ff3c73e52";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "28af1f6bb95808067fbce59985cff3b8fae2e890caa2f445d67e10bd1a52056d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-examples/default.nix
+++ b/distros/melodic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-examples";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "000790b0952db90d98d0cbbf3d31066a8f5d03463e2e1aa58a7f23877a09edbd";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "fb688f2b8905a9cbb414a08849e2a92d68e868404be692e55f57d61dd3cd578b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-msgs/default.nix
+++ b/distros/melodic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-msgs";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "c5b8d445d5a6d6a2fc11ebf91619d9ee10db7f4f7648e624b0b89af9f4cafae0";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "7677415b6cbd69839c1fb3a95f7118b655206b169bfd6eb5f4439a0ff3c2c3aa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/microstrain-inertial-rqt/default.nix
+++ b/distros/melodic/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rospy, rqt-gui, rqt-gui-py, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-microstrain-inertial-rqt";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_rqt/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "83b204b04296355b808c626b8c6672899db01064b8c6f67c8a3f4d5803d6a9f8";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_rqt/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "f3041bbd95ac8a94952c1f994cdf48aa9a060319ea89f1715c979fa44b95abea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ntrip-client/default.nix
+++ b/distros/melodic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ntrip-client";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "fbcea3209e67715ce474f01810f73ab5179b80b60344f81352d7a664ffe00232";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "bd8fa6101b2348b83714b27576dfea851faea7194fc89910a59060912b387220";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pcl-conversions/default.nix
+++ b/distros/melodic/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, pcl, pcl-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pcl-conversions";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_conversions/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "c39fde1d353721e726cb1f09337098545dc97ba9eb3d2360497c429e03d6c0a1";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_conversions/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "802d6bc106aac351f44e40da87ccab4e8c48c710c80123181e3f3399fbc93a5c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pcl-ros/default.nix
+++ b/distros/melodic/pcl-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen, geometry-msgs, message-filters, nodelet, nodelet-topic-tools, pcl, pcl-conversions, pcl-msgs, pluginlib, rosbag, rosconsole, roscpp, roslib, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, message-filters, nodelet, nodelet-topic-tools, pcl, pcl-conversions, pcl-msgs, pluginlib, rosbag, rosconsole, roscpp, roslib, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pcl-ros";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_ros/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "f7377e1788ce4ac31b1aea62601b40be17ecbd982869526fff7d6bdc77c02313";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_ros/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "81c8f34db4e676394e91982470aaf3e88b0e23f955a4f5b49efbddbe812dada8";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules rosconsole roslib ];
+  buildInputs = [ rosconsole roslib ];
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ dynamic-reconfigure eigen geometry-msgs message-filters nodelet nodelet-topic-tools pcl pcl-conversions pcl-msgs pluginlib rosbag roscpp sensor-msgs std-msgs tf tf2 tf2-eigen tf2-ros ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/perception-pcl/default.nix
+++ b/distros/melodic/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-melodic-perception-pcl";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/perception_pcl/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "503b98798df94bcbce84828d6f07a175a87f4e9719eb3a56198dc97792378359";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/perception_pcl/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "2599983e343b30b490122b261c020ce74a17328ab748cbe840007753e9579608";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "434704c185cf69d766d543a78f030522c6b43127bcde587282dfb50c85fac2f3";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "35f3edd5acf701eeb588bf21b22d2122a4d89267f39ba73ed4994832fc92a77f";
   };
 
   buildType = "cmake";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.4.0-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "1581461ad87fa7b2cac9f968bba2f50c6d1035e0d1d19028732b7b193d2e6e19";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "aec266a97a65c0fef6f01b4820b1a88b06a170e2a502433b1fbb210a18e2b428";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/melodic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rc-hand-eye-calibration-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "1ec1067c217bdef0a3c5e30b3bde1dbc415cb3c531853d593273aabef2edeb9a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "28a9e136b7b771c3e45a08f9124c3ea050e91df384d56cffad6572bbef29a9e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-pick-client/default.nix
+++ b/distros/melodic/rc-pick-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-pick-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "8e4b3c36d1fd8c068236e6390631a69a297d9f9ecc8d5b1f9666cd2b45c4e63a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b039f18e7f474e9f5fb2eec1f1ace65facca17dc31754f1753cd6e7fadcb8d4f";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ curl dynamic-reconfigure geometry-msgs message-runtime rc-common-msgs rcdiscover roscpp shape-msgs std-srvs tf tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ curl dynamic-reconfigure geometry-msgs message-runtime rc-common-msgs rcdiscover roscpp std-srvs tf tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rc-reason-clients/default.nix
+++ b/distros/melodic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, pythonPackages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-clients";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "773d5496e448df0f049a9c7280153920e3040461070b2b9cb5a131bcfcec71a5";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "5680aca20acb26716ada6a8fb89a11b099535eab0eea9976e07cb35e2379feb9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-msgs/default.nix
+++ b/distros/melodic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-msgs";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "ff54aa120cbcc25182a8b936b4528ea8f7e2ad0cc174a8bdd0f83d9090508fb7";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "ed41aa1d94c1f1f73d7b36a780e835adebd9fb42dbcce24e1be957b952f6e684";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-silhouettematch-client/default.nix
+++ b/distros/melodic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-silhouettematch-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "60b0b638e9e7dd2916e95f4dafdac396665ba00a4da4e1d2c542130c73e639d3";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "9d0c7d8cb5051a7a60da5b414bf8db02a4dacf7ec7e340a37d32860bfc817bc7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-tagdetect-client/default.nix
+++ b/distros/melodic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-tagdetect-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "a8bf4f7f7f185ee22adaa73df2f53ebdd6a74eadb385784cb16a5840bc905433";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "1e05e9ee50122d94fbc654cab6de61861d62585272500861a718c9b3da626886";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-description/default.nix
+++ b/distros/melodic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-description";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "621d2975c45002d2114671c16b9781934a274675019e26c0ec7594bbf8ca37bb";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "06e14260580313d2a6dbe4fa67afff2a56d1b78b4e81bf0b6e968fc43124390e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-driver/default.nix
+++ b/distros/melodic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-driver";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "6a0ca88bd27602bdf4f5fff8470f91f1bcf0fa6479aca677e4c41d9faac380b4";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "6dbe6edfa1132c3aade3347f98a0dd430bed1a822c611e91e2c3468f9c848207";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard/default.nix
+++ b/distros/melodic/rc-visard/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
+{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "686f98970cd7ea2cab688a10ab7f819b0db8da05e3f84c4cb26844751958e81b";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "05579726c188abb8e4801fa04e5761d035e40bd1136d6c5590965519ed3ca2e1";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-roi-manager-gui rc-silhouettematch-client rc-tagdetect-client rc-visard-description rc-visard-driver ];
+  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-silhouettematch-client rc-tagdetect-client rc-visard-description rc-visard-driver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/recorder-msgs/default.nix
+++ b/distros/melodic/recorder-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-recorder-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/recorder_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f5a741c359bf9420a8bdb479bc65c235a72e3af4f510eb8a8f3716f832019246";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/recorder_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "3065e9f7c51beeff9d0e8d10c1cc7b8d3968086a85228cd715c7e29f7cd19503";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-monitoring-msgs/default.nix
+++ b/distros/melodic/ros-monitoring-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-monitoring-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/ros_monitoring_msgs-release/archive/release/melodic/ros_monitoring_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d9215590fe7e1d5c0dadd7a19195db12250e64327bd5423ad6292c0a7e920165";
+    url = "https://github.com/aws-gbp/ros_monitoring_msgs-release/archive/release/melodic/ros_monitoring_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "0f33f8a0c1a4de6309dbbb24d8ab3f0dbb1f7533bb4d956c540dea8235f03a08";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-cloud-recorders/default.nix
+++ b/distros/melodic/rosbag-cloud-recorders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gtest, recorder-msgs, rosbag-storage, roscpp, roslint, rostest, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-cloud-recorders";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/rosbag_cloud_recorders/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "7558cdb87a1dc7a56a0dc4eaeedc550724cdb293a0b56a7e5a44a707adcb8e9a";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/rosbag_cloud_recorders/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "35540e67e87bbd85c8311535c8b585de9736b7fb2e640e7b45dcd6d802de098c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.23-r1";
+  version = "1.13.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.23-1.tar.gz";
-    name = "1.13.23-1.tar.gz";
-    sha256 = "e9d1065e70ebde27ea0cf3939466985ca7eb2c1b73b96d0a8734bd5e02cb0955";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.24-1.tar.gz";
+    name = "1.13.24-1.tar.gz";
+    sha256 = "06e0d574a662310e1590864b338785434720b6f44fad84d9036ede48425a25ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/s3-common/default.nix
+++ b/distros/melodic/s3-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, gtest }:
 buildRosPackage {
   pname = "ros-melodic-s3-common";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_common/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "020e7dcb88eb4b7c3efc63814fd190051ca4769345fc180807b576ee018e9bbb";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_common/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "660dfd0718cfc11abc19f8d61c046f14c85e2c0e6670af3244b8f8776004a9e9";
   };
 
   buildType = "cmake";

--- a/distros/melodic/s3-file-uploader/default.nix
+++ b/distros/melodic/s3-file-uploader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gtest, roscpp, rostest, s3-common }:
 buildRosPackage {
   pname = "ros-melodic-s3-file-uploader";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_file_uploader/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c0dcc4dbd3ec1ee24590acc7b770caef82b6b4a4434517b277754f5738d6836a";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_file_uploader/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "160dab31e75756e0997e3589c8281431a33ff4af07c561af0948a2784e622b59";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tts/default.nix
+++ b/distros/melodic/tts/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, pythonPackages, rospy, rostest, rosunit, sound-play, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, pythonPackages, rospy, rostest, rosunit, sound-play, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-tts";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/tts-release/archive/release/melodic/tts/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "ff9513ecc2e040bc38e882badee1407e351c9c1abb6cd8c75ec1ac81dcfe5cd1";
+    url = "https://github.com/aws-gbp/tts-release/archive/release/melodic/tts/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "58c5eeaf9d04747a09cdcf3cdadd673b1dcb20afd3173c8d62a090b7b407f172";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation rostest rosunit ];
   checkInputs = [ pythonPackages.mock ];
-  propagatedBuildInputs = [ actionlib-msgs message-runtime pythonPackages.boto3 rospy sound-play std-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime pythonPackages.boto3 rospy sound-play std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.15-r1";
+  version = "1.13.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.15-1.tar.gz";
-    name = "1.13.15-1.tar.gz";
-    sha256 = "0f01804df71628567ea2ff5bbec1adeba929552ab70a6e2a09d4a1c6086825b1";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.17-1.tar.gz";
+    name = "1.13.17-1.tar.gz";
+    sha256 = "a3498a10fe808e967361b2defc52bc76726c8fa882711b4ad8aeb3e208590789";
   };
 
   buildType = "catkin";

--- a/distros/noetic/avt-vimba-camera/default.nix
+++ b/distros/noetic/avt-vimba-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-proc, image-transport, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-noetic-avt-vimba-camera";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/noetic/avt_vimba_camera/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "49dff7f903af47dab6e53a0fc001016c2254a52a9eff3fd170189ed6584bc692";
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/noetic/avt_vimba_camera/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0bc50924547603cf97f41dfb59ee695582d035802a8e6c3b5bcc9e52a2f1ecce";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "cec96e8188342a16daaf1573e5847edaccee8a37f612207ffd72ac07f38d0cc4";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "bf147ab9bd62fed718dc4cf7b587ad2cc12110247863f5e483442bc0c37b5165";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-gazebo/default.nix
+++ b/distros/noetic/dingo-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dingo-control, dingo-description, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, ridgeback-gazebo-plugins, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-gazebo";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_gazebo/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "7b35e2a11f815c324bb1b6c9cbd9fab92f97c6f13602c1350080683b489b90c3";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dingo-control dingo-description gazebo-plugins gazebo-ros gazebo-ros-control hector-gazebo-plugins ridgeback-gazebo-plugins ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launchfiles to use Dingo in Gazebo.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dingo-simulator/default.nix
+++ b/distros/noetic/dingo-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dingo-gazebo }:
+buildRosPackage {
+  pname = "ros-noetic-dingo-simulator";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_simulator/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "09094dfe9128e2ce280c7c62ba092c9ac08630d405ce6639df972304f50b5394";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dingo-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Packages for simulating Dingo.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.9-r1";
+  version = "2.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "9449ffa6a473d13b3f73a3fa96b1ab6cf45ec6a14caaeb7fbf17afefcc037342";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.10-1.tar.gz";
+    name = "2.6.10-1.tar.gz";
+    sha256 = "9b36e533876ad0228e73157bb4f036092174ae382192fc7c61b51b85d22eb79d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/euslisp/default.nix
+++ b/distros/noetic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-noetic-euslisp";
-  version = "9.28.0-r1";
+  version = "9.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/noetic/euslisp/9.28.0-1.tar.gz";
-    name = "9.28.0-1.tar.gz";
-    sha256 = "e96dd4d4acd2d76c5b1fa660982b54e0e06efd9746a6f7ce7909dc128abccd95";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/noetic/euslisp/9.29.0-1.tar.gz";
+    name = "9.29.0-1.tar.gz";
+    sha256 = "ecbf0b5ab05617eac190bb25eaf140fe576d01de47e779b5ad9c2a911d800693";
   };
 
   buildType = "cmake";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -548,9 +548,13 @@ self: super: {
 
  dingo-desktop = self.callPackage ./dingo-desktop {};
 
+ dingo-gazebo = self.callPackage ./dingo-gazebo {};
+
  dingo-msgs = self.callPackage ./dingo-msgs {};
 
  dingo-navigation = self.callPackage ./dingo-navigation {};
+
+ dingo-simulator = self.callPackage ./dingo-simulator {};
 
  dingo-viz = self.callPackage ./dingo-viz {};
 
@@ -1448,6 +1452,8 @@ self: super: {
 
  lockfree = self.callPackage ./lockfree {};
 
+ lockmount-description = self.callPackage ./lockmount-description {};
+
  locomotor = self.callPackage ./locomotor {};
 
  locomotor-msgs = self.callPackage ./locomotor-msgs {};
@@ -2223,8 +2229,6 @@ self: super: {
  rc-reason-clients = self.callPackage ./rc-reason-clients {};
 
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
-
- rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
 
  rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
 

--- a/distros/noetic/husky-control/default.nix
+++ b/distros/noetic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-husky-control";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "8cfd0f3c160bd304b33cb3c7c476d975ea4161f307270cca7c75f8592a3ce045";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "efd3033e019a3262c8653390ba34b2933cf5f88fcea1d439fa54723ef5b1514f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-description/default.nix
+++ b/distros/noetic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-husky-description";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "fa2c87c8322939488df03e9e2ebeac17a19f651332a640c4392772b67167a536";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "8f335ec34e1831ff0be69850d67a75730e973c150340b05e64e1e598a8e5c20b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-desktop/default.nix
+++ b/distros/noetic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-noetic-husky-desktop";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "c10bf434897ac56ce4f78c89e117d94e61993916331f04d6f47d56c1bc90bb80";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "d9eb767589795f5e848b0cef73f96f45c9ff066439626686f53103f685045749";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-gazebo/default.nix
+++ b/distros/noetic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-husky-gazebo";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "d2dbd02265c894dcdfe2625465370a263cc3020efce16d859e9ff07c37e75558";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "9d243e1af40acf3683331ed65cfcd2dd262b9fc632072b907d8e93b6aca752a6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-msgs/default.nix
+++ b/distros/noetic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-husky-msgs";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "0bfe0629237a8b51d8d6ff0be87c36c5b89c58c090ffb0b224cb0ee375e8fec1";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "6de2ebf432e6585b1b3b6fee258a7da36c6dbc89339fb6094604299e39d84064";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-navigation/default.nix
+++ b/distros/noetic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-husky-navigation";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "c456785c370bd7553a85877b67dd60b4ba4313946788af2111b367424e1b000e";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "c39aeb9bfa3ce058c79e61b48f12ceef93a4aa0f544bdb96565ac09ab2a0dc67";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-simulator/default.nix
+++ b/distros/noetic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-noetic-husky-simulator";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "e60fff6e5baa66173db7ad7c09add9c55e9c71ab47103e64fa94441e84c94b9a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "89a6fb7ec65c7c1ffeabb82086155027cd96f326c1c72caac0261133f8ae4a64";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-viz/default.nix
+++ b/distros/noetic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-noetic-husky-viz";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "e605d8eaefaab4e5280dd2e62672fbb9a4389f70dd7f3fb8cac0eecef1d1a879";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "50323e6030035e6cc0570711b693ed2390f60ccb44faac2930fcf99619beba0f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-control/default.nix
+++ b/distros/noetic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-jackal-control";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "ced42cd284f2812cffab0ad95f6a443c33599453dcb45a0b88c3e532b096fca1";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "b162798840859474434b5e66d06cae31713aab0f1ab7b4cea5386d0d84188dd7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-description/default.nix
+++ b/distros/noetic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-description";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "915b1059ce39c82b08443244b8c111a66d7d255a5908af86c1d2d4dbb50eefc8";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "250b3be524f51ce0b12dce6cfb4df7c6260f321a2be4bc8f87b47ce84bf53f56";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-msgs/default.nix
+++ b/distros/noetic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jackal-msgs";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "02fa7c383a610011fbadaf9750dac3d419eb3575e9f1aa502473cdc4ba8793ad";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "730f22e8f5366b4d2908906953ed1b722874759273b79549df5c24c9f2e9e80d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-navigation/default.nix
+++ b/distros/noetic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-navigation";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "76be20fcbfd0c181b7cdf5fc059e734ffe8b98ac34031a5ff2480ef7b1810947";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "56a7d9fb1daf75b1f0f50d7c114c66ad78e692f29abecc909043c097fd832e94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-tutorials/default.nix
+++ b/distros/noetic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-noetic-jackal-tutorials";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "180abe6296db19d9bdd9e75a91701e7caf0f29e8b8a3aa7d3c32059be38cb7e1";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "c298a327681f7e615e6539b3618cb156e223711f50c729d1556c70aa8f186556";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-publisher-gui/default.nix
+++ b/distros/noetic/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, python-qt-binding, rospy }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-publisher-gui";
-  version = "1.15.0-r1";
+  version = "1.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher_gui/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "40f83e70d4bacb6a8d16d83bd1a14fac295facf2acd8233ecf8ce8658f4574d2";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher_gui/1.15.1-1.tar.gz";
+    name = "1.15.1-1.tar.gz";
+    sha256 = "0a285a9ff411a8dc5944e4540fade94f52a067f70fe79656ae40061938f8dc34";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-publisher/default.nix
+++ b/distros/noetic/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-publisher";
-  version = "1.15.0-r1";
+  version = "1.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "beddd248a4bdb8434c627b98ec548ebb007cf63c613e5e6f5df98b7b28f027aa";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher/1.15.1-1.tar.gz";
+    name = "1.15.1-1.tar.gz";
+    sha256 = "e12c52894f255b6b5682d14ebe3a12c0d865a72d92455992987a31e51922115a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "806e09a99be47f8209d1b5b3513d9a16c9a4c29706f8e668c9d3f4375dd59176";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "6723ab5b8a0e57657c681a44c7937b21a379255c5abefb1ef5a814f1cf4a2899";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lockmount-description/default.nix
+++ b/distros/noetic/lockmount-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-lockmount-description";
+  version = "0.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/lockmount_description-release/archive/release/noetic/lockmount_description/0.0.2-2.tar.gz";
+    name = "0.0.2-2.tar.gz";
+    sha256 = "f5d300fd7edb3a9391a63e9aeae28547ccb83403a162ee7fef2e12487a2d2222";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF Macro for adding an adjustable, locking mount used for cameras and other sensors'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2022.1.5-r1";
+  version = "2022.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.1.5-1.tar.gz";
-    name = "2022.1.5-1.tar.gz";
-    sha256 = "6ff80173db17b9b162d3b6529c09bf8a9733402c10583fc6c59925bdd890ad3f";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.2.2-1.tar.gz";
+    name = "2022.2.2-1.tar.gz";
+    sha256 = "631d98097760a71fc92d2d06020c15d5a3250d96aeb3b366988108ef97f2faf5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mia-hand-bringup/default.nix
+++ b/distros/noetic/mia-hand-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mia-hand-description, mia-hand-driver, mia-hand-gazebo, mia-hand-ros-control }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-bringup";
-  version = "1.0.0-r13";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_bringup/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "54ea4beba19456237a3ca82d07a4e120f5af1553f3075bdd89db35962da5d955";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_bringup/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "68d68e63d33613b45e437abc06eb8fe24037aad21fa119a46b09a0f191fcf3e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-description/default.nix
+++ b/distros/noetic/mia-hand-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-limits-interface, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roscpp, rostime, rviz, sensor-msgs, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-description";
-  version = "1.0.0-r13";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_description/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "eb7181d71b31e2949accf0af96bdf8eedb9164c1a514d3cd739214e17b8963a1";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_description/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "e27ef85e461f7ad68703b67a616c26277c5f582c5ae7997a718be8972702a7c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-gazebo/default.nix
+++ b/distros/noetic/mia-hand-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-manager, gazebo-ros-control, hardware-interface, joint-limits-interface, mia-hand-description, mia-hand-ros-control, pluginlib, roscpp, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-gazebo";
-  version = "1.0.0-r13";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_gazebo/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "d6c0d9e445c9924203c1d902c8e1dd4b548e5a09b7d0c1b289a65bfa792894f7";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_gazebo/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "65a76cc981c7e7283376aef273ece732f8be91c6a9e9da27ea4be9b0d3d3ebb4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-moveit-config/default.nix
+++ b/distros/noetic/mia-hand-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, mia-hand-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-moveit-config";
-  version = "1.0.0-r13";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_moveit_config/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "60a66c548e9d3b6c3d51b8dae65ff26fb17f6bb4407385428e5a6f63bc3e0644";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_moveit_config/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "2a8a6765846be755de46b935417af73097ff848e3f62efb5dae4c87b9e95c645";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-msgs/default.nix
+++ b/distros/noetic/mia-hand-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-msgs";
-  version = "1.0.0-r13";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_msgs/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "79bbde4295d3ab46307fabc372618919142f7ab82ee17de8b9f04340c5a8d6d1";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "2185777f63221499fe20d4d2e01ec4dec24a319ccad0a013ee12b3e17fb371b4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-ros-control/default.nix
+++ b/distros/noetic/mia-hand-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-manager, hardware-interface, joint-limits-interface, mia-hand-description, mia-hand-driver, pluginlib, ros-controllers, roscpp, rqt-joint-trajectory-controller, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-ros-control";
-  version = "1.0.0-r13";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_control/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "3bb26cf31e64e8b7c4aa3e95787dbd80788af7266903ac712b79eec0363469cb";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_control/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "7533ff9d9288bc4a672a546a7a6dd93cb96148cc37808003375be12d573e1e28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mia-hand-ros-pkgs/default.nix
+++ b/distros/noetic/mia-hand-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mia-hand-bringup, mia-hand-description, mia-hand-driver, mia-hand-gazebo, mia-hand-moveit-config, mia-hand-msgs, mia-hand-ros-control }:
 buildRosPackage {
   pname = "ros-noetic-mia-hand-ros-pkgs";
-  version = "1.0.0-r13";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_pkgs/1.0.0-13.tar.gz";
-    name = "1.0.0-13.tar.gz";
-    sha256 = "4b6fbbffe891c2277bf148c60d2277e1c69328ed925bf5257edead7fb9e23edb";
+    url = "https://github.com/Prensilia-srl/mia_hand_ros_pkgs-release/archive/release/noetic/mia_hand_ros_pkgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "e068a990866f6332cca52d145391755c07bab1f8205373d82c8fc2469ca539d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, mavros-msgs, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "c0d9c2d7d66864da90a0b49dd510113333f010c626cb238ed8727c946188b529";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "6a83fa11da153804ad3a4b16e81454074cc4902e94461e78ff1f6bf0a242b16e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "cb97c730e0220d15311a059f8083a3d157b3cd25dcb9eb88286304ba244a9daf";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "fdd79f51e5aacbbf2e2557c60a6780c907a4e1f135ec35b553e68135a4bb851f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "e9c47f085a993b61a84499776972e5724437624ac33e7611e6ee7ae7427f10c2";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "56516efbca075a3f6b27c9a0cfcff00e8c3e912f087b38859b0c59810ebaa2ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-rqt/default.nix
+++ b/distros/noetic/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rospy, rqt-gui, rqt-gui-py, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-rqt";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "dfd0ff518442d1c217be2b304e69d415a94bbee5ffbb28afa993f624c974d33e";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "34a20fe927e2fc49d7e9b37892d7f61b8a54cd8463c98995a3d221b4a8465460";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-actions/default.nix
+++ b/distros/noetic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-actions";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "759f12d67b06697ebe3ddd9471c22c6f6d0cd8c48646886cff5c077c26c2c261";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "b3bd695a626160669565c4f2ae7b9e63a1c8559cfcffffc0a31b658b48940313";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-description/default.nix
+++ b/distros/noetic/mir-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, hector-gazebo-plugins, joint-state-controller, joint-state-publisher, joint-state-publisher-gui, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-plugins, gazebo-ros-control, hector-gazebo-plugins, joint-state-controller, joint-state-publisher, joint-state-publisher-gui, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-mir-description";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "1e308f4ab82aa18f324050e6aa3f705b304157865ec7b241bf29cabb988b8638";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "1493c3d5d2f284a4385487e1bce11491b798464c2d1690eea3051b26309daa06";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ diff-drive-controller gazebo-ros-control hector-gazebo-plugins joint-state-controller joint-state-publisher joint-state-publisher-gui position-controllers robot-state-publisher rviz urdf xacro ];
+  propagatedBuildInputs = [ diff-drive-controller gazebo-plugins gazebo-ros-control hector-gazebo-plugins joint-state-controller joint-state-publisher joint-state-publisher-gui position-controllers robot-state-publisher rviz urdf xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mir-dwb-critics/default.nix
+++ b/distros/noetic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, python3Packages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-dwb-critics";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "40ed5b44cf81e2ebb2d198312c48cf9cda4fc482c7c66542802fd4adbc308c89";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "1e3a2c6855cc7b2ccd67a16e1ecf9ed9f219a6ad583436c6f14b65947092d525";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-gazebo/default.nix
+++ b/distros/noetic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mir-gazebo";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "2216a17b7eac1c7fc9a62164e67e946a4e9c15318401b52c34f704ab96ff9499";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "54beba93b845ad70a5d910144c1e2a2c535edc34b63fa0a63e85b9fb261593d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-msgs/default.nix
+++ b/distros/noetic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-mir-msgs";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "9207bda20d2d6f5cc4edcf04c947f79cb6ce8497402b58178c7b86a6a3498959";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "86904b4498b5e34ba6f5c45a8d42a33a01ca6b635bf5ded2ff1793912c617992";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-navigation/default.nix
+++ b/distros/noetic/mir-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner, teb-local-planner }:
 buildRosPackage {
   pname = "ros-noetic-mir-navigation";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "f1737dfaaa067e4fab7549cac0c5ce097b2453b60143cec7055d6d7f2be8363c";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "b42ee51d5475f82a4a1ae62e1ab0823a5cd1faff91a35b7e97afab1abf4c4a49";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-robot/default.nix
+++ b/distros/noetic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-noetic-mir-robot";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "1d42da1666a62d58ed6b61b4f50f476d1a82d4ab409681f963f0bf1e4d7b132b";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "1ac77b5e6f4c9ccbceca3a88bd8571865b9032029b5d817d449de91022e28257";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ntrip-client/default.nix
+++ b/distros/noetic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ntrip-client";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f4de7fad28471c2f4d1307e157b3cf4ff6f953133f241ac801b5b5a2e221fb81";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cf1cf0459dbbd26305989ef21308f7a52c57e6842ab07e651530c8096148fefc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pcl-conversions/default.nix
+++ b/distros/noetic/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, pcl, pcl-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pcl-conversions";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/noetic/pcl_conversions/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "d28ce7647f4e4360aa87d539c1dfeb5a6d17fda83b4093408c1666ba66a922bb";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/noetic/pcl_conversions/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "45306daa50a760bad09b95e2f544068caca7d0a872f4afca5d67237f2d44aa76";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pcl-ros/default.nix
+++ b/distros/noetic/pcl-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen, geometry-msgs, message-filters, nodelet, nodelet-topic-tools, pcl, pcl-conversions, pcl-msgs, pluginlib, rosbag, rosconsole, roscpp, roslib, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, message-filters, nodelet, nodelet-topic-tools, pcl, pcl-conversions, pcl-msgs, pluginlib, rosbag, rosconsole, roscpp, roslib, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pcl-ros";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/noetic/pcl_ros/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "0378051027dcf91b4ac1110cbbaee2709d61416420f5d09ed93ad25a30d0b93e";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/noetic/pcl_ros/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "98c1f6dc4248b1bb110c904cae66c7e17c6d04b6117ace3bc4ea1fe515ad5138";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules rosconsole roslib ];
+  buildInputs = [ rosconsole roslib ];
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ dynamic-reconfigure eigen geometry-msgs message-filters nodelet nodelet-topic-tools pcl pcl-conversions pcl-msgs pluginlib rosbag roscpp sensor-msgs std-msgs tf tf2 tf2-eigen tf2-ros ];
   nativeBuildInputs = [ catkin ];

--- a/distros/noetic/perception-pcl/default.nix
+++ b/distros/noetic/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-noetic-perception-pcl";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/noetic/perception_pcl/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "8fea51a392c757f1afa686bfe09cb08a6445633c55f5b4787cfc27d07b5bcbe8";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/noetic/perception_pcl/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "3077dfaf130b76eb2399373a28c4d9d403a0a9046c56e7f79352c34d8bb99fdd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "9727a7b444899b9f7c2e0a5a24c4963e2bd6e21a582fe07876b90eca8e8c202f";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "74a65238216f7f671a94afc09679c10541f3f6b64dd4b5e643507191716af550";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "d2f570c460eda9d845679a2eac374c0cb3d5964a46015f50bd7cf08d236d3bcb";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f570c059509fe693320108951481a65bee8ff1b614ab7923426ec6424c543595";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-outputs/default.nix
+++ b/distros/noetic/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-outputs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7ed1418505107f24f34145f24f712f6eb56c287e5f68cf4e3ed23a331f0a11dd";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "e8cbb685f292ea3900eb38dcdee08dd34654608707c0492f73a314f82606825c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "45071f52a6739e7cee0c90ba66d3c47d1fc99ef83b9c3bacd363c9fb0050e43a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9f6439b71bb3dbd37a13b4e43f765b26e320d8ed8cda2aa61a90f14bb6f30b06";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "d4da941af4858e285196bd8775b01206e07e25f86bc117687d5a8dda4b96abd3";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "0f7c0180dca584f1d368b56af94f915728735aec0c5f989eca1ead67b319041b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "4ea1d736ca2f3cea82a69813271f67efc6fef6ef1760675bdc88de153c8624aa";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "224c3e2d79e37d890f031792e2979a5e515b5dfcecc3f789e7701ae99bc00f7b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "e4c35d6314101680fe8ae9e236b7dbd8da81047fb234db66dc6a70a5bc39f964";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9b70a7c2a7aaff93afb735cbea1e93f624a553f208b370d991b3decb8475a67c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "a61696b21a19d3e04ca7c11168f03833ef8876e8325ab93bcb51a18c4d511777";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9fd0c6d3ec73a911dd38644bf60c1d00a57f8b28a7d0d33b461a0433effa7eb9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "fea1d7fa183d9486db34c847d6c762752a12c35645e00894f20d4017036bd513";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "c8c94e5e2cbcf3393c074c97d3780327a3a5a8aee950ee8afb36f91935e1d880";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "07cc130db6cf7e60f0df08327aa5847e4abb7057c2233842c029458653c00b78";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "277a898fd96e3313bf7537df81f03325b8b64df1498ae9afaafb180b0e8af4c0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "cce08918a421de2700306136c5444bf596ab035d8d1f328a7c9e313db1d94986";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "73800ad3fb6f953f1d0392786e7c879f074dc2896f7a8b0c4d30075927eedb1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1cfab052c00cd1b71db8140a92db6f667942b3952816740f2e40eb5ae36521d6";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "5346c8aa6c85462d36fecc72b6471c2e5bc6a165e29bc1df46a46194b8e11458";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "da4ac36447679992d0aec4c802fb33a8f5efb1d75af3b2a5d706d8e033b92014";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "eaab21af0334ebc85fe0ab7ee365ebc7a0ddd9b05211f03d3f113744bbe5662a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "17d87ddae46879a5dc801a4385a2581cc928f749870b6aa69ef0705edca948ef";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "91cff1ffd1b7f7a690127551df92e82361eddb1891fb8e2a8db36415d6316b61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "313bda644a067e12605534832360fd4dcc324a1ee91e86f93882419e8d7220bc";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "dd271bf6b1904b1d5fd45c1654150b651ddfa69bbe684127b6773e118c9679f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "3344ad8eb1728111af01b13240c2fb355fb7b754f022243f3d282eea16c191b3";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "ae04b7e0c795345cd909ad3382f3f9c50b53507a3a0ff71cf9b7572c5bea0a18";
   };
 
   buildType = "cmake";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.4.0-r1";
+  version = "3.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "0bf81812bb0126f18b7b63246cbb7eab86fbef63896dba3eae517126f0460a85";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.2-1.tar.gz";
+    name = "3.4.2-1.tar.gz";
+    sha256 = "047dbb614f2192f9fcfca7050118da60251ef560f84cb5e9ca25b6cb418acf09";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/noetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rc-hand-eye-calibration-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "6ec7f891026a63058ea6b2c3c2516d4780d7525a4100e0efd5eee8dbd86553ac";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "715ae9a0ac5de90317a2b79d9fb89ffe558c157151973bb3ac86bfbcb76af5f5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-pick-client/default.nix
+++ b/distros/noetic/rc-pick-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-pick-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "f3f6744392d979b541428e6baba79db332295232adcbb4223cd6b4bf9c6e30e1";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "6d5c40b7c07eb60e55d5b03e9256c772632d2af3cf61d32010438e810a9cfd33";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ curl dynamic-reconfigure geometry-msgs message-runtime rc-common-msgs rcdiscover roscpp shape-msgs std-srvs tf tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ curl dynamic-reconfigure geometry-msgs message-runtime rc-common-msgs rcdiscover roscpp std-srvs tf tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rc-reason-clients/default.nix
+++ b/distros/noetic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, python3Packages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-clients";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "79146598921a250241531a7325675c63fb5a5ac72dd40aaa81730bd674c4697f";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "ec48963acb27603b1a8c263587f51a6d75d5043afcfcdfad004c61939a9bb9d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-msgs/default.nix
+++ b/distros/noetic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-msgs";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "ba2c6748e5e0f8b2a0660a91627b99b7323acfc906771fa76426a17545047ba5";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "50a7fbb919cef19e7fc1136fadb1379b05b32ead2bc6eb11c88a5bbfe8dfc5d5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-silhouettematch-client/default.nix
+++ b/distros/noetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-silhouettematch-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "9c1b76daf6850be40457324fc3a05087f310f1948312b65181679f53588f0946";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "6055a1d35f50d73185b933d4f5d33cbc486c2d64189b530c5ce0abb1dccb8014";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-tagdetect-client/default.nix
+++ b/distros/noetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-tagdetect-client";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "a998f52aba14807852fb27e7945dc5d9c7f60037fd7009c861dd6e0c8ab726f8";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "02771061c647b098b540c5f51a966fc74b0b6f0fd8fe448cc40a8385c90aacc9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-description/default.nix
+++ b/distros/noetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-description";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "3794077fe641b35ae3a0fba0cfd10c7e67f2ef44373ada0b16f6b65e4de20697";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "0c1266b9286368bb458125f92194db590af5455ecab9ed82c09389139c85a553";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-driver/default.nix
+++ b/distros/noetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-driver";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "18cdbf2a9e849eb91b29bb889c296e4ec579aa533e9866532317b81b441edf9b";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "bfe55fb7df68fab23ff3d4c4a76c38befe3bded2e05f36a5126197ff8915cf53";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard/default.nix
+++ b/distros/noetic/rc-visard/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
+{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard";
-  version = "3.2.4-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.2.4-1.tar.gz";
-    name = "3.2.4-1.tar.gz";
-    sha256 = "dc0ff43e305b3f3507dcb8775babca5c466b8fd1fc0c191311b7cdacc76957e0";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "e4401da3d1dee223d2640fe3f28fbc6cf737652895120b4f3a4a78734a651eca";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-roi-manager-gui rc-silhouettematch-client rc-tagdetect-client rc-visard-description rc-visard-driver ];
+  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-silhouettematch-client rc-tagdetect-client rc-visard-description rc-visard-driver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/robot-upstart/default.nix
+++ b/distros/noetic/robot-upstart/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, util-linux, xacro }:
 buildRosPackage {
   pname = "ros-noetic-robot-upstart";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/noetic/robot_upstart/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "148590e64f794942f3942dfc780d193eaaca9529bc085cc9627c4859df8f65ee";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/noetic/robot_upstart/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "3c22f90aa2a8fb62bfb8826fe47b3a3f10a58f3afa5012825e33272d21d5edb3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.13-r1";
+  version = "1.14.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.13-1.tar.gz";
-    name = "1.14.13-1.tar.gz";
-    sha256 = "7f2c7faef59fcc623aa7c1bc6206bfe5d1692f44c014e0538bb425f72cfc5d85";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.14-1.tar.gz";
+    name = "1.14.14-1.tar.gz";
+    sha256 = "11c239574d5773e8565989cbe525c5f1ae44658092fabc6b59d68a388e613738";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sdc21x0/default.nix
+++ b/distros/noetic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sdc21x0";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "7c7f8bf81d2689966dbe1dbaf4283e4a3fd3c0f04da95186af3b5db24cae7fe2";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "d95c044b2b9d73ade6fc5921a8d47449029ee4e9aada6728837d5d6f1ae9a0bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vision-visp/default.nix
+++ b/distros/noetic/vision-visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, visp-auto-tracker, visp-bridge, visp-camera-calibration, visp-hand2eye-calibration, visp-tracker }:
 buildRosPackage {
   pname = "ros-noetic-vision-visp";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/vision_visp/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "28e44cc1fa6ce206e0f09ab8528665508bd9aa363bb4adde97ba9b2e0c29ce8b";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/vision_visp/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "bd8f775318847558e0feac28da4be1977f100cf9541e1d2a9022073776ce387d";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''Virtual package providing ViSP related packages.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ gpl2 ];
   };
 }

--- a/distros/noetic/visp-auto-tracker/default.nix
+++ b/distros/noetic/visp-auto-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, libdmtx, message-filters, resource-retriever, roscpp, sensor-msgs, std-msgs, usb-cam, visp, visp-bridge, visp-tracker, zbar }:
 buildRosPackage {
   pname = "ros-noetic-visp-auto-tracker";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_auto_tracker/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "9c7f711b183dab46d36a7de358e24e878fb681762930f94789dd6d44d8a249bb";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_auto_tracker/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "8d5104d242ba38ceb8c5b5cb150ded191f048b8697bdb4ff71545536e546d86d";
   };
 
   buildType = "catkin";
@@ -22,7 +22,7 @@ buildRosPackage {
 
     visp_auto_tracker wraps model-based trackers provided by ViSP visual
     servoing library into a ROS package. The tracked object should have a
-    QRcode of Flash code pattern. Based on the pattern, the object is
+    QRcode, Flash code, or April tag pattern. Based on the pattern, the object is
     automaticaly detected. The detection allows then to initialise the
     model-based trackers. When lost of tracking achieves a new detection
     is performed that will be used to re-initialize the tracker.

--- a/distros/noetic/visp-bridge/default.nix
+++ b/distros/noetic/visp-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, visp }:
 buildRosPackage {
   pname = "ros-noetic-visp-bridge";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_bridge/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "a81134c3961592a9433960ed40a3d6a534cf1488bf9ca27164027eba9c58050c";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_bridge/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "d47d8f96d5dd8a078c839c74297c685aefc992e0ea50ab765b56eaa2f7cf8553";
   };
 
   buildType = "catkin";

--- a/distros/noetic/visp-camera-calibration/default.nix
+++ b/distros/noetic/visp-camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, message-generation, message-runtime, roscpp, rqt-console, sensor-msgs, std-msgs, visp, visp-bridge }:
 buildRosPackage {
   pname = "ros-noetic-visp-camera-calibration";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_camera_calibration/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "3b1049c3cb0dca52fa13b3b211f1ccc055f58db595f282b219fb98e7771b5790";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_camera_calibration/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "912fdfd3ff356d1297d781258f6f67f0f930e964690faf1ad71d73194ce58c06";
   };
 
   buildType = "catkin";

--- a/distros/noetic/visp-hand2eye-calibration/default.nix
+++ b/distros/noetic/visp-hand2eye-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, image-proc, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, visp, visp-bridge }:
 buildRosPackage {
   pname = "ros-noetic-visp-hand2eye-calibration";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_hand2eye_calibration/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "c35a9ce9f4cd7d0e2ed71726e48e26a621163858b25fe21d115d670dd4e7391e";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_hand2eye_calibration/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "e19ebcbaf577c8f28e35b5b22f58b0d96212614905f8f1b4110834a5b7f877ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/visp-tracker/default.nix
+++ b/distros/noetic/visp-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, image-proc, image-transport, message-generation, message-runtime, nodelet, resource-retriever, roscpp, rospy, sensor-msgs, std-msgs, tf, visp }:
 buildRosPackage {
   pname = "ros-noetic-visp-tracker";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_tracker/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "b5642e82a21c8dae985149f9dca3b9044bea1d40fe8a669b3a9a2e5569b9d971";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_tracker/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "315fa708cb143c5aa62bcdf27a94da59d0db535c3d96504ef631990293327992";
   };
 
   buildType = "catkin";
@@ -24,6 +24,6 @@ buildRosPackage {
     This computer vision algorithm computes the pose (i.e. position
     and orientation) of an object in an image. It is fast enough to
     allow object online tracking using a camera.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ gpl2 ];
   };
 }

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.11-r1";
+  version = "1.14.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.11-1.tar.gz";
-    name = "1.14.11-1.tar.gz";
-    sha256 = "1712842c68c78411bf166dc17c8b149e3e1915ffd5d5ff707e3350f2374ce333";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.13-1.tar.gz";
+    name = "1.14.13-1.tar.gz";
+    sha256 = "da0265272c2cb9ae4842f23acfd181924500e61951afec6ab483d839ac322ca2";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit d28a39debdb152610b21a9b432c817b2f74bdec1.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *bag-recorder-nodes 0.3.9-r1*
* *bosch-locator-bridge 2.0.4-r1 --> 2.0.5-r1*
* *dataspeed-can 2.0.1-r1*
* *dataspeed-can-msg-filters 2.0.1-r1*
* *dataspeed-can-usb 2.0.1-r1*
* *eigenpy 2.6.10-r1 --> 2.6.10-r3*
* *foonathan-memory-vendor 1.0.0-r1 --> 1.2.0-r1*
* *gscam 2.0.0-r1*
* *libphidget22 2.0.2-r1 --> 2.1.1-r1*
* *lusb 2.0.1-r1*
* *microstrain-inertial-driver 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-examples 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-msgs 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-rqt 2.5.0-r1 --> 2.5.1-r1*
* *nmea-hardware-interface 0.0.1-r1 --> 0.0.2-r1*
* *ntrip-client 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-accelerometer 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-analog-inputs 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-api 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-digital-inputs 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-digital-outputs 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-drivers 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-gyroscope 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-high-speed-encoder 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-ik 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-magnetometer 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-motors 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-msgs 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-spatial 2.0.2-r1 --> 2.1.1-r1*
* *phidgets-temperature 2.0.2-r1 --> 2.1.1-r1*
* *plotjuggler 3.4.0-r1 --> 3.4.2-r1*
* *plotjuggler-ros 1.6.2-r1 --> 1.7.2-r1*
* *python-qt-binding 1.0.5-r1 --> 1.0.6-r2*
* *quaternion-operation 0.0.7-r1 --> 0.0.11-r1*
* *rc-reason-clients 0.2.1-r1 --> 0.3.0-r1*
* *rc-reason-msgs 0.2.1-r1 --> 0.3.0-r1*
* *rcl 1.1.12-r1 --> 1.1.13-r1*
* *rcl-action 1.1.12-r1 --> 1.1.13-r1*
* *rcl-lifecycle 1.1.12-r1 --> 1.1.13-r1*
* *rcl-yaml-param-parser 1.1.12-r1 --> 1.1.13-r1*
* *realsense-hardware-interface 0.0.1-r1 --> 0.0.2-r1*
* *rmw-cyclonedds-cpp 0.7.7-r1 --> 0.7.8-r1*
* *robot-upstart 1.0.0-r2*
* *ros2-socketcan 1.0.0-r1 --> 1.1.0-r1*
* *ros2bag 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-compression 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-converter-default-plugins 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-cpp 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-storage 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-storage-default-plugins 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-test-common 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-tests 0.3.8-r1 --> 0.3.9-r1*
* *rosbag2-transport 0.3.8-r1 --> 0.3.9-r1*
* *rviz-assimp-vendor 8.2.5-r1 --> 8.2.6-r1*
* *rviz-common 8.2.5-r1 --> 8.2.6-r1*
* *rviz-default-plugins 8.2.5-r1 --> 8.2.6-r1*
* *rviz-ogre-vendor 8.2.5-r1 --> 8.2.6-r1*
* *rviz-rendering 8.2.5-r1 --> 8.2.6-r1*
* *rviz-rendering-tests 8.2.5-r1 --> 8.2.6-r1*
* *rviz-visual-testing-framework 8.2.5-r1 --> 8.2.6-r1*
* *rviz2 8.2.5-r1 --> 8.2.6-r1*
* *shared-queues-vendor 0.3.8-r1 --> 0.3.9-r1*
* *sqlite3-vendor 0.3.8-r1 --> 0.3.9-r1*
* *tango-icons-vendor 0.0.1-r1 --> 0.1.0-r1*
* *tvm-vendor 0.7.3-r1 --> 0.8.0-r1*
* *velodyne 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-driver 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-laserscan 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-msgs 2.1.0-r1 --> 2.1.1-r1*
* *velodyne-pointcloud 2.1.0-r1 --> 2.1.1-r1*
* *zstd-vendor 0.3.8-r1 --> 0.3.9-r1*

Galactic Changes:
-----------------
* *chomp-motion-planner 2.3.3-r1 --> 2.3.4-r1*
* *controller-interface 1.3.0-r1 --> 1.4.0-r1*
* *controller-manager 1.3.0-r1 --> 1.4.0-r1*
* *controller-manager-msgs 1.3.0-r1 --> 1.4.0-r1*
* *foonathan-memory-vendor 1.0.0-r3 --> 1.2.0-r1*
* *gscam 2.0.0-r1*
* *hardware-interface 1.3.0-r1 --> 1.4.0-r1*
* *libphidget22 2.2.1-r1 --> 2.2.2-r1*
* *microstrain-inertial-driver 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-examples 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-msgs 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-rqt 2.5.0-r1 --> 2.5.1-r1*
* *moveit 2.3.3-r1 --> 2.3.4-r1*
* *moveit-chomp-optimizer-adapter 2.3.3-r1 --> 2.3.4-r1*
* *moveit-common 2.3.3-r1 --> 2.3.4-r1*
* *moveit-configs-utils 2.3.4-r1*
* *moveit-core 2.3.3-r1 --> 2.3.4-r1*
* *moveit-hybrid-planning 2.3.3-r1 --> 2.3.4-r1*
* *moveit-kinematics 2.3.3-r1 --> 2.3.4-r1*
* *moveit-planners 2.3.3-r1 --> 2.3.4-r1*
* *moveit-planners-chomp 2.3.3-r1 --> 2.3.4-r1*
* *moveit-planners-ompl 2.3.3-r1 --> 2.3.4-r1*
* *moveit-plugins 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-moveit-config 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-pg70-support 2.3.3-r1 --> 2.3.4-r1*
* *moveit-resources-prbt-support 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-benchmarks 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-control-interface 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-move-group 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-occupancy-map-monitor 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-perception 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-planning 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-planning-interface 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-robot-interaction 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-visualization 2.3.3-r1 --> 2.3.4-r1*
* *moveit-ros-warehouse 2.3.3-r1 --> 2.3.4-r1*
* *moveit-runtime 2.3.3-r1 --> 2.3.4-r1*
* *moveit-servo 2.3.3-r1 --> 2.3.4-r1*
* *moveit-setup-assistant 2.3.3-r1 --> 2.3.4-r1*
* *moveit-simple-controller-manager 2.3.3-r1 --> 2.3.4-r1*
* *nao-lola 0.0.3-r1 --> 0.0.4-r1*
* *nmea-hardware-interface 0.0.1-r1 --> 0.0.2-r1*
* *ntrip-client 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-accelerometer 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-analog-inputs 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-api 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-digital-inputs 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-digital-outputs 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-drivers 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-gyroscope 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-high-speed-encoder 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-ik 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-magnetometer 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-motors 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-msgs 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-spatial 2.2.1-r1 --> 2.2.2-r1*
* *phidgets-temperature 2.2.1-r1 --> 2.2.2-r1*
* *pilz-industrial-motion-planner 2.3.3-r1 --> 2.3.4-r1*
* *pilz-industrial-motion-planner-testutils 2.3.3-r1 --> 2.3.4-r1*
* *plansys2-bringup 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-bt-actions 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-core 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-domain-expert 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-executor 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-lifecycle-manager 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-msgs 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-pddl-parser 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-planner 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-popf-plan-solver 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-problem-expert 2.0.0-r3 --> 2.0.1-r3*
* *plansys2-terminal 2.0.0-r3 --> 2.0.1-r3*
* *plotjuggler 3.3.4-r1 --> 3.4.2-r1*
* *plotjuggler-ros 1.5.1-r1 --> 1.7.1-r1*
* *quaternion-operation 0.0.7-r1 --> 0.0.11-r1*
* *rc-reason-clients 0.2.1-r1 --> 0.3.0-r1*
* *rc-reason-msgs 0.2.1-r1 --> 0.3.0-r1*
* *robot-state-publisher 2.5.2-r1 --> 2.5.3-r1*
* *ros-ign 0.233.3-r1 --> 0.233.4-r1*
* *ros-ign-interfaces 0.233.3-r1 --> 0.233.4-r1*
* *ros2-control 1.3.0-r1 --> 1.4.0-r1*
* *ros2-control-test-assets 1.3.0-r1 --> 1.4.0-r1*
* *ros2-socketcan 1.0.0-r2 --> 1.1.0-r1*
* *ros2controlcli 1.3.0-r1 --> 1.4.0-r1*
* *rqt-bag 1.1.1-r2 --> 1.1.2-r1*
* *rqt-bag-plugins 1.1.1-r2 --> 1.1.2-r1*
* *transmission-interface 1.3.0-r1 --> 1.4.0-r1*
* *tvm-vendor 0.7.3-r1 --> 0.8.0-r1*
* *ur-client-library 1.0.0-r3*
* *velodyne 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-driver 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-laserscan 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-msgs 2.1.1-r2 --> 2.2.0-r1*
* *velodyne-pointcloud 2.1.1-r2 --> 2.2.0-r1*
* *visp 3.4.0-r2 --> 3.5.0-r3*

Melodic Changes:
----------------
* *avt-vimba-camera 1.0.0-r1 --> 1.1.0-r1*
* *aws-common 2.2.0-r1 --> 2.2.1-r1*
* *aws-ros1-common 2.0.1-r2 --> 2.0.3-r1*
* *cloudwatch-logger 2.3.1-r1 --> 2.3.2-r1*
* *cloudwatch-logs-common 1.1.5-r1 --> 1.1.6-r1*
* *cloudwatch-metrics-collector 2.2.1-r2 --> 2.2.2-r1*
* *cloudwatch-metrics-common 1.1.5-r1 --> 1.1.6-r1*
* *dataflow-lite 1.1.5-r1 --> 1.1.6-r1*
* *eigenpy 2.6.9-r1 --> 2.6.10-r1*
* *euslisp 9.27.0-r1 --> 9.29.0-r1*
* *file-management 1.1.5-r1 --> 1.1.6-r1*
* *file-uploader-msgs 1.0.1-r1 --> 1.0.2-r1*
* *h264-encoder-core 2.0.3-r1 --> 2.0.4-r1*
* *health-metric-collector 2.0.2-r1 --> 2.0.3-r1*
* *kinesis-manager 2.0.3-r1 --> 2.0.4-r1*
* *kinesis-video-msgs 2.0.3-r1 --> 2.0.4-r1*
* *kinesis-video-streamer 2.0.3-r1 --> 2.0.4-r1*
* *lex-common 1.0.0-r1 --> 1.0.1-r1*
* *lex-common-msgs 2.0.2-r1 --> 2.0.3-r1*
* *lex-node 2.0.2-r1 --> 2.0.3-r1*
* *mavlink 2022.1.5-r1 --> 2022.2.2-r1*
* *microstrain-inertial-driver 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-examples 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-msgs 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-rqt 2.5.0-r1 --> 2.5.1-r1*
* *ntrip-client 1.0.0-r1 --> 1.0.1-r1*
* *pcl-conversions 1.7.3-r1 --> 1.7.4-r1*
* *pcl-ros 1.7.3-r1 --> 1.7.4-r1*
* *perception-pcl 1.7.3-r1 --> 1.7.4-r1*
* *pinocchio 2.6.4-r1 --> 2.6.5-r1*
* *plotjuggler 3.4.0-r1 --> 3.4.2-r1*
* *rc-hand-eye-calibration-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-pick-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-reason-clients 0.2.1-r1 --> 0.3.0-r1*
* *rc-reason-msgs 0.2.1-r1 --> 0.3.0-r1*
* *rc-silhouettematch-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-tagdetect-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard-description 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard-driver 3.2.4-r1 --> 3.3.0-r1*
* *recorder-msgs 1.0.1-r1 --> 1.0.2-r1*
* *ros-monitoring-msgs 1.0.1-r1 --> 1.0.2-r1*
* *rosbag-cloud-recorders 1.0.1-r1 --> 1.0.2-r1*
* *rviz 1.13.23-r1 --> 1.13.24-r1*
* *s3-common 1.0.1-r1 --> 1.0.2-r1*
* *s3-file-uploader 1.0.1-r1 --> 1.0.2-r1*
* *tts 1.0.2-r1 --> 1.0.3-r1*
* *xacro 1.13.15-r1 --> 1.13.17-r1*

Noetic Changes:
---------------
* *avt-vimba-camera 1.0.0-r1 --> 1.1.0-r1*
* *bosch-locator-bridge 1.0.4-r1 --> 1.0.5-r1*
* *dingo-gazebo 0.1.1-r1*
* *dingo-simulator 0.1.1-r1*
* *eigenpy 2.6.9-r1 --> 2.6.10-r1*
* *euslisp 9.28.0-r1 --> 9.29.0-r1*
* *husky-control 0.6.1-r1 --> 0.6.2-r1*
* *husky-description 0.6.1-r1 --> 0.6.2-r1*
* *husky-desktop 0.6.1-r1 --> 0.6.2-r1*
* *husky-gazebo 0.6.1-r1 --> 0.6.2-r1*
* *husky-msgs 0.6.1-r1 --> 0.6.2-r1*
* *husky-navigation 0.6.1-r1 --> 0.6.2-r1*
* *husky-simulator 0.6.1-r1 --> 0.6.2-r1*
* *husky-viz 0.6.1-r1 --> 0.6.2-r1*
* *jackal-control 0.8.1-r1 --> 0.8.2-r1*
* *jackal-description 0.8.1-r1 --> 0.8.2-r1*
* *jackal-msgs 0.8.1-r1 --> 0.8.2-r1*
* *jackal-navigation 0.8.1-r1 --> 0.8.2-r1*
* *jackal-tutorials 0.8.1-r1 --> 0.8.2-r1*
* *joint-state-publisher 1.15.0-r1 --> 1.15.1-r1*
* *joint-state-publisher-gui 1.15.0-r1 --> 1.15.1-r1*
* *libphidget22 1.0.4-r1 --> 1.0.5-r1*
* *lockmount-description 0.0.2-r2*
* *mavlink 2022.1.5-r1 --> 2022.2.2-r1*
* *mia-hand-bringup 1.0.0-r13 --> 1.0.2-r1*
* *mia-hand-description 1.0.0-r13 --> 1.0.2-r1*
* *mia-hand-gazebo 1.0.0-r13 --> 1.0.2-r1*
* *mia-hand-moveit-config 1.0.0-r13 --> 1.0.2-r1*
* *mia-hand-msgs 1.0.0-r13 --> 1.0.2-r1*
* *mia-hand-ros-control 1.0.0-r13 --> 1.0.2-r1*
* *mia-hand-ros-pkgs 1.0.0-r13 --> 1.0.2-r1*
* *microstrain-inertial-driver 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-examples 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-msgs 2.5.0-r1 --> 2.5.1-r1*
* *microstrain-inertial-rqt 2.5.0-r1 --> 2.5.1-r1*
* *mir-actions 1.1.4-r1 --> 1.1.5-r1*
* *mir-description 1.1.4-r1 --> 1.1.5-r1*
* *mir-dwb-critics 1.1.4-r1 --> 1.1.5-r1*
* *mir-gazebo 1.1.4-r1 --> 1.1.5-r1*
* *mir-msgs 1.1.4-r1 --> 1.1.5-r1*
* *mir-navigation 1.1.4-r1 --> 1.1.5-r1*
* *mir-robot 1.1.4-r1 --> 1.1.5-r1*
* *ntrip-client 1.0.0-r1 --> 1.0.1-r1*
* *pcl-conversions 1.7.3-r1 --> 1.7.4-r1*
* *pcl-ros 1.7.3-r1 --> 1.7.4-r1*
* *perception-pcl 1.7.3-r1 --> 1.7.4-r1*
* *phidgets-accelerometer 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-analog-inputs 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-analog-outputs 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-api 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-digital-inputs 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-digital-outputs 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-drivers 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-gyroscope 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-high-speed-encoder 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-ik 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-magnetometer 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-motors 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-msgs 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-spatial 1.0.4-r1 --> 1.0.5-r1*
* *phidgets-temperature 1.0.4-r1 --> 1.0.5-r1*
* *pinocchio 2.6.4-r1 --> 2.6.5-r1*
* *plotjuggler 3.4.0-r1 --> 3.4.2-r1*
* *rc-hand-eye-calibration-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-pick-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-reason-clients 0.2.1-r1 --> 0.3.0-r1*
* *rc-reason-msgs 0.2.1-r1 --> 0.3.0-r1*
* *rc-silhouettematch-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-tagdetect-client 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard-description 3.2.4-r1 --> 3.3.0-r1*
* *rc-visard-driver 3.2.4-r1 --> 3.3.0-r1*
* *robot-upstart 0.4.1-r1 --> 0.4.2-r1*
* *rviz 1.14.13-r1 --> 1.14.14-r1*
* *sdc21x0 1.1.4-r1 --> 1.1.5-r1*
* *vision-visp 0.12.1-r1 --> 0.13.0-r1*
* *visp-auto-tracker 0.12.1-r1 --> 0.13.0-r1*
* *visp-bridge 0.12.1-r1 --> 0.13.0-r1*
* *visp-camera-calibration 0.12.1-r1 --> 0.13.0-r1*
* *visp-hand2eye-calibration 0.12.1-r1 --> 0.13.0-r1*
* *visp-tracker 0.12.1-r1 --> 0.13.0-r1*
* *xacro 1.14.11-r1 --> 1.14.13-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

