### PR TITLE
rosdistro sync, Fri Apr  1 13:23:38 2022

### DIFF
--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -682,9 +682,13 @@ self: super: {
 
  leo-description = self.callPackage ./leo-description {};
 
+ leo-desktop = self.callPackage ./leo-desktop {};
+
  leo-msgs = self.callPackage ./leo-msgs {};
 
  leo-teleop = self.callPackage ./leo-teleop {};
+
+ leo-viz = self.callPackage ./leo-viz {};
 
  lgsvl-bridge = self.callPackage ./lgsvl-bridge {};
 

--- a/distros/foxy/leo-desktop/default.nix
+++ b/distros/foxy/leo-desktop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-viz }:
+buildRosPackage {
+  pname = "ros-foxy-leo-desktop";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_desktop/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4f34333148bab9701d44586849abe7bab78b12c3207345c37fd82f492587467a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ leo leo-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for operating Leo Rover from ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/leo-viz/default.nix
+++ b/distros/foxy/leo-viz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, leo-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-foxy-leo-viz";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_viz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f1fe34a25448ceb368f97f35618d6f91c61ac2acb43238151bb63cf6d73c47aa";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Visualization launch files and RViz configurations for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -442,6 +442,8 @@ self: super: {
 
  io-context = self.callPackage ./io-context {};
 
+ irobot-create-msgs = self.callPackage ./irobot-create-msgs {};
+
  joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
@@ -1581,6 +1583,8 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur-client-library = self.callPackage ./ur-client-library {};
+
+ ur-description = self.callPackage ./ur-description {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/galactic/irobot-create-msgs/default.nix
+++ b/distros/galactic/irobot-create-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-msgs";
+  version = "1.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/irobot_create_msgs-release/archive/release/galactic/irobot_create_msgs/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "413cd833f869337ea912082491b86527a7e0f1a8951306b4e96aeb1de98208c5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Package containing action, message, and service definitions used by the iRobot(R) Create(R) platform'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/paho-mqtt-c/default.nix
+++ b/distros/galactic/paho-mqtt-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl }:
 buildRosPackage {
   pname = "ros-galactic-paho-mqtt-c";
-  version = "1.3.9-r3";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/galactic/paho-mqtt-c/1.3.9-3.tar.gz";
-    name = "1.3.9-3.tar.gz";
-    sha256 = "b4b2e2af11a7f3eef5e150ea64958d0e37e06f3016565d2c49fd1bc460604347";
+    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/galactic/paho-mqtt-c/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "f1181f06d3b2e1a354cb4cb2bc6394531adcacb81cddd6f61f9a490bbb11efc8";
   };
 
   buildType = "cmake";

--- a/distros/galactic/ur-description/default.nix
+++ b/distros/galactic/ur-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-ur-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/galactic/ur_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c6e240359dbcd83108e71d30e64f3035fedf23f6355559fcf213bb26e387b961";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pytest launch-testing-ament-cmake launch-testing-ros urdfdom xacro ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-ros robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF description for Universal Robots'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/melodic/cv-bridge-python3/default.nix
+++ b/distros/melodic/cv-bridge-python3/default.nix
@@ -1,0 +1,32 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, opencv3, python3, python3Packages, rosconsole, rostest, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-cv-bridge-python3";
+  version = "1.13.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/vision_opencv_python3-release/archive/release/melodic/cv_bridge_python3/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "fc5be865a9818dc753774113387a7a5a6efbe9b817a91707cb502076b9ab9704";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ python3Packages.numpy rostest ];
+  propagatedBuildInputs = [ boost opencv3 python3 python3Packages.opencv3 rosconsole sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This contains CvBridge, which converts between ROS
+    Image messages and OpenCV images.
+    ==
+    This package intentionally link against boost-python3 and
+    install under /opt/ros/ROS_DISTRO/lib/python3/dist-package
+    Please add
+    import sys, os; sys.path.insert(0,'/opt/ros/' + os.environ['ROS_DISTRO'] + '/lib/python3/dist-packages/')
+    before you call import cv_bridge'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -614,6 +614,8 @@ self: super: {
 
  cv-bridge = self.callPackage ./cv-bridge {};
 
+ cv-bridge-python3 = self.callPackage ./cv-bridge-python3 {};
+
  cv-camera = self.callPackage ./cv-camera {};
 
  cvp-mesh-planner = self.callPackage ./cvp-mesh-planner {};

--- a/distros/noetic/aruco-msgs/default.nix
+++ b/distros/noetic/aruco-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-msgs";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco_msgs/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "8cc41f88a983ea32a2cc48288dc5e2ea2edba95b6c85911f7c20ebbf3ca48a39";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The aruco_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/aruco-ros/default.nix
+++ b/distros/noetic/aruco-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, aruco, aruco-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, roscpp, sensor-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-ros";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco_ros/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "894fb18c3cc48440a8762f55394a688a18295ae22f393e1579ddc1651e700696";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ aruco aruco-msgs cv-bridge dynamic-reconfigure geometry-msgs image-transport roscpp sensor-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/aruco/default.nix
+++ b/distros/noetic/aruco/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen }:
+buildRosPackage {
+  pname = "ros-noetic-aruco";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "79ecb1dd67c8a0b5de6b7f226b219241c23298aa07c882990fcff7b578f7cb61";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/diffbot-base/default.nix
+++ b/distros/noetic/diffbot-base/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-manager, diagnostic-updater, diff-drive-controller, diffbot-msgs, dynamic-reconfigure, hardware-interface, roscpp, rosparam-shortcuts, rosserial, sensor-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-base";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_base/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5793ae3fa559221f08b2ea983cd5178aa65c91c2bb4b76eb62ddb2cfc4369553";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox controller-manager diagnostic-updater diff-drive-controller diffbot-msgs dynamic-reconfigure hardware-interface roscpp rosparam-shortcuts rosserial sensor-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_base package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-bringup/default.nix
+++ b/distros/noetic/diffbot-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-bringup";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_bringup/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7baeb9418cea432d5c7bf5e33c071c1f0bb5fa3c48f5038fe9389f4e9558d230";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ teleop-twist-keyboard ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_bringup package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-control/default.nix
+++ b/distros/noetic/diffbot-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, hardware-interface, joint-state-controller, robot-state-publisher, roscpp, rosparam-shortcuts, sensor-msgs, transmission-interface }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-control";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_control/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ada0f8358f106cdae3eebc4c2b230777642ea690c221764cdd8d672c0bfa4c99";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller hardware-interface joint-state-controller robot-state-publisher roscpp rosparam-shortcuts sensor-msgs transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_control package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-description/default.nix
+++ b/distros/noetic/diffbot-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-description";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "32719217c0f5e92134fe65d59e595ab4bf653ff6b93a1671cf10ba4f7811fca1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_description package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-gazebo/default.nix
+++ b/distros/noetic/diffbot-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diffbot-control, diffbot-description, gazebo-plugins, gazebo-ros, gazebo-ros-control, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-gazebo";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_gazebo/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "95278be8b2a56029fc0fa84e5bb39f8047a0ee7ef7f7776a5db585fdbec844ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diffbot-control diffbot-description gazebo-plugins gazebo-ros gazebo-ros-control xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_gazebo package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-mbf/default.nix
+++ b/distros/noetic/diffbot-mbf/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-mbf";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_mbf/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "40146515e32b5c6cab410888f442f88300f554b5f8e0156f4e6d08d53cfaf620";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_mbf package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-msgs/default.nix
+++ b/distros/noetic/diffbot-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c6404745cd18b1c665f906125c24f00445e66a7f8a5934841e99185d03bd3823";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_msgs package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-navigation/default.nix
+++ b/distros/noetic/diffbot-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, diffbot-bringup, dwa-local-planner, map-server, move-base }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-navigation";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_navigation/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0c54acf1c3175299b7cc671a559f681e8a7d623685451a5d38b3bf2e47262706";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl base-local-planner diffbot-bringup dwa-local-planner map-server move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_navigation package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-robot/default.nix
+++ b/distros/noetic/diffbot-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diffbot-base, diffbot-bringup, diffbot-control, diffbot-description, diffbot-gazebo, diffbot-navigation }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-robot";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_robot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8bd9225c1c10e57da7791284740ba78979933f13d1250f965bbb32c72c0c4549";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diffbot-base diffbot-bringup diffbot-control diffbot-description diffbot-gazebo diffbot-navigation ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_robot package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-slam/default.nix
+++ b/distros/noetic/diffbot-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gmapping }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-slam";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_slam/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c7f5bc4db8e9b59bdc242c1be21403d10e7c9245dca66f0db7a4ce01edde9d4b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gmapping ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_slam package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/flir-camera-description/default.nix
+++ b/distros/noetic/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-description";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "1ce22f64636aa9e5653ee0802d835149b980fdf37864292b423c4805d869c22c";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "676469d8c3b0ba4fb88223eb948aaba9ecd1bbf1a74f93fdb12b30c1e36e202a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/flir-camera-driver/default.nix
+++ b/distros/noetic/flir-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flir-camera-description, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "e96cf184635319e217b3799bf62b64c12f949ecfded4c6960da579af6c034074";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d7c34b9c69f6f63522013884324ee24bf4a372a6e4e9a791f806def69d47ccdd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-control/default.nix
+++ b/distros/noetic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, joint-trajectory-controller, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-control";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "511b0fb4d672f0bd462c9acae0b2b7488888e9cbe9a2136fba3cf5321d7d89f3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "46917738d8d13685d8e0bdecd910e881900227d2e05af23f5dd5eb645d6c4c9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-description/default.nix
+++ b/distros/noetic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-description";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "d1cddd9544a4c15a7a93f19b1e2d0a8c9795f61009360566d656e34fa764de5e";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "0eb74a8ab64bd4432f7deaea3e2de639d1ec19a6d40529b3bc3b49886fcb421a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-example-controllers/default.nix
+++ b/distros/noetic/franka-example-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, moveit-commander, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-franka-example-controllers";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "0d58c4cdf6e937bbb57245cffdf4b76787c9f9ef76f2c1581cc3285a77416fb8";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "82f27a07e4072b5b94973334f2fba6b17bda397ee3e93aed72022940a459ce1a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-gazebo/default.nix
+++ b/distros/noetic/franka-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-gazebo";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "23b547c3f722c2c0cae80c8be1461e2a648b482d3f5bf84d34aa1698d49aeb66";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "1ad2d4c734d088942a44b5d19c8ec6991410ec61b00e1c084c09bf198bb00d7c";
   };
 
   buildType = "catkin";
   buildInputs = [ gazebo-dev ];
   checkInputs = [ geometry-msgs gtest rostest sensor-msgs ];
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp std-msgs transmission-interface urdf ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp roslaunch rospy std-msgs transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-gripper/default.nix
+++ b/distros/noetic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-franka-gripper";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "1b960bab716c41f29c37c542035b9352d431f0719be7e21e0b769de7d0b1c4b6";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "2f47f8aacaa7c14ab9e144808b4251b04d65a3b0c21edfbb3e6f73a447f0178a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-hw/default.nix
+++ b/distros/noetic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-hw";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "eefa550cd5990552d18dae41d48771b19a03eb484e980ef6ac4e309cc671aaf4";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e3fb18e603d6c90616136b887d09b047027b0aabf85e5cb5c0f9056e7932a247";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-msgs/default.nix
+++ b/distros/noetic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-msgs";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "9e3b6c243b474f240e7ce29139e00e7fa2bba094aab93b3b71967708ef9e804b";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e0fda6c228ccf1a692dc951dcca53197c446070599c16b8bbbe67a9bc82395fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-ros/default.nix
+++ b/distros/noetic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-franka-ros";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "97aafc59d74299b9971bec7496a4e597d9839fd6dd47b6fa858ea5d1e985dfdf";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f3c6821400ec368e35794d03054d8d0680819bc630baf553dfda1382f1c6da9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-visualization/default.nix
+++ b/distros/noetic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-visualization";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "65f02970bf80cf6e8572b54f91bd121a56de4e4b6159d3aa13dffd1542e0f3f3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "a1da047e01bad191f935c70794cbad86971b5f134b26be18da9aa3253696fa7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -50,7 +50,13 @@ self: super: {
 
  arbotix-sensors = self.callPackage ./arbotix-sensors {};
 
+ aruco = self.callPackage ./aruco {};
+
  aruco-detect = self.callPackage ./aruco-detect {};
+
+ aruco-msgs = self.callPackage ./aruco-msgs {};
+
+ aruco-ros = self.callPackage ./aruco-ros {};
 
  assimp-devel = self.callPackage ./assimp-devel {};
 
@@ -553,6 +559,26 @@ self: super: {
  diagnostics = self.callPackage ./diagnostics {};
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
+
+ diffbot-base = self.callPackage ./diffbot-base {};
+
+ diffbot-bringup = self.callPackage ./diffbot-bringup {};
+
+ diffbot-control = self.callPackage ./diffbot-control {};
+
+ diffbot-description = self.callPackage ./diffbot-description {};
+
+ diffbot-gazebo = self.callPackage ./diffbot-gazebo {};
+
+ diffbot-mbf = self.callPackage ./diffbot-mbf {};
+
+ diffbot-msgs = self.callPackage ./diffbot-msgs {};
+
+ diffbot-navigation = self.callPackage ./diffbot-navigation {};
+
+ diffbot-robot = self.callPackage ./diffbot-robot {};
+
+ diffbot-slam = self.callPackage ./diffbot-slam {};
 
  dijkstra-mesh-planner = self.callPackage ./dijkstra-mesh-planner {};
 
@@ -2324,15 +2350,9 @@ self: super: {
 
  rm-common = self.callPackage ./rm-common {};
 
- rm-control = self.callPackage ./rm-control {};
-
  rm-controllers = self.callPackage ./rm-controllers {};
 
  rm-dbus = self.callPackage ./rm-dbus {};
-
- rm-description = self.callPackage ./rm-description {};
-
- rm-gazebo = self.callPackage ./rm-gazebo {};
 
  rm-gimbal-controllers = self.callPackage ./rm-gimbal-controllers {};
 
@@ -3029,6 +3049,8 @@ self: super: {
  topic-tools = self.callPackage ./topic-tools {};
 
  toposens = self.callPackage ./toposens {};
+
+ toposens-sensor-library = self.callPackage ./toposens-sensor-library {};
 
  toposens-bringup = self.callPackage ./toposens-bringup {};
 

--- a/distros/noetic/graceful-controller-ros/default.nix
+++ b/distros/noetic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller-ros";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "dbf471ed9f9227880baa95f95e1ce2f58d39867fcd4e4cc3244f095cf5ec77ec";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f72edbfa7a0dd5a22e30194a5a040a51c424d25a36e882547b55f3967e6b8315";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller/default.nix
+++ b/distros/noetic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0228d4c198dc85dd886df9ca9a96299fbb202bfbb67bdf056e719c9ce181ceba";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f32d7af9a5f1d8acaef59eec3f9ed9f2221fa8ae43f318c3769961c69bfa54a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/paho-mqtt-c/default.nix
+++ b/distros/noetic/paho-mqtt-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl }:
 buildRosPackage {
   pname = "ros-noetic-paho-mqtt-c";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "b6e040899f9a5520d8bef21744a8d721c9800c5adb553c1742da104328ef652b";
+    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "5574da546a6aca7a06e1f094fad9b9916795e98f9c1f8c93ea9c8ded6afc0976";
   };
 
   buildType = "cmake";

--- a/distros/noetic/picovoice-driver/default.nix
+++ b/distros/noetic/picovoice-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, picovoice-msgs, portaudio, roscpp, roslib }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, libyamlcpp, picovoice-msgs, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-driver";
-  version = "0.0.4-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "7fde59976511d7247a0558dc5ff1c040a381aa1923f8b0279a7cbd94d772d22d";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "696208227a732a4918b3aec973035bdbf57f5218e2d71bef2e057660d19b2d64";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile picovoice-msgs portaudio roscpp roslib ];
+  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile libyamlcpp picovoice-msgs roscpp roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/picovoice-msgs/default.nix
+++ b/distros/noetic/picovoice-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-msgs";
-  version = "0.0.4-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "029e8ce3645694b964d6405c19286ff2b9cd24c249d0877ca2a6bde6c416d2b7";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d63ee582eba6b4e8fe24de8e2b6289cbabcc4fbea585966e10f7605cda05975a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, imu-complementary-filter, imu-filter-madgwick, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "2b22d278701759dfc20d8906a2b75f360d702cd954269ef160a5ed9e37c9819f";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "1be7406cb7d1863bb6b9ac222901d35f95ac83edcff7334eeea22cfe0212ea63";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ control-msgs controller-manager-msgs dynamic-reconfigure eigen geometry-msgs realtime-tools rm-msgs roscpp roslint tf ];
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs dynamic-reconfigure eigen geometry-msgs imu-complementary-filter imu-filter-madgwick realtime-tools rm-msgs roscpp roslint tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "1c2609f762d77aeaff69d77b5116621e214ee111723b172b99b0efcf8dfbd7ab";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "4301db8fa908c0555a0873c635afa3a75c6be3c5892a49b7194ab83d98bd948a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "174d644c0047c6a7a3a0dc21349907bff7001b3c2de8c5f5e71833726925a6c3";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "f32f80c430acad9121609a58c39416cdfe1f3e82f0076aa4541311a89f1944f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "48910b968e4135eec5de29d3ce421465cd099b83fb8d6a5cb3a0c86c3b4bc43e";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "15ca0ffae88015250ce02b74ebd809ef105972bb24762945df904fa42e73efa1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-tf-tree/default.nix
+++ b/distros/noetic/rqt-tf-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, rospy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rqt-tf-tree";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "db171b666480146b4ae5978f86eaa4f07c498367b04b860ab0d1cf78766d9d32";
+    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "5f07d027e135ff74636fc97216b666aa0ee16aa5f10cd631db1f2226496bb351";
   };
 
   buildType = "catkin";

--- a/distros/noetic/spinnaker-camera-driver/default.nix
+++ b/distros/noetic/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-noetic-spinnaker-camera-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "5dec1b14ea0bd0846d2140656b5a3f00576970a509761f8edb26547f77854e34";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d011ea1c0289cdf7318a96d0af10c0f23bfb7aad54062ee92d473119ecd7941d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-sensor-library/default.nix
+++ b/distros/noetic/toposens-sensor-library/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-sensor-library";
+  version = "1.1.3-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/noetic/toposens-sensor-library/1.1.3-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "e17bd3510385845d7038cc633ba4602ee410c6f75b33a09d86944d8fb764091a";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Driver for toposens echo sensor'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 638cbba3fd2b9af096ca6a5bc2db44668e47116a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *leo-desktop 1.0.0-r1*
* *leo-viz 1.0.0-r1*

Galactic Changes:
-----------------
* *irobot-create-msgs 1.2.4-r1*
* *paho-mqtt-c 1.3.9-r3 --> 1.3.10-r1*
* *ur-description 2.0.0-r1*

Melodic Changes:
----------------
* *cv-bridge-python3 1.13.1-r1*

Noetic Changes:
---------------
* *aruco 3.0.1-r3*
* *aruco-msgs 3.0.1-r3*
* *aruco-ros 3.0.1-r3*
* *diffbot-base 1.1.0-r1*
* *diffbot-bringup 1.1.0-r1*
* *diffbot-control 1.1.0-r1*
* *diffbot-description 1.1.0-r1*
* *diffbot-gazebo 1.1.0-r1*
* *diffbot-mbf 1.1.0-r1*
* *diffbot-msgs 1.1.0-r1*
* *diffbot-navigation 1.1.0-r1*
* *diffbot-robot 1.1.0-r1*
* *diffbot-slam 1.1.0-r1*
* *flir-camera-description 0.2.1-r1 --> 0.2.2-r1*
* *flir-camera-driver 0.2.1-r1 --> 0.2.2-r1*
* *franka-control 0.8.2-r2 --> 0.9.0-r1*
* *franka-description 0.8.2-r2 --> 0.9.0-r1*
* *franka-example-controllers 0.8.2-r2 --> 0.9.0-r1*
* *franka-gazebo 0.8.2-r2 --> 0.9.0-r1*
* *franka-gripper 0.8.2-r2 --> 0.9.0-r1*
* *franka-hw 0.8.2-r2 --> 0.9.0-r1*
* *franka-msgs 0.8.2-r2 --> 0.9.0-r1*
* *franka-ros 0.8.2-r2 --> 0.9.0-r1*
* *franka-visualization 0.8.2-r2 --> 0.9.0-r1*
* *graceful-controller 0.4.1-r1 --> 0.4.2-r1*
* *graceful-controller-ros 0.4.1-r1 --> 0.4.2-r1*
* *paho-mqtt-c 1.3.9-r1 --> 1.3.10-r1*
* *picovoice-driver 0.0.4-r1 --> 1.0.1-r1*
* *picovoice-msgs 0.0.4-r1 --> 1.0.1-r1*
* *rm-common 0.1.8-r2 --> 0.1.9-r3*
* *rm-dbus 0.1.8-r2 --> 0.1.9-r3*
* *rm-hw 0.1.8-r2 --> 0.1.9-r3*
* *rm-msgs 0.1.8-r2 --> 0.1.9-r3*
* *rqt-tf-tree 0.6.2-r1 --> 0.6.3-r1*
* *spinnaker-camera-driver 0.2.1-r1 --> 0.2.2-r1*
* *toposens-sensor-library 1.1.3-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-conan-pip
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rm_description
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

