### PR TITLE
rosdistro sync, Fri Apr 15 13:36:09 2022

### DIFF
--- a/distros/foxy/compressed-depth-image-transport/default.nix
+++ b/distros/foxy/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-foxy-compressed-depth-image-transport";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_depth_image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "d8f93971d2fb9d720cd4a88db0e07ea34b205f874b1146fb798906467faf18da";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_depth_image_transport/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "e1bf6334b75ef1ecbfdd8e386ac7b2b9e48ba135ce101c8fc4a0c66d09e4acb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/compressed-image-transport/default.nix
+++ b/distros/foxy/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-foxy-compressed-image-transport";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "11d25042dff6fbe7f4b9da7757c98c0ca8e25347e2d21e1c5a3c3818569b678a";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_image_transport/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "844a5cd20dbb449b9f00468a1af049091b0ab7c7c13d3171bb9e0427cfe9a537";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.6.11-r1";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.6.11-1.tar.gz";
-    name = "2.6.11-1.tar.gz";
-    sha256 = "3edd1ecaecb8bc8c8aec9f0631010f16bcffea6a2ff946ed67172edcc5029ab3";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "e3637144855bbb3c368388069ebfc8caa5181d570c5359b36d226df3f5e70b44";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -600,6 +600,8 @@ self: super: {
 
  imu-sensor-broadcaster = self.callPackage ./imu-sensor-broadcaster {};
 
+ interactive-marker-twist-server = self.callPackage ./interactive-marker-twist-server {};
+
  interactive-markers = self.callPackage ./interactive-markers {};
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
@@ -682,9 +684,13 @@ self: super: {
 
  leo-description = self.callPackage ./leo-description {};
 
+ leo-desktop = self.callPackage ./leo-desktop {};
+
  leo-msgs = self.callPackage ./leo-msgs {};
 
  leo-teleop = self.callPackage ./leo-teleop {};
+
+ leo-viz = self.callPackage ./leo-viz {};
 
  lgsvl-bridge = self.callPackage ./lgsvl-bridge {};
 
@@ -1594,6 +1600,10 @@ self: super: {
 
  smac-planner = self.callPackage ./smac-planner {};
 
+ smacc2 = self.callPackage ./smacc2 {};
+
+ smacc2-msgs = self.callPackage ./smacc2-msgs {};
+
  smclib = self.callPackage ./smclib {};
 
  snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
@@ -1787,6 +1797,8 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur-client-library = self.callPackage ./ur-client-library {};
+
+ ur-msgs = self.callPackage ./ur-msgs {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/foxy/image-transport-plugins/default.nix
+++ b/distros/foxy/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-foxy-image-transport-plugins";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/image_transport_plugins/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "a8523812ca9d9100d185b1d247003a8a3fa4db17a31c445a80edcff9808abf54";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/image_transport_plugins/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "7b19313282785c7640029f68db7a3c4cfab2f46ce2781574fa64451ffac8ee4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/interactive-marker-twist-server/default.nix
+++ b/distros/foxy/interactive-marker-twist-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, interactive-markers, rclcpp, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-interactive-marker-twist-server";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/foxy/interactive_marker_twist_server/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "e0958a2f57438f75d0a35eb85f910ed51fb617129b5d922b33196d0ff8eec78a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs interactive-markers rclcpp tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interactive control for generic Twist-based robots using interactive markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/leo-desktop/default.nix
+++ b/distros/foxy/leo-desktop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-viz }:
+buildRosPackage {
+  pname = "ros-foxy-leo-desktop";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_desktop/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4f34333148bab9701d44586849abe7bab78b12c3207345c37fd82f492587467a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ leo leo-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for operating Leo Rover from ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/leo-viz/default.nix
+++ b/distros/foxy/leo-viz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, leo-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-foxy-leo-viz";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_viz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f1fe34a25448ceb368f97f35618d6f91c61ac2acb43238151bb63cf6d73c47aa";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Visualization launch files and RViz configurations for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/libphidget22/default.nix
+++ b/distros/foxy/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-foxy-libphidget22";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/libphidget22/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ea4aeece6ab2abe32b65ff08ae275ce3b70c2491951c42b9d70c827347cdce29";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/libphidget22/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "a592430c589a1ff98b2ec86f8223186cd378a0781892aaf203c6fc9e0b37e581";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-accelerometer/default.nix
+++ b/distros/foxy/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-accelerometer";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_accelerometer/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "a962e77c9136467ad8127e90f65e1abec50cd212a98cb99f031b5a1cacb42ae5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_accelerometer/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "2bbb3a148e162663b8a236bb614c84e8b802d17c60a35e241ef5e178e5645dd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-analog-inputs/default.nix
+++ b/distros/foxy/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-analog-inputs";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_analog_inputs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "7ab4c69e38d29306d8a678a2d815791d8b3e298f90fbf171d9982ff0906e8a18";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_analog_inputs/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "68de3330d81107cd47632be5dd6dc3950c81f3bb5bf52f3c160d4c41d232fd70";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-api/default.nix
+++ b/distros/foxy/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-api";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_api/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ef33bfcb1e4046fce79ef924fe748cbf307a7e55a127fc0f98370305147b6660";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_api/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "ad71b362a36d03cf333d374d229011f8f4f0652b47d2eff0b78069f3a01cd147";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-digital-inputs/default.nix
+++ b/distros/foxy/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-digital-inputs";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_inputs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "58519a24ad3905484650e77d2124bda79f4366a2be254bbd8d33af9dbc468878";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_inputs/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "a36f9e201a750fdb8c323b40a7f42799f875267cf19fe0214986b03b22f0f598";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-digital-outputs/default.nix
+++ b/distros/foxy/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-digital-outputs";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_outputs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "536cc54b9af1e0fc389e8fa446017326c97da12e359901b59e6f95c741a6948d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_digital_outputs/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "af3cf33c950347d0b22e70200ba8892438a45eb561c17a4e13c4bf740bea0d71";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-drivers/default.nix
+++ b/distros/foxy/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-drivers";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_drivers/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ffe7ad2720db74835fc2a70362be9d52907fb304637c8aebc92c4532cd15466d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_drivers/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "cbf2a624e2d0965c1b10e660b81df3e9698011dd705a9ad4af24377299fc0416";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-gyroscope/default.nix
+++ b/distros/foxy/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-gyroscope";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_gyroscope/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "7b0e237bd95bc729d79eafca5ea0a52e8b32d86edeb01e7cc053609dfe9e72c7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_gyroscope/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "92cc37fa9a65a97e8fc3926ec74e5337e34bb2fbd77d45c9b75e69001443c409";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-high-speed-encoder/default.nix
+++ b/distros/foxy/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-high-speed-encoder";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_high_speed_encoder/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "3f2e7f3de2fe94afc8c0a511cb29b717433c1094c798cf2da9d02aa58c8112f5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_high_speed_encoder/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "b065f2002e42cb7f3e456d38794346aa07e6428a8a96b227cc627b18e56b252c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-ik/default.nix
+++ b/distros/foxy/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-ik";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_ik/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "524deb70a8b4ab74b58c2a4928711a8abdaf2ec61011ce04280aa193334713d3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_ik/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "e6d73610c1c819c64e894ae3a0eb6e5bfd59538bb2e777bab02ca6c1b9c16d76";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-magnetometer/default.nix
+++ b/distros/foxy/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-magnetometer";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_magnetometer/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "9b826b1e41109b9a42310dfbbb0fe9d8dfb21928899b5072f961aa5ea0035ea1";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_magnetometer/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "362aab68803fa18ccc0a1b586f7ddee8bdf3b46762becd2d2e9dd1d9adde0e49";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-motors/default.nix
+++ b/distros/foxy/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-motors";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_motors/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "88078bee5be0729eec6cf4d313d9188f6ed913690081a4cff05b9ca7bbbc01b2";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_motors/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "9dc4a63d173cc2d092731fbf808a8755cfc1bcb39d8b0370cf33852248a1bef8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-msgs/default.nix
+++ b/distros/foxy/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "acd3a36aada61d45437e9d1e55d203268a3914ef3ccc1c247ba0b3da3eebcee6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_msgs/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "786b6b5ee0509a653e95000c25433c31ffbe4528b1defc04f6ff44f7c04fe226";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-spatial/default.nix
+++ b/distros/foxy/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-spatial";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_spatial/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "43b2fb8b2dea4de62f6f33b667c6656edbde5a83e271e721c3cf12f87e2a14bf";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_spatial/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "fac1edb693dd1d7882cd8213450cf61393876e8148f8ebce79712dcf16a11e9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/phidgets-temperature/default.nix
+++ b/distros/foxy/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-phidgets-temperature";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_temperature/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "4eca76e80249050cc615fc6285a1601a8b5cabda73b1170a6b916e1de74615fe";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/foxy/phidgets_temperature/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "0dc8d261431a54e04b3a2f9b4c1df8b6a962dd2d06c90e270e7e1d2733523db2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/robot-upstart/default.nix
+++ b/distros/foxy/robot-upstart/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-robot-upstart";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/foxy/robot_upstart/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "714def52f4fa3531267624ce03b54de412e18d35a7f098a4184bff1f3242f595";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/foxy/robot_upstart/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f5d061ef21b1f997084a715a047383b746c2863ebd0510a5ecfa8577acaea0e6";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python ];
 
   meta = {
     description = ''The robot_upstart package provides scripts which may be used to install

--- a/distros/foxy/smacc2-msgs/default.nix
+++ b/distros/foxy/smacc2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-smacc2-msgs";
+  version = "0.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/foxy/smacc2_msgs/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "93c70d854e29debfed1a295b312af1d737a213e7eb4f212bf9a17e0e6689fe89";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages and services used in smacc2.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/smacc2/default.nix
+++ b/distros/foxy/smacc2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, lttng-ust, rcl, rclcpp, rclcpp-action, smacc2-msgs, tracetools, tracetools-launch, tracetools-trace }:
+buildRosPackage {
+  pname = "ros-foxy-smacc2";
+  version = "0.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/foxy/smacc2/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "613c6185074ebd40ea2e3f853cc2ae3bb56ff1b04e56ebd28a1b599bfb2fb8b1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost lttng-ust rcl rclcpp rclcpp-action smacc2-msgs tracetools tracetools-launch tracetools-trace ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An Event-Driven, Asynchronous, Behavioral State Machine Library for ROS2 (Robotic Operating System) applications written in C++.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/theora-image-transport/default.nix
+++ b/distros/foxy/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, cv-bridge, image-transport, libogg, libtheora, pluginlib, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-theora-image-transport";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/theora_image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "fdad4bc6a4aac029ae0aad4856aca3f27434997c9b8034d99736cccad3b0f552";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/theora_image_transport/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "2435aebaff4096dce6b1d3478a56b8474ecddb768f51aaed54f97fb6ee6af1ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ublox-gps/default.nix
+++ b/distros/foxy/ublox-gps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, asio, diagnostic-msgs, diagnostic-updater, geometry-msgs, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-foxy-ublox-gps";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/foxy/ublox_gps/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9c7aecadc3643bec4b92286d257a6334e8c0f6cbd1b403b1095824e2d883af05";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/foxy/ublox_gps/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b1ef018e9e276cb4cf3ec87978ef94326739e608de36465170a50181686f4b5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ublox-msgs/default.nix
+++ b/distros/foxy/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rosidl-default-generators, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-foxy-ublox-msgs";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/foxy/ublox_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "b3837ea1bad8cbdbe1b12020a742fafb0f9968b557ba2233a146a97a324eb169";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/foxy/ublox_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "cc114c1e0cb3339e9678254001fb02ba943b54c897ed568203d17092e7a2ae59";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ublox-serialization/default.nix
+++ b/distros/foxy/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-ublox-serialization";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/foxy/ublox_serialization/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "ac874bcd362f1af81d883cdd9daa385bd04838e764d3caef681b7b76f66523ad";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/foxy/ublox_serialization/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "4f42a93a500feac28525a5908300e3e19baf80334170c560bc1e522b0b1e5921";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ublox/default.nix
+++ b/distros/foxy/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-foxy-ublox";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/foxy/ublox/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "dde07c43dbcd5b2952b5cfae42bb781aec4a7005df3ec196043a7c496b57d9da";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/foxy/ublox/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "3e5e64fd859c7f95736cb96bf761a3ea83a67ecd05a2265c00b243ef1bf55fbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-msgs/default.nix
+++ b/distros/foxy/ur-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-ur-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/foxy/ur_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "71ab6336239fd1082a491f9c7ff7eb2321429591e54f46a291e6c0bd8d83b406";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message and service definitions for interacting with Universal Robots robot controllers.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/velodyne-driver/default.nix
+++ b/distros/foxy/velodyne-driver/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_driver/2.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/foxy/velodyne_driver/2.1.1-1.tar.gz";
     name = "2.1.1-1.tar.gz";
     sha256 = "9b53724abc6976b2fa6ea09db9adc0144c1b6ad398045e772a8f622a091c2d0e";
   };

--- a/distros/foxy/velodyne-laserscan/default.nix
+++ b/distros/foxy/velodyne-laserscan/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_laserscan/2.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/foxy/velodyne_laserscan/2.1.1-1.tar.gz";
     name = "2.1.1-1.tar.gz";
     sha256 = "6c8e5434b0d44c53c2239ec6d48f612e526e073d4ce925189c75036ba50290af";
   };

--- a/distros/foxy/velodyne-msgs/default.nix
+++ b/distros/foxy/velodyne-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_msgs/2.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/foxy/velodyne_msgs/2.1.1-1.tar.gz";
     name = "2.1.1-1.tar.gz";
     sha256 = "0e1988c6ca72a6ba237845af37bfbd41d46f10a0404ebf2c68202524d46ef857";
   };

--- a/distros/foxy/velodyne-pointcloud/default.nix
+++ b/distros/foxy/velodyne-pointcloud/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_pointcloud/2.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/foxy/velodyne_pointcloud/2.1.1-1.tar.gz";
     name = "2.1.1-1.tar.gz";
     sha256 = "c50a8b5c5affd431ec85665ce710532bf81a0d0f85d8fc4548d8c9c9e726c879";
   };

--- a/distros/foxy/velodyne/default.nix
+++ b/distros/foxy/velodyne/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne/2.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/foxy/velodyne/2.1.1-1.tar.gz";
     name = "2.1.1-1.tar.gz";
     sha256 = "7b8eea45da04784f481634bfeb2fd0c41990b24a69ea4ca412b329d2a90b187e";
   };

--- a/distros/galactic/compressed-depth-image-transport/default.nix
+++ b/distros/galactic/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-galactic-compressed-depth-image-transport";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_depth_image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "65640347a63e52460e4cf0d66a6112951840bcdabf34ce54260775c9126c405e";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_depth_image_transport/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "dda2b122d940adf12f72be1c93dc67642879d2895fa3d5617f17a5b9a828ab7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/compressed-image-transport/default.nix
+++ b/distros/galactic/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-galactic-compressed-image-transport";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "def53261c78f0c5506df72d3c2aecce2b7f2d898c3465c3e7013dda512aae7be";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_image_transport/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "6b4f99fcf6978ea5daff7db6d451b0e269979af8c11edd59b1cf8174bf20183e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -442,6 +442,30 @@ self: super: {
 
  io-context = self.callPackage ./io-context {};
 
+ irobot-create-common-bringup = self.callPackage ./irobot-create-common-bringup {};
+
+ irobot-create-control = self.callPackage ./irobot-create-control {};
+
+ irobot-create-description = self.callPackage ./irobot-create-description {};
+
+ irobot-create-gazebo-bringup = self.callPackage ./irobot-create-gazebo-bringup {};
+
+ irobot-create-gazebo-plugins = self.callPackage ./irobot-create-gazebo-plugins {};
+
+ irobot-create-gazebo-sim = self.callPackage ./irobot-create-gazebo-sim {};
+
+ irobot-create-ignition-bringup = self.callPackage ./irobot-create-ignition-bringup {};
+
+ irobot-create-ignition-sim = self.callPackage ./irobot-create-ignition-sim {};
+
+ irobot-create-ignition-toolbox = self.callPackage ./irobot-create-ignition-toolbox {};
+
+ irobot-create-msgs = self.callPackage ./irobot-create-msgs {};
+
+ irobot-create-nodes = self.callPackage ./irobot-create-nodes {};
+
+ irobot-create-toolbox = self.callPackage ./irobot-create-toolbox {};
+
  joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
@@ -750,6 +774,10 @@ self: super: {
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
 
+ novatel-gps-driver = self.callPackage ./novatel-gps-driver {};
+
+ novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  ntrip-client = self.callPackage ./ntrip-client {};
@@ -865,6 +893,8 @@ self: super: {
  plansys2-problem-expert = self.callPackage ./plansys2-problem-expert {};
 
  plansys2-terminal = self.callPackage ./plansys2-terminal {};
+
+ plansys2-tools = self.callPackage ./plansys2-tools {};
 
  plotjuggler = self.callPackage ./plotjuggler {};
 
@@ -1084,6 +1114,8 @@ self: super: {
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
+ robot-upstart = self.callPackage ./robot-upstart {};
+
  ros1-bridge = self.callPackage ./ros1-bridge {};
 
  ros1-rosbag-storage-vendor = self.callPackage ./ros1-rosbag-storage-vendor {};
@@ -1187,6 +1219,8 @@ self: super: {
  rosbag2-storage = self.callPackage ./rosbag2-storage {};
 
  rosbag2-storage-default-plugins = self.callPackage ./rosbag2-storage-default-plugins {};
+
+ rosbag2-storage-mcap = self.callPackage ./rosbag2-storage-mcap {};
 
  rosbag2-test-common = self.callPackage ./rosbag2-test-common {};
 
@@ -1581,6 +1615,10 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur-client-library = self.callPackage ./ur-client-library {};
+
+ ur-description = self.callPackage ./ur-description {};
+
+ ur-msgs = self.callPackage ./ur-msgs {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/galactic/image-transport-plugins/default.nix
+++ b/distros/galactic/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-galactic-image-transport-plugins";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/image_transport_plugins/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "f771323208546bf66408b6d662b19010c19e3aa84d42968c5e778d4ba7957469";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/image_transport_plugins/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "ebe622b6ed053c93bb3e29c9e7abae3f738af0ed4f5ccfd0713af7007c324100";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/irobot-create-common-bringup/default.nix
+++ b/distros/galactic/irobot-create-common-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, irobot-create-control, irobot-create-description, joint-state-publisher, robot-state-publisher, ros2launch, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-common-bringup";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_common_bringup/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ed35e63aa0b5df102b5a1949c54e432b3458448f2a9a7b970760afd845ec9b80";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ irobot-create-control irobot-create-description joint-state-publisher robot-state-publisher ros2launch rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides common launch and configuration scripts for a simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-control/default.nix
+++ b/distros/galactic/irobot-create-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-ros2-control, ign-ros2-control, irobot-create-nodes, joint-state-broadcaster, ros2-controllers, ros2launch }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-control";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_control/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ee286c9cb22bfc3ad9aa2f77fc923b8a9709fc7ce1f2c00e600eda433dc735af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ gazebo-ros2-control ign-ros2-control irobot-create-nodes joint-state-broadcaster ros2-controllers ros2launch ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides the diff-drive controller for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-description/default.nix
+++ b/distros/galactic/irobot-create-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, irobot-create-control, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-description";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5e5324978a0a6743b10055ed00c1f9ad8efcac63be0c1b0b1eeeb028822902b0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ irobot-create-control urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides the model description for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-gazebo-bringup/default.nix
+++ b/distros/galactic/irobot-create-gazebo-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-plugins, gazebo-ros, irobot-create-common-bringup, irobot-create-control, irobot-create-description, irobot-create-gazebo-plugins, ros2launch }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-gazebo-bringup";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_bringup/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c00a3c924a91fbcdaf58fceebac25e7f8d82beedc9fce74e6acda0a8364e0bcb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros irobot-create-common-bringup irobot-create-control irobot-create-description irobot-create-gazebo-plugins ros2launch ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides launch and configuration scripts for a Gazebo simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-gazebo-plugins/default.nix
+++ b/distros/galactic/irobot-create-gazebo-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-dev, gazebo-ros, geometry-msgs, irobot-create-msgs, irobot-create-toolbox, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-gazebo-plugins";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_plugins/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "18c9abaa0c8ef6e8b4e82744beb0b7224ba931dc55fa64a6f536c958f74326b8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ gazebo-dev gazebo-ros geometry-msgs irobot-create-msgs irobot-create-toolbox rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides the Gazebo plugins for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-gazebo-sim/default.nix
+++ b/distros/galactic/irobot-create-gazebo-sim/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-common-bringup, irobot-create-control, irobot-create-description, irobot-create-gazebo-bringup, irobot-create-gazebo-plugins, irobot-create-nodes }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-gazebo-sim";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_sim/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d1bc88502efe404a34c4e3e1373bca5ec5ae24768fef2c48bef7cd5685566363";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ irobot-create-common-bringup irobot-create-control irobot-create-description irobot-create-gazebo-bringup irobot-create-gazebo-plugins irobot-create-nodes ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for the iRobot(R) Create(R) 3 robot Gazebo simulator<a href="http://gazebosim.org/">Gazebo</a> simulation stack.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-ignition-bringup/default.nix
+++ b/distros/galactic/irobot-create-ignition-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-plugins, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-nodes, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-ignition-bringup";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_bringup/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2ef3fb4ae67087039d5000d2698533aec18b0335c564dffa938005ecea54624e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-plugins irobot-create-ignition-toolbox irobot-create-msgs irobot-create-nodes ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides launch and configuration scripts for a Ignition simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-ignition-sim/default.nix
+++ b/distros/galactic/irobot-create-ignition-sim/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-plugins, irobot-create-ignition-toolbox, irobot-create-nodes }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-ignition-sim";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_sim/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d1c568dacdb8de4e04b2901a5950715fcdad463ad868ac63000ed9bbd49cb1e0";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ irobot-create-common-bringup irobot-create-description irobot-create-ignition-bringup irobot-create-ignition-plugins irobot-create-ignition-toolbox irobot-create-nodes ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for the iRobot(R) Create(R) 3 robot Ignition simulator'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-ignition-toolbox/default.nix
+++ b/distros/galactic/irobot-create-ignition-toolbox/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, control-msgs, irobot-create-msgs, irobot-create-toolbox, nav-msgs, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-ignition-toolbox";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_toolbox/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f2e4159206765027f4ce4f2106aa78e3bb4119ede5cb40ab74867e10193d0f88";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ control-msgs irobot-create-msgs irobot-create-toolbox nav-msgs rclcpp rclcpp-action rcutils ros-ign-interfaces sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Nodes and tools for simulating in Ignition iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-msgs/default.nix
+++ b/distros/galactic/irobot-create-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-msgs";
+  version = "1.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/irobot_create_msgs-release/archive/release/galactic/irobot_create_msgs/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "413cd833f869337ea912082491b86527a7e0f1a8951306b4e96aeb1de98208c5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Package containing action, message, and service definitions used by the iRobot(R) Create(R) platform'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-nodes/default.nix
+++ b/distros/galactic/irobot-create-nodes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, angles, boost, control-msgs, geometry-msgs, irobot-create-msgs, irobot-create-toolbox, nav-msgs, rclcpp, rclcpp-action, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-nodes";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_nodes/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "eff3a2a6943772dd2ba1b53e65883006b6fd859351f264018002cebb6a8947b8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ angles boost control-msgs geometry-msgs irobot-create-msgs irobot-create-toolbox nav-msgs rclcpp rclcpp-action rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 Nodes for the simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/irobot-create-toolbox/default.nix
+++ b/distros/galactic/irobot-create-toolbox/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, ignition, rclcpp }:
+buildRosPackage {
+  pname = "ros-galactic-irobot-create-toolbox";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_toolbox/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "e10b7413e5fbd5e815c0396a373ba8868af036a7eded9f786ac75314b2a6d457";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ignition.math6 rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Components and helpers for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/libphidget22/default.nix
+++ b/distros/galactic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-galactic-libphidget22";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/libphidget22/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "46dc58a7b8e145a772b6c26892bdd082775c3b2d62515eca39264845d329d813";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/libphidget22/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "c91c3a49106020613554ece910435d677cea5c6eed3c8c51a6a5459a4ce7b7f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/novatel-gps-driver/default.nix
+++ b/distros/galactic/novatel-gps-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-novatel-gps-driver";
+  version = "4.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/galactic/novatel_gps_driver/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "944a0932c865a2e283950e27b0905dfb0f4cf2599992871212358e3f9f2000cd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-roscpp swri-serial-util tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Driver for NovAtel receivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/novatel-gps-msgs/default.nix
+++ b/distros/galactic/novatel-gps-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-novatel-gps-msgs";
+  version = "4.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/galactic/novatel_gps_msgs/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "29a8c0727f0c3e65f6b24bc415772300829d320848530195051fca27c37b86cf";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for proprietary (non-NMEA) sentences from Novatel GPS receivers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/paho-mqtt-c/default.nix
+++ b/distros/galactic/paho-mqtt-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl }:
 buildRosPackage {
   pname = "ros-galactic-paho-mqtt-c";
-  version = "1.3.9-r3";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/galactic/paho-mqtt-c/1.3.9-3.tar.gz";
-    name = "1.3.9-3.tar.gz";
-    sha256 = "b4b2e2af11a7f3eef5e150ea64958d0e37e06f3016565d2c49fd1bc460604347";
+    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/galactic/paho-mqtt-c/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "f1181f06d3b2e1a354cb4cb2bc6394531adcacb81cddd6f61f9a490bbb11efc8";
   };
 
   buildType = "cmake";

--- a/distros/galactic/phidgets-accelerometer/default.nix
+++ b/distros/galactic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-accelerometer";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_accelerometer/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "3552109fe2aba6f22c01da260b65ea790007f88558067211037f0cce47d82b4a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_accelerometer/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "b513c97a15af7ff867ac729ce3a84c8ee17542d2934f0cb25166c940b89a82b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-analog-inputs/default.nix
+++ b/distros/galactic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-analog-inputs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_analog_inputs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "4c1d526cc93d436b3e72679b83336b9a61b404ba86b1d256b9ff452674bebf37";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_analog_inputs/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "2c81b078a3c99cc1d14cb04d63d5489e8af187a778eced872acc93d3a1ec4695";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-api/default.nix
+++ b/distros/galactic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-api";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_api/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "ed76b730aed3c954b83fc4c9ab9e53edb48d19deaaff81dcd1def5c40893c709";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_api/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "d2a87c8c80b007786af8b41e9d7f5c8155cbb63b195799b2bc2dc114f4e4bdd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-digital-inputs/default.nix
+++ b/distros/galactic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-digital-inputs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_inputs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "a9dca4591b281eb8897ee9cf6694c09ddf7d5c0f80b6f9ce72c6aae0d32349e5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_inputs/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "5e1a31b7067011d59cb014234daff37fbaf67099f4fe04fadcf811cb6eda990f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-digital-outputs/default.nix
+++ b/distros/galactic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-digital-outputs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_outputs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "4ce5efa8eaf008f9ff3305d84ed7fe8fcf16c8f41d294fad3d22a37ea856863f";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_outputs/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "2946b534c41f492d753ed9a09627e2ba219b1c3cddfe3c3fa78861e55f97f64e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-drivers/default.nix
+++ b/distros/galactic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-drivers";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_drivers/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "bc1d57e7db3949cb63f598314f9cbd3d327e00e4ae4260c1c81e56dcd6a5b26e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_drivers/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "5d3bbd66508940bd20ec399c628ca3e86b7b138361cb45e23469ff5889b532e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-gyroscope/default.nix
+++ b/distros/galactic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-gyroscope";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_gyroscope/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b612146ee61ce866b53f375f2aae0a48de18eeacbb372108e3fb531d269b04d1";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_gyroscope/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "bc3d6746f21fb61a2a25237fb0dfd8538f7efe6bdc8d75928491aa31403002e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-high-speed-encoder/default.nix
+++ b/distros/galactic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-high-speed-encoder";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_high_speed_encoder/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "3beb416be7b352d97a470388d8c2c4e5f20633bc14b883a40bd042d64378f21d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_high_speed_encoder/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "88e0a75d30f421d3e1c769aa642554f19132df4749eb3cca9c1d45236acc8ffd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-ik/default.nix
+++ b/distros/galactic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-ik";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_ik/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "fbef84b727378fe2651f54d67545727ffb9eccd668115dcd61560062ff13eb18";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_ik/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "98255f5c2ab6205b9b6f6fa6ae8bb311c8fdf20145fc4cd4a3bf8dcb77cb7510";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-magnetometer/default.nix
+++ b/distros/galactic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-magnetometer";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_magnetometer/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "0f27e5bcc85fc78996bf6273b5459c194fce2e92d074ef72516d24004e6f845c";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_magnetometer/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ded6828e4422bd945e57124af531b99982b5326f86a401b4c9bc2f4388d91b70";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-motors/default.nix
+++ b/distros/galactic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-motors";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_motors/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "43abee1dda1ba2df130645ca50a842b7f5065ecca9aa5a789c1973d5f4e2f659";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_motors/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "984d9d4886277eeb663fc8ff32fc60ca25ed63b8dabef69d82d2477a9687e037";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-msgs/default.nix
+++ b/distros/galactic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-msgs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_msgs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "8ea44817055d6f636245c2f196e7e4216099e301ff16df229778f8d3aca91f65";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_msgs/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "5951f7b5d06ef7595615dfa673c952ba8ac4e93e8f833e10115d1642346e09fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-spatial/default.nix
+++ b/distros/galactic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-spatial";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_spatial/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "e0ec470bc2ae39c43f3b6d18a129840a3d46ace5b8ec4f330a964a6b3e81eacb";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_spatial/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "a331f1688a0ce367fff21625bd38f0f11191ac6eb7f890e9fea191c8c7001f5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-temperature/default.nix
+++ b/distros/galactic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-temperature";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_temperature/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "ccfcae3ba0509c7465fa62f9eec74dd685a3c4ea438163a9733c54edcca284af";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_temperature/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "a995c08fb08a011ad18105e3e0d703a02af9d8ec6eb591a3ddc77a54a30e0bc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-bringup/default.nix
+++ b/distros/galactic/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bringup";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "570a0835dc87b3265b21ebec7afdf75740a2122c54c16ba93c7ddc0b2ccc0f5f";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2e2e9c1e9dcec819330320432762e5a2b3ad41846f7c5e12845d04dd9ddfcb7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-bt-actions/default.nix
+++ b/distros/galactic/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bt-actions";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "fb1c1520a6d88e1d270de2d31df2802139274cbee2292c5144b1aeda9c78d49b";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a9b40b750e71b1ba28271ba7ae4fe528d9ee839fb9766d67d3efbaed7e1653fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-core/default.nix
+++ b/distros/galactic/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-core";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "c4725cb608eee1b2def71c343c1645feb5b52577c51eebd9eda51c0851136e7d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "b6a3f70da0c71aafb8abf5e3b53d52ec45332fde6d07f2e046e5b98f57a84b3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-domain-expert/default.nix
+++ b/distros/galactic/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-domain-expert";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "a5dd7d002571c5070a88ae662cc0f7d16fd0ac312e45bb53d743ed9401bf92d6";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2972f9835094bacaeb7bedbcb04489fcf97492f794d2af46d14d675bfb9b0a0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-executor/default.nix
+++ b/distros/galactic/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-executor";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "a3a9e981c0b690cd60e9dfb8cfa33b0fad16c7d47380d8ac54e74057c349d572";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c0edaed5b43d4650bf9b36931860c2d0661600a73ea403f4c80fbfc2618a4827";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-lifecycle-manager/default.nix
+++ b/distros/galactic/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-lifecycle-manager";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "cd2e7aab5f6c54b14a5db4bddf7ddb0fef029cdfc5e98487bb0af1855e0a0fcb";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5f7a78fa8107ce014792326d65c9f89838b483953e226e86c3545049e1477983";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-msgs/default.nix
+++ b/distros/galactic/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-msgs";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "df7293e4a536542b9a255ef6a9f87c9c8c308895904154fd3296676924911906";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "d35ed688059a2a25c54d5b6a8a4c9b75e0bbe931f0634ae99c499d855214421f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-pddl-parser/default.nix
+++ b/distros/galactic/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-pddl-parser";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "3441ffa0121b3d29187032ae8c8001b898a81e6d4ffec30667c8acf7a8185705";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "88b2c6abe44d8c92c636fd558b6889e97e9063c57c2f0a276fc88388612780b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-planner/default.nix
+++ b/distros/galactic/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-planner";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "da3097b12deb5ce38008ede6036e90e478d25222a4c1485c6d79a7327c94e1e1";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "11372fdb90bbda11dcdce91336c0a796493a0fafa978630d64aa5d265598b11a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-popf-plan-solver/default.nix
+++ b/distros/galactic/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-popf-plan-solver";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "e746cba7018b9c81cc72ec5d0f3484b648ba715100319c5894af53c4c298b923";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "cebb036cdb2633dd49818cce4d84863de6375a228753c0dd12bbae13b05e3e02";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-problem-expert/default.nix
+++ b/distros/galactic/plansys2-problem-expert/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, qt5, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-problem-expert";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "943ec906da4502a7edbce2e532d1ef437140fd4db413777f25aa9dcd99efe91b";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f4d99128bd5dde330e82f4e5325de8270fb17085132de6fde13a9d76065a6d85";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser qt5.qtbase rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/plansys2-terminal/default.nix
+++ b/distros/galactic/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-terminal";
-  version = "2.0.1-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "e8defbc2e94d2a4aa0b65e4558adcf2daba402c0e73a906c093ea6653d904e44";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "213296f5c99afa2dbc6eff8ec385dc0dbe639c54f11462a79c01bf6349a21976";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-tools/default.nix
+++ b/distros/galactic/plansys2-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-tools";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "91c4b2e84bb8d13c0329f25f9d22f668011488cb55726de0c7c782a08abd3fa7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-problem-expert qt-gui-cpp rclcpp rclcpp-lifecycle rqt-gui rqt-gui-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A set of tools for monitoring ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/robot-upstart/default.nix
+++ b/distros/galactic/robot-upstart/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-robot-upstart";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/galactic/robot_upstart/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "da6d007b9110ea957e9fd9c6b698e494429d47b17c9176b8d433ebb0cf5c4b6f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python ];
+
+  meta = {
+    description = ''The robot_upstart package provides scripts which may be used to install
+    and uninstall Ubuntu Linux upstart jobs which launch groups of roslaunch files.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rosbag2-storage-mcap/default.nix
+++ b/distros/galactic/rosbag2-storage-mcap/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, python3Packages, rcutils, ros-environment, rosbag2-storage }:
+buildRosPackage {
+  pname = "ros-galactic-rosbag2-storage-mcap";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "add936e76c297124bdc1dab1f588ecc16c0d5ae3c6eb95083afc9e221faabe5f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp pluginlib rcutils ros-environment rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake python3Packages.pip ];
+
+  meta = {
+    description = ''rosbag2 storage plugin using the MCAP file format'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/smacc2-msgs/default.nix
+++ b/distros/galactic/smacc2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-smacc2-msgs";
-  version = "0.1.0-r1";
+  version = "0.3.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "e8e86cb1727ae7c1e66e3d7d663b0d5a111d13308437c824b9b8513ca29787ef";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2_msgs/0.3.0-3.tar.gz";
+    name = "0.3.0-3.tar.gz";
+    sha256 = "280fb1c6480b859476b1bb03bd4e78a3765d3e2eaf33fdb3eb053180eec6d6d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/smacc2/default.nix
+++ b/distros/galactic/smacc2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, lttng-ust, rcl, rclcpp, rclcpp-action, smacc2-msgs, tracetools, tracetools-launch, tracetools-trace }:
 buildRosPackage {
   pname = "ros-galactic-smacc2";
-  version = "0.1.0-r1";
+  version = "0.3.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "08e3221e2ab93c13ea21d927d859a98bfb6d56d633cf5fa6234797a53bc6814e";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2/0.3.0-3.tar.gz";
+    name = "0.3.0-3.tar.gz";
+    sha256 = "0d35fc3fa12186ac35359635166317ff65a4bdf012f7b3c775b19ec890bfeaa6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/theora-image-transport/default.nix
+++ b/distros/galactic/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, cv-bridge, image-transport, libogg, libtheora, pluginlib, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-theora-image-transport";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/theora_image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "f1ff380ed47fa07afc04a90138f5787165056e7da5352b06a7be6ebf7ff91154";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/theora_image_transport/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "f5329c4e23f21705c704054118cbf019b5db1a9f65bfcc67a52ebcefc9f4a848";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-gps/default.nix
+++ b/distros/galactic/ublox-gps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, asio, diagnostic-msgs, diagnostic-updater, geometry-msgs, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-galactic-ublox-gps";
-  version = "2.0.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox_gps/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "e2801ca0a8a9e8e169ea759bdd51e0b412c728571860440c5460a015cf61c6e6";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox_gps/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "1c8aff6dc5db7da7960f118518b830706010b29fdbafe9abbf2acc61c2957b55";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-msgs/default.nix
+++ b/distros/galactic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rosidl-default-generators, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-galactic-ublox-msgs";
-  version = "2.0.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox_msgs/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "0113650136af7affb3af3f6aa0cc3a066b6849ba9bdb51adb1eca7b69b0d1214";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "3993c5a8e646795c33351042535c5fc3f61bd5a27d41afe262edce5e6e744b52";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-serialization/default.nix
+++ b/distros/galactic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-ublox-serialization";
-  version = "2.0.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox_serialization/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "6f3db1e6efc9d802ebe7a30850b808fdd2cb99fb847b1a31cf7b5db50d365097";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox_serialization/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "4e94c853e242f192f253d1d6708fd901b08e771455d736fc1f134efb862a5e29";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox/default.nix
+++ b/distros/galactic/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-galactic-ublox";
-  version = "2.0.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "723d35182f43351c3f13e2d2228259df820e5e8ad363fa8948a6177b4b711222";
+    url = "https://github.com/ros2-gbp/ublox-release/archive/release/galactic/ublox/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ef463943cb33a9c6c386ffe67ee1e8d7d556e1a799cc03b9f54db696b56fd088";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ur-description/default.nix
+++ b/distros/galactic/ur-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-ur-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/galactic/ur_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c6e240359dbcd83108e71d30e64f3035fedf23f6355559fcf213bb26e387b961";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pytest launch-testing-ament-cmake launch-testing-ros urdfdom xacro ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-ros robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF description for Universal Robots'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/galactic/ur-msgs/default.nix
+++ b/distros/galactic/ur-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-ur-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/galactic/ur_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "851593ad9412aa2d6ba7a1d6e752fe024ba59b342de9e6da5aab7dcdbebab6db";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message and service definitions for interacting with Universal Robots robot controllers.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/galactic/velodyne-driver/default.nix
+++ b/distros/galactic/velodyne-driver/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "63b305d7113d4ec7f977da66faba82f3427cfa4453da6993709bbb50a43402de";
   };

--- a/distros/galactic/velodyne-laserscan/default.nix
+++ b/distros/galactic/velodyne-laserscan/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "409d3a53c5b4a6c7164b3f85d7e9a4635119751820fd22c7c46b8730b3ee1794";
   };

--- a/distros/galactic/velodyne-msgs/default.nix
+++ b/distros/galactic/velodyne-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "5557887b891ea9c9b3ac06a8aae9129c7c78badbba97b18a145055c1c72fc4fb";
   };

--- a/distros/galactic/velodyne-pointcloud/default.nix
+++ b/distros/galactic/velodyne-pointcloud/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "14336818e211d7231a126ab5e45762cd4170f4f9472f1af3e505d67e8c6e2796";
   };

--- a/distros/galactic/velodyne/default.nix
+++ b/distros/galactic/velodyne/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/galactic/velodyne/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "838f82656dfefc285648931d87839ae27b2dfcf13ad7c7d81803012b1ff3b6c7";
   };

--- a/distros/melodic/apriltag-ros/default.nix
+++ b/distros/melodic/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-generation, message-runtime, nodelet, opencv3, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-apriltag-ros";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/melodic/apriltag_ros/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "a309e7dc7f6febb4aa237c98d3be84bf476331102064b5b8f2cbace1c50b5faf";
+    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/melodic/apriltag_ros/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f3ca9ce2dccc9169f47f78e6e591e4daad245e508ef63d1636809ab07ca72296";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "e449a9cd40c6016617ea822e0a776867a9a7bd712b74237b0be752976f964681";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "eb0c1d00f163a0153263b81275aa8ab0014a406196d4a201d01f16ad8d9d63f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "2fa2c49d7c20011de78ea20187f3608ae6338f8d55c4ac96b9f8b47d06d992c2";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "5afc90d19df7b952f315fff30132e1e1d12640748fe9f8d6f80139be09509b2b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "a459a57a6f6e797b4d980fc71482a072a0df75a68349f2417a50f342b49717b5";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "ba1a9d6405d72171f455d1f950f91d263619e9f2961ea66dcafd67051ce67de5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "ee5613f0a767a2a6dda6b40df2c3a332537ecf5b734452b261da0a426347ae8a";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "59c3e9adb8200d6c296674e7405700e2bec35a2feba21605ed6bd19d5eeba6e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/avt-vimba-camera/default.nix
+++ b/distros/melodic/avt-vimba-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-proc, image-transport, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-avt-vimba-camera";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "3e91999ce02aa63045feae3ec63bbf82f1badc08c3553ded70decc109967548d";
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "74b42283532f9c9c2b19646b0d4138cbd1aa95a2755191027fb72923070be070";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "ab7fb26613d6211c7c1bcc9aae7657d0b7c5ff182a5f2ba96f096f0592f14dda";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "7770553df791212fe6f509e6e8516463585f9b428e02b7d54084785a704961a8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cv-bridge-python3/default.nix
+++ b/distros/melodic/cv-bridge-python3/default.nix
@@ -1,0 +1,32 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, opencv3, python3, python3Packages, rosconsole, rostest, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-cv-bridge-python3";
+  version = "1.13.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/vision_opencv_python3-release/archive/release/melodic/cv_bridge_python3/1.13.2-1.tar.gz";
+    name = "1.13.2-1.tar.gz";
+    sha256 = "c1e18d1a33ff149385882ca616fdd8cc706b6dbf80f293e1962c63498c3a8d24";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ python3Packages.numpy rostest ];
+  propagatedBuildInputs = [ boost opencv3 python3 python3Packages.opencv3 rosconsole sensor-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.catkin-pkg ];
+
+  meta = {
+    description = ''This contains CvBridge, which converts between ROS
+    Image messages and OpenCV images.
+    ==
+    This package intentionally link against boost-python3 and
+    install under /opt/ros/ROS_DISTRO/lib/python3/dist-package
+    Please add
+    import sys, os; sys.path.insert(0,'/opt/ros/' + os.environ['ROS_DISTRO'] + '/lib/python3/dist-packages/')
+    before you call import cv_bridge'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.11-r1";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.6.11-1.tar.gz";
-    name = "2.6.11-1.tar.gz";
-    sha256 = "f7d311d01dec93ce128867019ff4d4bb38523bb644a5122a3d9a94e6db28ebca";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "e7f905efc3fe4c02ad5375fe89bdd6932d897349a61ba9f7284e0163b267465d";
   };
 
   buildType = "cmake";

--- a/distros/melodic/end-effector/default.nix
+++ b/distros/melodic/end-effector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, joint-state-publisher-gui, kdl-parser, libyamlcpp, message-runtime, moveit-ros-planning-interface, muparser, roscpp, rosee-msg, rospy, srdfdom }:
 buildRosPackage {
   pname = "ros-melodic-end-effector";
-  version = "1.0.4-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ADVRHumanoids/ROSEndEffector-release/archive/release/melodic/end_effector/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7bfaf2e109b2c7cb6a21eb989e3092513a2a4b94b3a8e9f1f5b945536f28721b";
+    url = "https://github.com/ADVRHumanoids/ROSEndEffector-release/archive/release/melodic/end_effector/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "57ec26ad6d42a58f7db0b640a0a0cf690ac56536b59fce65848b7f83f33b135e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -614,6 +614,8 @@ self: super: {
 
  cv-bridge = self.callPackage ./cv-bridge {};
 
+ cv-bridge-python3 = self.callPackage ./cv-bridge-python3 {};
+
  cv-camera = self.callPackage ./cv-camera {};
 
  cvp-mesh-planner = self.callPackage ./cvp-mesh-planner {};

--- a/distros/melodic/imu-complementary-filter/default.nix
+++ b/distros/melodic/imu-complementary-filter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-filters, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-imu-complementary-filter";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "c77dc4623d5940a2df13eaf732e6b46fde54392efdcf7b53bca5cd1c941b9498";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "9a68b1c5a4b5cda44fe3b6b1852d8dfd91c104eaf42c1d9b3bb014ca685e784c";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ message-filters roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ geometry-msgs message-filters nodelet roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/imu-filter-madgwick/default.nix
+++ b/distros/melodic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-imu-filter-madgwick";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "6bca1c317388c21f816acbb6427c104400d24a35926726724e56b25fc914ebc7";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "e601d53201c05037df73d084e72ceeeefa6eb05d169b5086b1a97a9974dd528c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-tools/default.nix
+++ b/distros/melodic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-imu-tools";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "29b4c0968c742e6bef6092ed35e1ec1d4c8bdbe1d65c4bf5a759ee972bfb3859";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "79367a68fc44b74309f50e3edc06aec98a2990d872b6454a3e3c59a57eb2b487";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "0aa68e1424b8e21bb3d27cab73f3e7a4c9bee1cf84fb73d5a9a29e99e0a1b7a5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "93497feb0d2d8acc5e9e0133e91d198c13176c61ab43b981aa294e4dcba4505e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kdl-parser-py/default.nix
+++ b/distros/melodic/kdl-parser-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, orocos-kdl, python-orocos-kdl, pythonPackages, rostest, urdf, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-orocos-kdl, pythonPackages, rostest, urdfdom-py }:
 buildRosPackage {
   pname = "ros-melodic-kdl-parser-py";
-  version = "1.13.1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/melodic/kdl_parser_py/1.13.1-0.tar.gz";
-    name = "1.13.1-0.tar.gz";
-    sha256 = "66da27c1d53a445cc5334768a54a2f792df8c46475fe24a91ff486675082c86a";
+    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/melodic/kdl_parser_py/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "5463332e38a5d3483f6dd76859eac55d39560a019eddb02709a04adbd98490b3";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ orocos-kdl python-orocos-kdl urdf urdfdom-py ];
-  nativeBuildInputs = [ catkin pythonPackages.catkin-pkg ];
+  propagatedBuildInputs = [ python-orocos-kdl urdfdom-py ];
+  nativeBuildInputs = [ catkin pythonPackages.catkin-pkg pythonPackages.setuptools ];
 
   meta = {
     description = ''The Kinematics and Dynamics Library (KDL) defines a tree structure

--- a/distros/melodic/kdl-parser/default.nix
+++ b/distros/melodic/kdl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, orocos-kdl, rosconsole, roscpp, rostest, tinyxml, tinyxml-2, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-melodic-kdl-parser";
-  version = "1.13.1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/melodic/kdl_parser/1.13.1-0.tar.gz";
-    name = "1.13.1-0.tar.gz";
-    sha256 = "5931eb562bb310633fedf3c2e40b435cfa6a8d25caddb4077c04932c66c2a8a9";
+    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/melodic/kdl_parser/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "3330b28612c51a321bfa0ab45e542b774ad69f8d73acb2f1377c20b65c90f50a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "a82ba6776ac74a814b8e18f83bb30699948bc26ebe57440a3e4c2e9e0ecdd067";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "b4c8d4d44de65616f62256198e7e0b0c83a603fb1adf980b78402d43eab82b29";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "1ba0aafb682f9d177fa2cb97553f5786a35a4455069ef5651868c2500a9561c5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "122b043304b5867f6664ed14cb1e26a6aab43780e318ea4096f6f5e0814728d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "132fe5a636eca3a9c04a9e883645afc4938e82eb29636e2e858a6e390081123a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "724526fda1e17c41b91fa4b54edf6dbbc254042e96b95c4ca2b534fdda6262ba";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "aefd8111a897070ed5cf567bc2e89b0f233d0a09809f9b54ec2601347dc7d2a7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "1ff537ae41f70249a409ee6e19fdc7d913e6789d6913e3d87910453ccdf7cf9f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "3cec04ea15c44867515cf290dda3099c5b21a27735a5601a35806ef7449c31ad";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "43f3b346311dcee72b3ce20a76dd42fb2dfdcb869c19e42cf9cb7481801e6fd2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/openni2-camera/default.nix
+++ b/distros/melodic/openni2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, dynamic-reconfigure, image-transport, message-generation, message-runtime, nodelet, openni2, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-openni2-camera";
-  version = "1.5.1-r1";
+  version = "1.6.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/melodic/openni2_camera/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "d1c49ec702ee89bce39cf2823c8bf1dca1eace9b9b6127736be24578036ff72c";
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/melodic/openni2_camera/1.6.0-2.tar.gz";
+    name = "1.6.0-2.tar.gz";
+    sha256 = "fa0cf0baee7eec9befcbc0d00e01a6a302f002d94063e441200b95f338a15f2c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/openni2-launch/default.nix
+++ b/distros/melodic/openni2-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depth-image-proc, image-proc, nodelet, openni2-camera, pythonPackages, rgbd-launch, roslaunch, rospy, roswtf, tf, usbutils }:
 buildRosPackage {
   pname = "ros-melodic-openni2-launch";
-  version = "1.5.1-r1";
+  version = "1.6.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/melodic/openni2_launch/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "6ed509a6d0c42f9a3942c7ced579c95d95705cfaa7086a89c14a6697e2b7c610";
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/melodic/openni2_launch/1.6.0-2.tar.gz";
+    name = "1.6.0-2.tar.gz";
+    sha256 = "f2b0d6a8e6264bd8c4b9b5f74695949a6c846b6fb497e0bb4f6a75cb4508280a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "36e2704519cec06d7e1ae79608c909c66e48918894a8ea4163f7a68a89e0c300";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "9df9a503805cd397f061712eeeed67a12f45d47f0713b1248c88525977147994";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-controller-interface/default.nix
+++ b/distros/melodic/pr2-controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, pr2-mechanism-model, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-pr2-controller-interface";
-  version = "1.8.18";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_interface/1.8.18-0.tar.gz";
-    name = "1.8.18-0.tar.gz";
-    sha256 = "0a6ffaecfd981a9b21e8895ac582bff371da30a6526c97a933827b9a97bf7607";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_interface/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "5995e8f908240cb86b088e71a7c9a21526ba960e2917341fab816e3a28b19299";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-controller-manager/default.nix
+++ b/distros/melodic/pr2-controller-manager/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, pluginlib, pr2-controller-interface, pr2-description, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model, pr2-mechanism-msgs, realtime-tools, roscpp, rosparam, rospy, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, pluginlib, pr2-controller-interface, pr2-description, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model, pr2-mechanism-msgs, realtime-tools, robot-state-publisher, roscpp, roslaunch, rosparam, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pr2-controller-manager";
-  version = "1.8.18";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_manager/1.8.18-0.tar.gz";
-    name = "1.8.18-0.tar.gz";
-    sha256 = "b8c00259af30026fbef6c1651f3b95332e5aab3922fbc66ed109515613d68da4";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_manager/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "f7f5a2b6fe73113e955a3dac37499052a0846510f01ab5d6dcc9829c8dea7663";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs pluginlib pr2-controller-interface pr2-description pr2-hardware-interface pr2-mechanism-diagnostics pr2-mechanism-model pr2-mechanism-msgs realtime-tools roscpp rosparam rospy sensor-msgs ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ diagnostic-msgs pluginlib pr2-controller-interface pr2-description pr2-hardware-interface pr2-mechanism-diagnostics pr2-mechanism-model pr2-mechanism-msgs realtime-tools robot-state-publisher roscpp rosparam rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/pr2-hardware-interface/default.nix
+++ b/distros/melodic/pr2-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-pr2-hardware-interface";
-  version = "1.8.18";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_hardware_interface/1.8.18-0.tar.gz";
-    name = "1.8.18-0.tar.gz";
-    sha256 = "abbcd1c6b4af9419057f2bb0b7f7677943e16e03abdd15933e41efdc16975247";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_hardware_interface/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "9ce45f51e932c93e2b463687e8b2a00756aa97f885b00636c9d2095f9b09b7d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-mechanism-diagnostics/default.nix
+++ b/distros/melodic/pr2-mechanism-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-msgs, diagnostic-updater, pr2-mechanism-model, pr2-mechanism-msgs, roscpp, rospy, rostest, std-msgs, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-pr2-mechanism-diagnostics";
-  version = "1.8.18";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_diagnostics/1.8.18-0.tar.gz";
-    name = "1.8.18-0.tar.gz";
-    sha256 = "3d6fbbd7282c6a07b6ea340848aa1fb79444832f19224508ed20fab0e73bf98c";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_diagnostics/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "233eefb27b334851a0fbc9e9d13215934b09f9ba90c7cc304a9188e24f41eea8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-mechanism-model/default.nix
+++ b/distros/melodic/pr2-mechanism-model/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, hardware-interface, kdl-parser, pluginlib, pr2-hardware-interface, roscpp, rostest, rosunit, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pr2-mechanism-model";
-  version = "1.8.18";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_model/1.8.18-0.tar.gz";
-    name = "1.8.18-0.tar.gz";
-    sha256 = "d20f677226a4c6286216f0b159340ec70dfc1a7473623ddd4c39c526f25947e0";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_model/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "f241977ea5b1ddc575ca11ead81f5a795c98c7a4258a36fe2c6d83edd1ae2fa9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-mechanism/default.nix
+++ b/distros/melodic/pr2-mechanism/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-controller-interface, pr2-controller-manager, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model }:
 buildRosPackage {
   pname = "ros-melodic-pr2-mechanism";
-  version = "1.8.18";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism/1.8.18-0.tar.gz";
-    name = "1.8.18-0.tar.gz";
-    sha256 = "c6ed5bf479132aac212fc57681dc0223a03708b808e2ee0c0c8c27318348f468";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "d9fc465f3077fe29eec22da9d34f1573c8639c010bf1707686b6fde3e233d7a0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz-imu-plugin/default.nix
+++ b/distros/melodic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-melodic-rviz-imu-plugin";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "1adab782a4bc97d91ec714b841e9761f4349ecbfc08434d3ca00b9f8783033f2";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "65f36dcbfb2f5b9f8bced4165b8ffcd873823fbc8b7e12397f3d1f13b8b18ff3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "91df82482074b066d3932750c965a3645c291faee74f052fc8a78b11683bb087";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "ae02e9074ca4e6942a12474adeccb2eeb4c2d7ae5b5e4ddac8288ebc84695447";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "fec23abd07d96f697bb2719220f801d492084cc9db119a3a959bebaf8454d6ab";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "9fa36cd87066348cf327f78343dd378ac008a31a7f1d067d0193b32a7dd38709";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "5617657b4446db96375b38f166d345a8fe89f7f4ace2633e6b72639ed7143f21";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "3dd560bf569f7dcfe1d2c7098e339932e3f9f092ee74c52f7f0a20f35887affa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/um7/default.nix
+++ b/distros/melodic/um7/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, roslint, sensor-msgs, serial }:
 buildRosPackage {
   pname = "ros-melodic-um7";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/um7-release/archive/release/melodic/um7/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "2def3dc297cb32a419cfed279aa05796da9a1129ea6d27a77ca28cc084ae5d39";
+    url = "https://github.com/ros-drivers-gbp/um7-release/archive/release/melodic/um7/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "2c3e906d3ea464379b5d44ae8834da5e8136d03b7ac108bc50d2f0116318a914";
   };
 
   buildType = "catkin";

--- a/distros/noetic/apriltag-ros/default.nix
+++ b/distros/noetic/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-generation, message-runtime, nodelet, opencv3, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-apriltag-ros";
-  version = "3.2.0-r1";
+  version = "3.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/noetic/apriltag_ros/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "2e7f1a6a2c72ad6563abb377f77f977af9c3dddfaad9214c45f47e95a11ec8a4";
+    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/noetic/apriltag_ros/3.2.1-3.tar.gz";
+    name = "3.2.1-3.tar.gz";
+    sha256 = "831217c3c023b76328b58657ab89f70691dffbe0bf3363bd2e60408c1cea8152";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aruco-msgs/default.nix
+++ b/distros/noetic/aruco-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-msgs";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco_msgs/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "8cc41f88a983ea32a2cc48288dc5e2ea2edba95b6c85911f7c20ebbf3ca48a39";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The aruco_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/aruco-ros/default.nix
+++ b/distros/noetic/aruco-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, aruco, aruco-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, roscpp, sensor-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-ros";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco_ros/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "894fb18c3cc48440a8762f55394a688a18295ae22f393e1579ddc1651e700696";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ aruco aruco-msgs cv-bridge dynamic-reconfigure geometry-msgs image-transport roscpp sensor-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/aruco/default.nix
+++ b/distros/noetic/aruco/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen }:
+buildRosPackage {
+  pname = "ros-noetic-aruco";
+  version = "3.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/noetic/aruco/3.0.1-3.tar.gz";
+    name = "3.0.1-3.tar.gz";
+    sha256 = "79ecb1dd67c8a0b5de6b7f226b219241c23298aa07c882990fcff7b578f7cb61";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/audio-capture/default.nix
+++ b/distros/noetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-capture";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "71568fe0b7464aedb6680df26c8f4994dda8f09cc084f2436d19271f695ae39d";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "c7f8daa90674584dc7db5cea6f0fdc0a602fbd5169632988601bffb8a940b810";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common-msgs/default.nix
+++ b/distros/noetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-audio-common-msgs";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "bb111d35a2c4435c9c0ef69b59684ac7881b99138f52bfc4169879dc0daae053";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "85b8bd7a7fd1348ea5fa0d84c05d9cca2e6f34c7b569e859cd606c8bd1c9e79f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common/default.nix
+++ b/distros/noetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-audio-common";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "65726768cee810e697a9a497c07119212732341bee0accf88dfe971f0ede4a1f";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "43f53161d90023ce760af643e6a29757a868fff9a3e0330af5bc5d1bdd700f1b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-play/default.nix
+++ b/distros/noetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-play";
-  version = "0.3.12-r1";
+  version = "0.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.12-1.tar.gz";
-    name = "0.3.12-1.tar.gz";
-    sha256 = "64f78c942eda1646e3d50397503e66d2e18600ef78607b22da77335f1b583223";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.13-1.tar.gz";
+    name = "0.3.13-1.tar.gz";
+    sha256 = "d8898cda69f7de2fa5d0fc3ce83c8281c1ecbb98c8399fd53843f46c883e8ab0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/avt-vimba-camera/default.nix
+++ b/distros/noetic/avt-vimba-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-proc, image-transport, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-noetic-avt-vimba-camera";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/noetic/avt_vimba_camera/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0bc50924547603cf97f41dfb59ee695582d035802a8e6c3b5bcc9e52a2f1ecce";
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/noetic/avt_vimba_camera/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f8050c08a4f1699866f490cb04fd69deee510a24bd6a4ddfd0e537b0e8488320";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "bf147ab9bd62fed718dc4cf7b587ad2cc12110247863f5e483442bc0c37b5165";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "adbad742a323f3939a4c759142e9570a23d939821522c71a805333bddd4a7fcf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "80ede502354c62089be299c64f0d40989fd8184cf0116723663ace20afd4f22a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "9ef0852470d1eb2afd6597aff3a4d923b1c3614339c518d8b7e56f474ea51088";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diffbot-base/default.nix
+++ b/distros/noetic/diffbot-base/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-manager, diagnostic-updater, diff-drive-controller, diffbot-msgs, dynamic-reconfigure, hardware-interface, roscpp, rosparam-shortcuts, rosserial, sensor-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-base";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_base/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5793ae3fa559221f08b2ea983cd5178aa65c91c2bb4b76eb62ddb2cfc4369553";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox controller-manager diagnostic-updater diff-drive-controller diffbot-msgs dynamic-reconfigure hardware-interface roscpp rosparam-shortcuts rosserial sensor-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_base package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-bringup/default.nix
+++ b/distros/noetic/diffbot-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-bringup";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_bringup/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7baeb9418cea432d5c7bf5e33c071c1f0bb5fa3c48f5038fe9389f4e9558d230";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ teleop-twist-keyboard ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_bringup package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-control/default.nix
+++ b/distros/noetic/diffbot-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, hardware-interface, joint-state-controller, robot-state-publisher, roscpp, rosparam-shortcuts, sensor-msgs, transmission-interface }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-control";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_control/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ada0f8358f106cdae3eebc4c2b230777642ea690c221764cdd8d672c0bfa4c99";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller hardware-interface joint-state-controller robot-state-publisher roscpp rosparam-shortcuts sensor-msgs transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_control package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-description/default.nix
+++ b/distros/noetic/diffbot-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-description";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "32719217c0f5e92134fe65d59e595ab4bf653ff6b93a1671cf10ba4f7811fca1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_description package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-gazebo/default.nix
+++ b/distros/noetic/diffbot-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diffbot-control, diffbot-description, gazebo-plugins, gazebo-ros, gazebo-ros-control, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-gazebo";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_gazebo/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "95278be8b2a56029fc0fa84e5bb39f8047a0ee7ef7f7776a5db585fdbec844ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diffbot-control diffbot-description gazebo-plugins gazebo-ros gazebo-ros-control xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_gazebo package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-mbf/default.nix
+++ b/distros/noetic/diffbot-mbf/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-mbf";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_mbf/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "40146515e32b5c6cab410888f442f88300f554b5f8e0156f4e6d08d53cfaf620";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_mbf package'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/noetic/diffbot-msgs/default.nix
+++ b/distros/noetic/diffbot-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c6404745cd18b1c665f906125c24f00445e66a7f8a5934841e99185d03bd3823";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_msgs package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-navigation/default.nix
+++ b/distros/noetic/diffbot-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, diffbot-bringup, dwa-local-planner, map-server, move-base }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-navigation";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_navigation/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0c54acf1c3175299b7cc671a559f681e8a7d623685451a5d38b3bf2e47262706";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl base-local-planner diffbot-bringup dwa-local-planner map-server move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_navigation package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-robot/default.nix
+++ b/distros/noetic/diffbot-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diffbot-base, diffbot-bringup, diffbot-control, diffbot-description, diffbot-gazebo, diffbot-navigation }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-robot";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_robot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8bd9225c1c10e57da7791284740ba78979933f13d1250f965bbb32c72c0c4549";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diffbot-base diffbot-bringup diffbot-control diffbot-description diffbot-gazebo diffbot-navigation ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_robot package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/diffbot-slam/default.nix
+++ b/distros/noetic/diffbot-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gmapping }:
+buildRosPackage {
+  pname = "ros-noetic-diffbot-slam";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-mobile-robots-release/diffbot-release/archive/release/noetic/diffbot_slam/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c7f5bc4db8e9b59bdc242c1be21403d10e7c9245dca66f0db7a4ce01edde9d4b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gmapping ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The diffbot_slam package'';
+    license = with lib.licenses; [ "BSDv3" ];
+  };
+}

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.11-r1";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.6.11-1.tar.gz";
-    name = "2.6.11-1.tar.gz";
-    sha256 = "bf9394a7c90e2add1249342bd5ce5645ff06c8f533e3263a22b91f1020a07c28";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "f303b60dc5a2132d470d111a83164716ac65647464aeaeb1670d9112abc8e421";
   };
 
   buildType = "cmake";

--- a/distros/noetic/end-effector/default.nix
+++ b/distros/noetic/end-effector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, joint-state-publisher-gui, kdl-parser, libyamlcpp, message-runtime, moveit-ros-planning-interface, muparser, roscpp, rosee-msg, rospy, srdfdom }:
+buildRosPackage {
+  pname = "ros-noetic-end-effector";
+  version = "1.0.6-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ADVRHumanoids/ROSEndEffector-release/archive/release/noetic/end_effector/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "c6716d446907ced796b669ebde7b12103cb5c532035c329b40d36f611d9c5edc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ joint-state-publisher-gui kdl-parser libyamlcpp message-runtime moveit-ros-planning-interface muparser roscpp rosee-msg rospy srdfdom ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''End-Effector package: provides a ROS-based set of standard interfaces to command robotics end-effectors in an agnostic fashion'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
+buildRosPackage {
+  pname = "ros-noetic-eus-assimp";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "a77826bcb3b116fb363b1747899a6b7e845ae8cd311d07d09d2548beb754c8a4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ euslisp pkg-config ];
+  propagatedBuildInputs = [ assimp-devel roseus ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''eus_assimp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, pythonPackages, roseus, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-eusurdf";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "b74f03dfd5d156cbf563c1ef108d74b646563d325141765ad541ec7defb63f86";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roseus ];
+  propagatedBuildInputs = [ collada-urdf-jsk-patch gazebo-ros pythonPackages.lxml rostest ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''urdf models converted from euslisp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/flir-camera-description/default.nix
+++ b/distros/noetic/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-description";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "1ce22f64636aa9e5653ee0802d835149b980fdf37864292b423c4805d869c22c";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "676469d8c3b0ba4fb88223eb948aaba9ecd1bbf1a74f93fdb12b30c1e36e202a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/flir-camera-driver/default.nix
+++ b/distros/noetic/flir-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flir-camera-description, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "e96cf184635319e217b3799bf62b64c12f949ecfded4c6960da579af6c034074";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d7c34b9c69f6f63522013884324ee24bf4a372a6e4e9a791f806def69d47ccdd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-control/default.nix
+++ b/distros/noetic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, joint-trajectory-controller, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-control";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "511b0fb4d672f0bd462c9acae0b2b7488888e9cbe9a2136fba3cf5321d7d89f3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "46917738d8d13685d8e0bdecd910e881900227d2e05af23f5dd5eb645d6c4c9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-description/default.nix
+++ b/distros/noetic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-description";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "d1cddd9544a4c15a7a93f19b1e2d0a8c9795f61009360566d656e34fa764de5e";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "0eb74a8ab64bd4432f7deaea3e2de639d1ec19a6d40529b3bc3b49886fcb421a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-example-controllers/default.nix
+++ b/distros/noetic/franka-example-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, moveit-commander, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-franka-example-controllers";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "0d58c4cdf6e937bbb57245cffdf4b76787c9f9ef76f2c1581cc3285a77416fb8";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "82f27a07e4072b5b94973334f2fba6b17bda397ee3e93aed72022940a459ce1a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-gazebo/default.nix
+++ b/distros/noetic/franka-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-gazebo";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "23b547c3f722c2c0cae80c8be1461e2a648b482d3f5bf84d34aa1698d49aeb66";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "1ad2d4c734d088942a44b5d19c8ec6991410ec61b00e1c084c09bf198bb00d7c";
   };
 
   buildType = "catkin";
   buildInputs = [ gazebo-dev ];
   checkInputs = [ geometry-msgs gtest rostest sensor-msgs ];
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp std-msgs transmission-interface urdf ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp roslaunch rospy std-msgs transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-gripper/default.nix
+++ b/distros/noetic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-franka-gripper";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "1b960bab716c41f29c37c542035b9352d431f0719be7e21e0b769de7d0b1c4b6";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "2f47f8aacaa7c14ab9e144808b4251b04d65a3b0c21edfbb3e6f73a447f0178a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-hw/default.nix
+++ b/distros/noetic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-hw";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "eefa550cd5990552d18dae41d48771b19a03eb484e980ef6ac4e309cc671aaf4";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e3fb18e603d6c90616136b887d09b047027b0aabf85e5cb5c0f9056e7932a247";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-msgs/default.nix
+++ b/distros/noetic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-msgs";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "9e3b6c243b474f240e7ce29139e00e7fa2bba094aab93b3b71967708ef9e804b";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e0fda6c228ccf1a692dc951dcca53197c446070599c16b8bbbe67a9bc82395fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-ros/default.nix
+++ b/distros/noetic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-franka-ros";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "97aafc59d74299b9971bec7496a4e597d9839fd6dd47b6fa858ea5d1e985dfdf";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f3c6821400ec368e35794d03054d8d0680819bc630baf553dfda1382f1c6da9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-visualization/default.nix
+++ b/distros/noetic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-visualization";
-  version = "0.8.2-r2";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.8.2-2.tar.gz";
-    name = "0.8.2-2.tar.gz";
-    sha256 = "65f02970bf80cf6e8572b54f91bd121a56de4e4b6159d3aa13dffd1542e0f3f3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "a1da047e01bad191f935c70794cbad86971b5f134b26be18da9aa3253696fa7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -50,7 +50,13 @@ self: super: {
 
  arbotix-sensors = self.callPackage ./arbotix-sensors {};
 
+ aruco = self.callPackage ./aruco {};
+
  aruco-detect = self.callPackage ./aruco-detect {};
+
+ aruco-msgs = self.callPackage ./aruco-msgs {};
+
+ aruco-ros = self.callPackage ./aruco-ros {};
 
  assimp-devel = self.callPackage ./assimp-devel {};
 
@@ -554,6 +560,26 @@ self: super: {
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
+ diffbot-base = self.callPackage ./diffbot-base {};
+
+ diffbot-bringup = self.callPackage ./diffbot-bringup {};
+
+ diffbot-control = self.callPackage ./diffbot-control {};
+
+ diffbot-description = self.callPackage ./diffbot-description {};
+
+ diffbot-gazebo = self.callPackage ./diffbot-gazebo {};
+
+ diffbot-mbf = self.callPackage ./diffbot-mbf {};
+
+ diffbot-msgs = self.callPackage ./diffbot-msgs {};
+
+ diffbot-navigation = self.callPackage ./diffbot-navigation {};
+
+ diffbot-robot = self.callPackage ./diffbot-robot {};
+
+ diffbot-slam = self.callPackage ./diffbot-slam {};
+
  dijkstra-mesh-planner = self.callPackage ./dijkstra-mesh-planner {};
 
  dingo-control = self.callPackage ./dingo-control {};
@@ -716,6 +742,8 @@ self: super: {
 
  eml = self.callPackage ./eml {};
 
+ end-effector = self.callPackage ./end-effector {};
+
  ergodic-exploration = self.callPackage ./ergodic-exploration {};
 
  ethercat-grant = self.callPackage ./ethercat-grant {};
@@ -724,9 +752,13 @@ self: super: {
 
  ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
 
+ eus-assimp = self.callPackage ./eus-assimp {};
+
  euslime = self.callPackage ./euslime {};
 
  euslisp = self.callPackage ./euslisp {};
+
+ eusurdf = self.callPackage ./eusurdf {};
 
  executive-smach = self.callPackage ./executive-smach {};
 
@@ -1318,6 +1350,8 @@ self: super: {
 
  jsk-interactive-test = self.callPackage ./jsk-interactive-test {};
 
+ jsk-model-tools = self.callPackage ./jsk-model-tools {};
+
  jsk-network-tools = self.callPackage ./jsk-network-tools {};
 
  jsk-recognition = self.callPackage ./jsk-recognition {};
@@ -1351,6 +1385,38 @@ self: super: {
  kdl-parser-py = self.callPackage ./kdl-parser-py {};
 
  key-teleop = self.callPackage ./key-teleop {};
+
+ khi-duaro-description = self.callPackage ./khi-duaro-description {};
+
+ khi-duaro-gazebo = self.callPackage ./khi-duaro-gazebo {};
+
+ khi-duaro-ikfast-plugin = self.callPackage ./khi-duaro-ikfast-plugin {};
+
+ khi-duaro-moveit-config = self.callPackage ./khi-duaro-moveit-config {};
+
+ khi-robot = self.callPackage ./khi-robot {};
+
+ khi-robot-bringup = self.callPackage ./khi-robot-bringup {};
+
+ khi-robot-control = self.callPackage ./khi-robot-control {};
+
+ khi-robot-msgs = self.callPackage ./khi-robot-msgs {};
+
+ khi-robot-test = self.callPackage ./khi-robot-test {};
+
+ khi-rs007l-moveit-config = self.callPackage ./khi-rs007l-moveit-config {};
+
+ khi-rs007n-moveit-config = self.callPackage ./khi-rs007n-moveit-config {};
+
+ khi-rs013n-moveit-config = self.callPackage ./khi-rs013n-moveit-config {};
+
+ khi-rs080n-moveit-config = self.callPackage ./khi-rs080n-moveit-config {};
+
+ khi-rs-description = self.callPackage ./khi-rs-description {};
+
+ khi-rs-gazebo = self.callPackage ./khi-rs-gazebo {};
+
+ khi-rs-ikfast-plugin = self.callPackage ./khi-rs-ikfast-plugin {};
 
  knowledge-representation = self.callPackage ./knowledge-representation {};
 
@@ -1451,6 +1517,8 @@ self: super: {
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libcmt = self.callPackage ./libcmt {};
+
+ libcreate = self.callPackage ./libcreate {};
 
  libdlib = self.callPackage ./libdlib {};
 
@@ -1860,6 +1928,10 @@ self: super: {
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
 
+ novatel-gps-driver = self.callPackage ./novatel-gps-driver {};
+
+ novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
+
  novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
 
  novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
@@ -1915,6 +1987,8 @@ self: super: {
  openni2-camera = self.callPackage ./openni2-camera {};
 
  openni2-launch = self.callPackage ./openni2-launch {};
+
+ openrtm-aist = self.callPackage ./openrtm-aist {};
 
  openslam-gmapping = self.callPackage ./openslam-gmapping {};
 
@@ -2108,6 +2182,8 @@ self: super: {
 
  pr2-controller-configuration = self.callPackage ./pr2-controller-configuration {};
 
+ pr2-controller-configuration-gazebo = self.callPackage ./pr2-controller-configuration-gazebo {};
+
  pr2-controller-interface = self.callPackage ./pr2-controller-interface {};
 
  pr2-controller-manager = self.callPackage ./pr2-controller-manager {};
@@ -2125,6 +2201,10 @@ self: super: {
  pr2-ethercat = self.callPackage ./pr2-ethercat {};
 
  pr2-ethercat-drivers = self.callPackage ./pr2-ethercat-drivers {};
+
+ pr2-gazebo = self.callPackage ./pr2-gazebo {};
+
+ pr2-gazebo-plugins = self.callPackage ./pr2-gazebo-plugins {};
 
  pr2-gripper-action = self.callPackage ./pr2-gripper-action {};
 
@@ -2165,6 +2245,8 @@ self: super: {
  pr2-self-test = self.callPackage ./pr2-self-test {};
 
  pr2-self-test-msgs = self.callPackage ./pr2-self-test-msgs {};
+
+ pr2-simulator = self.callPackage ./pr2-simulator {};
 
  pr2-teleop = self.callPackage ./pr2-teleop {};
 
@@ -2229,6 +2311,8 @@ self: super: {
  qb-move-description = self.callPackage ./qb-move-description {};
 
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
+
+ qt-advanced-docking = self.callPackage ./qt-advanced-docking {};
 
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
 
@@ -2339,6 +2423,8 @@ self: super: {
  rm-hw = self.callPackage ./rm-hw {};
 
  rm-msgs = self.callPackage ./rm-msgs {};
+
+ rm-orientation-controller = self.callPackage ./rm-orientation-controller {};
 
  rm-shooter-controllers = self.callPackage ./rm-shooter-controllers {};
 
@@ -3030,6 +3116,8 @@ self: super: {
 
  toposens = self.callPackage ./toposens {};
 
+ toposens-sensor-library = self.callPackage ./toposens-sensor-library {};
+
  toposens-bringup = self.callPackage ./toposens-bringup {};
 
  toposens-description = self.callPackage ./toposens-description {};
@@ -3133,6 +3221,8 @@ self: super: {
  udp-com = self.callPackage ./udp-com {};
 
  ueye-cam = self.callPackage ./ueye-cam {};
+
+ um7 = self.callPackage ./um7 {};
 
  unique-id = self.callPackage ./unique-id {};
 

--- a/distros/noetic/graceful-controller-ros/default.nix
+++ b/distros/noetic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller-ros";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "dbf471ed9f9227880baa95f95e1ce2f58d39867fcd4e4cc3244f095cf5ec77ec";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f72edbfa7a0dd5a22e30194a5a040a51c424d25a36e882547b55f3967e6b8315";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller/default.nix
+++ b/distros/noetic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0228d4c198dc85dd886df9ca9a96299fbb202bfbb67bdf056e719c9ce181ceba";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f32d7af9a5f1d8acaef59eec3f9ed9f2221fa8ae43f318c3769961c69bfa54a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-complementary-filter/default.nix
+++ b/distros/noetic/imu-complementary-filter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-filters, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-imu-complementary-filter";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_complementary_filter/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "e4fb380b8e4d8aee751f8c42882a8a4ebe6cab0c8403622b9aedae1c156b43e8";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_complementary_filter/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "142c83020a468fc94249bb22a25d87af485d663b2e0f9ce713388747d514e7de";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ message-filters roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ geometry-msgs message-filters nodelet roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/imu-filter-madgwick/default.nix
+++ b/distros/noetic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-imu-filter-madgwick";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_filter_madgwick/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "0382ec399bdcb8c01e15ab9bd84347f69e8c0292379af84472c1aa83ae99b8a1";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_filter_madgwick/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "4ec47c1bd9321cda3de6e97cdfacf8c0ce4998a1a9b2c4f5c34126bf87c5219f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-tools/default.nix
+++ b/distros/noetic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-noetic-imu-tools";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_tools/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "904844b49082ed7b5171294492843ce842d6e9aa67965a512b5077eb11a592e4";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_tools/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "efff8b7a40704c52b99449f289963b2c8ad829aa308f92af05e6c7250aa0999d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "5e4fe32e95179e67843f342f9bc7017f51770548d8c6e7eda02238c89410f1ca";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "ad8e3063c16bed7e06a5a61a70e3dbce6d5d683656c8908d2cc6f00562aee11d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-model-tools";
+  version = "0.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "1629e8ab27a3570996b0dda67032e3cfc6ce2467dbc0512cc90984e8f51aeeeb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eus-assimp euscollada ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains model_tools package for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/kdl-parser-py/default.nix
+++ b/distros/noetic/kdl-parser-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rostest, urdfdom-py }:
 buildRosPackage {
   pname = "ros-noetic-kdl-parser-py";
-  version = "1.14.1-r1";
+  version = "1.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/noetic/kdl_parser_py/1.14.1-1.tar.gz";
-    name = "1.14.1-1.tar.gz";
-    sha256 = "a5d621fcd4752eec65b43af22543b33c9bc47b513438d8285ac51fd61b16602e";
+    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/noetic/kdl_parser_py/1.14.2-1.tar.gz";
+    name = "1.14.2-1.tar.gz";
+    sha256 = "21e02913bc61d60fb30d14533c9073c4ce350f6c8d642e40301bca23c6df351c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/kdl-parser/default.nix
+++ b/distros/noetic/kdl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, orocos-kdl, rosconsole, roscpp, rostest, tinyxml, tinyxml-2, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-noetic-kdl-parser";
-  version = "1.14.1-r1";
+  version = "1.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/noetic/kdl_parser/1.14.1-1.tar.gz";
-    name = "1.14.1-1.tar.gz";
-    sha256 = "f14b7ce20d5cb7c9070b3176dc0ede096744dcef6348ec4b8043a48a7687c253";
+    url = "https://github.com/ros-gbp/kdl_parser-release/archive/release/noetic/kdl_parser/1.14.2-1.tar.gz";
+    name = "1.14.2-1.tar.gz";
+    sha256 = "a7236d3f21524007defe5bfc596e71b2b6febaebda9c991bbb79a8a7d348865d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/khi-duaro-description/default.nix
+++ b/distros/noetic/khi-duaro-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-khi-duaro-description";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_duaro_description/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "ec3d893121f8dea57c5a3bb3050a22ea785bf5a0bd7eb25ff81b7f4ecbb00f42";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_duaro_description package'';
+    license = with lib.licenses; [ bsdOriginal "KHI-CAD-license-mesh-data,-see-readme-" ];
+  };
+}

--- a/distros/noetic/khi-duaro-gazebo/default.nix
+++ b/distros/noetic/khi-duaro-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros-control }:
+buildRosPackage {
+  pname = "ros-noetic-khi-duaro-gazebo";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_duaro_gazebo/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "3b9c35cc2850ce1f3b7b7686ddc507688b73c7f1555d17aa9fadc7c859b4657d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ gazebo-ros-control ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_duaro_gazebo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-duaro-ikfast-plugin/default.nix
+++ b/distros/noetic/khi-duaro-ikfast-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
+buildRosPackage {
+  pname = "ros-noetic-khi-duaro-ikfast-plugin";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_duaro_ikfast_plugin/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "8e04bf9a27110105da896f1bfc4a47241f7269c0faf124bb354355a1181c191a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ liblapack moveit-core pluginlib roscpp tf-conversions ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_duaro_ikfast_plugin package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-duaro-moveit-config/default.nix
+++ b/distros/noetic/khi-duaro-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-duaro-description, khi-duaro-ikfast-plugin, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-khi-duaro-moveit-config";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_duaro_moveit_config/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "2bd499fbbe1bf10d666740baf31871cbb07ae712e22fc6f5babcc9669d2e1bfe";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-duaro-description khi-duaro-ikfast-plugin moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-simple-controller-manager robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_duaro with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-robot-bringup/default.nix
+++ b/distros/noetic/khi-robot-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, joint-state-controller, joint-trajectory-controller, khi-duaro-description, khi-duaro-moveit-config, khi-robot-control, position-controllers, robot-state-publisher, roslaunch, rostest, tf }:
+buildRosPackage {
+  pname = "ros-noetic-khi-robot-bringup";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_robot_bringup/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "2fb5d538ff7cca22d2210aac7ff0f6ca52d388b2fbd6eee3920de9fdb3909c81";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ controller-manager joint-state-controller joint-trajectory-controller khi-duaro-description khi-duaro-moveit-config khi-robot-control position-controllers robot-state-publisher tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package contains bringup scripts/config/tools for KHI Robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-robot-control/default.nix
+++ b/distros/noetic/khi-robot-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-updater, hardware-interface, joint-limits-interface, joint-state-controller, joint-trajectory-controller, khi-robot-msgs, position-controllers, realtime-tools, rostest, trajectory-msgs, transmission-interface }:
+buildRosPackage {
+  pname = "ros-noetic-khi-robot-control";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_robot_control/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "527e8a00ea752dfc9aa391ba39e90c1e0d88b4ccc595eb08778e35c3a14f0f50";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ realtime-tools ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ controller-manager diagnostic-updater hardware-interface joint-limits-interface joint-state-controller joint-trajectory-controller khi-robot-msgs position-controllers trajectory-msgs transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS KHI robot controller package based on ros_control'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-robot-msgs/default.nix
+++ b/distros/noetic/khi-robot-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-khi-robot-msgs";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_robot_msgs/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "aecc5dda3fef55a0d6f319fef0eb0e928359af996bf18d38e2286bf5047fc99b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains KHI ROS robot msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-robot-test/default.nix
+++ b/distros/noetic/khi-robot-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, khi-duaro-moveit-config, khi-robot-bringup, khi-robot-control, khi-robot-msgs, khi-rs007l-moveit-config, khi-rs007n-moveit-config, khi-rs013n-moveit-config, khi-rs080n-moveit-config, moveit-commander, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-khi-robot-test";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_robot_test/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "e3b618300bb7535964da9ae8d925debfe23dfcd653d104bd6f893495e4397468";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ khi-duaro-moveit-config khi-robot-bringup khi-robot-control khi-robot-msgs khi-rs007l-moveit-config khi-rs007n-moveit-config khi-rs013n-moveit-config khi-rs080n-moveit-config moveit-commander rostest ];
+  propagatedBuildInputs = [ khi-robot-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Test package for khi_robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-robot/default.nix
+++ b/distros/noetic/khi-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, khi-duaro-description, khi-duaro-gazebo, khi-duaro-ikfast-plugin, khi-duaro-moveit-config, khi-robot-bringup, khi-robot-control, khi-robot-msgs, khi-rs-description, khi-rs-gazebo, khi-rs-ikfast-plugin, khi-rs007l-moveit-config, khi-rs007n-moveit-config, khi-rs013n-moveit-config, khi-rs080n-moveit-config }:
+buildRosPackage {
+  pname = "ros-noetic-khi-robot";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_robot/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "38402ef00c78324a9a31b42d3d8962b81edbbdb6fa8e14fa9e01f2bdc868a439";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ khi-duaro-description khi-duaro-gazebo khi-duaro-ikfast-plugin khi-duaro-moveit-config khi-robot-bringup khi-robot-control khi-robot-msgs khi-rs-description khi-rs-gazebo khi-rs-ikfast-plugin khi-rs007l-moveit-config khi-rs007n-moveit-config khi-rs013n-moveit-config khi-rs080n-moveit-config ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package for khi_robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-rs-description/default.nix
+++ b/distros/noetic/khi-rs-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-khi-rs-description";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_rs_description/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "eaac6a38c8730a093ab13599e9c2abcfe588c4ea5bd2c3c0bdc662c6b953a757";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_rs_description package'';
+    license = with lib.licenses; [ bsdOriginal "KHI-CAD-license-mesh-data,-see-readme-" ];
+  };
+}

--- a/distros/noetic/khi-rs-gazebo/default.nix
+++ b/distros/noetic/khi-rs-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, gazebo-ros-control }:
+buildRosPackage {
+  pname = "ros-noetic-khi-rs-gazebo";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_rs_gazebo/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "26191af79756afa3964934a023f720205ede62cc2203746726d0cfada5312fb7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros gazebo-ros-control ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_rs_gazebo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-rs-ikfast-plugin/default.nix
+++ b/distros/noetic/khi-rs-ikfast-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
+buildRosPackage {
+  pname = "ros-noetic-khi-rs-ikfast-plugin";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_rs_ikfast_plugin/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "ba133fc7343e832ac36593564aa79567291e050d9c5a4a72fe197517da6827b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ liblapack moveit-core pluginlib roscpp tf-conversions ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_rs_ikfast_plugin package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-rs007l-moveit-config/default.nix
+++ b/distros/noetic/khi-rs007l-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, khi-rs-ikfast-plugin, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-khi-rs007l-moveit-config";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_rs007l_moveit_config/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "d088992459383496125e2d552275b0c1937f872754cced1a61586d69dfbf6ceb";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-rs-description khi-rs-ikfast-plugin moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_rs007l with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-rs007n-moveit-config/default.nix
+++ b/distros/noetic/khi-rs007n-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, khi-rs-ikfast-plugin, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-khi-rs007n-moveit-config";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_rs007n_moveit_config/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "03dc6f0443fda959dbe275eaaf711ce0344140656acccdff112ad7bea54cf7c1";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-rs-description khi-rs-ikfast-plugin moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_rs007n with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-rs013n-moveit-config/default.nix
+++ b/distros/noetic/khi-rs013n-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, khi-rs-ikfast-plugin, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-khi-rs013n-moveit-config";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_rs013n_moveit_config/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "06c90df22698e6ba21c701fc39cdeec0afb7d1d74c2034d665ae64e724f5d22d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-rs-description khi-rs-ikfast-plugin moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_rs013n with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/khi-rs080n-moveit-config/default.nix
+++ b/distros/noetic/khi-rs080n-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, khi-rs-ikfast-plugin, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-khi-rs080n-moveit-config";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/noetic/khi_rs080n_moveit_config/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "0d2d13e6379d9cb141f147a1ab4be91180059db4c5bb15aecd26ecc7d9cb7158";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-rs-description khi-rs-ikfast-plugin moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_rs080n with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/libcreate/default.nix
+++ b/distros/noetic/libcreate/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, gtest }:
+buildRosPackage {
+  pname = "ros-noetic-libcreate";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/AutonomyLab/libcreate-release/archive/release/noetic/libcreate/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "8bc46366b2db0f0cdcf37790f74d2dde46bb3e552f4a42d6701a41f82dcd14c7";
+  };
+
+  buildType = "cmake";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''C++ library for interfacing with iRobot's Create 1 and Create 2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "9e8dafb2ce2c95ac7a7ce5413040ec39d105a0e54c5352abedae7eb63da2dcea";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "66e823da2743503cf4f541769282d8517cf9a646fe49394990f89aa9568429d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "cf82e9ebebce7a60148998cd5911bd44643ca67ed1369f55d9f769a95e2e95bc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "99867366412b3cdda7ada38987083c0cefdd91bdeaf605cb003bae9c117f2070";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "0e6012cd8c6c8c852328da1156ef6c1038f2240b3ba9bc93896cda3b43135c75";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "3f995c56c91db2d26dc40561a4206d69766d1f428a61ebc43d6705774f7de2f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "16aa39d8c2d133be2c86426a984f51455ef9f86651f0e67b17d0eb1fec1cb98e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "77430da5ef95b43cde1a9f83ca860c72576ffe9d77df3d6ceea34abf1c2a23a6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/novatel-gps-driver/default.nix
+++ b/distros/noetic/novatel-gps-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, gps-common, libpcap, nav-msgs, nodelet, novatel-gps-msgs, roscpp, sensor-msgs, std-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-serial-util, swri-string-util, tf }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-gps-driver";
+  version = "3.9.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/noetic/novatel_gps_driver/3.9.0-2.tar.gz";
+    name = "3.9.0-2.tar.gz";
+    sha256 = "db385458cdcd49d01f50734f2c45984973b0a5d1acb53f73d6ca8aa45d8769da";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-common libpcap nav-msgs nodelet novatel-gps-msgs roscpp sensor-msgs std-msgs swri-math-util swri-nodelet swri-roscpp swri-serial-util swri-string-util tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for NovAtel receivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/novatel-gps-msgs/default.nix
+++ b/distros/noetic/novatel-gps-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-gps-msgs";
+  version = "3.9.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/noetic/novatel_gps_msgs/3.9.0-2.tar.gz";
+    name = "3.9.0-2.tar.gz";
+    sha256 = "385a28ccf1b1a41cae25d151638c9f75cee572ac0d5cd788a1c4f545a948abee";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for proprietary (non-NMEA) sentences from Novatel GPS receivers.'';
+    license = with lib.licenses; [ "Southwest-Research-Institute-Proprietary" ];
+  };
+}

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "0fb8c4d1a3819d7f785ec7f2fe9280b727ffa86c7afb665182ae786398d72f82";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "0e7d51261ef5d100ee63b16415f9846cc79992839bd516570e1928b0e0a966e8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openni2-camera/default.nix
+++ b/distros/noetic/openni2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, dynamic-reconfigure, image-transport, message-generation, message-runtime, nodelet, openni2, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-openni2-camera";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_camera/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "b904ddec8179c97f8540ac925572ac91ae7540453fb8231201bcd3ac39e35716";
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_camera/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "be6698786c1add6f19733466b7ae1d97f59b1ac340c3cb8d479532eaae953076";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openni2-launch/default.nix
+++ b/distros/noetic/openni2-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depth-image-proc, image-proc, nodelet, openni2-camera, python3Packages, rgbd-launch, roslaunch, rospy, roswtf, tf, usbutils }:
 buildRosPackage {
   pname = "ros-noetic-openni2-launch";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_launch/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "2098408bbcc2be3e62fd7a620d0bb6eef88874e805316f27670b13e2f3df6c59";
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_launch/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "eb365e4d85b763816ba56ad2b2d369d519a801907b1b5ef66e695981191f2483";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openrtm-aist/default.nix
+++ b/distros/noetic/openrtm-aist/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, automake, catkin, cmake, doxygen, libtool, omniorb, pkg-config, pythonPackages, util-linux }:
+buildRosPackage {
+  pname = "ros-noetic-openrtm-aist";
+  version = "1.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/openrtm_aist-release/archive/release/noetic/openrtm_aist/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "cf609f4f2f92ea3c3542391b6b73eb9e032e0ec1e4bdac3a3327100c06f910f6";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen pythonPackages.python ];
+  propagatedBuildInputs = [ catkin omniorb util-linux ];
+  nativeBuildInputs = [ automake cmake libtool pkg-config ];
+
+  meta = {
+    description = ''<p>This package represents <a href="http://openrtm.org/">OpenRTM-aist</a> that's built within ROS eco system. Although being ROS-agnostic by itself, you can use this via ROS together with the packages in <a href="http://www.ros.org/wiki/rtmros_common">rtmros_common</a> that bridge between two framework.</p>
+   <p><i>OpenRTM-aist is an <a href="http://ieeexplore.ieee.org/xpl/login.jsp?tp=&amp;arnumber=1545521&amp;url=http%3A%2F%2Fieeexplore.ieee.org%2Fiel5%2F10375%2F32977%2F01545521.pdf%3Farnumber%3D1545521">RT-Middleware</a>-baseed, component-oriented software platform to robotics development that is made and maintained in AIST (National Institute of Advanced Industrial Science and Technology) in Japan </i> (<a href="http://openrtm.org/openrtm/en/content/introduction-0">excerpts from here</a>)</p>
+
+   <p>Its development is happening at <a href="http://www.openrtm.org/pub/OpenRTM-aist/">openrtm.org/pub/OpenRTM-aist</a>. The repository listed below is where the development of its ROS wrapper happening.</p>'';
+    license = with lib.licenses; [ "EPL" ];
+  };
+}

--- a/distros/noetic/paho-mqtt-c/default.nix
+++ b/distros/noetic/paho-mqtt-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl }:
 buildRosPackage {
   pname = "ros-noetic-paho-mqtt-c";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "b6e040899f9a5520d8bef21744a8d721c9800c5adb553c1742da104328ef652b";
+    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "5574da546a6aca7a06e1f094fad9b9916795e98f9c1f8c93ea9c8ded6afc0976";
   };
 
   buildType = "cmake";

--- a/distros/noetic/picovoice-driver/default.nix
+++ b/distros/noetic/picovoice-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, picovoice-msgs, portaudio, roscpp, roslib }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, libyamlcpp, picovoice-msgs, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-driver";
-  version = "0.0.4-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "7fde59976511d7247a0558dc5ff1c040a381aa1923f8b0279a7cbd94d772d22d";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "696208227a732a4918b3aec973035bdbf57f5218e2d71bef2e057660d19b2d64";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile picovoice-msgs portaudio roscpp roslib ];
+  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile libyamlcpp picovoice-msgs roscpp roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/picovoice-msgs/default.nix
+++ b/distros/noetic/picovoice-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-msgs";
-  version = "0.0.4-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "029e8ce3645694b964d6405c19286ff2b9cd24c249d0877ca2a6bde6c416d2b7";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d63ee582eba6b4e8fe24de8e2b6289cbabcc4fbea585966e10f7605cda05975a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "ef918034bda9457eb147d47124d9bd275d06142083a5799bada315207c295f07";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "bee09c8e3ed4f307b8eb24a4325f7c9cc6ade5edcc9216596dd1f1ec6ab2ae4d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-controller-configuration-gazebo/default.nix
+++ b/distros/noetic/pr2-controller-configuration-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo, pr2-controller-manager, pr2-gripper-action, pr2-head-action, single-joint-position-action }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-controller-configuration-gazebo";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_simulator-release/archive/release/noetic/pr2_controller_configuration_gazebo/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "8f2ae6424d2d1db440118a8feabc55b9ed4369c3fb1fba8907203030cc412fa2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo pr2-controller-manager pr2-gripper-action pr2-head-action single-joint-position-action ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A copy of the pr2_controller_configuration package, for use in 
+    the PR2 simulator.  We maintain two copies to allow for controller
+    gains to be set differently between hardware and simulation.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-controller-interface/default.nix
+++ b/distros/noetic/pr2-controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, pr2-mechanism-model, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-pr2-controller-interface";
-  version = "1.8.18-r1";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_interface/1.8.18-1.tar.gz";
-    name = "1.8.18-1.tar.gz";
-    sha256 = "da37c9ff94757ceed49d33cd7005f40aa70423360bd56ef165edef1d413bd3dd";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_interface/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "342a638061f38dae1fafd79fdfb455d8e72bf18baf33f8da65e8c2921b90aadf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-controller-manager/default.nix
+++ b/distros/noetic/pr2-controller-manager/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, pluginlib, pr2-controller-interface, pr2-description, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model, pr2-mechanism-msgs, realtime-tools, roscpp, rosparam, rospy, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, pluginlib, pr2-controller-interface, pr2-description, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model, pr2-mechanism-msgs, realtime-tools, robot-state-publisher, roscpp, roslaunch, rosparam, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pr2-controller-manager";
-  version = "1.8.18-r1";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_manager/1.8.18-1.tar.gz";
-    name = "1.8.18-1.tar.gz";
-    sha256 = "638d95d7d320d0a42acfe8b8d9b165d81cf1748c9de1cc5c873edcfe5668a5d1";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_manager/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "72589694697a9398ef49985c274570dabe03428f2595844565e4903ca2be9315";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs pluginlib pr2-controller-interface pr2-description pr2-hardware-interface pr2-mechanism-diagnostics pr2-mechanism-model pr2-mechanism-msgs realtime-tools roscpp rosparam rospy sensor-msgs ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ diagnostic-msgs pluginlib pr2-controller-interface pr2-description pr2-hardware-interface pr2-mechanism-diagnostics pr2-mechanism-model pr2-mechanism-msgs realtime-tools robot-state-publisher roscpp rosparam rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/pr2-gazebo-plugins/default.nix
+++ b/distros/noetic/pr2-gazebo-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, cv-bridge, diagnostic-msgs, diagnostic-updater, gazebo-msgs, gazebo-plugins, gazebo-ros, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, orocos-kdl, polled-camera, pr2-controller-manager, pr2-hardware-interface, pr2-mechanism-model, pr2-msgs, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-gazebo-plugins";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_simulator-release/archive/release/noetic/pr2_gazebo_plugins/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "115e2a383daf840fab400d4eaf78e732cbc03aa660085efe4f4abd0498862b96";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ std-srvs ];
+  propagatedBuildInputs = [ angles cv-bridge diagnostic-msgs diagnostic-updater gazebo-msgs gazebo-plugins gazebo-ros geometry-msgs image-transport message-generation message-runtime nav-msgs orocos-kdl polled-camera pr2-controller-manager pr2-hardware-interface pr2-mechanism-model pr2-msgs roscpp rospy sensor-msgs std-msgs tf urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Gazebo Plugins for various PR2-specific sensors and actuators on the robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-gazebo/default.nix
+++ b/distros/noetic/pr2-gazebo/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, fingertip-pressure, gazebo, gazebo-plugins, gazebo-ros, geometry-msgs, image-proc, joint-trajectory-action, pr2-controller-configuration-gazebo, pr2-controller-manager, pr2-dashboard-aggregator, pr2-description, pr2-gazebo-plugins, pr2-gripper-action, pr2-head-action, pr2-machine, pr2-mechanism-controllers, pr2-msgs, pr2-tuckarm, robot-mechanism-controllers, robot-pose-ekf, robot-state-publisher, rospy, rostest, rostopic, single-joint-position-action, std-msgs, stereo-image-proc, tf2-ros, topic-tools, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-gazebo";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_simulator-release/archive/release/noetic/pr2_gazebo/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "c076638d44c6dc0a5db2bce6b4c2863fc48bab11f7a2862a12c1803f67960379";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ pr2-machine pr2-tuckarm rostest ];
+  propagatedBuildInputs = [ diagnostic-aggregator fingertip-pressure gazebo gazebo-plugins gazebo-ros geometry-msgs image-proc joint-trajectory-action pr2-controller-configuration-gazebo pr2-controller-manager pr2-dashboard-aggregator pr2-description pr2-gazebo-plugins pr2-gripper-action pr2-head-action pr2-mechanism-controllers pr2-msgs robot-mechanism-controllers robot-pose-ekf robot-state-publisher rospy rostopic single-joint-position-action std-msgs stereo-image-proc tf2-ros topic-tools xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch scripts for simulating the PR2 in <a href="http://ros.org/wiki/gazebo">gazebo</a>.
+    The simulation equivalent of pr2.launch is found here.
+    pr2_fingertip_pressure_contact_translator produces the same ROS topics as fingertip_pressure package for simulated PR2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-hardware-interface/default.nix
+++ b/distros/noetic/pr2-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-pr2-hardware-interface";
-  version = "1.8.18-r1";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_hardware_interface/1.8.18-1.tar.gz";
-    name = "1.8.18-1.tar.gz";
-    sha256 = "d5db1ae2046e093858fd1173e54ec11f759df74d4b27d8fbf2831c5edbd98e66";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_hardware_interface/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "73009b090f3fb86f9d2a2b888711cca808fcfa69b2d867feb3c46005b43cd3d2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-mechanism-diagnostics/default.nix
+++ b/distros/noetic/pr2-mechanism-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-msgs, diagnostic-updater, pr2-mechanism-model, pr2-mechanism-msgs, roscpp, rospy, rostest, std-msgs, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-pr2-mechanism-diagnostics";
-  version = "1.8.18-r1";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_diagnostics/1.8.18-1.tar.gz";
-    name = "1.8.18-1.tar.gz";
-    sha256 = "8c5cf89b66046177484726ae4ca3c7a1f7d9e481fd78323338c096e325ab3e99";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_diagnostics/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "de4e8793e5c1bd642890966d940651c6c80d5245106228ee6a8917041b5d682c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-mechanism-model/default.nix
+++ b/distros/noetic/pr2-mechanism-model/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, hardware-interface, kdl-parser, pluginlib, pr2-hardware-interface, roscpp, rostest, rosunit, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pr2-mechanism-model";
-  version = "1.8.18-r1";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_model/1.8.18-1.tar.gz";
-    name = "1.8.18-1.tar.gz";
-    sha256 = "8b5f4e54d8c25dc2971661b757e38c1c1af64695d7791c778fbd9af6107e4e42";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_model/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "d0666b26576067e36060036a57987b3488edde73c3c9b04ed95d8e5bc0d667f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-mechanism/default.nix
+++ b/distros/noetic/pr2-mechanism/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-controller-interface, pr2-controller-manager, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model }:
 buildRosPackage {
   pname = "ros-noetic-pr2-mechanism";
-  version = "1.8.18-r1";
+  version = "1.8.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism/1.8.18-1.tar.gz";
-    name = "1.8.18-1.tar.gz";
-    sha256 = "b99a9448bc9863fb5f69443a636d48434a2b3214f2c0b0eb6f6cba68a3a7de00";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism/1.8.20-1.tar.gz";
+    name = "1.8.20-1.tar.gz";
+    sha256 = "baa3422215d31a8e1f7dd865ec5976aee4b61df00e8038c9ce064f518e10ad4c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-simulator/default.nix
+++ b/distros/noetic/pr2-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-controller-configuration-gazebo, pr2-gazebo, pr2-gazebo-plugins }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-simulator";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_simulator-release/archive/release/noetic/pr2_simulator/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "0763e5edcd2d1434193a0386d06a5d296e2d8bd11528523a8e6913828447ae8f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pr2-controller-configuration-gazebo pr2-gazebo pr2-gazebo-plugins ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_simulator package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/qt-advanced-docking/default.nix
+++ b/distros/noetic/qt-advanced-docking/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, qt5 }:
+buildRosPackage {
+  pname = "ros-noetic-qt-advanced-docking";
+  version = "3.8.2-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tesseract-robotics-release/qt_advanced_docking_system-release/archive/release/noetic/qt_advanced_docking/3.8.2-4.tar.gz";
+    name = "3.8.2-4.tar.gz";
+    sha256 = "a93ef0a15575aa81018a59dc9f8946f85c957f7ee1c9b345d072a6fa47173432";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ qt5.qtbase ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Qt Advanced Docking System lets you create customizable layouts using
+    a full featured window docking system similar to what is found in many
+    popular integrated development environments (IDEs) such as Visual Studio.'';
+    license = with lib.licenses; [ lgpl21 ];
+  };
+}

--- a/distros/noetic/rm-calibration-controllers/default.nix
+++ b/distros/noetic/rm-calibration-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, effort-controllers, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-calibration-controllers";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "3ea9c13800fbc56e1856520da5b0254151ea1a85ffe1b97aef7f3e87e301e6a9";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "384e759ee250a8f4f6d6d8fada2486cdce215ae5e8865489d2ef07a8730aad4d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-chassis-controllers/default.nix
+++ b/distros/noetic/rm-chassis-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, nav-msgs, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-chassis-controllers";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "d94c8a2cd9048b30a08d74494769f6683376acffc6a7607b598c490691369f97";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "123787c1c1c9a52fbd1d48c934270a87bb17e23997130545af3b70116839864b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, imu-complementary-filter, imu-filter-madgwick, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "2b22d278701759dfc20d8906a2b75f360d702cd954269ef160a5ed9e37c9819f";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "1be7406cb7d1863bb6b9ac222901d35f95ac83edcff7334eeea22cfe0212ea63";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ control-msgs controller-manager-msgs dynamic-reconfigure eigen geometry-msgs realtime-tools rm-msgs roscpp roslint tf ];
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs dynamic-reconfigure eigen geometry-msgs imu-complementary-filter imu-filter-madgwick realtime-tools rm-msgs roscpp roslint tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, rm-description, rm-gazebo, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "efd157dd7d795bcce650d6188ac05d2e50785d0388c59c75fde8c6cd927ae910";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "3026be0baedc1d4e8f6989022b2dc839bc99a21d2a36b3c5d62e18a9d8d3990b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-controllers/default.nix
+++ b/distros/noetic/rm-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-controller }:
 buildRosPackage {
   pname = "ros-noetic-rm-controllers";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "3318a6d1d48e1490ca1fb5d7a2902198e381d3cb1767fb3dd31f3db42bd9405d";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "a73af4e4204b17aea33f8687006a3b153f1affc078d027e4442bf538a953bf22";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "1c2609f762d77aeaff69d77b5116621e214ee111723b172b99b0efcf8dfbd7ab";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "4301db8fa908c0555a0873c635afa3a75c6be3c5892a49b7194ab83d98bd948a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-description/default.nix
+++ b/distros/noetic/rm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rm-description";
-  version = "0.1.8-r2";
+  version = "0.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "17ba696169d8fe55c2d0b0fe844f5c6f8da2d2efd5c0bd6e0f134c7b12570a00";
+    url = "https://github.com/rm-controls/rm_description-release/archive/release/noetic/rm_description/0.1.9-1.tar.gz";
+    name = "0.1.9-1.tar.gz";
+    sha256 = "c947b61f5e4064b3d11ec7321c6780f0688059d999b64a0a297a1e5d23e3b9fa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "a8087e4cbb3feb8f9183334e8189e31cfa282c38ecc3be80f221703020b3495b";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "5f32b2b0fb9c49ce87e19a0f8533e60c83e0d0c0f21dbf34bc22b1c99cfcc0ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gimbal-controllers/default.nix
+++ b/distros/noetic/rm-gimbal-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-eigen, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-gimbal-controllers";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "161f683559716e9fc4120b6e54f178a3cb4068d53ff4b2305d617a4db57c5ce7";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "13f36cf07f1620c070c2ea80383c60014edcb879a285bd2f04ab1f40b2d09c42";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ angles control-toolbox controller-interface dynamic-reconfigure effort-controllers forward-command-controller hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint tf2 tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ angles control-toolbox controller-interface dynamic-reconfigure effort-controllers forward-command-controller hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint tf2 tf2-eigen tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "174d644c0047c6a7a3a0dc21349907bff7001b3c2de8c5f5e71833726925a6c3";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "f32f80c430acad9121609a58c39416cdfe1f3e82f0076aa4541311a89f1944f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.8-r2";
+  version = "0.1.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.8-2.tar.gz";
-    name = "0.1.8-2.tar.gz";
-    sha256 = "48910b968e4135eec5de29d3ce421465cd099b83fb8d6a5cb3a0c86c3b4bc43e";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.9-3.tar.gz";
+    name = "0.1.9-3.tar.gz";
+    sha256 = "15ca0ffae88015250ce02b74ebd809ef105972bb24762945df904fa42e73efa1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-orientation-controller/default.nix
+++ b/distros/noetic/rm-orientation-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, sensor-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rm-orientation-controller";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_orientation_controller/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "87f54d252f402d884f89c2ba785aaafdba3fbee5926e12d2f82a75f5b11b9e4a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ angles controller-interface forward-command-controller hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint sensor-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RoboMaster standard robot orientation controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-shooter-controllers/default.nix
+++ b/distros/noetic/rm-shooter-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-shooter-controllers";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "62bb8a6d21f988af0ddc855df146b5a2f6d8bed9953c9af5eb3a93f94f2b9801";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "750e6484c75bc973c124f3ff07329f06000a28a8d369dd614a6c443ae024e607";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-state-controller/default.nix
+++ b/distros/noetic/robot-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, kdl-parser, pluginlib, realtime-tools, rm-common, roscpp, roslint, tf2-kdl, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-controller";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "bbe3ed5c9b5aa781c1f9e96cdd184a9358c0fac23a0da3807729922431b42743";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "5cc6b5ff5c0ad898e994c691a3272714087f3fce9d503edd38af77fb5227b757";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-tf-tree/default.nix
+++ b/distros/noetic/rqt-tf-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, rospy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rqt-tf-tree";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "db171b666480146b4ae5978f86eaa4f07c498367b04b860ab0d1cf78766d9d32";
+    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "5f07d027e135ff74636fc97216b666aa0ee16aa5f10cd631db1f2226496bb351";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz-imu-plugin/default.nix
+++ b/distros/noetic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-rviz-imu-plugin";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/rviz_imu_plugin/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "9126da97631404722996aaec8fde11f96a3e4d897839e8be62304130fdba8555";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/rviz_imu_plugin/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "da043709e2e8e483082f6ac54b228471ed2071a236692473cd7fb9214c04f225";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "c426135ac700f623207b81edd8727548181c58585a422c22c24c543c8f2c717e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "37453b18c8d6af04dc7ce2ea33d4c59610de57ea052d5b4dea53d125f01b783e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/spinnaker-camera-driver/default.nix
+++ b/distros/noetic/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-noetic-spinnaker-camera-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "5dec1b14ea0bd0846d2140656b5a3f00576970a509761f8edb26547f77854e34";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d011ea1c0289cdf7318a96d0af10c0f23bfb7aad54062ee92d473119ecd7941d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-sensor-library/default.nix
+++ b/distros/noetic/toposens-sensor-library/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-sensor-library";
+  version = "1.1.3-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/noetic/toposens-sensor-library/1.1.3-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "e17bd3510385845d7038cc633ba4602ee410c6f75b33a09d86944d8fb764091a";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Driver for toposens echo sensor'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "53c22fdd38d49e9c36e83fc7c7e8b2b16e421122ea6653d947a58d33cb047631";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "d86bace24916802bdecf648563de5e5485500109b5e968dc09e89317e05759a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "ecb6b520f3065d02b71e9f9b2164e6886c9999aa92c49277fcb8ed62bcb35bc9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "379f24eec4ea136dab01e975a27ef3f15aa0025478944eb0da2e1721140678e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/um7/default.nix
+++ b/distros/noetic/um7/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, roslint, sensor-msgs, serial }:
+buildRosPackage {
+  pname = "ros-noetic-um7";
+  version = "0.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/um7-release/archive/release/noetic/um7/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "5d5a3f21139972a21ef808586bf3239794e197067c2523dc7c8cf8c4f6a22adc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ message-runtime roscpp sensor-msgs serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The um7 package provides a C++ implementation of the CH Robotics serial protocol, and a
+    corresponding ROS node for publishing standard ROS orientation topics from a UM7.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/vision-msgs/default.nix
+++ b/distros/noetic/vision-msgs/default.nix
@@ -5,17 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosunit, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-vision-msgs";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Kukanani/vision_msgs-release/archive/release/noetic/vision_msgs/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "a2fe139f1c97bb56e6d891da6881080d5f8d5b31190d9f3db5fcf7f6bc462974";
+    url = "https://github.com/Kukanani/vision_msgs-release/archive/release/noetic/vision_msgs/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "aa7c87e6b6bd88fe1f2f7626d97fe0940afee038a5c7bbd95d6d29c5859c0507";
   };
 
   buildType = "catkin";
+  buildInputs = [ message-generation ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 638cbba3fd2b9af096ca6a5bc2db44668e47116a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *compressed-depth-image-transport 2.3.1-r1 --> 2.3.3-r1*
* *compressed-image-transport 2.3.1-r1 --> 2.3.3-r1*
* *eigenpy 2.6.11-r1 --> 2.7.1-r1*
* *image-transport-plugins 2.3.1-r1 --> 2.3.3-r1*
* *interactive-marker-twist-server 2.0.0-r2*
* *leo-desktop 1.0.0-r1*
* *leo-viz 1.0.0-r1*
* *libphidget22 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-accelerometer 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-analog-inputs 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-api 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-digital-inputs 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-digital-outputs 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-drivers 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-gyroscope 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-high-speed-encoder 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-ik 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-magnetometer 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-motors 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-msgs 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-spatial 2.1.1-r1 --> 2.1.2-r1*
* *phidgets-temperature 2.1.1-r1 --> 2.1.2-r1*
* *robot-upstart 1.0.0-r2 --> 1.0.1-r1*
* *smacc2 0.2.0-r2*
* *smacc2-msgs 0.2.0-r2*
* *theora-image-transport 2.3.1-r1 --> 2.3.3-r1*
* *ublox 2.0.0-r1 --> 2.1.0-r1*
* *ublox-gps 2.0.0-r1 --> 2.1.0-r1*
* *ublox-msgs 2.0.0-r1 --> 2.1.0-r1*
* *ublox-serialization 2.0.0-r1 --> 2.1.0-r1*
* *ur-msgs 2.0.0-r1*

Galactic Changes:
-----------------
* *compressed-depth-image-transport 2.3.1-r1 --> 2.3.3-r1*
* *compressed-image-transport 2.3.1-r1 --> 2.3.3-r1*
* *image-transport-plugins 2.3.1-r1 --> 2.3.3-r1*
* *irobot-create-common-bringup 1.0.1-r1*
* *irobot-create-control 1.0.1-r1*
* *irobot-create-description 1.0.1-r1*
* *irobot-create-gazebo-bringup 1.0.1-r1*
* *irobot-create-gazebo-plugins 1.0.1-r1*
* *irobot-create-gazebo-sim 1.0.1-r1*
* *irobot-create-ignition-bringup 1.0.1-r1*
* *irobot-create-ignition-sim 1.0.1-r1*
* *irobot-create-ignition-toolbox 1.0.1-r1*
* *irobot-create-msgs 1.2.4-r1*
* *irobot-create-nodes 1.0.1-r1*
* *irobot-create-toolbox 1.0.1-r1*
* *libphidget22 2.2.2-r1 --> 2.2.3-r1*
* *novatel-gps-driver 4.1.0-r1*
* *novatel-gps-msgs 4.1.0-r1*
* *paho-mqtt-c 1.3.9-r3 --> 1.3.10-r1*
* *phidgets-accelerometer 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-analog-inputs 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-api 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-digital-inputs 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-digital-outputs 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-drivers 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-gyroscope 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-high-speed-encoder 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-ik 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-magnetometer 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-motors 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-msgs 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-spatial 2.2.2-r1 --> 2.2.3-r1*
* *phidgets-temperature 2.2.2-r1 --> 2.2.3-r1*
* *plansys2-bringup 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-bt-actions 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-core 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-domain-expert 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-executor 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-lifecycle-manager 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-msgs 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-pddl-parser 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-planner 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-popf-plan-solver 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-problem-expert 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-terminal 2.0.1-r3 --> 2.0.3-r1*
* *plansys2-tools 2.0.3-r1*
* *robot-upstart 1.0.1-r1*
* *rosbag2-storage-mcap 0.1.1-r1*
* *smacc2 0.1.0-r1 --> 0.3.0-r3*
* *smacc2-msgs 0.1.0-r1 --> 0.3.0-r3*
* *theora-image-transport 2.3.1-r1 --> 2.3.3-r1*
* *ublox 2.0.0-r3 --> 2.2.0-r1*
* *ublox-gps 2.0.0-r3 --> 2.2.0-r1*
* *ublox-msgs 2.0.0-r3 --> 2.2.0-r1*
* *ublox-serialization 2.0.0-r3 --> 2.2.0-r1*
* *ur-description 2.0.0-r1*
* *ur-msgs 2.0.0-r1*

Melodic Changes:
----------------
* *apriltag-ros 3.2.0-r1 --> 3.2.1-r1*
* *audio-capture 0.3.12-r1 --> 0.3.13-r1*
* *audio-common 0.3.12-r1 --> 0.3.13-r1*
* *audio-common-msgs 0.3.12-r1 --> 0.3.13-r1*
* *audio-play 0.3.12-r1 --> 0.3.13-r1*
* *avt-vimba-camera 1.1.0-r1 --> 1.2.0-r1*
* *costmap-cspace 0.11.3-r1 --> 0.11.4-r1*
* *cv-bridge-python3 1.13.2-r1*
* *eigenpy 2.6.11-r1 --> 2.7.1-r1*
* *end-effector 1.0.4-r1 --> 1.0.6-r2*
* *imu-complementary-filter 1.2.3-r1 --> 1.2.4-r1*
* *imu-filter-madgwick 1.2.3-r1 --> 1.2.4-r1*
* *imu-tools 1.2.3-r1 --> 1.2.4-r1*
* *joystick-interrupt 0.11.3-r1 --> 0.11.4-r1*
* *kdl-parser 1.13.1 --> 1.13.3-r1*
* *kdl-parser-py 1.13.1 --> 1.13.3-r1*
* *map-organizer 0.11.3-r1 --> 0.11.4-r1*
* *neonavigation 0.11.3-r1 --> 0.11.4-r1*
* *neonavigation-common 0.11.3-r1 --> 0.11.4-r1*
* *neonavigation-launch 0.11.3-r1 --> 0.11.4-r1*
* *obj-to-pointcloud 0.11.3-r1 --> 0.11.4-r1*
* *openni2-camera 1.5.1-r1 --> 1.6.0-r2*
* *openni2-launch 1.5.1-r1 --> 1.6.0-r2*
* *planner-cspace 0.11.3-r1 --> 0.11.4-r1*
* *pr2-controller-interface 1.8.18 --> 1.8.20-r1*
* *pr2-controller-manager 1.8.18 --> 1.8.20-r1*
* *pr2-hardware-interface 1.8.18 --> 1.8.20-r1*
* *pr2-mechanism 1.8.18 --> 1.8.20-r1*
* *pr2-mechanism-diagnostics 1.8.18 --> 1.8.20-r1*
* *pr2-mechanism-model 1.8.18 --> 1.8.20-r1*
* *rviz-imu-plugin 1.2.3-r1 --> 1.2.4-r1*
* *safety-limiter 0.11.3-r1 --> 0.11.4-r1*
* *track-odometry 0.11.3-r1 --> 0.11.4-r1*
* *trajectory-tracker 0.11.3-r1 --> 0.11.4-r1*
* *um7 0.0.6-r1 --> 0.0.7-r1*

Noetic Changes:
---------------
* *apriltag-ros 3.2.0-r1 --> 3.2.1-r3*
* *aruco 3.0.1-r3*
* *aruco-msgs 3.0.1-r3*
* *aruco-ros 3.0.1-r3*
* *audio-capture 0.3.12-r1 --> 0.3.13-r1*
* *audio-common 0.3.12-r1 --> 0.3.13-r1*
* *audio-common-msgs 0.3.12-r1 --> 0.3.13-r1*
* *audio-play 0.3.12-r1 --> 0.3.13-r1*
* *avt-vimba-camera 1.1.0-r1 --> 1.2.0-r1*
* *bosch-locator-bridge 1.0.5-r1 --> 1.0.6-r1*
* *costmap-cspace 0.11.3-r1 --> 0.11.4-r1*
* *diffbot-base 1.1.0-r1*
* *diffbot-bringup 1.1.0-r1*
* *diffbot-control 1.1.0-r1*
* *diffbot-description 1.1.0-r1*
* *diffbot-gazebo 1.1.0-r1*
* *diffbot-mbf 1.1.0-r1*
* *diffbot-msgs 1.1.0-r1*
* *diffbot-navigation 1.1.0-r1*
* *diffbot-robot 1.1.0-r1*
* *diffbot-slam 1.1.0-r1*
* *eigenpy 2.6.11-r1 --> 2.7.1-r1*
* *end-effector 1.0.6-r2*
* *eus-assimp 0.4.3-r1*
* *eusurdf 0.4.3-r1*
* *flir-camera-description 0.2.1-r1 --> 0.2.2-r1*
* *flir-camera-driver 0.2.1-r1 --> 0.2.2-r1*
* *franka-control 0.8.2-r2 --> 0.9.0-r1*
* *franka-description 0.8.2-r2 --> 0.9.0-r1*
* *franka-example-controllers 0.8.2-r2 --> 0.9.0-r1*
* *franka-gazebo 0.8.2-r2 --> 0.9.0-r1*
* *franka-gripper 0.8.2-r2 --> 0.9.0-r1*
* *franka-hw 0.8.2-r2 --> 0.9.0-r1*
* *franka-msgs 0.8.2-r2 --> 0.9.0-r1*
* *franka-ros 0.8.2-r2 --> 0.9.0-r1*
* *franka-visualization 0.8.2-r2 --> 0.9.0-r1*
* *graceful-controller 0.4.1-r1 --> 0.4.2-r1*
* *graceful-controller-ros 0.4.1-r1 --> 0.4.2-r1*
* *imu-complementary-filter 1.2.3-r1 --> 1.2.4-r1*
* *imu-filter-madgwick 1.2.3-r1 --> 1.2.4-r1*
* *imu-tools 1.2.3-r1 --> 1.2.4-r1*
* *joystick-interrupt 0.11.3-r1 --> 0.11.4-r1*
* *jsk-model-tools 0.4.3-r1*
* *kdl-parser 1.14.1-r1 --> 1.14.2-r1*
* *kdl-parser-py 1.14.1-r1 --> 1.14.2-r1*
* *khi-duaro-description 1.3.0-r2*
* *khi-duaro-gazebo 1.3.0-r2*
* *khi-duaro-ikfast-plugin 1.3.0-r2*
* *khi-duaro-moveit-config 1.3.0-r2*
* *khi-robot 1.3.0-r2*
* *khi-robot-bringup 1.3.0-r2*
* *khi-robot-control 1.3.0-r2*
* *khi-robot-msgs 1.3.0-r2*
* *khi-robot-test 1.3.0-r2*
* *khi-rs-description 1.3.0-r2*
* *khi-rs-gazebo 1.3.0-r2*
* *khi-rs-ikfast-plugin 1.3.0-r2*
* *khi-rs007l-moveit-config 1.3.0-r2*
* *khi-rs007n-moveit-config 1.3.0-r2*
* *khi-rs013n-moveit-config 1.3.0-r2*
* *khi-rs080n-moveit-config 1.3.0-r2*
* *libcreate 3.0.0-r1*
* *map-organizer 0.11.3-r1 --> 0.11.4-r1*
* *neonavigation 0.11.3-r1 --> 0.11.4-r1*
* *neonavigation-common 0.11.3-r1 --> 0.11.4-r1*
* *neonavigation-launch 0.11.3-r1 --> 0.11.4-r1*
* *novatel-gps-driver 3.9.0-r2*
* *novatel-gps-msgs 3.9.0-r2*
* *obj-to-pointcloud 0.11.3-r1 --> 0.11.4-r1*
* *openni2-camera 1.5.1-r1 --> 1.6.0-r1*
* *openni2-launch 1.5.1-r1 --> 1.6.0-r1*
* *openrtm-aist 1.1.2-r2*
* *paho-mqtt-c 1.3.9-r1 --> 1.3.10-r1*
* *picovoice-driver 0.0.4-r1 --> 1.0.1-r1*
* *picovoice-msgs 0.0.4-r1 --> 1.0.1-r1*
* *planner-cspace 0.11.3-r1 --> 0.11.4-r1*
* *pr2-controller-configuration-gazebo 2.1.0-r1*
* *pr2-controller-interface 1.8.18-r1 --> 1.8.20-r1*
* *pr2-controller-manager 1.8.18-r1 --> 1.8.20-r1*
* *pr2-gazebo 2.1.0-r1*
* *pr2-gazebo-plugins 2.1.0-r1*
* *pr2-hardware-interface 1.8.18-r1 --> 1.8.20-r1*
* *pr2-mechanism 1.8.18-r1 --> 1.8.20-r1*
* *pr2-mechanism-diagnostics 1.8.18-r1 --> 1.8.20-r1*
* *pr2-mechanism-model 1.8.18-r1 --> 1.8.20-r1*
* *pr2-simulator 2.1.0-r1*
* *qt-advanced-docking 3.8.2-r4*
* *rm-calibration-controllers 0.1.2-r1 --> 0.1.3-r1*
* *rm-chassis-controllers 0.1.2-r1 --> 0.1.3-r1*
* *rm-common 0.1.8-r2 --> 0.1.9-r3*
* *rm-control 0.1.8-r2 --> 0.1.9-r3*
* *rm-controllers 0.1.2-r1 --> 0.1.3-r1*
* *rm-dbus 0.1.8-r2 --> 0.1.9-r3*
* *rm-description 0.1.8-r2 --> 0.1.9-r1*
* *rm-gazebo 0.1.8-r2 --> 0.1.9-r3*
* *rm-gimbal-controllers 0.1.2-r1 --> 0.1.3-r1*
* *rm-hw 0.1.8-r2 --> 0.1.9-r3*
* *rm-msgs 0.1.8-r2 --> 0.1.9-r3*
* *rm-orientation-controller 0.1.3-r1*
* *rm-shooter-controllers 0.1.2-r1 --> 0.1.3-r1*
* *robot-state-controller 0.1.2-r1 --> 0.1.3-r1*
* *rqt-tf-tree 0.6.2-r1 --> 0.6.3-r1*
* *rviz-imu-plugin 1.2.3-r1 --> 1.2.4-r1*
* *safety-limiter 0.11.3-r1 --> 0.11.4-r1*
* *spinnaker-camera-driver 0.2.1-r1 --> 0.2.2-r1*
* *toposens-sensor-library 1.1.3-r1*
* *track-odometry 0.11.3-r1 --> 0.11.4-r1*
* *trajectory-tracker 0.11.3-r1 --> 0.11.4-r1*
* *um7 0.0.7-r1*
* *vision-msgs 0.0.1-r1 --> 0.0.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

