### PR TITLE
rosdistro sync, Fri Apr  8 13:47:42 2022

### DIFF
--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.6.11-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.11-1.tar.gz";
-    name = "2.6.11-1.tar.gz";
-    sha256 = "3edd1ecaecb8bc8c8aec9f0631010f16bcffea6a2ff946ed67172edcc5029ab3";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "0e47cdbf56c9a1523f7be182702e017ec08a012bd26f1f3d048ca13c079508d5";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -682,9 +682,13 @@ self: super: {
 
  leo-description = self.callPackage ./leo-description {};
 
+ leo-desktop = self.callPackage ./leo-desktop {};
+
  leo-msgs = self.callPackage ./leo-msgs {};
 
  leo-teleop = self.callPackage ./leo-teleop {};
+
+ leo-viz = self.callPackage ./leo-viz {};
 
  lgsvl-bridge = self.callPackage ./lgsvl-bridge {};
 
@@ -1593,6 +1597,10 @@ self: super: {
  slider-publisher = self.callPackage ./slider-publisher {};
 
  smac-planner = self.callPackage ./smac-planner {};
+
+ smacc2 = self.callPackage ./smacc2 {};
+
+ smacc2-msgs = self.callPackage ./smacc2-msgs {};
 
  smclib = self.callPackage ./smclib {};
 

--- a/distros/foxy/leo-desktop/default.nix
+++ b/distros/foxy/leo-desktop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-viz }:
+buildRosPackage {
+  pname = "ros-foxy-leo-desktop";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_desktop/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4f34333148bab9701d44586849abe7bab78b12c3207345c37fd82f492587467a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ leo leo-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for operating Leo Rover from ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/leo-viz/default.nix
+++ b/distros/foxy/leo-viz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, leo-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-foxy-leo-viz";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_viz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f1fe34a25448ceb368f97f35618d6f91c61ac2acb43238151bb63cf6d73c47aa";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Visualization launch files and RViz configurations for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/robot-upstart/default.nix
+++ b/distros/foxy/robot-upstart/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-robot-upstart";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/foxy/robot_upstart/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "714def52f4fa3531267624ce03b54de412e18d35a7f098a4184bff1f3242f595";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/foxy/robot_upstart/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f5d061ef21b1f997084a715a047383b746c2863ebd0510a5ecfa8577acaea0e6";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python ];
 
   meta = {
     description = ''The robot_upstart package provides scripts which may be used to install

--- a/distros/foxy/smacc2-msgs/default.nix
+++ b/distros/foxy/smacc2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-smacc2-msgs";
+  version = "0.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/foxy/smacc2_msgs/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "93c70d854e29debfed1a295b312af1d737a213e7eb4f212bf9a17e0e6689fe89";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages and services used in smacc2.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/smacc2/default.nix
+++ b/distros/foxy/smacc2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, lttng-ust, rcl, rclcpp, rclcpp-action, smacc2-msgs, tracetools, tracetools-launch, tracetools-trace }:
+buildRosPackage {
+  pname = "ros-foxy-smacc2";
+  version = "0.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/foxy/smacc2/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "613c6185074ebd40ea2e3f853cc2ae3bb56ff1b04e56ebd28a1b599bfb2fb8b1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost lttng-ust rcl rclcpp rclcpp-action smacc2-msgs tracetools tracetools-launch tracetools-trace ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An Event-Driven, Asynchronous, Behavioral State Machine Library for ROS2 (Robotic Operating System) applications written in C++.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -442,6 +442,8 @@ self: super: {
 
  io-context = self.callPackage ./io-context {};
 
+ irobot-create-msgs = self.callPackage ./irobot-create-msgs {};
+
  joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
@@ -866,6 +868,8 @@ self: super: {
 
  plansys2-terminal = self.callPackage ./plansys2-terminal {};
 
+ plansys2-tools = self.callPackage ./plansys2-tools {};
+
  plotjuggler = self.callPackage ./plotjuggler {};
 
  plotjuggler-msgs = self.callPackage ./plotjuggler-msgs {};
@@ -1187,6 +1191,8 @@ self: super: {
  rosbag2-storage = self.callPackage ./rosbag2-storage {};
 
  rosbag2-storage-default-plugins = self.callPackage ./rosbag2-storage-default-plugins {};
+
+ rosbag2-storage-mcap = self.callPackage ./rosbag2-storage-mcap {};
 
  rosbag2-test-common = self.callPackage ./rosbag2-test-common {};
 
@@ -1581,6 +1587,8 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur-client-library = self.callPackage ./ur-client-library {};
+
+ ur-description = self.callPackage ./ur-description {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/galactic/irobot-create-msgs/default.nix
+++ b/distros/galactic/irobot-create-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-msgs";
+  version = "1.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/irobot_create_msgs-release/archive/release/galactic/irobot_create_msgs/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "413cd833f869337ea912082491b86527a7e0f1a8951306b4e96aeb1de98208c5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Package containing action, message, and service definitions used by the iRobot(R) Create(R) platform'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/paho-mqtt-c/default.nix
+++ b/distros/galactic/paho-mqtt-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl }:
 buildRosPackage {
   pname = "ros-galactic-paho-mqtt-c";
-  version = "1.3.9-r3";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/galactic/paho-mqtt-c/1.3.9-3.tar.gz";
-    name = "1.3.9-3.tar.gz";
-    sha256 = "b4b2e2af11a7f3eef5e150ea64958d0e37e06f3016565d2c49fd1bc460604347";
+    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/galactic/paho-mqtt-c/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "f1181f06d3b2e1a354cb4cb2bc6394531adcacb81cddd6f61f9a490bbb11efc8";
   };
 
   buildType = "cmake";

--- a/distros/galactic/plansys2-bringup/default.nix
+++ b/distros/galactic/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bringup";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "570a0835dc87b3265b21ebec7afdf75740a2122c54c16ba93c7ddc0b2ccc0f5f";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2e2e9c1e9dcec819330320432762e5a2b3ad41846f7c5e12845d04dd9ddfcb7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-bt-actions/default.nix
+++ b/distros/galactic/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bt-actions";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "fb1c1520a6d88e1d270de2d31df2802139274cbee2292c5144b1aeda9c78d49b";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a9b40b750e71b1ba28271ba7ae4fe528d9ee839fb9766d67d3efbaed7e1653fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-core/default.nix
+++ b/distros/galactic/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-core";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "c4725cb608eee1b2def71c343c1645feb5b52577c51eebd9eda51c0851136e7d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "b6a3f70da0c71aafb8abf5e3b53d52ec45332fde6d07f2e046e5b98f57a84b3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-domain-expert/default.nix
+++ b/distros/galactic/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-domain-expert";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "a5dd7d002571c5070a88ae662cc0f7d16fd0ac312e45bb53d743ed9401bf92d6";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2972f9835094bacaeb7bedbcb04489fcf97492f794d2af46d14d675bfb9b0a0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-executor/default.nix
+++ b/distros/galactic/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-executor";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "a3a9e981c0b690cd60e9dfb8cfa33b0fad16c7d47380d8ac54e74057c349d572";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c0edaed5b43d4650bf9b36931860c2d0661600a73ea403f4c80fbfc2618a4827";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-lifecycle-manager/default.nix
+++ b/distros/galactic/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-lifecycle-manager";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "cd2e7aab5f6c54b14a5db4bddf7ddb0fef029cdfc5e98487bb0af1855e0a0fcb";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5f7a78fa8107ce014792326d65c9f89838b483953e226e86c3545049e1477983";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-msgs/default.nix
+++ b/distros/galactic/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-msgs";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "df7293e4a536542b9a255ef6a9f87c9c8c308895904154fd3296676924911906";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "d35ed688059a2a25c54d5b6a8a4c9b75e0bbe931f0634ae99c499d855214421f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-pddl-parser/default.nix
+++ b/distros/galactic/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-pddl-parser";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "3441ffa0121b3d29187032ae8c8001b898a81e6d4ffec30667c8acf7a8185705";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "88b2c6abe44d8c92c636fd558b6889e97e9063c57c2f0a276fc88388612780b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-planner/default.nix
+++ b/distros/galactic/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-planner";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "da3097b12deb5ce38008ede6036e90e478d25222a4c1485c6d79a7327c94e1e1";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "11372fdb90bbda11dcdce91336c0a796493a0fafa978630d64aa5d265598b11a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-popf-plan-solver/default.nix
+++ b/distros/galactic/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-popf-plan-solver";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "e746cba7018b9c81cc72ec5d0f3484b648ba715100319c5894af53c4c298b923";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "cebb036cdb2633dd49818cce4d84863de6375a228753c0dd12bbae13b05e3e02";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-problem-expert/default.nix
+++ b/distros/galactic/plansys2-problem-expert/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, qt5, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-problem-expert";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "943ec906da4502a7edbce2e532d1ef437140fd4db413777f25aa9dcd99efe91b";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f4d99128bd5dde330e82f4e5325de8270fb17085132de6fde13a9d76065a6d85";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser qt5.qtbase rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/plansys2-terminal/default.nix
+++ b/distros/galactic/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-terminal";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "e8defbc2e94d2a4aa0b65e4558adcf2daba402c0e73a906c093ea6653d904e44";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "213296f5c99afa2dbc6eff8ec385dc0dbe639c54f11462a79c01bf6349a21976";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-tools/default.nix
+++ b/distros/galactic/plansys2-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-tools";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "91c4b2e84bb8d13c0329f25f9d22f668011488cb55726de0c7c782a08abd3fa7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-problem-expert qt-gui-cpp rclcpp rclcpp-lifecycle rqt-gui rqt-gui-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A set of tools for monitoring ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rosbag2-storage-mcap/default.nix
+++ b/distros/galactic/rosbag2-storage-mcap/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, python3Packages, rcutils, ros-environment, rosbag2-storage }:
+buildRosPackage {
+  pname = "ros-galactic-rosbag2-storage-mcap";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "add936e76c297124bdc1dab1f588ecc16c0d5ae3c6eb95083afc9e221faabe5f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp pluginlib rcutils ros-environment rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake python3Packages.pip ];
+
+  meta = {
+    description = ''rosbag2 storage plugin using the MCAP file format'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/smacc2-msgs/default.nix
+++ b/distros/galactic/smacc2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-smacc2-msgs";
-  version = "0.1.0-r1";
+  version = "0.3.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "e8e86cb1727ae7c1e66e3d7d663b0d5a111d13308437c824b9b8513ca29787ef";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2_msgs/0.3.0-3.tar.gz";
+    name = "0.3.0-3.tar.gz";
+    sha256 = "280fb1c6480b859476b1bb03bd4e78a3765d3e2eaf33fdb3eb053180eec6d6d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/smacc2/default.nix
+++ b/distros/galactic/smacc2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, lttng-ust, rcl, rclcpp, rclcpp-action, smacc2-msgs, tracetools, tracetools-launch, tracetools-trace }:
 buildRosPackage {
   pname = "ros-galactic-smacc2";
-  version = "0.1.0-r1";
+  version = "0.3.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "08e3221e2ab93c13ea21d927d859a98bfb6d56d633cf5fa6234797a53bc6814e";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2/0.3.0-3.tar.gz";
+    name = "0.3.0-3.tar.gz";
+    sha256 = "0d35fc3fa12186ac35359635166317ff65a4bdf012f7b3c775b19ec890bfeaa6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ur-description/default.nix
+++ b/distros/galactic/ur-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-ur-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/galactic/ur_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c6e240359dbcd83108e71d30e64f3035fedf23f6355559fcf213bb26e387b961";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pytest launch-testing-ament-cmake launch-testing-ros urdfdom xacro ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-ros robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF description for Universal Robots'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/melodic/apriltag-ros/default.nix
+++ b/distros/melodic/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-generation, message-runtime, nodelet, opencv3, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-apriltag-ros";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/melodic/apriltag_ros/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "a309e7dc7f6febb4aa237c98d3be84bf476331102064b5b8f2cbace1c50b5faf";
+    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/melodic/apriltag_ros/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f3ca9ce2dccc9169f47f78e6e591e4daad245e508ef63d1636809ab07ca72296";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "e449a9cd40c6016617ea822e0a776867a9a7bd712b74237b0be752976f964681";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "eb0c1d00f163a0153263b81275aa8ab0014a406196d4a201d01f16ad8d9d63f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "2fa2c49d7c20011de78ea20187f3608ae6338f8d55c4ac96b9f8b47d06d992c2";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "5afc90d19df7b952f315fff30132e1e1d12640748fe9f8d6f80139be09509b2b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "a459a57a6f6e797b4d980fc71482a072a0df75a68349f2417a50f342b49717b5";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "ba1a9d6405d72171f455d1f950f91d263619e9f2961ea66dcafd67051ce67de5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "ee5613f0a767a2a6dda6b40df2c3a332537ecf5b734452b261da0a426347ae8a";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "59c3e9adb8200d6c296674e7405700e2bec35a2feba21605ed6bd19d5eeba6e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cv-bridge-python3/default.nix
+++ b/distros/melodic/cv-bridge-python3/default.nix
@@ -1,0 +1,32 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, opencv3, python3, python3Packages, rosconsole, rostest, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-cv-bridge-python3";
+  version = "1.13.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/vision_opencv_python3-release/archive/release/melodic/cv_bridge_python3/1.13.2-1.tar.gz";
+    name = "1.13.2-1.tar.gz";
+    sha256 = "c1e18d1a33ff149385882ca616fdd8cc706b6dbf80f293e1962c63498c3a8d24";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ python3Packages.numpy rostest ];
+  propagatedBuildInputs = [ boost opencv3 python3 python3Packages.opencv3 rosconsole sensor-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.catkin-pkg ];
+
+  meta = {
+    description = ''This contains CvBridge, which converts between ROS
+    Image messages and OpenCV images.
+    ==
+    This package intentionally link against boost-python3 and
+    install under /opt/ros/ROS_DISTRO/lib/python3/dist-package
+    Please add
+    import sys, os; sys.path.insert(0,'/opt/ros/' + os.environ['ROS_DISTRO'] + '/lib/python3/dist-packages/')
+    before you call import cv_bridge'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.11-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.11-1.tar.gz";
-    name = "2.6.11-1.tar.gz";
-    sha256 = "f7d311d01dec93ce128867019ff4d4bb38523bb644a5122a3d9a94e6db28ebca";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "f45636d6e2b858898f47588d529b800be19448bed4b4d87b87aac2e5526b60cc";
   };
 
   buildType = "cmake";

--- a/distros/melodic/end-effector/default.nix
+++ b/distros/melodic/end-effector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, joint-state-publisher-gui, kdl-parser, libyamlcpp, message-runtime, moveit-ros-planning-interface, muparser, roscpp, rosee-msg, rospy, srdfdom }:
 buildRosPackage {
   pname = "ros-melodic-end-effector";
-  version = "1.0.4-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ADVRHumanoids/ROSEndEffector-release/archive/release/melodic/end_effector/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7bfaf2e109b2c7cb6a21eb989e3092513a2a4b94b3a8e9f1f5b945536f28721b";
+    url = "https://github.com/ADVRHumanoids/ROSEndEffector-release/archive/release/melodic/end_effector/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "57ec26ad6d42a58f7db0b640a0a0cf690ac56536b59fce65848b7f83f33b135e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -614,6 +614,8 @@ self: super: {
 
  cv-bridge = self.callPackage ./cv-bridge {};
 
+ cv-bridge-python3 = self.callPackage ./cv-bridge-python3 {};
+
  cv-camera = self.callPackage ./cv-camera {};
 
  cvp-mesh-planner = self.callPackage ./cvp-mesh-planner {};

--- a/distros/noetic/apriltag-ros/default.nix
+++ b/distros/noetic/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-generation, message-runtime, nodelet, opencv3, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-apriltag-ros";
-  version = "3.2.0-r1";
+  version = "3.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/noetic/apriltag_ros/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "2e7f1a6a2c72ad6563abb377f77f977af9c3dddfaad9214c45f47e95a11ec8a4";
+    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/noetic/apriltag_ros/3.2.1-3.tar.gz";
+    name = "3.2.1-3.tar.gz";
+    sha256 = "831217c3c023b76328b58657ab89f70691dffbe0bf3363bd2e60408c1cea8152";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aruco-msgs/default.nix
+++ b/distros/noetic/aruco-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-msgs";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco_msgs/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "8cc41f88a983ea32a2cc48288dc5e2ea2edba95b6c85911f7c20ebbf3ca48a39";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The aruco_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/aruco-ros/default.nix
+++ b/distros/noetic/aruco-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, aruco, aruco-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, roscpp, sensor-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-ros";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco_ros/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "894fb18c3cc48440a8762f55394a688a18295ae22f393e1579ddc1651e700696";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ aruco aruco-msgs cv-bridge dynamic-reconfigure geometry-msgs image-transport roscpp sensor-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/aruco/default.nix
+++ b/distros/noetic/aruco/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen }:
+buildRosPackage {
+  pname = "ros-noetic-aruco";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "79ecb1dd67c8a0b5de6b7f226b219241c23298aa07c882990fcff7b578f7cb61";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/audio-capture/default.nix
+++ b/distros/noetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-capture";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "71568fe0b7464aedb6680df26c8f4994dda8f09cc084f2436d19271f695ae39d";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "c7f8daa90674584dc7db5cea6f0fdc0a602fbd5169632988601bffb8a940b810";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common-msgs/default.nix
+++ b/distros/noetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-audio-common-msgs";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "bb111d35a2c4435c9c0ef69b59684ac7881b99138f52bfc4169879dc0daae053";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "85b8bd7a7fd1348ea5fa0d84c05d9cca2e6f34c7b569e859cd606c8bd1c9e79f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common/default.nix
+++ b/distros/noetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-audio-common";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "65726768cee810e697a9a497c07119212732341bee0accf88dfe971f0ede4a1f";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "43f53161d90023ce760af643e6a29757a868fff9a3e0330af5bc5d1bdd700f1b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-play/default.nix
+++ b/distros/noetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-play";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "64f78c942eda1646e3d50397503e66d2e18600ef78607b22da77335f1b583223";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "d8898cda69f7de2fa5d0fc3ce83c8281c1ecbb98c8399fd53843f46c883e8ab0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diffbot-base/default.nix
+++ b/distros/noetic/diffbot-base/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-manager, diagnostic-updater, diff-drive-controller, diffbot-msgs, dynamic-reconfigure, hardware-interface, roscpp, rosparam-shortcuts, rosserial, sensor-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-base";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_base/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5793ae3fa559221f08b2ea983cd5178aa65c91c2bb4b76eb62ddb2cfc4369553";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox controller-manager diagnostic-updater diff-drive-controller diffbot-msgs dynamic-reconfigure hardware-interface roscpp rosparam-shortcuts rosserial sensor-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_base package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-bringup/default.nix
+++ b/distros/noetic/diffbot-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-bringup";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_bringup/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7baeb9418cea432d5c7bf5e33c071c1f0bb5fa3c48f5038fe9389f4e9558d230";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ teleop-twist-keyboard ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_bringup package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-control/default.nix
+++ b/distros/noetic/diffbot-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, hardware-interface, joint-state-controller, robot-state-publisher, roscpp, rosparam-shortcuts, sensor-msgs, transmission-interface }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-control";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_control/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ada0f8358f106cdae3eebc4c2b230777642ea690c221764cdd8d672c0bfa4c99";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller hardware-interface joint-state-controller robot-state-publisher roscpp rosparam-shortcuts sensor-msgs transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_control package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-description/default.nix
+++ b/distros/noetic/diffbot-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-description";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "32719217c0f5e92134fe65d59e595ab4bf653ff6b93a1671cf10ba4f7811fca1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_description package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-gazebo/default.nix
+++ b/distros/noetic/diffbot-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diffbot-control, diffbot-description, gazebo-plugins, gazebo-ros, gazebo-ros-control, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-gazebo";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_gazebo/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "95278be8b2a56029fc0fa84e5bb39f8047a0ee7ef7f7776a5db585fdbec844ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diffbot-control diffbot-description gazebo-plugins gazebo-ros gazebo-ros-control xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_gazebo package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-mbf/default.nix
+++ b/distros/noetic/diffbot-mbf/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-mbf";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_mbf/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "40146515e32b5c6cab410888f442f88300f554b5f8e0156f4e6d08d53cfaf620";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_mbf package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-msgs/default.nix
+++ b/distros/noetic/diffbot-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c6404745cd18b1c665f906125c24f00445e66a7f8a5934841e99185d03bd3823";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_msgs package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-navigation/default.nix
+++ b/distros/noetic/diffbot-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, diffbot-bringup, dwa-local-planner, map-server, move-base }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-navigation";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_navigation/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0c54acf1c3175299b7cc671a559f681e8a7d623685451a5d38b3bf2e47262706";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl base-local-planner diffbot-bringup dwa-local-planner map-server move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_navigation package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-robot/default.nix
+++ b/distros/noetic/diffbot-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diffbot-base, diffbot-bringup, diffbot-control, diffbot-description, diffbot-gazebo, diffbot-navigation }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-robot";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_robot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8bd9225c1c10e57da7791284740ba78979933f13d1250f965bbb32c72c0c4549";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diffbot-base diffbot-bringup diffbot-control diffbot-description diffbot-gazebo diffbot-navigation ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_robot package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-slam/default.nix
+++ b/distros/noetic/diffbot-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gmapping }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-slam";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_slam/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c7f5bc4db8e9b59bdc242c1be21403d10e7c9245dca66f0db7a4ce01edde9d4b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gmapping ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_slam package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.11-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.11-1.tar.gz";
-    name = "2.6.11-1.tar.gz";
-    sha256 = "bf9394a7c90e2add1249342bd5ce5645ff06c8f533e3263a22b91f1020a07c28";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "f49f4ae8a9b36848286a0678cb27bab859aacd04f35097e4703a54dc9612ff8c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/end-effector/default.nix
+++ b/distros/noetic/end-effector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, joint-state-publisher-gui, kdl-parser, libyamlcpp, message-runtime, moveit-ros-planning-interface, muparser, roscpp, rosee-msg, rospy, srdfdom }:
+buildRosPackage {
+  pname = "ros-noetic-end-effector";
+  version = "1.0.6-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ADVRHumanoids/ROSEndEffector-release/archive/release/noetic/end_effector/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "c6716d446907ced796b669ebde7b12103cb5c532035c329b40d36f611d9c5edc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ joint-state-publisher-gui kdl-parser libyamlcpp message-runtime moveit-ros-planning-interface muparser roscpp rosee-msg rospy srdfdom ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''End-Effector package: provides a ROS-based set of standard interfaces to command robotics end-effectors in an agnostic fashion'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
+buildRosPackage {
+  pname = "ros-noetic-eus-assimp";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "a77826bcb3b116fb363b1747899a6b7e845ae8cd311d07d09d2548beb754c8a4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ euslisp pkg-config ];
+  propagatedBuildInputs = [ assimp-devel roseus ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''eus_assimp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, pythonPackages, roseus, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-eusurdf";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "b74f03dfd5d156cbf563c1ef108d74b646563d325141765ad541ec7defb63f86";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roseus ];
+  propagatedBuildInputs = [ collada-urdf-jsk-patch gazebo-ros pythonPackages.lxml rostest ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''urdf models converted from euslisp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/flir-camera-description/default.nix
+++ b/distros/noetic/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-description";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "1ce22f64636aa9e5653ee0802d835149b980fdf37864292b423c4805d869c22c";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "676469d8c3b0ba4fb88223eb948aaba9ecd1bbf1a74f93fdb12b30c1e36e202a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/flir-camera-driver/default.nix
+++ b/distros/noetic/flir-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flir-camera-description, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "e96cf184635319e217b3799bf62b64c12f949ecfded4c6960da579af6c034074";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d7c34b9c69f6f63522013884324ee24bf4a372a6e4e9a791f806def69d47ccdd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-control/default.nix
+++ b/distros/noetic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, joint-trajectory-controller, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-control";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "511b0fb4d672f0bd462c9acae0b2b7488888e9cbe9a2136fba3cf5321d7d89f3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "46917738d8d13685d8e0bdecd910e881900227d2e05af23f5dd5eb645d6c4c9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-description/default.nix
+++ b/distros/noetic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-description";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "d1cddd9544a4c15a7a93f19b1e2d0a8c9795f61009360566d656e34fa764de5e";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "0eb74a8ab64bd4432f7deaea3e2de639d1ec19a6d40529b3bc3b49886fcb421a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-example-controllers/default.nix
+++ b/distros/noetic/franka-example-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, moveit-commander, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-franka-example-controllers";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "0d58c4cdf6e937bbb57245cffdf4b76787c9f9ef76f2c1581cc3285a77416fb8";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "82f27a07e4072b5b94973334f2fba6b17bda397ee3e93aed72022940a459ce1a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-gazebo/default.nix
+++ b/distros/noetic/franka-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-gazebo";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "23b547c3f722c2c0cae80c8be1461e2a648b482d3f5bf84d34aa1698d49aeb66";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "1ad2d4c734d088942a44b5d19c8ec6991410ec61b00e1c084c09bf198bb00d7c";
   };
 
   buildType = "catkin";
   buildInputs = [ gazebo-dev ];
   checkInputs = [ geometry-msgs gtest rostest sensor-msgs ];
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp std-msgs transmission-interface urdf ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp roslaunch rospy std-msgs transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-gripper/default.nix
+++ b/distros/noetic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-franka-gripper";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "1b960bab716c41f29c37c542035b9352d431f0719be7e21e0b769de7d0b1c4b6";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "2f47f8aacaa7c14ab9e144808b4251b04d65a3b0c21edfbb3e6f73a447f0178a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-hw/default.nix
+++ b/distros/noetic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-hw";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "eefa550cd5990552d18dae41d48771b19a03eb484e980ef6ac4e309cc671aaf4";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e3fb18e603d6c90616136b887d09b047027b0aabf85e5cb5c0f9056e7932a247";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-msgs/default.nix
+++ b/distros/noetic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-msgs";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "9e3b6c243b474f240e7ce29139e00e7fa2bba094aab93b3b71967708ef9e804b";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e0fda6c228ccf1a692dc951dcca53197c446070599c16b8bbbe67a9bc82395fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-ros/default.nix
+++ b/distros/noetic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-franka-ros";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "97aafc59d74299b9971bec7496a4e597d9839fd6dd47b6fa858ea5d1e985dfdf";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f3c6821400ec368e35794d03054d8d0680819bc630baf553dfda1382f1c6da9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-visualization/default.nix
+++ b/distros/noetic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-visualization";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "65f02970bf80cf6e8572b54f91bd121a56de4e4b6159d3aa13dffd1542e0f3f3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "a1da047e01bad191f935c70794cbad86971b5f134b26be18da9aa3253696fa7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -50,7 +50,13 @@ self: super: {
 
  arbotix-sensors = self.callPackage ./arbotix-sensors {};
 
+ aruco = self.callPackage ./aruco {};
+
  aruco-detect = self.callPackage ./aruco-detect {};
+
+ aruco-msgs = self.callPackage ./aruco-msgs {};
+
+ aruco-ros = self.callPackage ./aruco-ros {};
 
  assimp-devel = self.callPackage ./assimp-devel {};
 
@@ -554,6 +560,26 @@ self: super: {
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
+ diffbot-base = self.callPackage ./diffbot-base {};
+
+ diffbot-bringup = self.callPackage ./diffbot-bringup {};
+
+ diffbot-control = self.callPackage ./diffbot-control {};
+
+ diffbot-description = self.callPackage ./diffbot-description {};
+
+ diffbot-gazebo = self.callPackage ./diffbot-gazebo {};
+
+ diffbot-mbf = self.callPackage ./diffbot-mbf {};
+
+ diffbot-msgs = self.callPackage ./diffbot-msgs {};
+
+ diffbot-navigation = self.callPackage ./diffbot-navigation {};
+
+ diffbot-robot = self.callPackage ./diffbot-robot {};
+
+ diffbot-slam = self.callPackage ./diffbot-slam {};
+
  dijkstra-mesh-planner = self.callPackage ./dijkstra-mesh-planner {};
 
  dingo-control = self.callPackage ./dingo-control {};
@@ -716,6 +742,8 @@ self: super: {
 
  eml = self.callPackage ./eml {};
 
+ end-effector = self.callPackage ./end-effector {};
+
  ergodic-exploration = self.callPackage ./ergodic-exploration {};
 
  ethercat-grant = self.callPackage ./ethercat-grant {};
@@ -724,9 +752,13 @@ self: super: {
 
  ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
 
+ eus-assimp = self.callPackage ./eus-assimp {};
+
  euslime = self.callPackage ./euslime {};
 
  euslisp = self.callPackage ./euslisp {};
+
+ eusurdf = self.callPackage ./eusurdf {};
 
  executive-smach = self.callPackage ./executive-smach {};
 
@@ -1318,6 +1350,8 @@ self: super: {
 
  jsk-interactive-test = self.callPackage ./jsk-interactive-test {};
 
+ jsk-model-tools = self.callPackage ./jsk-model-tools {};
+
  jsk-network-tools = self.callPackage ./jsk-network-tools {};
 
  jsk-recognition = self.callPackage ./jsk-recognition {};
@@ -1451,6 +1485,8 @@ self: super: {
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libcmt = self.callPackage ./libcmt {};
+
+ libcreate = self.callPackage ./libcreate {};
 
  libdlib = self.callPackage ./libdlib {};
 
@@ -1916,6 +1952,8 @@ self: super: {
 
  openni2-launch = self.callPackage ./openni2-launch {};
 
+ openrtm-aist = self.callPackage ./openrtm-aist {};
+
  openslam-gmapping = self.callPackage ./openslam-gmapping {};
 
  openzen-sensor = self.callPackage ./openzen-sensor {};
@@ -2229,6 +2267,8 @@ self: super: {
  qb-move-description = self.callPackage ./qb-move-description {};
 
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
+
+ qt-advanced-docking = self.callPackage ./qt-advanced-docking {};
 
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
 
@@ -3029,6 +3069,8 @@ self: super: {
  topic-tools = self.callPackage ./topic-tools {};
 
  toposens = self.callPackage ./toposens {};
+
+ toposens-sensor-library = self.callPackage ./toposens-sensor-library {};
 
  toposens-bringup = self.callPackage ./toposens-bringup {};
 

--- a/distros/noetic/graceful-controller-ros/default.nix
+++ b/distros/noetic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller-ros";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "dbf471ed9f9227880baa95f95e1ce2f58d39867fcd4e4cc3244f095cf5ec77ec";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f72edbfa7a0dd5a22e30194a5a040a51c424d25a36e882547b55f3967e6b8315";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller/default.nix
+++ b/distros/noetic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0228d4c198dc85dd886df9ca9a96299fbb202bfbb67bdf056e719c9ce181ceba";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f32d7af9a5f1d8acaef59eec3f9ed9f2221fa8ae43f318c3769961c69bfa54a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-model-tools";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "1629e8ab27a3570996b0dda67032e3cfc6ce2467dbc0512cc90984e8f51aeeeb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eus-assimp euscollada ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains model_tools package for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/libcreate/default.nix
+++ b/distros/noetic/libcreate/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-noetic-libcreate";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/AutonomyLab/libcreate-release/archive/release/noetic/libcreate/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "8bc46366b2db0f0cdcf37790f74d2dde46bb3e552f4a42d6701a41f82dcd14c7";
+  };
+
+  buildType = "cmake";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''C++ library for interfacing with iRobot's Create 1 and Create 2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/openrtm-aist/default.nix
+++ b/distros/noetic/openrtm-aist/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, automake, catkin, cmake, doxygen, libtool, omniorb, pkg-config, pythonPackages, util-linux }:
+buildRosPackage {
+  pname = "ros-noetic-openrtm-aist";
+  version = "1.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/openrtm_aist-release/archive/release/noetic/openrtm_aist/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "cf609f4f2f92ea3c3542391b6b73eb9e032e0ec1e4bdac3a3327100c06f910f6";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen pythonPackages.python ];
+  propagatedBuildInputs = [ catkin omniorb util-linux ];
+  nativeBuildInputs = [ automake cmake libtool pkg-config ];
+
+  meta = {
+    description = ''<p>This package represents <a href="http://openrtm.org/">OpenRTM-aist</a> that's built within ROS eco system. Although being ROS-agnostic by itself, you can use this via ROS together with the packages in <a href="http://www.ros.org/wiki/rtmros_common">rtmros_common</a> that bridge between two framework.</p>
+   <p><i>OpenRTM-aist is an <a href="http://ieeexplore.ieee.org/xpl/login.jsp?tp=&amp;arnumber=1545521&amp;url=http%3A%2F%2Fieeexplore.ieee.org%2Fiel5%2F10375%2F32977%2F01545521.pdf%3Farnumber%3D1545521">RT-Middleware</a>-baseed, component-oriented software platform to robotics development that is made and maintained in AIST (National Institute of Advanced Industrial Science and Technology) in Japan </i> (<a href="http://openrtm.org/openrtm/en/content/introduction-0">excerpts from here</a>)</p>
+
+   <p>Its development is happening at <a href="http://www.openrtm.org/pub/OpenRTM-aist/">openrtm.org/pub/OpenRTM-aist</a>. The repository listed below is where the development of its ROS wrapper happening.</p>'';
+    license = with lib.licenses; [ "EPL" ];
+  };
+}

--- a/distros/noetic/paho-mqtt-c/default.nix
+++ b/distros/noetic/paho-mqtt-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl }:
 buildRosPackage {
   pname = "ros-noetic-paho-mqtt-c";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "b6e040899f9a5520d8bef21744a8d721c9800c5adb553c1742da104328ef652b";
+    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "5574da546a6aca7a06e1f094fad9b9916795e98f9c1f8c93ea9c8ded6afc0976";
   };
 
   buildType = "cmake";

--- a/distros/noetic/picovoice-driver/default.nix
+++ b/distros/noetic/picovoice-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, picovoice-msgs, portaudio, roscpp, roslib }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, libyamlcpp, picovoice-msgs, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-driver";
-  version = "0.0.4-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "7fde59976511d7247a0558dc5ff1c040a381aa1923f8b0279a7cbd94d772d22d";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "696208227a732a4918b3aec973035bdbf57f5218e2d71bef2e057660d19b2d64";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile picovoice-msgs portaudio roscpp roslib ];
+  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile libyamlcpp picovoice-msgs roscpp roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/picovoice-msgs/default.nix
+++ b/distros/noetic/picovoice-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-msgs";
-  version = "0.0.4-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "029e8ce3645694b964d6405c19286ff2b9cd24c249d0877ca2a6bde6c416d2b7";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d63ee582eba6b4e8fe24de8e2b6289cbabcc4fbea585966e10f7605cda05975a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-advanced-docking/default.nix
+++ b/distros/noetic/qt-advanced-docking/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, qt5 }:
+buildRosPackage {
+  pname = "ros-noetic-qt-advanced-docking";
+  version = "3.8.2-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release/archive/release/noetic/qt_advanced_docking/3.8.2-4.tar.gz";
+    name = "3.8.2-4.tar.gz";
+    sha256 = "3e52f05aa30717efb696bff81b915de1a470c13cdf7f83afc34880b6967e3385";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ qt5.qtbase ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Qt Advanced Docking System lets you create customizable layouts using
+    a full featured window docking system similar to what is found in many
+    popular integrated development environments (IDEs) such as Visual Studio.'';
+    license = with lib.licenses; [ lgpl21 ];
+  };
+}

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, imu-complementary-filter, imu-filter-madgwick, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "2b22d278701759dfc20d8906a2b75f360d702cd954269ef160a5ed9e37c9819f";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "1be7406cb7d1863bb6b9ac222901d35f95ac83edcff7334eeea22cfe0212ea63";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ control-msgs controller-manager-msgs dynamic-reconfigure eigen geometry-msgs realtime-tools rm-msgs roscpp roslint tf ];
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs dynamic-reconfigure eigen geometry-msgs imu-complementary-filter imu-filter-madgwick realtime-tools rm-msgs roscpp roslint tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, rm-description, rm-gazebo, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "efd157dd7d795bcce650d6188ac05d2e50785d0388c59c75fde8c6cd927ae910";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "3026be0baedc1d4e8f6989022b2dc839bc99a21d2a36b3c5d62e18a9d8d3990b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "1c2609f762d77aeaff69d77b5116621e214ee111723b172b99b0efcf8dfbd7ab";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "4301db8fa908c0555a0873c635afa3a75c6be3c5892a49b7194ab83d98bd948a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-description/default.nix
+++ b/distros/noetic/rm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rm-description";
-  version = "0.1.8-r2";
+  version = "0.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "17ba696169d8fe55c2d0b0fe844f5c6f8da2d2efd5c0bd6e0f134c7b12570a00";
+    url = "https://github.com/rm-controls/rm_description-release/archive/release/noetic/rm_description/0.1.9-1.tar.gz";
+    name = "0.1.9-1.tar.gz";
+    sha256 = "c947b61f5e4064b3d11ec7321c6780f0688059d999b64a0a297a1e5d23e3b9fa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "a8087e4cbb3feb8f9183334e8189e31cfa282c38ecc3be80f221703020b3495b";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "5f32b2b0fb9c49ce87e19a0f8533e60c83e0d0c0f21dbf34bc22b1c99cfcc0ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "174d644c0047c6a7a3a0dc21349907bff7001b3c2de8c5f5e71833726925a6c3";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "f32f80c430acad9121609a58c39416cdfe1f3e82f0076aa4541311a89f1944f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "48910b968e4135eec5de29d3ce421465cd099b83fb8d6a5cb3a0c86c3b4bc43e";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "15ca0ffae88015250ce02b74ebd809ef105972bb24762945df904fa42e73efa1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-tf-tree/default.nix
+++ b/distros/noetic/rqt-tf-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, rospy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rqt-tf-tree";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "db171b666480146b4ae5978f86eaa4f07c498367b04b860ab0d1cf78766d9d32";
+    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "5f07d027e135ff74636fc97216b666aa0ee16aa5f10cd631db1f2226496bb351";
   };
 
   buildType = "catkin";

--- a/distros/noetic/spinnaker-camera-driver/default.nix
+++ b/distros/noetic/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-noetic-spinnaker-camera-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "5dec1b14ea0bd0846d2140656b5a3f00576970a509761f8edb26547f77854e34";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d011ea1c0289cdf7318a96d0af10c0f23bfb7aad54062ee92d473119ecd7941d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-sensor-library/default.nix
+++ b/distros/noetic/toposens-sensor-library/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-sensor-library";
+  version = "1.1.3-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/noetic/toposens-sensor-library/1.1.3-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "e17bd3510385845d7038cc633ba4602ee410c6f75b33a09d86944d8fb764091a";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Driver for toposens echo sensor'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 638cbba3fd2b9af096ca6a5bc2db44668e47116a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *eigenpy 2.6.11-r1 --> 2.7.0-r1*
* *leo-desktop 1.0.0-r1*
* *leo-viz 1.0.0-r1*
* *robot-upstart 1.0.0-r2 --> 1.0.1-r1*
* *smacc2 0.2.0-r2*
* *smacc2-msgs 0.2.0-r2*

Galactic Changes:
-----------------
* *irobot-create-msgs 1.2.4-r1*
* *paho-mqtt-c 1.3.9-r3 --> 1.3.10-r1*
* *plansys2-bringup 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-bt-actions 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-core 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-domain-expert 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-executor 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-lifecycle-manager 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-msgs 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-pddl-parser 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-planner 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-popf-plan-solver 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-problem-expert 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-terminal 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-tools 2.0.3-r1*
* *rosbag2-storage-mcap 0.1.1-r1*
* *smacc2 0.1.0-r1 --> 0.3.0-r3*
* *smacc2-msgs 0.1.0-r1 --> 0.3.0-r3*
* *ur-description 2.0.0-r1*

Melodic Changes:
----------------
* *apriltag-ros 3.2.0-r1 --> 3.2.1-r1*
* *audio-capture 0.3.12-r1 --> 0.3.13-r1*
* *audio-common 0.3.12-r1 --> 0.3.13-r1*
* *audio-common-msgs 0.3.12-r1 --> 0.3.13-r1*
* *audio-play 0.3.12-r1 --> 0.3.13-r1*
* *cv-bridge-python3 1.13.2-r1*
* *eigenpy 2.6.11-r1 --> 2.7.0-r1*
* *end-effector 1.0.4-r1 --> 1.0.6-r2*

Noetic Changes:
---------------
* *apriltag-ros 3.2.0-r1 --> 3.2.1-r3*
* *aruco 3.0.1-r3*
* *aruco-msgs 3.0.1-r3*
* *aruco-ros 3.0.1-r3*
* *audio-capture 0.3.12-r1 --> 0.3.13-r1*
* *audio-common 0.3.12-r1 --> 0.3.13-r1*
* *audio-common-msgs 0.3.12-r1 --> 0.3.13-r1*
* *audio-play 0.3.12-r1 --> 0.3.13-r1*
* *diffbot-base 1.1.0-r1*
* *diffbot-bringup 1.1.0-r1*
* *diffbot-control 1.1.0-r1*
* *diffbot-description 1.1.0-r1*
* *diffbot-gazebo 1.1.0-r1*
* *diffbot-mbf 1.1.0-r1*
* *diffbot-msgs 1.1.0-r1*
* *diffbot-navigation 1.1.0-r1*
* *diffbot-robot 1.1.0-r1*
* *diffbot-slam 1.1.0-r1*
* *eigenpy 2.6.11-r1 --> 2.7.0-r1*
* *end-effector 1.0.6-r2*
* *eus-assimp 0.4.3-r1*
* *eusurdf 0.4.3-r1*
* *flir-camera-description 0.2.1-r1 --> 0.2.2-r1*
* *flir-camera-driver 0.2.1-r1 --> 0.2.2-r1*
* *franka-control 0.8.2-r2 --> 0.9.0-r1*
* *franka-description 0.8.2-r2 --> 0.9.0-r1*
* *franka-example-controllers 0.8.2-r2 --> 0.9.0-r1*
* *franka-gazebo 0.8.2-r2 --> 0.9.0-r1*
* *franka-gripper 0.8.2-r2 --> 0.9.0-r1*
* *franka-hw 0.8.2-r2 --> 0.9.0-r1*
* *franka-msgs 0.8.2-r2 --> 0.9.0-r1*
* *franka-ros 0.8.2-r2 --> 0.9.0-r1*
* *franka-visualization 0.8.2-r2 --> 0.9.0-r1*
* *graceful-controller 0.4.1-r1 --> 0.4.2-r1*
* *graceful-controller-ros 0.4.1-r1 --> 0.4.2-r1*
* *jsk-model-tools 0.4.3-r1*
* *libcreate 3.0.0-r1*
* *openrtm-aist 1.1.2-r2*
* *paho-mqtt-c 1.3.9-r1 --> 1.3.10-r1*
* *picovoice-driver 0.0.4-r1 --> 1.0.1-r1*
* *picovoice-msgs 0.0.4-r1 --> 1.0.1-r1*
* *qt-advanced-docking 3.8.2-r4*
* *rm-common 0.1.8-r2 --> 0.1.9-r3*
* *rm-control 0.1.8-r2 --> 0.1.9-r3*
* *rm-dbus 0.1.8-r2 --> 0.1.9-r3*
* *rm-description 0.1.8-r2 --> 0.1.9-r1*
* *rm-gazebo 0.1.8-r2 --> 0.1.9-r3*
* *rm-hw 0.1.8-r2 --> 0.1.9-r3*
* *rm-msgs 0.1.8-r2 --> 0.1.9-r3*
* *rqt-tf-tree 0.6.2-r1 --> 0.6.3-r1*
* *spinnaker-camera-driver 0.2.1-r1 --> 0.2.2-r1*
* *toposens-sensor-library 1.1.3-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

