### PR TITLE
rosdistro sync, Fri Mar 11 13:36:15 2022

### DIFF
--- a/distros/foxy/behaviortree-cpp-v3/default.nix
+++ b/distros/foxy/behaviortree-cpp-v3/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, cppzmq, ncurses, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, cppzmq, ncurses, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-behaviortree-cpp-v3";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/foxy/behaviortree_cpp_v3/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "815de4f03f7de7dccc05d26030c59ba7ac72c52bcdeb5d62d0845c2f70e6a2ad";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/foxy/behaviortree_cpp_v3/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "1650215dfeff9009bb656a5554d379673c51167e50d1ba630e4a107bd16f1ec3";
   };
 
   buildType = "catkin";
   checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ boost cppzmq ncurses rclcpp ];
+  propagatedBuildInputs = [ ament-index-cpp boost cppzmq ncurses rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/bno055/default.nix
+++ b/distros/foxy/bno055/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, python3Packages, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-bno055";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/flynneva/bno055-release/archive/release/foxy/bno055/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "444f83424513607b8be15beae9fa39e66a5e5d14453fa05d045d511a3ecf3bc2";
+    url = "https://github.com/flynneva/bno055-release/archive/release/foxy/bno055/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2fa11534723964ea51cb8f3ecff54480fc62241b367feb845d4630926cd6226c";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ python3Packages.pyserial rclpy std-msgs ];
+  propagatedBuildInputs = [ example-interfaces python3Packages.pyserial rclpy std-msgs ];
 
   meta = {
     description = ''Bosch BNO055 IMU driver for ROS2'';

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.6.10-r3";
+  version = "2.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.10-3.tar.gz";
-    name = "2.6.10-3.tar.gz";
-    sha256 = "e7d63e79cc0ee6fe27218e70722464eabfd762a5724c771cac1f5d888c8a0fac";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.11-1.tar.gz";
+    name = "2.6.11-1.tar.gz";
+    sha256 = "3edd1ecaecb8bc8c8aec9f0631010f16bcffea6a2ff946ed67172edcc5029ab3";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -674,6 +674,14 @@ self: super: {
 
  launch-yaml = self.callPackage ./launch-yaml {};
 
+ leo = self.callPackage ./leo {};
+
+ leo-description = self.callPackage ./leo-description {};
+
+ leo-msgs = self.callPackage ./leo-msgs {};
+
+ leo-teleop = self.callPackage ./leo-teleop {};
+
  lgsvl-bridge = self.callPackage ./lgsvl-bridge {};
 
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};

--- a/distros/foxy/gscam/default.nix
+++ b/distros/foxy/gscam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, class-loader, cv-bridge, gst_all_1, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gscam";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gscam-release/archive/release/foxy/gscam/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "09cd4e9b8487bc99bf4a2d6268ff6a9773fdaec31a90b62efeae3134f65ee70e";
+    url = "https://github.com/ros2-gbp/gscam-release/archive/release/foxy/gscam/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5f2b7b23e6286011a20d42dd460dd08acdbf70ba0a3d29b8da3ebc2745de88ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-description/default.nix
+++ b/distros/foxy/leo-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-leo-description";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo_description/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "52b7db585dbb3417330df7dbb7b6f62aff6876716da2659fc8410e6c37fbecda";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF Description package for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/leo-msgs/default.nix
+++ b/distros/foxy/leo-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-leo-msgs";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "6096b894264b03494622b85278d7fba9e5762beb6dc1bc69a4244b043cbcd641";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Message and Service definitions for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/leo-teleop/default.nix
+++ b/distros/foxy/leo-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joy, teleop-twist-joy, teleop-twist-keyboard }:
+buildRosPackage {
+  pname = "ros-foxy-leo-teleop";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo_teleop/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "6268a726125a3c6a86c6912738eff3c225329df6a6a2f8dd69e16a5401117eb6";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joy teleop-twist-joy teleop-twist-keyboard ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Scripts and launch files for Leo Rover teleoperation'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/leo/default.nix
+++ b/distros/foxy/leo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
+buildRosPackage {
+  pname = "ros-foxy-leo";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a77e234c62a9b2732c31950d07b571872159f568de5cc63f92a2cdcad900eaf0";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ leo-description leo-msgs leo-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for Leo Rover common to the robot and ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/libmavconn/default.nix
+++ b/distros/foxy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-libmavconn";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6fae1529b98c7e19ef3beb5c482d3cfff55cf48f0696fcff5bfb4cee4e950125";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "f31cbb06026b3ed309b36920d7ed3a977e0ea7d1632301af9b6d638c4f11f782";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2022.2.2-r1";
+  version = "2022.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2022.2.2-1.tar.gz";
-    name = "2022.2.2-1.tar.gz";
-    sha256 = "07bdc61dcb7bc8bef637b6c0f7bfe17ff0569264cf6ad4aeafc682eac89853c0";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2022.3.3-1.tar.gz";
+    name = "2022.3.3-1.tar.gz";
+    sha256 = "2206076e39973e5c844dd5dc7f1c38da3c8aec2f5f96511cb0bea63618f21ad6";
   };
 
   buildType = "cmake";

--- a/distros/foxy/mavros-extras/default.nix
+++ b/distros/foxy/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-mavros-extras";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_extras/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "79ebbbb51ffd178bbc8c9a27695c6ef60f131a2911b65a7fc7d6cd5d7d106606";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_extras/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "484eea15452265cebb47baff3ccb80bafe74daeb011981164a8c135e028636fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros-msgs/default.nix
+++ b/distros/foxy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8b241b8954e5759159ac35220260a0ff29482143897a69dc8fc1d56b5e1fbf99";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "73f3724945a5c5ca409ca904996a847c57a23754dde8105c9a70e2a06beca662";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros/default.nix
+++ b/distros/foxy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "20710a70523b739fc79d21e643bdb947b329a28d61d9027db7ce7ff718c4b3a7";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "7497441d83ba7483101c24f8187fb5075b4faeb3aac581657011c5e53bebb04c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nerian-stereo/default.nix
+++ b/distros/foxy/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nerian-stereo";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b4a0bf390da4dcb6ed8b609f29a46e2108459549c8679cd0edfb92af92482c22";
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "05e71aa04a65bab2517eec019ff8e82b91c030e39092c08c903e037e254392c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "4a322a505075e35205ae44b3ee0781c3ed50165b8b1f590dc8f4de724f5eb4a9";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "be3ba195a60718a5080a63e34385447a84daba6f8d74c15a771652321bb6f502";
   };
 
   buildType = "catkin";

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.2.3-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "9d8d0bd3e56c0ad46580fb6ea458761a6bc9590db6152f0d71620aea73f90708";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "61e336e0799b56ff9422fbde6dac20d0432516befbbe54f2fbbd030b092d5087";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.2.3-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "e283cd48d576c999fcc27f39694ec9b199e9dab6f26c37b0a153b9c83150175b";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "79c6f5f97c2f31343085597d0272af76cbf4a8ba8ee63ead7b606c991cb2b5e6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
-  propagatedBuildInputs = [ builtin-interfaces cv-bridge diagnostic-updater eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge diagnostic-updater eigen geometry-msgs image-transport launch-ros librealsense2 rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''RealSense Camera package allowing access to Intel SR300, D400 and L500 3D cameras'';
+    description = ''RealSense Camera package allowing access to Intel T265 Tracking module and SR300 and D400 3D cameras'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.2.3-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "8d238db512b7d475f2eb9b284dfcb039cc64dbe6c409b2b10549fc12ba4384e4";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "1ecba40f3b2b9279cef5376d7f2e48e7ce686fee89ed0af0ce8210ca762bf661";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gscam/default.nix
+++ b/distros/galactic/gscam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, class-loader, cv-bridge, gst_all_1, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-gscam";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gscam-release/archive/release/galactic/gscam/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d38faf4ca581daac146630bd806b3ad68ebc81a052ae4a4518bdd4a86a988c43";
+    url = "https://github.com/ros2-gbp/gscam-release/archive/release/galactic/gscam/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "25e99d587c1e7eefa7a2d4b862fe8deb48ea0685dce5148e8796380074d4935d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/libmavconn/default.nix
+++ b/distros/galactic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-libmavconn";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/libmavconn/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7877caa7bd6b0aba682ea2d6ddab73f97ba1a70baf4690b9b88d9c4eacc4d627";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/libmavconn/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "c17308a631d480dbd39e2e08e740a867bf2c48b2b892e156c1c352cbf9bb67bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavlink/default.nix
+++ b/distros/galactic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mavlink";
-  version = "2022.2.2-r1";
+  version = "2022.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2022.2.2-1.tar.gz";
-    name = "2022.2.2-1.tar.gz";
-    sha256 = "2bd6714c23e96e163284d71a8a769a62a7752e66b9436eb1b57c47d5911513e8";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2022.3.3-1.tar.gz";
+    name = "2022.3.3-1.tar.gz";
+    sha256 = "8ea5950b0b03c85325d4298fb33cd6cfd1c969019c75b9d9c6357502577f9ec6";
   };
 
   buildType = "cmake";

--- a/distros/galactic/mavros-extras/default.nix
+++ b/distros/galactic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-mavros-extras";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_extras/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "bb147cdeca51ca2570b1570565d0f6a2b22b886a75945711554370aaa59fb673";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_extras/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "fd4331b72778a697b9dad1154050f5f8b11f09c50ffde306a482fd4b613f2c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavros-msgs/default.nix
+++ b/distros/galactic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-mavros-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a383db0ac0791ad379b73c734061f41896e22a30bb665b8211f828e83cd6571f";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3370d0ec96f5cda3572f050322ccb8d2d386cde550a4d472634173e8232d462d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavros/default.nix
+++ b/distros/galactic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-mavros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ab2e9a9e6805628ff2096675174b5a7eec2f4cb31d61b0393636af6e160c017a";
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "45a24283442fc80e7942d9a6633749d2ba101f014c97a26df432667e7ba13fa9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plotjuggler-msgs/default.nix
+++ b/distros/galactic/plotjuggler-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler-msgs";
-  version = "0.1.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/galactic/plotjuggler_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "7ff43f03d9b027a4ec4b54cf73168c3eba87ba81dbb9c9671f40da0887af8e5d";
+    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/galactic/plotjuggler_msgs/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "34ed10630b4a9d8f9b4158f1feab145091b0267ce283ec37281639fe9b5351a0";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-cmake ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/galactic/realsense2-camera-msgs/default.nix
+++ b/distros/galactic/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera-msgs";
-  version = "3.2.3-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "a3edf50c8fc2fd0a4b18614a49bd7b94dab94294fcec0d13ac5fe931025ed346";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "298487e94d36a4b0b6ae67483c39613ff90888ff4ba6771a3824f3e44326b16c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-camera/default.nix
+++ b/distros/galactic/realsense2-camera/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera";
-  version = "3.2.3-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "7d93c3e45ecc700fa0ced10bb6fee870d909839e802501077aa471f1bc4d32e9";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "5c9d2bbffef3a4992fbed45c4d792bd61765b153d233a09c07fa20ee0d4c0e4b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
-  propagatedBuildInputs = [ builtin-interfaces cv-bridge diagnostic-updater eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge diagnostic-updater eigen geometry-msgs image-transport launch-ros librealsense2 rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''RealSense Camera package allowing access to Intel SR300, D400 and L500 3D cameras'';
+    description = ''RealSense Camera package allowing access to Intel T265 Tracking module and SR300 and D400 3D cameras'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/realsense2-description/default.nix
+++ b/distros/galactic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-description";
-  version = "3.2.3-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.3-1.tar.gz";
-    name = "3.2.3-1.tar.gz";
-    sha256 = "5a12d964f9742e97a944c6070d36a9b3d922f023ae4c69122f0932318d6b3b2d";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "9e88417662b028d54f04ec4c4a3366ed519ad2c96400c07a556833082048fa1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-image-overlay-layer/default.nix
+++ b/distros/galactic/rqt-image-overlay-layer/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, message-filters, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rqt-image-overlay-layer";
-  version = "0.0.1-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-sports/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "45f842bcefbcf76b7e39366fb17ee88fa281bf7f3e53b718a34f608363f58156";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "3c66b2074b6921a2ba521db9bb2a821168ddd3cea9dfa87493e532543d9edb20";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ pluginlib qt5.qtbase rclcpp rcpputils rosidl-runtime-cpp ];
+  propagatedBuildInputs = [ message-filters pluginlib qt5.qtbase rclcpp rcpputils rosidl-runtime-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rqt-image-overlay/default.nix
+++ b/distros/galactic/rqt-image-overlay/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs, theora-image-transport }:
 buildRosPackage {
   pname = "ros-galactic-rqt-image-overlay";
-  version = "0.0.1-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-sports/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "be7f3bfb16e7183f2491b8992cb7cd74d53790a8f680609c3cf96a6b11d69f3f";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "f38f3cfae30ff105182072deaab7bcc4705184d730ab7908724e9b68f858fa88";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common std-msgs theora-image-transport ];
   propagatedBuildInputs = [ image-transport pluginlib qt5.qtbase rclcpp ros-image-to-qimage rqt-gui-cpp rqt-image-overlay-layer ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/melodic/assisted-teleop/default.nix
+++ b/distros/melodic/assisted-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, base-local-planner, catkin, costmap-2d, eigen, filters, geometry-msgs, message-filters, move-base-msgs, pluginlib, roscpp, roslib, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-assisted-teleop";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/assisted_teleop/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "56f3c08c49d88b8801f49b04f690b0d95ba6abe6dcbc0c4794674dd4cb5eb8e6";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/assisted_teleop/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "db8bba55cf2e596068f53c33bcb492ccf0c66ee9cbcd27405c10fa9aa1f00407";
   };
 
   buildType = "catkin";

--- a/distros/melodic/behaviortree-cpp-v3/default.nix
+++ b/distros/melodic/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cppzmq, ncurses, roslib }:
 buildRosPackage {
   pname = "ros-melodic-behaviortree-cpp-v3";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/melodic/behaviortree_cpp_v3/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "948b583cb3a4fd0c8b51650981b1591785a5896a555b22a711d47c3791861b54";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/melodic/behaviortree_cpp_v3/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "7b0cdac49844985116bdbcdd988112fbc3d4cc922707863279b4353ab7d3b35b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/chomp-motion-planner/default.nix
+++ b/distros/melodic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-chomp-motion-planner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "b8a6e1cd04276478ab4672056b7c0a687267f3d7b678701d5257e384c9227d1a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "53de1e137edb925c6533eaa48579df890284e4e120135e66bb19276c4f95dc37";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.10-r1";
+  version = "2.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.10-1.tar.gz";
-    name = "2.6.10-1.tar.gz";
-    sha256 = "8712716a3329c801296de538d2347558fada0cbb202b114a43d5e353d8f7c35c";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.11-1.tar.gz";
+    name = "2.6.11-1.tar.gz";
+    sha256 = "f7d311d01dec93ce128867019ff4d4bb38523bb644a5122a3d9a94e6db28ebca";
   };
 
   buildType = "cmake";

--- a/distros/melodic/euslisp/default.nix
+++ b/distros/melodic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-melodic-euslisp";
-  version = "9.29.0-r4";
+  version = "9.29.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.29.0-4.tar.gz";
-    name = "9.29.0-4.tar.gz";
-    sha256 = "9c7b800c4049a0597cb8aff7875fd7488f3a56682e5879965399cc10f3da8166";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.29.0-6.tar.gz";
+    name = "9.29.0-6.tar.gz";
+    sha256 = "efe3908a6cc4183a28bcb0df8480fa00e08a3aa356d81e52c0d60ae84a744e33";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1438,6 +1438,8 @@ self: super: {
 
  hpp-fcl = self.callPackage ./hpp-fcl {};
 
+ hri = self.callPackage ./hri {};
+
  hri-msgs = self.callPackage ./hri-msgs {};
 
  hrpsys = self.callPackage ./hrpsys {};
@@ -2999,8 +3001,6 @@ self: super: {
  pyquaternion = self.callPackage ./pyquaternion {};
 
  pyros-test = self.callPackage ./pyros-test {};
-
- pyros-utils = self.callPackage ./pyros-utils {};
 
  python-orocos-kdl = self.callPackage ./python-orocos-kdl {};
 

--- a/distros/melodic/goal-passer/default.nix
+++ b/distros/melodic/goal-passer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, nav-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-goal-passer";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/goal_passer/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "aa5365192935a8a55a6695d24dfb17b40314c667637c986a03b5e7161cc58951";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/goal_passer/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "8cbbf4230f8a3fec125d43ebd44745cbe25f73e5750a048db1be74cdcbfce06b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hri/default.nix
+++ b/distros/melodic/hri/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, geometry-msgs, hri-msgs, rosconsole, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-hri";
+  version = "0.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/libhri-release/archive/release/melodic/hri/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "be2ec0e8fe1e453b9ee5e53dd7b47bbaf0b6b8594aac0ddfd5c2d8c33d51c20c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs hri-msgs rosconsole roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A wrapper library around the ROS4HRI ROS topics'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/jskeus/default.nix
+++ b/distros/melodic/jskeus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, euslisp }:
 buildRosPackage {
   pname = "ros-melodic-jskeus";
-  version = "1.2.2-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jskeus-release/archive/release/melodic/jskeus/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "513db833024ebb0d9946faa34d1efbd566900217928b9ab3ba488a684a3e1a7f";
+    url = "https://github.com/tork-a/jskeus-release/archive/release/melodic/jskeus/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "09ad2aa44249d07cecf8ebb717ca99194f310e93a836dc4ec4107d2a057e313f";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2022.2.2-r1";
+  version = "2022.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.2.2-1.tar.gz";
-    name = "2022.2.2-1.tar.gz";
-    sha256 = "1aaa955279437353c8111c7d6aa8e1a052721861da7f0a091f2ad2c3433fb28e";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.3.3-1.tar.gz";
+    name = "2022.3.3-1.tar.gz";
+    sha256 = "5c587284e9bc5f352e6d968ddfd1d3ff1c36b97c56f7ac5612a1addb46f9d571";
   };
 
   buildType = "cmake";

--- a/distros/melodic/moose-control/default.nix
+++ b/distros/melodic/moose-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, twist-mux, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moose-control";
-  version = "0.1.0-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/moose-release/archive/release/melodic/moose_control/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f50a333e218c43523c15fe346cffeba3d2eda02b3dec0798f1d084a61d59308b";
+    url = "https://github.com/clearpath-gbp/moose-release/archive/release/melodic/moose_control/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "dddeeba8753258287685cba99d83f9337a546e27b0834e002367c46ea7144354";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moose-description/default.nix
+++ b/distros/melodic/moose-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moose-description";
-  version = "0.1.0-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/moose-release/archive/release/melodic/moose_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "5485525cc3ffe5fd10d38ccde691d182fcc04308598f8b90a668d08181c65ed6";
+    url = "https://github.com/clearpath-gbp/moose-release/archive/release/melodic/moose_description/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "d80ac9eb4647a97b167fb7dacb49a567b4ed3162f3057d1822df3b6d18393a5e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moose-msgs/default.nix
+++ b/distros/melodic/moose-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moose-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/moose-release/archive/release/melodic/moose_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "56ed8ed04d1dc05c96e7d477c0b8c4d79e7f510a4c0d4269b9e40a008d333f60";
+    url = "https://github.com/clearpath-gbp/moose-release/archive/release/melodic/moose_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "d209489cb9586c4bb2edfd3df3020fc7e2741671914f9961480a387158b9c744";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-moveit-chomp-optimizer-adapter";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "faefef3533dacce0068cd97b47a42726989b97ee4e5afd923ecf4e37590504c0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "5fedfef0e8a7750c25a616530241c78f8c381fb9e006cd97a670762fe08850b0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-controller-manager-example/default.nix
+++ b/distros/melodic/moveit-controller-manager-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-controller-manager-example";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "29db84056386658a974326a447244b577071cdb94fda971a9e3c8c57fc1fbd8c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "851923c57633a0529d37483bfe003f0ee1ae74c1f125dfd825db8447af237641";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-core/default.nix
+++ b/distros/melodic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, catkin, code-coverage, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-core";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_core/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "981e5af27f7decb864acda9283d0960fb48ed3c91dd0e09fa4f6b27d6dae7e5f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_core/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "346fa984f3ce197af32b0f1a59f9ce00c3a9f8ee56d4ae79c9b5a756d82bca4c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-fake-controller-manager/default.nix
+++ b/distros/melodic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-fake-controller-manager";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "da64c249f0135875757379af24feac7ab7cbd49103936ba549228f5d932422bc";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b3172004c3b4d13351c39d53f88725f16a466e78357d2ab3be2aa4772d77ca88";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-kinematics/default.nix
+++ b/distros/melodic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-kinematics";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "3720bf517ae0ea8d51065a9a5a59bebec0a1cafa658b7b3dd459ee3605a7bbe3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "5d439e41aa67c006be0d0a58c71e55a5cd77eea5aa0518544204c37f40d93801";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-chomp/default.nix
+++ b/distros/melodic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-chomp";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "2a199e44e95d12a89a7c6d3c2ae6e250281eb010cc8194d2fe86d70c879f32eb";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1c88e86a08cdbaf8a79f9a02d06a845385c7663f1757947e8a0e5f5ec2870ff8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-ompl/default.nix
+++ b/distros/melodic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-ompl";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "5ba1e5c5541d484ec18493b555e5e099386e9128da534ab71147f824e6814491";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "59f8cd58de15c40c8039aef76a231b1e2cf4f2481b36f19512d43bcd87edc7c9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners/default.nix
+++ b/distros/melodic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "7bd95dab6f83fe637cb3b464697a703ec6b430f0cfb552a6ecf8a59d37ccdb16";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "7116e4ae2d84b46090bb29031751a85b36c285014b4074e3519e17168c2a11fb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-plugins/default.nix
+++ b/distros/melodic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-melodic-moveit-plugins";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "c24e33872f03d46a6fa658f754939c4578333316fb17d248d4929933c7cdbf3d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "384cd273bc8d20cb3f6b2439678dfbf833525538a04ef10de3de33b9fc939b9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-benchmarks/default.nix
+++ b/distros/melodic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-benchmarks";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "25dcdd54a6348f5a0a261df9279751e146b434f03273ed91f23ff1c8abd985dc";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "f98440d74f483ad433009a1cfcf368f64311c15c8a4dd76d9b20846e554cc2db";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-control-interface/default.nix
+++ b/distros/melodic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-control-interface";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1a4024f9ea02b1fd5cf44d5a85f0833b06830032872fbf22073c9dc2ebba4192";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "140b85b3308e520dc8be902b55de2f6a4bb466db42d7d79e6abd870bec08ce71";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-manipulation/default.nix
+++ b/distros/melodic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-manipulation";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0157c9ea1954d3ba5d1bbf9a859b0fdb637a963546141d023096a7d3ae6bd71c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "f010579f50b6479155b9a397031239d4c69c7ae6636aed586429fbe9819c2db6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-move-group/default.nix
+++ b/distros/melodic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-move-group";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "375f6b60939e178cfcb1662f24fbf801b544b000d1514408342d9d0dfa646ad9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b4a63e7700267c9bb2adcb206e67777346cbe1e5148d6b83994795d9e3e4e281";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-occupancy-map-monitor";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "5961c601be710142ced99f50bba1642fa8ba900844595fa420e4b40b61c0cc7c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "e4347707d0ccd76f7f99ff84f81e11ac2081469964b21b4741f659b2f49e29aa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-perception/default.nix
+++ b/distros/melodic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, nodelet, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-perception";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "5a695f12133d2236b180157b708dde2fab7fcf91055c49fcbc9fefd17935d61d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "ac4e902878daa41ba09459d8ffeaec046cdeec7a32e76fec75761464709e4093";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning-interface/default.nix
+++ b/distros/melodic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigen-conversions, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning-interface";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "59fe2ccc91a2170322e3ac9a5b4ff304a53df4184554fa3cc609eb5993af80af";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "470e33e7ea0bca30a0d9eda9f2146e918ae3c1d7969de4d787638657f0a2e5b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning/default.nix
+++ b/distros/melodic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "174ece09b8742ff6e25c45c8bf1d7e7fb52ad754e9e6741f5201008d84d3bb23";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "68571a4ffff06c1c48bfb75c347c4c32247bb34d3178ff7087423df30afcf28b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-robot-interaction/default.nix
+++ b/distros/melodic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-robot-interaction";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "3844e5d077b61e9b33c5b2d057dccc1cb7467f0c5166f30a896caa2b32e765e1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "36e9494ac585f9c9c6316aafbbd373d3c504e14901e88cbe970963ecc527c4d1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-visualization/default.nix
+++ b/distros/melodic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-visualization";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0dc4e09bd1b122d9f2c92acc86544a97d7a5935586000e631e73e458b5287d7d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "c75ff74c49435aa9479e1d7bf1c3b82aaad95a554b773d328d14cad390abccd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-warehouse/default.nix
+++ b/distros/melodic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-warehouse";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "7b5b96895482a99edcaac8cfce2fd127e6e57faa5b0b4261584c0bafd9e80ef6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "c8000fb309062cfa03907f87b1488cd3febed12d5961219cf9dc9b9a55d40289";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros/default.nix
+++ b/distros/melodic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "ca1ea1bef99d4935f08e7695242006765aacdaad470924026b555f87824b7b33";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "c503ab19e286492969022f7593f8947f415f7b3090b519e118d10d703c819d53";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-runtime/default.nix
+++ b/distros/melodic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-runtime";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "280d898404b1f1aa065e7a41f28d6ff3b06818101d2dbec884783031eaee2253";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "77cf5d006f124fb7d1d0b1d87bbea3b4698748082b1a73813c014de82f86ff39";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-servo/default.nix
+++ b/distros/melodic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-servo";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_servo/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "dbeedb354a5a3a109f0b9e36e2d3625fdccf9007869e76ca406a41e190eb3da4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_servo/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "a2a3739a4130e9b55607ba5cdcb7ef167b5bda81ed30ea6cef566d6532de2911";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-setup-assistant/default.nix
+++ b/distros/melodic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-setup-assistant";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0e023fc13c67e92da1c0ca43807e0736a28ac54cdf977a6cf46fe3449cad67c9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "d3b88b77920cb8fc4302df0f514f758b1f0791cc6f5d3c383773084cc51e5dff";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-simple-controller-manager/default.nix
+++ b/distros/melodic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-simple-controller-manager";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a3fe131162e48d591afea7f8e54df433ed3550aa2d3b28191cf27a218f08eea8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "f0b98330fbd4083b4da3e63a756f159a39140561effb7718a1008d25e3be782c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit/default.nix
+++ b/distros/melodic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-melodic-moveit";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "bbc58b05b24105e311d50f9690b5f09a2f939cbfc561cd11c0a740553da88fb2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "3d44545c045db2065f3a32d6e4787f3ba9eca78bbb535be0a386819412d3fee7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mrpt-msgs/default.nix
+++ b/distros/melodic/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-msgs";
-  version = "0.1.22";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.1.22-0.tar.gz";
-    name = "0.1.22-0.tar.gz";
-    sha256 = "baf8fd73e1c316f837c29fcaea20d6cb5cb84d4083813944b09005de9297de1d";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "0160776a2d1aaf5360e5a76730dee50a1077ba77fb006aa0378fea3aed1b505e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/navigation-experimental/default.nix
+++ b/distros/melodic/navigation-experimental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assisted-teleop, catkin, goal-passer, pose-base-controller, pose-follower, sbpl-lattice-planner, sbpl-recovery, twist-recovery }:
 buildRosPackage {
   pname = "ros-melodic-navigation-experimental";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/navigation_experimental/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "dfb18ed3954940c6f6416c2f9e2ab9a38a01327aebe7cb19b8e83cfe53157c0c";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/navigation_experimental/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "3d5a94a36c11ba70d55bf05b923c1165b055f1d2b754ac28d2cacc1680cea961";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nerian-stereo/default.nix
+++ b/distros/melodic/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-nerian-stereo";
-  version = "3.9.0-r3";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.9.0-3.tar.gz";
-    name = "3.9.0-3.tar.gz";
-    sha256 = "76e540e8302dc7084e49c711a0b0ca0a6c0bbef6f14a9e808cfcab7079b2dac8";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "abba9d9164a09220a25d121267acf7c0409d604e19d2e734d20dace5184ca303";
   };
 
   buildType = "catkin";

--- a/distros/melodic/novatel-oem7-driver/default.nix
+++ b/distros/melodic/novatel-oem7-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nav-msgs, nmea-msgs, nodelet, novatel-oem7-msgs, rosbag, roscpp, rostest, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-melodic-novatel-oem7-driver";
-  version = "3.0.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_driver/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "72b1ea89a42b082e62983de1e6b6406cadb2be037ba037691ae06595224b2fdc";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_driver/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "3dfcc86539028edf327362ff9ca52f5ee899d6f26adfed7a6b64f046c4b7d99b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/novatel-oem7-msgs/default.nix
+++ b/distros/melodic/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-novatel-oem7-msgs";
-  version = "3.0.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f578782b25732b5357f60e1cf63d9eeb99bda7662156af44caa442365178f04c";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_msgs/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "b1806982b4865c8c545fa1f03fc1ca794b2c41cf9f54ea38433c2fc259b47093";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/melodic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-commander, moveit-core, moveit-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion-planner-testutils";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner_testutils/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "603fe2048ede53337529ef90ca92e6cb7745fd9946223dac259dc12488734264";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner_testutils/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "a97682fe9e8a0c7ed6516f024dfb740bd0c8d7b43b7ec7df5c56f755160da944";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion-planner/default.nix
+++ b/distros/melodic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, eigen-conversions, joint-limits-interface, kdl-conversions, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion-planner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f25c57870aed98bda6bed473e6877555a9bc37fb6e911a2627d71784614fecd5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/pilz_industrial_motion_planner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "4a63d41342b26a8a1f2cccfbf6a752ec4f8ee3d2626ad712cdd3093283ed0dcf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "aec266a97a65c0fef6f01b4820b1a88b06a170e2a502433b1fbb210a18e2b428";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "e536e5798bca5add4a0ab13c06ba675e107eeae8c3587aab0b355379dcc46e30";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pose-base-controller/default.nix
+++ b/distros/melodic/pose-base-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, move-base-msgs, nav-msgs, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pose-base-controller";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_base_controller/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "b18cf02ddbaaa806e9f580e6051492c37a21112cf46394a67ecbc3a150278242";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_base_controller/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "dc8b3aae19934ec7bd206c78fd089edde0404e43c832e576928cad3251510d81";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pose-follower/default.nix
+++ b/distros/melodic/pose-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, nav-core, nav-msgs, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pose-follower";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_follower/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "d41dd5aab341f0af1b8eec70fb7db581f1857cf8d0d5574f5039f53288b3761b";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_follower/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "3d7469e679df65dbb213d895ea3297f9ca9e1df52c25e8edc8e561c08a38a14f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sbpl-lattice-planner/default.nix
+++ b/distros/melodic/sbpl-lattice-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, roscpp, sbpl, tf2 }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, roscpp, sbpl, tf, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-sbpl-lattice-planner";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_lattice_planner/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "efbfed3e3ac9b17303e77d216eeb675137a63ec6b524088191e4ca06207588c2";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_lattice_planner/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "28cc0a3b8237491c92b65bf277ea73d41e077c64cbeb937e75a001f7fa483f53";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ costmap-2d geometry-msgs message-runtime nav-core nav-msgs pluginlib roscpp sbpl tf2 ];
+  propagatedBuildInputs = [ costmap-2d geometry-msgs message-runtime nav-core nav-msgs pluginlib roscpp sbpl tf tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/sbpl-recovery/default.nix
+++ b/distros/melodic/sbpl-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, nav-core, pluginlib, pose-follower, roscpp, sbpl-lattice-planner, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-sbpl-recovery";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_recovery/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "24aab134f21caea064f1e410dfc852452977c99f2e064b97203e2e701c31ded5";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_recovery/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "740c25ade316477bc2ab37c5e138c35ae2122911d2a766fad2b39aa63a89e9e3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-recovery/default.nix
+++ b/distros/melodic/twist-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, geometry-msgs, nav-core, pluginlib, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-twist-recovery";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/twist_recovery/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "42f3ed698ba40488337c23be1ee88d0980097420c6ef3c81003dcfdad3d75d0b";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/twist_recovery/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "dc76ad46cb3e96c0e8335fc419562933eba699b3a9270983f69355bf0a9cb592";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urg-node/default.nix
+++ b/distros/melodic/urg-node/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c, xacro }:
 buildRosPackage {
   pname = "ros-melodic-urg-node";
-  version = "0.1.16-r1";
+  version = "0.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.16-1.tar.gz";
-    name = "0.1.16-1.tar.gz";
-    sha256 = "4c09ff097705c9302cbf155d4b914f0512a6483c3e0c4ff6bfe3ec90b3870674";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.17-1.tar.gz";
+    name = "0.1.17-1.tar.gz";
+    sha256 = "5d9e11e6e34a7141f8b940226a746fda2ddf1a17a2138a6467c88e49cf9af3bd";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch roslint ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure laser-proc message-generation message-runtime nodelet rosconsole roscpp sensor-msgs std-msgs std-srvs tf urg-c ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure laser-proc message-generation message-runtime nodelet rosconsole roscpp sensor-msgs std-msgs std-srvs tf urg-c xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/assisted-teleop/default.nix
+++ b/distros/noetic/assisted-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, base-local-planner, catkin, costmap-2d, eigen, filters, geometry-msgs, message-filters, move-base-msgs, pluginlib, roscpp, roslib, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-assisted-teleop";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/assisted_teleop/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "54e2f5fb25c042c5fc3bd1162643bc1dc5bdc9b6d8d79401dd0c11840e1726d5";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/assisted_teleop/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "4db7036fd5901f1e7a514966a4303ee7b1c9b6578164111de50b168d90d41c20";
   };
 
   buildType = "catkin";

--- a/distros/noetic/behaviortree-cpp-v3/default.nix
+++ b/distros/noetic/behaviortree-cpp-v3/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cppzmq, ncurses, roslib }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cppzmq, ncurses, roslib }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp-v3";
-  version = "3.5.6-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/noetic/behaviortree_cpp_v3/3.5.6-1.tar.gz";
-    name = "3.5.6-1.tar.gz";
-    sha256 = "84953f257a1688fedaa43e75b5bab98ad2fca50aac91823f0d0d9b109aa31631";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/noetic/behaviortree_cpp_v3/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "42c49e6b91efe43ec00b72f4bdae877f258c0dff8faea55e4b55ba2339883508";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cppzmq ncurses roslib ];
+  propagatedBuildInputs = [ boost cppzmq ncurses roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "9334b32c623a34051a915f42c958b33ab2539a578541f38cc7f12c08ad8db7fd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "0f3f94e517c4e83ae76b323ea3b2549391f7befbb8963d9a1e5e974acba6fa98";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cnpy/default.nix
+++ b/distros/noetic/cnpy/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, zlib }:
+{ lib, buildRosPackage, fetchurl, catkin, zlib }:
 buildRosPackage {
   pname = "ros-noetic-cnpy";
-  version = "0.0.7-r3";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/PeterMitrano/cnpy-release/archive/release/noetic/cnpy/0.0.7-3.tar.gz";
-    name = "0.0.7-3.tar.gz";
-    sha256 = "782dc178efb2fd281be33e1d8205e268597dc72086649a1b5695948019f36b20";
+    url = "https://github.com/PeterMitrano/cnpy-release/archive/release/noetic/cnpy/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "87f066147c2ba2f9c142065072514b6cecef45bf5aa506dcc85fbc0b07c5eee3";
   };
 
-  buildType = "cmake";
-  buildInputs = [ cmake zlib ];
+  buildType = "catkin";
+  buildInputs = [ zlib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.10-r1";
+  version = "2.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.10-1.tar.gz";
-    name = "2.6.10-1.tar.gz";
-    sha256 = "9b36e533876ad0228e73157bb4f036092174ae382192fc7c61b51b85d22eb79d";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.11-1.tar.gz";
+    name = "2.6.11-1.tar.gz";
+    sha256 = "bf9394a7c90e2add1249342bd5ce5645ff06c8f533e3263a22b91f1020a07c28";
   };
 
   buildType = "cmake";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1740,6 +1740,8 @@ self: super: {
 
  mqtt-bridge = self.callPackage ./mqtt-bridge {};
 
+ mrpt-bridge = self.callPackage ./mrpt-bridge {};
+
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
@@ -1763,6 +1765,8 @@ self: super: {
  multisense-lib = self.callPackage ./multisense-lib {};
 
  multisense-ros = self.callPackage ./multisense-ros {};
+
+ mvsim = self.callPackage ./mvsim {};
 
  nav2d = self.callPackage ./nav2d {};
 
@@ -2049,6 +2053,8 @@ self: super: {
  polled-camera = self.callPackage ./polled-camera {};
 
  pose-base-controller = self.callPackage ./pose-base-controller {};
+
+ pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
  pose-follower = self.callPackage ./pose-follower {};
 

--- a/distros/noetic/goal-passer/default.nix
+++ b/distros/noetic/goal-passer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, nav-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-goal-passer";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/goal_passer/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "5657fffc4495dba6d4928f8a03e0c698c8e810111eaf892ca4a42d42c8f4535f";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/goal_passer/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c35af8ad4759e84af61025a9d15d5b8c121d95a26df65a6910533e142109a6ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hri/default.nix
+++ b/distros/noetic/hri/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, geometry-msgs, hri-msgs, rosconsole, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-hri";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/libhri-release/archive/release/noetic/hri/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "6fb681ec7fded935f81ad6d621fce9dc1c2bea37a3e14cccb98b31f612e3184d";
+    url = "https://github.com/ros4hri/libhri-release/archive/release/noetic/hri/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "24b156be2728899d62333ef0bd551207d64a10aad1f6d8220be406c60a693fa9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-bringup/default.nix
+++ b/distros/noetic/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-bringup";
-  version = "2.0.3-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "b6688572cd6e6d6f077c2600a3d9ef4ad551fdcfd9f3488132575a8e34fd7193";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e01e5e55d3a99680f1776d0825d6966542701ff67c9d4c590564f9d73bf4e729";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-msgs, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-leo-fw";
-  version = "2.0.3-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "e2b093da980a6f30d82cd4fe98fe3ed3615ec759f0ed6070c352bea85788f250";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "2be53278f90953952edafa0b613c32b127136f163956e019966c63133441220e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-robot/default.nix
+++ b/distros/noetic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-noetic-leo-robot";
-  version = "2.0.3-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "648a0d7d096a61441577f3d24de3e51ae11457e50bba14ae087cfed8cdb6c87c";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5825d14bb9749a38a87ea6c8795ab25f458e672a48eb2bc53dd5ca790a58cfa3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2022.2.2-r1";
+  version = "2022.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.2.2-1.tar.gz";
-    name = "2022.2.2-1.tar.gz";
-    sha256 = "631d98097760a71fc92d2d06020c15d5a3250d96aeb3b366988108ef97f2faf5";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.3.3-1.tar.gz";
+    name = "2022.3.3-1.tar.gz";
+    sha256 = "1b43282c412bb02003e41c25a1de724b1c1530b5fb4ec63cb561dcd77f48f223";
   };
 
   buildType = "cmake";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "a7c8a298a01c4df6978b9fdf1d34a667b5dafd700d1a6272997e098265953adc";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "cd6820dbf38dcd292224726191f9b14ad2c9b599861bdc9d71b95623c5cdae16";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-catkin, python3, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "0b236dc4d3624c25a6597fdd45940a4a152f231007468788081ef24eb58d907b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "f20d9941e16aa7b3e2db53a4c844ced3e4a5bb2a09b6673be674ed4f54e4afe0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "94d7d851357704141ec7d779e19ebf0e1ed544d7e09b77893cb8f06172bba1f1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "6fd6e4a125b5def168f3618850b3587f241bd885b48e341d564d33cbb6fd18ea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "03687d5259a3f5a66a2243c2397c580103f8c0eb4e763d69ce4ae4d03b0b6f76";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "e0fdc54b122a00d6b924e5a67b2ed451b952334efb98eb323e754b840f7be0fc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "df76003010a69edee0bc7da7a978851c555a2cffcc066c6488f298d997de78cb";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "493b9991d18fac107c15964ac49e5d58f98df89a455c0c5a611c326a20a3893c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "6c48a632a3a1d7ea4b500c3ec7b5989786ca7d5e1022016db8cffd61953fa605";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "405f654dfd84589ff7bbfca263a5b62e94853d451e20fa2661eb008776b6689a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "6543d6f8c2e1cc2a2f0a370438f9e9fb6683de7a2fc1bb2632ea5d506d3303dd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "b163a52b698678c8d6368cca0157222f04b94edc62536c599ca97cb7cb41de85";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "0b5d238a794ec5755fec5780ba0015a77b694c1678da41c3c8ac0f4ae72bb980";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d17b5892c158418d0ca87fb772640b850df8cb040f99b2758a827dc9a40b4149";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "5a5f9758ddb476a5760e50599658762924ae353e149b136635b184076e4b1276";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "42ded382bddfbf7a67f0f08f714d5351ac65807abb1d7c86aa20abe80f84945f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "c8c82248c587998ccee514643bd3dbfa4502871e0c4351238c79cd56377a6398";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "3e2dbcb59f7d464d5eb36a27ebda907433d210a2a8309697a7ddeab1e632a963";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "598bedd2a287e983b7d00268b4766adc63bbee49e80c1c65ebb0383fdf95e3a5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "acce2bae20bc0a62578bbd938f0ec28aab38cec558cde7436d3a62088482a84d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "3dfcc82072e0e722a6a8a6bdf2d895013b720f7adbecb64a9b8d6b58b1f81bf8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d23b9ae82c541e259442634dae23ab6159d20f9b776e8aab2f8c19a1a71f75d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "9ae85d86e22892fa109affe129ffa3bf8d386f3248db955ece0fc72091c91501";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "b84eb5e713bc7615aacc59889e5bac1d8c78d2b2dbb9fbf5ef3abd03f8129120";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-perception/default.nix
+++ b/distros/noetic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, nodelet, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-perception";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "cae7fffe5c97fde2883d7c1acb41ef8eb71fe62a65cb5b5adc83f57963d9e6ff";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "691eb43445cea77b1f438538507b00e35da0990e501b60a6f6efa0fefebe0133";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "eea570b8930fb16c21bd062533df99edd2bd2e8b1ccabc7de35398bd68f170ee";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "27783f6b3a0ae8477b4145fa9999ad6dc957d337e6cbca37f73f4a9e7d34cef4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "4087d9c243cf1651060651ae228d24aef5c22b8cc7f4f8e0619a05f40bc38b7e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "5e29b8043a89e81c76da4d164cacde605e66784e9919c6e27149294248f83197";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "d912ebe793380e5303a928e3a6c1eae2695e7573084c005f6875691017d9ac5f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "8ee76a6dcff36bd17de4ef9432bb103b14d341a223f1918fff3e8a6438ff5b2a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "4761c4a04ddcd8c1caaa57cb7d26ebf7d5125d58d3a6d6bc83b090e000d09a78";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "f71d3aa8d55045c5f849bfc83a030f994d9a3775f4c8db98ba8fdc61fb905dc5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "e32f763877c925dd67a19331e392d50bb7e9853a30d2b6987e0c3650e4c318f1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "0fa525c301e9fe2461c573f631a9ebb8e538523149738dd84758bf7a668be5ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "d22abc04c1e19e335692312e159ba4693f5fe3676c1e02dbe31c53d38542ee7b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "624c00a2099e14fdd95438e91b0f979d7197f2122d96c9f69e5c37514dd07963";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "b5454ce2bac0f4a9106a946800880054cf04fc986b82b8f3aa8df0bd15347473";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d12137dad043bf2a136244ee1f1f63da365ec7dd1a98a8af7350533c3596cf3c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "9d553e886be25c85ece54c64013b1a7f01a923ca81cabc06810f0f6337f45bb7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "b191c7208f7e850bf395a3fdc4cf6f93abed62e546f4d90c1f30b72bcc97f0fe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "b5ad7738792879f519f117d00a7c0f2e91a723b307326cff93bdb2ab7456e22b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "fb223adf91ce4a14e97e69be0d44bbf437dd11a6b981dd6b89b4d434e1776ee6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "cf42a560ae8e4920898c202936e09ea25e3e5e3196d09df75630db28fa3408a2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "e2dccea6a0bbf4edcd0baf9c2551af9d6c52a49fae1a65c69e894c154b529e46";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "28c5157f447f87ae7815b430a897293602c9f993a7caea07dcc289be8d899e82";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "3ada889fa12189417e302385b5ca86b1050e5b3f761c6d2fd5e5b0cb590c83ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-bridge/default.nix
+++ b/distros/noetic/mrpt-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gtest, marker-msgs, message-generation, message-runtime, mrpt-msgs, mrpt2, nav-msgs, pcl, pcl-conversions, qt5, roscpp, rosunit, sensor-msgs, std-msgs, stereo-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-bridge";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release/archive/release/noetic/mrpt_bridge/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e12355e480e0d0894780c09077b348567522f187086170bbc47d54bb045dcfd9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ pcl pcl-conversions qt5.qtbase ];
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs marker-msgs message-generation message-runtime mrpt-msgs mrpt2 nav-msgs roscpp sensor-msgs std-msgs stereo-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library to convert between ROS messages and MRPT classes'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-msgs/default.nix
+++ b/distros/noetic/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs";
-  version = "0.1.23-r1";
+  version = "0.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.1.23-1.tar.gz";
-    name = "0.1.23-1.tar.gz";
-    sha256 = "baaef671a4973919ee36f2f356dc4aa507b2ef78d41f587f2263f7d59dc85f1d";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "4e19f99e5c7510dc49b081269f50518b26904f96300ed11cda4af31daa56aad2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, mrpt-bridge, mrpt2, nav-msgs, roscpp, sensor-msgs, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mvsim";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "e26d38a2565cb8f3cc9d77bfaa01b9557e7105c52f360a294d16aef40bc31c64";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure message-generation message-runtime mrpt-bridge mrpt2 nav-msgs roscpp sensor-msgs std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Node for the &quot;multivehicle simulator&quot; framework.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/navigation-experimental/default.nix
+++ b/distros/noetic/navigation-experimental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assisted-teleop, catkin, goal-passer, pose-base-controller, pose-follower, sbpl-lattice-planner, sbpl-recovery, twist-recovery }:
 buildRosPackage {
   pname = "ros-noetic-navigation-experimental";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/navigation_experimental/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "f34b9e69bcb084cbc6c3909ab561d0ea09499d1f7f18376b5cec9abda07cc35a";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/navigation_experimental/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "983a17e89402e54c4cb8dd6e895158f93a6d8ee9f453f28cd2ddd66da5482226";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nerian-stereo/default.nix
+++ b/distros/noetic/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-nerian-stereo";
-  version = "3.9.0-r5";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/noetic/nerian_stereo/3.9.0-5.tar.gz";
-    name = "3.9.0-5.tar.gz";
-    sha256 = "0f8b2dd99bcbb9052a4363ca0a69fd51c932ac9c0866326c12287b40e6346d44";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/noetic/nerian_stereo/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "945a07fb5c85e0c49c8197a74a3d11971469e263ff82ee3d1f765161e1dd9f52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/novatel-oem7-driver/default.nix
+++ b/distros/noetic/novatel-oem7-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nav-msgs, nmea-msgs, nodelet, novatel-oem7-msgs, rosbag, roscpp, rostest, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-novatel-oem7-driver";
-  version = "3.0.0-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_driver/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "8ed2fcf702325852eb7e9a4bf1cb1080d5dc5105de808757d6d93744330eb2c0";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_driver/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "35d850869c4e4f84280d16fc9af9e511ba718123a194b1372ae09f25e3c83a97";
   };
 
   buildType = "catkin";

--- a/distros/noetic/novatel-oem7-msgs/default.nix
+++ b/distros/noetic/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-novatel-oem7-msgs";
-  version = "3.0.0-r2";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "529b477319363b059a756ba5890176aa9339129e3fe9691d30a4aef7b58cc24f";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_msgs/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "635f364bd43680cdbb48e578ab79bccfee1920781a8cb9ac1e86516d92a0ba81";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "2c735dd904725db7a446855546c12cb4a6c08eccf463016127c82b564d92158f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "e337afd4770e69b31c0fbd5e3b87bb4e1952ca3dd2f404d075917dbe3606fc7e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "669120abf81e9d5dd56fc19bd18907c295b5fa538b837de028ef5c313e2a22b9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "ebfad06bfa5b1c4302c3af82056068c5be36a9a26ebd4ed96ba808e54c0f4a18";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "047dbb614f2192f9fcfca7050118da60251ef560f84cb5e9ca25b6cb418acf09";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "6ab175c195eb7bf73cdc1bf2761e92f225d28568bc70b20eaca3f7c3541e88d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pose-base-controller/default.nix
+++ b/distros/noetic/pose-base-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, move-base-msgs, nav-msgs, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pose-base-controller";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_base_controller/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "9ecad9f30d8a04f5e2f9efbe2edd14c86ee667ce64e5eaf7289f70f3829e46d5";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_base_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8f3cf09557eb016ea6cb2fa3e1877dd9ba475f2b2b669f6a45aafa8609036004";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt2, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-pose-cov-ops";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2ea9a6b1920a4d26e45ece0f8363b1c95126a2eaa84039dd531631207914f612";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ geometry-msgs mrpt-bridge mrpt2 roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library for SE(2/3) pose and 2D/3D point
+    composition operations with uncertainty'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pose-follower/default.nix
+++ b/distros/noetic/pose-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, nav-core, nav-msgs, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pose-follower";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_follower/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "5085658f83f9fa2ac70eeca6fcc79c581a692e91fc9b0bc3b103907bfdfa1adf";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_follower/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d37380604adbf15365d7e93126512fb0710e993c8c35fd03d5a2cd8167e2d57a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy-message-converter/default.nix
+++ b/distros/noetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rospy-message-converter";
-  version = "0.5.7-r1";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.7-1.tar.gz";
-    name = "0.5.7-1.tar.gz";
-    sha256 = "96c5848b0adf9e1b9ef5a0039e6ef3bfbcfd4d446ce1c0da05cad09ceef75945";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.8-1.tar.gz";
+    name = "0.5.8-1.tar.gz";
+    sha256 = "095252693dbf87558cb8fd5d085286675b6ec88f382251a6d277417ee38560e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sbpl-lattice-planner/default.nix
+++ b/distros/noetic/sbpl-lattice-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, roscpp, sbpl, tf2 }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, roscpp, sbpl, tf, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-sbpl-lattice-planner";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_lattice_planner/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "68ba37794fcf0bc0da2fadad7852c0123f9bd3fc358430f75089bd98a426063e";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_lattice_planner/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "a6378d5a6b96b3cb01b050222567a96bbebb15bdffc0121df162a1bea90b6145";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ costmap-2d geometry-msgs message-runtime nav-core nav-msgs pluginlib roscpp sbpl tf2 ];
+  propagatedBuildInputs = [ costmap-2d geometry-msgs message-runtime nav-core nav-msgs pluginlib roscpp sbpl tf tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sbpl-recovery/default.nix
+++ b/distros/noetic/sbpl-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, nav-core, pluginlib, pose-follower, roscpp, sbpl-lattice-planner, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-sbpl-recovery";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_recovery/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "4c77993dc6998a1db0f75d158911a87769229aa6196f65616f06d0d106765162";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_recovery/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "a49c0fc38311c59b0d800abd526710e6a101283aaea8c3c08cd97d954ff0fc6d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/twist-recovery/default.nix
+++ b/distros/noetic/twist-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, geometry-msgs, nav-core, pluginlib, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-twist-recovery";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/twist_recovery/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "981abb5d9d30672e4fc93e21ba5a8880b4dab24f881a0725d89a558efa912bc7";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/twist_recovery/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "efaf93a0fdec9670c8c0703c607b31d137d7d383a5d563257f78d3404f7634b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-node/default.nix
+++ b/distros/noetic/urg-node/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c, xacro }:
 buildRosPackage {
   pname = "ros-noetic-urg-node";
-  version = "0.1.16-r1";
+  version = "0.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/noetic/urg_node/0.1.16-1.tar.gz";
-    name = "0.1.16-1.tar.gz";
-    sha256 = "1011c7818f280d7104bc6cb80a0e5a036965d4427f19a8814dc6bd7bbce7b725";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/noetic/urg_node/0.1.17-1.tar.gz";
+    name = "0.1.17-1.tar.gz";
+    sha256 = "d1427c65a42f1797bdd269376eefe1e1143eff988ccbfe6413171eb55dd8113b";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch roslint ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure laser-proc message-generation message-runtime nodelet rosconsole roscpp sensor-msgs std-msgs std-srvs tf urg-c ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure laser-proc message-generation message-runtime nodelet rosconsole roscpp sensor-msgs std-msgs std-srvs tf urg-c xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 58251544893cd76d711a040e2792e888bd07ce12.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *behaviortree-cpp-v3 3.6.0-r1 --> 3.6.1-r1*
* *bno055 0.2.0-r1 --> 0.3.0-r1*
* *eigenpy 2.6.10-r3 --> 2.6.11-r1*
* *gscam 2.0.0-r1 --> 2.0.1-r1*
* *leo 1.0.2-r1*
* *leo-description 1.0.2-r1*
* *leo-msgs 1.0.2-r1*
* *leo-teleop 1.0.2-r1*
* *libmavconn 2.1.0-r1 --> 2.1.1-r1*
* *mavlink 2022.2.2-r1 --> 2022.3.3-r1*
* *mavros 2.1.0-r1 --> 2.1.1-r1*
* *mavros-extras 2.1.0-r1 --> 2.1.1-r1*
* *mavros-msgs 2.1.0-r1 --> 2.1.1-r1*
* *nerian-stereo 1.0.2-r1 --> 1.0.3-r1*
* *plotjuggler 3.4.2-r1 --> 3.4.3-r1*
* *realsense2-camera 3.2.3-r1 --> 4.0.2-r1*
* *realsense2-camera-msgs 3.2.3-r1 --> 4.0.2-r1*
* *realsense2-description 3.2.3-r1 --> 4.0.2-r1*

Galactic Changes:
-----------------
* *gscam 2.0.0-r1 --> 2.0.1-r1*
* *libmavconn 2.1.0-r1 --> 2.1.1-r1*
* *mavlink 2022.2.2-r1 --> 2022.3.3-r1*
* *mavros 2.1.0-r1 --> 2.1.1-r1*
* *mavros-extras 2.1.0-r1 --> 2.1.1-r1*
* *mavros-msgs 2.1.0-r1 --> 2.1.1-r1*
* *plotjuggler-msgs 0.1.2-r1 --> 0.2.3-r1*
* *realsense2-camera 3.2.3-r1 --> 4.0.2-r1*
* *realsense2-camera-msgs 3.2.3-r1 --> 4.0.2-r1*
* *realsense2-description 3.2.3-r1 --> 4.0.2-r1*
* *rqt-image-overlay 0.0.1-r1 --> 0.0.4-r1*
* *rqt-image-overlay-layer 0.0.1-r1 --> 0.0.4-r1*

Melodic Changes:
----------------
* *assisted-teleop 0.3.3-r1 --> 0.3.5-r1*
* *behaviortree-cpp-v3 3.6.0-r1 --> 3.6.1-r1*
* *chomp-motion-planner 1.0.9-r1 --> 1.0.10-r1*
* *eigenpy 2.6.10-r1 --> 2.6.11-r1*
* *euslisp 9.29.0-r4 --> 9.29.0-r6*
* *goal-passer 0.3.3-r1 --> 0.3.5-r1*
* *hri 0.4.1-r1*
* *jskeus 1.2.2-r1 --> 1.2.5-r1*
* *mavlink 2022.2.2-r1 --> 2022.3.3-r1*
* *moose-control 0.1.0-r1 --> 0.1.2-r1*
* *moose-description 0.1.0-r1 --> 0.1.2-r1*
* *moose-msgs 0.1.0-r1 --> 0.1.2-r1*
* *moveit 1.0.9-r1 --> 1.0.10-r1*
* *moveit-chomp-optimizer-adapter 1.0.9-r1 --> 1.0.10-r1*
* *moveit-controller-manager-example 1.0.9-r1 --> 1.0.10-r1*
* *moveit-core 1.0.9-r1 --> 1.0.10-r1*
* *moveit-fake-controller-manager 1.0.9-r1 --> 1.0.10-r1*
* *moveit-kinematics 1.0.9-r1 --> 1.0.10-r1*
* *moveit-planners 1.0.9-r1 --> 1.0.10-r1*
* *moveit-planners-chomp 1.0.9-r1 --> 1.0.10-r1*
* *moveit-planners-ompl 1.0.9-r1 --> 1.0.10-r1*
* *moveit-plugins 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-benchmarks 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-control-interface 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-manipulation 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-move-group 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-occupancy-map-monitor 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-perception 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-planning 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-planning-interface 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-robot-interaction 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-visualization 1.0.9-r1 --> 1.0.10-r1*
* *moveit-ros-warehouse 1.0.9-r1 --> 1.0.10-r1*
* *moveit-runtime 1.0.9-r1 --> 1.0.10-r1*
* *moveit-servo 1.0.9-r1 --> 1.0.10-r1*
* *moveit-setup-assistant 1.0.9-r1 --> 1.0.10-r1*
* *moveit-simple-controller-manager 1.0.9-r1 --> 1.0.10-r1*
* *mrpt-msgs 0.1.22 --> 0.2.0-r1*
* *navigation-experimental 0.3.3-r1 --> 0.3.5-r1*
* *nerian-stereo 3.9.0-r3 --> 3.9.1-r1*
* *novatel-oem7-driver 3.0.0-r1 --> 4.0.0-r1*
* *novatel-oem7-msgs 3.0.0-r1 --> 4.0.0-r1*
* *pilz-industrial-motion-planner 1.0.9-r1 --> 1.0.10-r1*
* *pilz-industrial-motion-planner-testutils 1.0.9-r1 --> 1.0.10-r1*
* *plotjuggler 3.4.2-r1 --> 3.4.3-r1*
* *pose-base-controller 0.3.3-r1 --> 0.3.5-r1*
* *pose-follower 0.3.3-r1 --> 0.3.5-r1*
* *sbpl-lattice-planner 0.3.3-r1 --> 0.3.5-r1*
* *sbpl-recovery 0.3.3-r1 --> 0.3.5-r1*
* *twist-recovery 0.3.3-r1 --> 0.3.5-r1*
* *urg-node 0.1.16-r1 --> 0.1.17-r1*

Noetic Changes:
---------------
* *assisted-teleop 0.3.4-r1 --> 0.4.0-r1*
* *behaviortree-cpp-v3 3.5.6-r1 --> 3.6.1-r1*
* *chomp-motion-planner 1.1.8-r1 --> 1.1.9-r1*
* *cnpy 0.0.7-r3 --> 0.0.8-r1*
* *eigenpy 2.6.10-r1 --> 2.6.11-r1*
* *goal-passer 0.3.4-r1 --> 0.4.0-r1*
* *hri 0.4.0-r1 --> 0.4.1-r1*
* *leo-bringup 2.0.3-r1 --> 2.1.1-r1*
* *leo-fw 2.0.3-r1 --> 2.1.1-r1*
* *leo-robot 2.0.3-r1 --> 2.1.1-r1*
* *mavlink 2022.2.2-r1 --> 2022.3.3-r1*
* *moveit 1.1.8-r1 --> 1.1.9-r1*
* *moveit-chomp-optimizer-adapter 1.1.8-r1 --> 1.1.9-r1*
* *moveit-core 1.1.8-r1 --> 1.1.9-r1*
* *moveit-fake-controller-manager 1.1.8-r1 --> 1.1.9-r1*
* *moveit-kinematics 1.1.8-r1 --> 1.1.9-r1*
* *moveit-planners 1.1.8-r1 --> 1.1.9-r1*
* *moveit-planners-chomp 1.1.8-r1 --> 1.1.9-r1*
* *moveit-planners-ompl 1.1.8-r1 --> 1.1.9-r1*
* *moveit-plugins 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-benchmarks 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-control-interface 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-manipulation 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-move-group 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-occupancy-map-monitor 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-perception 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-planning 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-planning-interface 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-robot-interaction 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-visualization 1.1.8-r1 --> 1.1.9-r1*
* *moveit-ros-warehouse 1.1.8-r1 --> 1.1.9-r1*
* *moveit-runtime 1.1.8-r1 --> 1.1.9-r1*
* *moveit-servo 1.1.8-r1 --> 1.1.9-r1*
* *moveit-setup-assistant 1.1.8-r1 --> 1.1.9-r1*
* *moveit-simple-controller-manager 1.1.8-r1 --> 1.1.9-r1*
* *mrpt-bridge 1.0.0-r1*
* *mrpt-msgs 0.1.23-r1 --> 0.2.0-r2*
* *mvsim 0.3.0-r1*
* *navigation-experimental 0.3.4-r1 --> 0.4.0-r1*
* *nerian-stereo 3.9.0-r5 --> 3.9.1-r1*
* *novatel-oem7-driver 3.0.0-r2 --> 4.0.0-r1*
* *novatel-oem7-msgs 3.0.0-r2 --> 4.0.0-r1*
* *pilz-industrial-motion-planner 1.1.8-r1 --> 1.1.9-r1*
* *pilz-industrial-motion-planner-testutils 1.1.8-r1 --> 1.1.9-r1*
* *plotjuggler 3.4.2-r1 --> 3.4.3-r1*
* *pose-base-controller 0.3.4-r1 --> 0.4.0-r1*
* *pose-cov-ops 0.3.0-r1*
* *pose-follower 0.3.4-r1 --> 0.4.0-r1*
* *rospy-message-converter 0.5.7-r1 --> 0.5.8-r1*
* *sbpl-lattice-planner 0.3.4-r1 --> 0.4.0-r1*
* *sbpl-recovery 0.3.4-r1 --> 0.4.0-r1*
* *twist-recovery 0.3.4-r1 --> 0.4.0-r1*
* *urg-node 0.1.16-r1 --> 0.1.17-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

