### PR TITLE
rosdistro sync, Fri May  6 13:41:33 2022

### DIFF
--- a/distros/foxy/clober-bringup/default.nix
+++ b/distros/foxy/clober-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-clober-bringup";
-  version = "0.1.0-r2";
+  version = "0.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_bringup/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "9d49343e86f45556902c07b874fe7cfc5ca810ab3bd32c48366ee52ad62e6cfd";
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_bringup/0.2.0-5.tar.gz";
+    name = "0.2.0-5.tar.gz";
+    sha256 = "4a81d8bbfaa193268b2cfda800c52fa48cf0b1870404e2c9ca20a7d6449e01dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/clober-description/default.nix
+++ b/distros/foxy/clober-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, urdf }:
 buildRosPackage {
   pname = "ros-foxy-clober-description";
-  version = "0.1.0-r2";
+  version = "0.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_description/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "0b710147a487951b92f552e85cfc7c5e2d07063309df208a0765a13c4ca4ca9e";
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_description/0.2.0-5.tar.gz";
+    name = "0.2.0-5.tar.gz";
+    sha256 = "fb3d188d7210abdfb7eda4863e5fb24d70963786f6a420699f34df85f0de09f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/clober-navigation/default.nix
+++ b/distros/foxy/clober-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-clober-navigation";
-  version = "0.1.0-r2";
+  version = "0.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_navigation/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "d36cee4a9460de25ff27ef99f5cd3fad4473d4dc0abbb4adc2555ff7bcf115d5";
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_navigation/0.2.0-5.tar.gz";
+    name = "0.2.0-5.tar.gz";
+    sha256 = "cc6453394d63624710d0e36cdde25e11896d8816ed5f153058605ac2dff49d8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/clober-serial/default.nix
+++ b/distros/foxy/clober-serial/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clober-msgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-clober-serial";
-  version = "0.1.0-r2";
+  version = "0.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_serial/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "c58f6d252084d39cca9281b2a6e4e4d4bef0c91fe599b3bf00f09aa4c79c8d54";
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_serial/0.2.0-5.tar.gz";
+    name = "0.2.0-5.tar.gz";
+    sha256 = "dce5dc67b73f212f8e4f16f4caa9241a2e92d57af73a755ef82826767d5618a5";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ clober-msgs geometry-msgs nav-msgs rclcpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/clober-simulation/default.nix
+++ b/distros/foxy/clober-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clober-description, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-clober-simulation";
-  version = "0.1.0-r2";
+  version = "0.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_simulation/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "a81879bcd4f968cc7352e1316e6b5a16d7feeca3588be006b3a89c91b93e449f";
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_simulation/0.2.0-5.tar.gz";
+    name = "0.2.0-5.tar.gz";
+    sha256 = "8bc93cb20f5763be35cf716538b3ea66dd3beda7309f1f6a0f3fcf7cdf8603cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/clober-slam/default.nix
+++ b/distros/foxy/clober-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-clober-slam";
-  version = "0.1.0-r2";
+  version = "0.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_slam/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "a931238806f15ac9d2addd9f2956788d7d704559521422bb1cc389c8cb164a6c";
+    url = "https://github.com/CLOBOT-Co-Ltd-release/clober_ros2-release/archive/release/foxy/clober_slam/0.2.0-5.tar.gz";
+    name = "0.2.0-5.tar.gz";
+    sha256 = "454b7fc14ff9029a21a4cefb0ad546989d5c5198c32c83188fcc953786a0991e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "e3637144855bbb3c368388069ebfc8caa5181d570c5359b36d226df3f5e70b44";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "212b9bf6732e306bb1e300ed9c42bb136b95166e0d51ae294dc9e045ec8db425";
   };
 
   buildType = "cmake";

--- a/distros/foxy/foxglove-msgs/default.nix
+++ b/distros/foxy/foxglove-msgs/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-foxglove-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/foxy/foxglove_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e275e4a1fac39e1aab5f9b241088f0ab59c4f9e3b0ced903a1c94c7148045a63";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''foxglove_msgs extends the common ROS visualization messages with additional
+    useful messages that are supported by Foxglove Studio.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -512,6 +512,8 @@ self: super: {
 
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
+ foxglove-msgs = self.callPackage ./foxglove-msgs {};
+
  gazebo-dev = self.callPackage ./gazebo-dev {};
 
  gazebo-msgs = self.callPackage ./gazebo-msgs {};
@@ -598,7 +600,13 @@ self: super: {
 
  image-view = self.callPackage ./image-view {};
 
+ imu-complementary-filter = self.callPackage ./imu-complementary-filter {};
+
+ imu-filter-madgwick = self.callPackage ./imu-filter-madgwick {};
+
  imu-sensor-broadcaster = self.callPackage ./imu-sensor-broadcaster {};
+
+ imu-tools = self.callPackage ./imu-tools {};
 
  interactive-marker-twist-server = self.callPackage ./interactive-marker-twist-server {};
 
@@ -761,6 +769,8 @@ self: super: {
  mavros-extras = self.callPackage ./mavros-extras {};
 
  mavros-msgs = self.callPackage ./mavros-msgs {};
+
+ mcap-vendor = self.callPackage ./mcap-vendor {};
 
  menge-vendor = self.callPackage ./menge-vendor {};
 
@@ -1402,6 +1412,8 @@ self: super: {
 
  rosbag2-storage-default-plugins = self.callPackage ./rosbag2-storage-default-plugins {};
 
+ rosbag2-storage-mcap = self.callPackage ./rosbag2-storage-mcap {};
+
  rosbag2-test-common = self.callPackage ./rosbag2-test-common {};
 
  rosbag2-tests = self.callPackage ./rosbag2-tests {};
@@ -1558,6 +1570,8 @@ self: super: {
 
  rviz-default-plugins = self.callPackage ./rviz-default-plugins {};
 
+ rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
+
  rviz-ogre-vendor = self.callPackage ./rviz-ogre-vendor {};
 
  rviz-rendering = self.callPackage ./rviz-rendering {};
@@ -1577,6 +1591,8 @@ self: super: {
  sensor-msgs = self.callPackage ./sensor-msgs {};
 
  sensor-msgs-py = self.callPackage ./sensor-msgs-py {};
+
+ septentrio-gnss-driver = self.callPackage ./septentrio-gnss-driver {};
 
  serial-driver = self.callPackage ./serial-driver {};
 

--- a/distros/foxy/grepros/default.nix
+++ b/distros/foxy/grepros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, builtin-interfaces, python3Packages, pythonPackages, rclpy, rosidl-parser, rosidl-runtime-py, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-grepros";
-  version = "0.4.4-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/suurjaak/grepros-release/archive/release/foxy/grepros/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "fee5e4face7dbfba341b71f0e54d0216be6c2ae33615c36fc368251f38327cb4";
+    url = "https://github.com/suurjaak/grepros-release/archive/release/foxy/grepros/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ed5c6379f572943f568a94451f51050090ee35b24665f471887b6accca44eb5c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/imu-complementary-filter/default.nix
+++ b/distros/foxy/imu-complementary-filter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, sensor-msgs, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-foxy-imu-complementary-filter";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_complementary_filter/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "12ae63436ea1535e29758548a2187d71ca2f0ba02073e9039d2a92d2acb3adbc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ geometry-msgs message-filters rclcpp sensor-msgs std-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into a quaternion to represent the orientation of the device wrt the global frame. Based on the algorithm by Roberto G. Valenti etal. described in the paper &quot;Keeping a Good Attitude: A Quaternion-Based Orientation Filter for IMUs and MARGs&quot; available at http://www.mdpi.com/1424-8220/15/8/19302 .'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/imu-filter-madgwick/default.nix
+++ b/distros/foxy/imu-filter-madgwick/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-imu-filter-madgwick";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_filter_madgwick/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "79643f2b8ed640cd8a2af433b9caf1b39686bdb1d4264e20f90e22b007334c6d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs nav-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into an orientation. Based on code by Sebastian Madgwick, http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms.'';
+    license = with lib.licenses; [ "GPL" ];
+  };
+}

--- a/distros/foxy/imu-tools/default.nix
+++ b/distros/foxy/imu-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
+buildRosPackage {
+  pname = "ros-foxy-imu-tools";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_tools/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "18edd4bed2e1136f553fa022b0e1bf20b3bbecf3e11e77739f1016db76b8c4bc";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ imu-complementary-filter imu-filter-madgwick rviz-imu-plugin ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Various tools for IMU devices'';
+    license = with lib.licenses; [ "BSD-&-GPL" ];
+  };
+}

--- a/distros/foxy/mcap-vendor/default.nix
+++ b/distros/foxy/mcap-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-mcap-vendor";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/mcap_vendor/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "6ed8100bdc3ad75c0c89c2b3cc1656990d6ff38c0a7f0a736df961a3af9163cb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''mcap vendor package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ntrip-client/default.nix
+++ b/distros/foxy/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ntrip-client";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "daac58e9448b27b4626a603a2b39635ea6f23c81be00e7f780e54fb43ea9c140";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e069a266132e088eaf0c3a7ee220905a2a3729d9fb602994a8d8a1e469c37c6f";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/robot-upstart/default.nix
+++ b/distros/foxy/robot-upstart/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-robot-upstart";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/foxy/robot_upstart/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f5d061ef21b1f997084a715a047383b746c2863ebd0510a5ecfa8577acaea0e6";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/foxy/robot_upstart/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "4247d0c32fca3a7e92edc2b832b76924359a069df0c552af2a1e11646337e0f4";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosbag2-storage-mcap/default.nix
+++ b/distros/foxy/rosbag2-storage-mcap/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
+buildRosPackage {
+  pname = "ros-foxy-rosbag2-storage-mcap";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/rosbag2_storage_mcap/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "709d83331da130c452606c4293bbbd02bc424da8d644dbb09e783fae96398bda";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''rosbag2 storage plugin using the MCAP file format'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rviz-imu-plugin/default.nix
+++ b/distros/foxy/rviz-imu-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, message-filters, pluginlib, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering, sensor-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-rviz-imu-plugin";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/rviz_imu_plugin/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4ecdcfd32d911fc6ed7310053c0181ba797089746fc912db68ad2279d1ee5879";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ message-filters pluginlib qt5.qtbase rclcpp rviz-common rviz-ogre-vendor rviz-rendering sensor-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RVIZ plugin for IMU visualization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/septentrio-gnss-driver/default.nix
+++ b/distros/foxy/septentrio-gnss-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-septentrio-gnss-driver";
+  version = "1.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/foxy/septentrio_gnss_driver/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "f168607051e842c13a598ed0a05dde24e3fb000fb69a90a7a93bfee511c0ab00";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ boost diagnostic-msgs geographiclib geometry-msgs gps-msgs libpcap nav-msgs nmea-msgs rclcpp rclcpp-components rosidl-default-runtime sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROSaic: C++ driver for Septentrio's mosaic receivers and beyond'';
+    license = with lib.licenses; [ "BSD-3-Clause-License" ];
+  };
+}

--- a/distros/foxy/simple-launch/default.nix
+++ b/distros/foxy/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-simple-launch";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "f3d0a0486141ce1946be4871af8bece2e04b6e3fbc111ad87bf6305bd8851f52";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "94b1612e8028b244406a5a2230f6bf8b1edd853355d7f0cfcfa3b4514140f7e1";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/slider-publisher/default.nix
+++ b/distros/foxy/slider-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-slider-publisher";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/foxy/slider_publisher/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7715b3d46594607c62853e0730287afc8115c0064e095ba1a15d8058595f4075";
+    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/foxy/slider_publisher/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "f8d6ff59786a362a617368a2c277020e4c20e40bfd591e6218026a8975b9e995";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/swri-console-util/default.nix
+++ b/distros/foxy/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-console-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_console_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "7ac8042ad5ada08f5a618e576f8dd284009113a5ef980eff8576b1cc07d88723";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_console_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "51560cf7c94d1d87566a7e9583cb41193bf7bcc913f2008d04d625fd7fb3c95d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-dbw-interface/default.nix
+++ b/distros/foxy/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-swri-dbw-interface";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_dbw_interface/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "7c1bd224d9dc07d2ff4da57a93f0fbb3db014eb4d4a8384c8fea794af8884f60";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_dbw_interface/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "a3589bed3f576efb7e2565b2d849f5d161455ceb8a4d3a7d849054c529a093cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-geometry-util/default.nix
+++ b/distros/foxy/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-swri-geometry-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_geometry_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "ebe0d24b2efdad12e36597ee3734c1a1a62055e438f960e64377760c89db0d4f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_geometry_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "9b48fe757848a5158966c1bf3d11f2c0d41a4be92d5396d9fa23dea8f4bd9fb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-image-util/default.nix
+++ b/distros/foxy/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-swri-image-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_image_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "5c5efdd09cfbddd9a9c055498ebc740c4cb2a3d89f2c1f6a8caf76d1dadf8f3f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_image_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "658f5d5a184a31919534fdec92ce07faabd7dfa855aa89a480c388676e4025e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-math-util/default.nix
+++ b/distros/foxy/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-math-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_math_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "52f51dfba83dbc21a8efe1aa1fd43d5632649acf63f3a78815aaaa5e1789a27d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_math_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "bf916a99ee754289d590854d320abf36fed0fec92db11bdf1651aec97ae29cee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-opencv-util/default.nix
+++ b/distros/foxy/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-foxy-swri-opencv-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_opencv_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "167e60dbd2012b88070b474c85628728dac3fa8db318c57895e0ba2d2d698ee2";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_opencv_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "335cb7552c6b780e9771aa9124615f1cd5748fd31f9297b7b44084c6555ed42a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-prefix-tools/default.nix
+++ b/distros/foxy/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-swri-prefix-tools";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_prefix_tools/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "8820840166871532f1aa6ffe3feeed6d744467324f33201488d7b33db14d364a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_prefix_tools/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "b524de5f7876182f2b0e754d63ac6886d6f1fa865d3c9743c7c4f5d838cea50e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-roscpp/default.nix
+++ b/distros/foxy/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-swri-roscpp";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_roscpp/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "3a38676a083821c0228aadadfb8096a2d8ebcf04cb8ecbe8d199bc772cbaca6a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_roscpp/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "b7af7f72e6b42c95df58e37e1dbd2f5640a5075636c92a196ad0c7297b4770c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-route-util/default.nix
+++ b/distros/foxy/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-swri-route-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_route_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "4e7846bf3a72a3115c2642f8c665a114933df9cfb5d974141318374e9bbf05a4";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_route_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "5e16e30fb1a79fa2c239020ec86e0800fec6907d9475b258348a478fbcbc3cc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-serial-util/default.nix
+++ b/distros/foxy/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-foxy-swri-serial-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_serial_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "1590cd00137823164d760f196553be51395f1069cd7b20180ea68c429c62053e";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_serial_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "829de85e258468f4b33d6e378ecce9ecaf88bf8e9625d28a1da5c4dd3ff9a87d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-system-util/default.nix
+++ b/distros/foxy/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-system-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_system_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "2924b3b8daa430b1a2142fe122588f75f7c67d19b1222331179cbfc3a38214a4";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_system_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "b2db6f502e97e73583c1deb674beb3f0ada045b4e9f12bab1fb89165241b497f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-transform-util/default.nix
+++ b/distros/foxy/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-swri-transform-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_transform_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "b7ea5b7420551928f282fee717706cfb3192e62bd50247c6f6be5f43ccedfca5";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_transform_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "e13047467f5a6864f3b77e024eadfbda227379e24b7d717e339fab93ee3e8639";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-client-library/default.nix
+++ b/distros/foxy/ur-client-library/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, console-bridge }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-foxy-ur-client-library";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d460990dd5bd6786184e7bcdc90cc7f1d4bf64054fc4e47dbfb08f532d003667";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "00006ad8ff6811fa5eb16eda7804e0f5e9ab738622df47c8773cded95fe696e8";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake console-bridge ];
+  propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/usb-cam/default.nix
+++ b/distros/foxy/usb-cam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-foxy-usb-cam";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/foxy/usb_cam/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "b890f9babfa81aa5c85b116196e9b99b69a6ec90595ad98e3dfab1d616d4c96f";
+    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/foxy/usb_cam/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "4ebd79d187833e24d7d24a13209274c528d271f073c4c700a73dcc57674f4b3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-clang-format/default.nix
+++ b/distros/galactic/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-clang-format";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_clang_format/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "f7bef72abc6b4a3e47e1fd45beb070c936193146c4da48b73b4e9d2d5b5f0a6c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_clang_format/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "997fa6fc77eb75d15d64b1dc92ad195b037de2b16d009266a4d73633447a03e0";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-clang-tidy/default.nix
+++ b/distros/galactic/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-clang-tidy";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_clang_tidy/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "14d7f00bb9d7c730cefc08ae69d5acb9aa56c62fe7f93b3ff2b4a35cd0509adf";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_clang_tidy/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "e3db2c5c8417fa5937c88461f6c8eb725885cd735efe48b5c6a69656fe7b2a9e";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-cmake-clang-format/default.nix
+++ b/distros/galactic/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-clang-format";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_clang_format/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "097e0264ecda25cf678d2f001d252f3b4ed74eeb842c574caac975769dd35aa0";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_clang_format/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "e403d4df307a19921e971935b320e2839891e9fbbf0a5cdb08404ed70a7fc0c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-clang-tidy/default.nix
+++ b/distros/galactic/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-clang-tidy";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_clang_tidy/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "e0548edbc862d39d8002d666b3a6bf8318265119bcb06e32eeda260517308bb7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_clang_tidy/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "b7a22da35f217f6693507ae7ecff021c79c1381f61ed7812ec3824d3d28bda33";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-copyright/default.nix
+++ b/distros/galactic/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-copyright";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_copyright/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "2c2221818c00602d8ac1afea332803bf3b0a0ce723ac7e96a160500b898b229f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_copyright/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "9f2a255778035f3a9c65a5129bd53843c7dd8a25ab6cbdc50a2b23e56338e1bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-cppcheck/default.nix
+++ b/distros/galactic/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-cppcheck";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_cppcheck/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "9eadb499d992cd23d146b60cec3e6534e7e459dcc29c25150c139a4126689397";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_cppcheck/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "1c82c386073af2aa0540ced914b528530b90ed43c947f5b82fdf5058c3598832";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-cpplint/default.nix
+++ b/distros/galactic/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-cpplint";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_cpplint/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "d7564bd7612c16e0b0d8f9020affe7dba9c5aefd9cb7b8b14639f16eb39783e4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_cpplint/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "93571bd20e60e48c8a9249695514d13a75d32e99b12004240900bcc1c97c5871";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-flake8/default.nix
+++ b/distros/galactic/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-flake8";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_flake8/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "c76c67bbf8e5f187bc0951d900ab55edfb09dcc433d48ac413106fe4764fdf1d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_flake8/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "bbc01e21f4cc66803b310b1906bfcdf26f3fff5d8b54e9073c9b3f226cf56f2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-lint-cmake/default.nix
+++ b/distros/galactic/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-lint-cmake";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_lint_cmake/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "db5e51ed8aa498159b2453d9a911150b7b7d22569a91b43611382d450494e2fd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_lint_cmake/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "f816753ff409873fb06e3c79558d694eee297e526be50317e4443be818a0f216";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-mypy/default.nix
+++ b/distros/galactic/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-mypy";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_mypy/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "019279efc7219e980906c2ca05cd5a43b5033fd8036cfe0788b49172ba142f04";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_mypy/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "1590afba2fb639f99993a442fb3aa5bfb899ec2c633ea58a11991e300d05bba4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-pclint/default.nix
+++ b/distros/galactic/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-pclint";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pclint/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "498093906c5a127e13bdbbd5558b29d427726408b9f8fce52fd4a928341eee9e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pclint/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "545fcbb48972ef444c354f4fd4ff4d5aaefefbb63b911078bd7544134a54e5a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-pep257/default.nix
+++ b/distros/galactic/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-pep257";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pep257/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "bd26f310bfc516a82ecf361ff43fd6e7d8deaf16b66fc33e866541be2f26c90e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pep257/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "c8b92f8a4b9b4e4be2a1f53bd3a3b7e0a71b06b4ffef7973c542e77aa5d8863b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-pycodestyle/default.nix
+++ b/distros/galactic/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-pycodestyle";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pycodestyle/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "075d8801ae66b457f7d754821ba032e1d7954be4aaaca5e0c38bf4149c324905";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pycodestyle/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "07b79eb6ec31db4ad61dd75a16a4c7ce94b1baab7d7cdf04f898351a84d53450";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-pyflakes/default.nix
+++ b/distros/galactic/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-pyflakes";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pyflakes/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "ecfac506223c7b76325bc5de94db154f51776658cdf64d71ec3f04df8d49f093";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_pyflakes/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "34387e05761a886d39e81dab3bd9dc19d8c586d6c8302dd8080f7f59e1334a95";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-uncrustify/default.nix
+++ b/distros/galactic/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-uncrustify";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_uncrustify/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "1da53f8d44ad240be9f6cb10714a3025bb1f2f318e0554fba02d76732c8ad268";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_uncrustify/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "24d22990ac236116b7d2cff586d05960cce543d1e994d0637902e0ee7547c541";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-xmllint/default.nix
+++ b/distros/galactic/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-xmllint";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_xmllint/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "225c3b42a550bc1ea016822445447c74971d88e3b0134600c7565e01d1f0d812";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cmake_xmllint/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "c3d3b23a12541b2efd5e846e8470e618ac8bf3da11ba67e2870b398f49a7a109";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-copyright/default.nix
+++ b/distros/galactic/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-copyright";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_copyright/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "959c6f579b14d15e57344f5f4c9b9abcab0b01931ccde3e92ece1034e1c39a16";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_copyright/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "301f88bee34d714c4cd5ce869f41a710ed4667ba14adc69524087c85916b61e0";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-cppcheck/default.nix
+++ b/distros/galactic/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-galactic-ament-cppcheck";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cppcheck/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "3d998c23923e2f0196a8d7d50b9618c9cabde72adb5cf4464530413a8bd4b52a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cppcheck/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "2b0bdeed6636714c0673c6d9a04b66f67b189bef8e61c1620134104bd2abfaee";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-cpplint/default.nix
+++ b/distros/galactic/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-cpplint";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cpplint/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "629481a2463601e7481c2993db4be89bf386617d27eba1a611e7172fff1bb274";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_cpplint/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "f95308ac4558cb016b4356667e98ee39d71b6c074f19b458a2bdd01bd1975b4f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-flake8/default.nix
+++ b/distros/galactic/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-ament-flake8";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_flake8/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "a96f04128b3af65553e20d9d233fe47945c9e557bdd1f1fa59396c156d1d4f0b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_flake8/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "b012fff38ebb9d1240a141a0d6acb7a01a8f6457b69d1bb5b5079933735b824b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-lint-auto/default.nix
+++ b/distros/galactic/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-galactic-ament-lint-auto";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint_auto/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "e00cf50e921f0baa06a80fb531eb74c373ac1392d056028a3e4527aefeadc820";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint_auto/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "987a915a4e8ae755c383132d2120ac0474fe3a65fe30b665a628aaf060ad99e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-lint-cmake/default.nix
+++ b/distros/galactic/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-lint-cmake";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint_cmake/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "2bdb74c5404d9c56ce24882a3a5ef7312db8e8f2768f79dc91c02397460d4bce";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint_cmake/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "d65237468ebb10486ec0d8f323b2f037ae33999f035d0a52fa591a0a192e612d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-lint-common/default.nix
+++ b/distros/galactic/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-galactic-ament-lint-common";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint_common/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "b7c8864ade3bbf384bb78eb9b80f9fa0f08e1fee8e83cdabe9b328406dae26c8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint_common/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "13ee627894126f71251f989cf9c352c39b9bf7fd7efcfed34f54c00aa96541cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-lint/default.nix
+++ b/distros/galactic/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-galactic-ament-lint";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "7fcf86bd8e3682d7be41d3a380cc36d7788ffc4eb36f326aa1b5732f2770a626";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_lint/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "001a447f73224c1912fc53d37653728db36c049cf88c85ad7e41be8dc9c60881";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-mypy/default.nix
+++ b/distros/galactic/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-mypy";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_mypy/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "a60ef820e2e6bd754b1d16beec3946ff192036876a5ebbb9df11948b6d9673a6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_mypy/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "8f336c21ac9c15caea9cf0a97a9985ad3d3ee009784b0f7cdf723aa00108eb74";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-pclint/default.nix
+++ b/distros/galactic/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-pclint";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pclint/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "13fe7586698f5ca1f85faa6ea622bf2fff38c53d11cf7bf933e1231779647cba";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pclint/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "7a942f8261c40d83f474e6b3326a69b5077a76f5ffad1fc8d283342fc3741f80";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-pep257/default.nix
+++ b/distros/galactic/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-pep257";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pep257/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "0fb8c7cf14987251fb6de586b93350d70bdd4d2505be73e6e9076e2f907ba1d4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pep257/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "f09f82bb6948fdb12ad1357d071f4638dceaad0c7cc7f7fe5d42f29b6f0159de";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-pycodestyle/default.nix
+++ b/distros/galactic/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-ament-pycodestyle";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pycodestyle/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "87e075428fa53ae434f405ee8a553108addf76e31a4a385a2698516884c87435";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pycodestyle/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "ba2458056125197e62d35ba7ff296ceef7569c109c2edcd774862c036e0d8e34";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-pyflakes/default.nix
+++ b/distros/galactic/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-pyflakes";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pyflakes/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "0e822ee6b432a76d104ad8b9e52beebaa121864646d3b7f0b48c884b8b1e44de";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_pyflakes/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "95db0a173769d631f923652bedeea47b82ef025afdce59fa84c6d37fbba8f88b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-uncrustify/default.nix
+++ b/distros/galactic/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-galactic-ament-uncrustify";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_uncrustify/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "a16d88d8454ec777c16e92815871bb3eca9b967be882dc9b51b97e1ef078773a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_uncrustify/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "77bf7841dca0533fe0005a51a197eeac712a508eb0c0f48aedffe27bf0626592";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ament-xmllint/default.nix
+++ b/distros/galactic/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-xmllint";
-  version = "0.10.6-r1";
+  version = "0.10.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_xmllint/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "6c0c578e58df6c88e60c28bb354ffb900a131000b69c25c0e83473d9549b8123";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_xmllint/0.10.7-1.tar.gz";
+    name = "0.10.7-1.tar.gz";
+    sha256 = "83740ed819e1875e5849df59b46371c7d9c5768f6e02174db0f55cd622cf94a8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/camera-calibration-parsers/default.nix
+++ b/distros/galactic/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-camera-calibration-parsers";
-  version = "2.3.0-r3";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_calibration_parsers/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "304399d4455346aa024c6748daa8482ef24069a65cdeab542a748fa72dd34d23";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_calibration_parsers/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "6a3dd247c289a58239c0f5f379d5433cb480f118cd61859901d9e9be3bbb4747";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/camera-info-manager/default.nix
+++ b/distros/galactic/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-camera-info-manager";
-  version = "2.3.0-r3";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_info_manager/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "a407e67f2d9ef011e26adcd56f1aa1f295b0ef6e37bc031a380c2009d168507c";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_info_manager/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ecef86201cb6ce31ac6650d46104673d030940187f54eb42f7c5bf41278d2a7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-controller-interface";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "0e7d5b9bcd4dd5f407f6a762784b8267d16aa3fb3ccb2e996df75bfb595c18fb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b0a494f0110a92d16ad372dbb17fbbd2232f07f9e220cbab58739e5d65833c55";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager-msgs";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "90c9901e61c07e7e229314510fada811f374a4ea41681e176d75b5acea021815";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "126776c78bea6ed41f113c16e4c504fe89c7c81564d6323cf796c550f807cd0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "c72d0162bcea201c8054b93f0543ef74dfac615f4e41bb3c7f4f5158302e5436";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ef4534caa315aff1a46eaa7ade22e3e4c9bf98067093e30dc5bcd82f504200e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/examples-tf2-py/default.nix
+++ b/distros/galactic/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-examples-tf2-py";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/examples_tf2_py/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "8f9997816b686643aac6eb5ba5898881f3fa8465ea776cb91d0605c1e523bc3a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/examples_tf2_py/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "36dbdc9c6a5dd2b66af43e8162bb16e8e5d542e12c9042eaf8930fffed535684";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/foxglove-msgs/default.nix
+++ b/distros/galactic/foxglove-msgs/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-foxglove-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/galactic/foxglove_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "bd726ad4c2433d21f43537ab02137ac1413b7c21bad4074595d2b1e565c0e810";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''foxglove_msgs extends the common ROS visualization messages with additional
+    useful messages that are supported by Foxglove Studio.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -346,6 +346,8 @@ self: super: {
 
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
+ foxglove-msgs = self.callPackage ./foxglove-msgs {};
+
  gazebo-dev = self.callPackage ./gazebo-dev {};
 
  gazebo-msgs = self.callPackage ./gazebo-msgs {};
@@ -434,7 +436,13 @@ self: super: {
 
  image-view = self.callPackage ./image-view {};
 
+ imu-complementary-filter = self.callPackage ./imu-complementary-filter {};
+
+ imu-filter-madgwick = self.callPackage ./imu-filter-madgwick {};
+
  imu-sensor-broadcaster = self.callPackage ./imu-sensor-broadcaster {};
+
+ imu-tools = self.callPackage ./imu-tools {};
 
  interactive-markers = self.callPackage ./interactive-markers {};
 
@@ -591,6 +599,8 @@ self: super: {
  mavros-extras = self.callPackage ./mavros-extras {};
 
  mavros-msgs = self.callPackage ./mavros-msgs {};
+
+ mcap-vendor = self.callPackage ./mcap-vendor {};
 
  menge-vendor = self.callPackage ./menge-vendor {};
 
@@ -1364,6 +1374,8 @@ self: super: {
 
  rviz-default-plugins = self.callPackage ./rviz-default-plugins {};
 
+ rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
+
  rviz-ogre-vendor = self.callPackage ./rviz-ogre-vendor {};
 
  rviz-rendering = self.callPackage ./rviz-rendering {};
@@ -1387,6 +1399,8 @@ self: super: {
  sensor-msgs = self.callPackage ./sensor-msgs {};
 
  sensor-msgs-py = self.callPackage ./sensor-msgs-py {};
+
+ septentrio-gnss-driver = self.callPackage ./septentrio-gnss-driver {};
 
  serial-driver = self.callPackage ./serial-driver {};
 
@@ -1584,6 +1598,24 @@ self: super: {
 
  turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
+ turtlebot4-description = self.callPackage ./turtlebot4-description {};
+
+ turtlebot4-desktop = self.callPackage ./turtlebot4-desktop {};
+
+ turtlebot4-ignition-bringup = self.callPackage ./turtlebot4-ignition-bringup {};
+
+ turtlebot4-ignition-toolbox = self.callPackage ./turtlebot4-ignition-toolbox {};
+
+ turtlebot4-msgs = self.callPackage ./turtlebot4-msgs {};
+
+ turtlebot4-navigation = self.callPackage ./turtlebot4-navigation {};
+
+ turtlebot4-node = self.callPackage ./turtlebot4-node {};
+
+ turtlebot4-simulator = self.callPackage ./turtlebot4-simulator {};
+
+ turtlebot4-viz = self.callPackage ./turtlebot4-viz {};
+
  turtlesim = self.callPackage ./turtlesim {};
 
  tvm-vendor = self.callPackage ./tvm-vendor {};
@@ -1614,11 +1646,23 @@ self: super: {
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
+ ur-bringup = self.callPackage ./ur-bringup {};
+
+ ur-calibration = self.callPackage ./ur-calibration {};
+
  ur-client-library = self.callPackage ./ur-client-library {};
+
+ ur-controllers = self.callPackage ./ur-controllers {};
+
+ ur-dashboard-msgs = self.callPackage ./ur-dashboard-msgs {};
 
  ur-description = self.callPackage ./ur-description {};
 
+ ur-moveit-config = self.callPackage ./ur-moveit-config {};
+
  ur-msgs = self.callPackage ./ur-msgs {};
+
+ ur-robot-driver = self.callPackage ./ur-robot-driver {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/galactic/geometry2/default.nix
+++ b/distros/galactic/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-galactic-geometry2";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/geometry2/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "a2b031d4a45b5c5ab409c7c949759404f307c9b5069ce36c81ea49f37f61b4d4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/geometry2/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "1a9c4fa0bf03c2c15c5e54e62448a2963b8336e9bb273e823bf1480fec5f3de1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-galactic-hardware-interface";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "597b7524a397dd58ee4e4210e8e75ce41e1619004dd49e800f4f06955dd5c2e3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b6401678c43cbfb28b5fa28f8c80f34f2fec28593338476167e2ffeb8e107bc6";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
+  propagatedBuildInputs = [ control-msgs lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/image-common/default.nix
+++ b/distros/galactic/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-galactic-image-common";
-  version = "2.3.0-r3";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_common/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "4567b119ceb2e52c78b5c1fd017901f7b91e33c6bbdb836f1d35db892dbb7090";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_common/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ae20aae3bf832989304e36066c7b6eb0c32086972fdc954b9483e8517dcddd73";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/image-transport/default.nix
+++ b/distros/galactic/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-image-transport";
-  version = "2.3.0-r3";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_transport/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "c09d67f62cc4ea67050aa1d8b9e73b21197a57ae9a8f3267601d6562aa9ef447";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_transport/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "d91cad7553e537d5a94395a4cf1ac807ff599d021f268ac14ac9b44e324a35c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-complementary-filter/default.nix
+++ b/distros/galactic/imu-complementary-filter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, sensor-msgs, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-imu-complementary-filter";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_complementary_filter/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "0124e2d1a244675bec830e3fd35b1d79c8896657cacfc6618cecc708ef5f2ea9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ geometry-msgs message-filters rclcpp sensor-msgs std-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into a quaternion to represent the orientation of the device wrt the global frame. Based on the algorithm by Roberto G. Valenti etal. described in the paper &quot;Keeping a Good Attitude: A Quaternion-Based Orientation Filter for IMUs and MARGs&quot; available at http://www.mdpi.com/1424-8220/15/8/19302 .'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/imu-filter-madgwick/default.nix
+++ b/distros/galactic/imu-filter-madgwick/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-imu-filter-madgwick";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_filter_madgwick/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "d08f33ba26deb665ba2385b490ee7ac1c46600d49c904ca7da930f7589e5f150";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs nav-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into an orientation. Based on code by Sebastian Madgwick, http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms.'';
+    license = with lib.licenses; [ "GPL" ];
+  };
+}

--- a/distros/galactic/imu-tools/default.nix
+++ b/distros/galactic/imu-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
+buildRosPackage {
+  pname = "ros-galactic-imu-tools";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_tools/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "b70b99282cbf82182b239499fbae570bda1c39d4a8cea531445b6ecd5bd33499";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ imu-complementary-filter imu-filter-madgwick rviz-imu-plugin ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Various tools for IMU devices'';
+    license = with lib.licenses; [ "BSD-&-GPL" ];
+  };
+}

--- a/distros/galactic/irobot-create-common-bringup/default.nix
+++ b/distros/galactic/irobot-create-common-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, irobot-create-control, irobot-create-description, joint-state-publisher, robot-state-publisher, ros2launch, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-common-bringup";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_common_bringup/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ed35e63aa0b5df102b5a1949c54e432b3458448f2a9a7b970760afd845ec9b80";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_common_bringup/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "47e3739e655fce791271407bbe0ca3c32a8ecde4ff2fd81bd6198e44af95ce8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/irobot-create-control/default.nix
+++ b/distros/galactic/irobot-create-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-ros2-control, ign-ros2-control, irobot-create-nodes, joint-state-broadcaster, ros2-controllers, ros2launch }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, joint-state-broadcaster, ros2-controllers, ros2launch }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-control";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_control/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ee286c9cb22bfc3ad9aa2f77fc923b8a9709fc7ce1f2c00e600eda433dc735af";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_control/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "acc2142ecef5c1686f554d40f55d48b3821881b12286f278905dd56cfecaef95";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ gazebo-ros2-control ign-ros2-control irobot-create-nodes joint-state-broadcaster ros2-controllers ros2launch ];
+  checkInputs = [ ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ joint-state-broadcaster ros2-controllers ros2launch ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/irobot-create-description/default.nix
+++ b/distros/galactic/irobot-create-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, irobot-create-control, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-lint-auto, urdf }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-description";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_description/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "5e5324978a0a6743b10055ed00c1f9ad8efcac63be0c1b0b1eeeb028822902b0";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_description/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "c9ecf65ec72d8f4f8d2486ab74903529f8f6787a13d07ccdb424284187570394";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ irobot-create-control urdf xacro ];
+  checkInputs = [ ament-cmake-lint-cmake ament-lint-auto ];
+  propagatedBuildInputs = [ urdf ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/irobot-create-gazebo-bringup/default.nix
+++ b/distros/galactic/irobot-create-gazebo-bringup/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-plugins, gazebo-ros, irobot-create-common-bringup, irobot-create-control, irobot-create-description, irobot-create-gazebo-plugins, ros2launch }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-plugins, gazebo-ros, gazebo-ros2-control, irobot-create-common-bringup, irobot-create-description, irobot-create-gazebo-plugins, ros2launch }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-gazebo-bringup";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_bringup/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c00a3c924a91fbcdaf58fceebac25e7f8d82beedc9fce74e6acda0a8364e0bcb";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_bringup/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "aa69dc89b6813b8af037cb7d9b9de62b65333ba6fda8b7d92610318523aeec83";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ gazebo-plugins gazebo-ros irobot-create-common-bringup irobot-create-control irobot-create-description irobot-create-gazebo-plugins ros2launch ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control irobot-create-common-bringup irobot-create-description irobot-create-gazebo-plugins ros2launch ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/irobot-create-gazebo-plugins/default.nix
+++ b/distros/galactic/irobot-create-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-dev, gazebo-ros, geometry-msgs, irobot-create-msgs, irobot-create-toolbox, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-gazebo-plugins";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_plugins/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "18c9abaa0c8ef6e8b4e82744beb0b7224ba931dc55fa64a6f536c958f74326b8";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_plugins/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "04cc691dc52b639b6699292aabfa47ab9fb13e1e4be26819adb1272be7d39960";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/irobot-create-gazebo-sim/default.nix
+++ b/distros/galactic/irobot-create-gazebo-sim/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-common-bringup, irobot-create-control, irobot-create-description, irobot-create-gazebo-bringup, irobot-create-gazebo-plugins, irobot-create-nodes }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-gazebo-bringup, irobot-create-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-gazebo-sim";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_sim/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d1bc88502efe404a34c4e3e1373bca5ec5ae24768fef2c48bef7cd5685566363";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_gazebo_sim/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d7c55ecbf3bc0c9f71cb7e5bcbc0e07f59f73fec6f4f5584af93df28ddfd5ae5";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ irobot-create-common-bringup irobot-create-control irobot-create-description irobot-create-gazebo-bringup irobot-create-gazebo-plugins irobot-create-nodes ];
+  propagatedBuildInputs = [ irobot-create-gazebo-bringup irobot-create-gazebo-plugins ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/irobot-create-ignition-bringup/default.nix
+++ b/distros/galactic/irobot-create-ignition-bringup/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-plugins, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-nodes, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, ign-ros2-control, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-plugins, irobot-create-ignition-toolbox, irobot-create-msgs, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-ignition-bringup";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_bringup/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "2ef3fb4ae67087039d5000d2698533aec18b0335c564dffa938005ecea54624e";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_bringup/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "ddf45e22944919d3cd9dc4d19b9ba25ca5c1978ed547db0ceb207fdfbb73eaeb";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-plugins irobot-create-ignition-toolbox irobot-create-msgs irobot-create-nodes ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs ign-ros2-control irobot-create-common-bringup irobot-create-description irobot-create-ignition-plugins irobot-create-ignition-toolbox irobot-create-msgs ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/irobot-create-ignition-sim/default.nix
+++ b/distros/galactic/irobot-create-ignition-sim/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-plugins, irobot-create-ignition-toolbox, irobot-create-nodes }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-ignition-bringup, irobot-create-ignition-plugins, irobot-create-ignition-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-ignition-sim";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_sim/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d1c568dacdb8de4e04b2901a5950715fcdad463ad868ac63000ed9bbd49cb1e0";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_sim/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "9454d36221968004272abf94ed8c19dc3c91daff5a87087f24b70b07a56a5ff8";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ irobot-create-common-bringup irobot-create-description irobot-create-ignition-bringup irobot-create-ignition-plugins irobot-create-ignition-toolbox irobot-create-nodes ];
+  propagatedBuildInputs = [ irobot-create-ignition-bringup irobot-create-ignition-plugins irobot-create-ignition-toolbox ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/irobot-create-ignition-toolbox/default.nix
+++ b/distros/galactic/irobot-create-ignition-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, control-msgs, irobot-create-msgs, irobot-create-toolbox, nav-msgs, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-ignition-toolbox";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_toolbox/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f2e4159206765027f4ce4f2106aa78e3bb4119ede5cb40ab74867e10193d0f88";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_ignition_toolbox/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "cd906f3b56485c235b34fab594e398447de07978aacbbe7d01cbe0db01b60395";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/irobot-create-nodes/default.nix
+++ b/distros/galactic/irobot-create-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, angles, boost, control-msgs, geometry-msgs, irobot-create-msgs, irobot-create-toolbox, nav-msgs, rclcpp, rclcpp-action, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-nodes";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_nodes/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "eff3a2a6943772dd2ba1b53e65883006b6fd859351f264018002cebb6a8947b8";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_nodes/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "fdc6f1adcfd8b407bad06d528d724f6d43091ffa4560da66d3dc1748f874d87e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/irobot-create-toolbox/default.nix
+++ b/distros/galactic/irobot-create-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, ignition, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-irobot-create-toolbox";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_toolbox/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "e10b7413e5fbd5e815c0396a373ba8868af036a7eded9f786ac75314b2a6d457";
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/galactic/irobot_create_toolbox/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "9c33925f0bbbf2e800375664aca44d2e7e13490d50f9683d771ef6fc458f9169";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/launch-ros/default.nix
+++ b/distros/galactic/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-launch-ros";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/galactic/launch_ros/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "db6c0cc59b01aa5492e04d342273b60adccd3d65c0b79016dcd8e695517acca8";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/galactic/launch_ros/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "397e2294e74ccaace65ef10693ac703b74f5f8e41e50cc2be83dbe526c28515e";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/launch-testing-ament-cmake/default.nix
+++ b/distros/galactic/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-galactic-launch-testing-ament-cmake";
-  version = "0.17.0-r2";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_testing_ament_cmake/0.17.0-2.tar.gz";
-    name = "0.17.0-2.tar.gz";
-    sha256 = "1bbf508f9115547cecbf44752216b4750178c1d205ecf860d6b7e09526b719e7";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_testing_ament_cmake/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "b95133b17b2cc27649a076ef30e2c4eeb8c1a3b0cdfb28f9504b8e66a2a62ad9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/launch-testing-ros/default.nix
+++ b/distros/galactic/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-launch-testing-ros";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/galactic/launch_testing_ros/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "05fe38c440681b7ff604b5860be4289c66e8f39d697a6319a4124fc1d5ffed93";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/galactic/launch_testing_ros/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "408abb6c347f333c16ae907e040f73d8ecc4da95e6bf2803038215da162785e1";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/launch-testing/default.nix
+++ b/distros/galactic/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-launch-testing";
-  version = "0.17.0-r2";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_testing/0.17.0-2.tar.gz";
-    name = "0.17.0-2.tar.gz";
-    sha256 = "47b3cc614ee67010d7530df0624c1464c8a784400228e5a702746d43a74c752c";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_testing/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "1ce8b919059dbde209593965e583a3e5e180ff98456bcc6d87822fcf3c96eff8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/launch-xml/default.nix
+++ b/distros/galactic/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-launch-xml";
-  version = "0.17.0-r2";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_xml/0.17.0-2.tar.gz";
-    name = "0.17.0-2.tar.gz";
-    sha256 = "5578e313f916bd281676442735cae3eabef572d2cc6ab23d96ac8dcfce132a5e";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_xml/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "95ab908bdb839a910c0964683de3661b468ad4054f5656a935a3136a006d5eb6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/launch-yaml/default.nix
+++ b/distros/galactic/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-launch-yaml";
-  version = "0.17.0-r2";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_yaml/0.17.0-2.tar.gz";
-    name = "0.17.0-2.tar.gz";
-    sha256 = "dbd7c6859d320ba315824997ba32a86ab9722300c3b3fc7bf2acbf87b04b5813";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch_yaml/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "f1f844af8829db7bc2df4e6f8a3ed77f7cdc365fa69a318bec7caaa8ddbef764";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/launch/default.nix
+++ b/distros/galactic/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-launch";
-  version = "0.17.0-r2";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch/0.17.0-2.tar.gz";
-    name = "0.17.0-2.tar.gz";
-    sha256 = "244263e074fb6e3af3df246ae3d742db28e17f9cfd97cce3a9562112620fbb83";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "884564d795060c5b2871a385951a108bf702f3d54f954a8ab54a3f645907697f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/mcap-vendor/default.nix
+++ b/distros/galactic/mcap-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-mcap-vendor";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/mcap_vendor/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "a790bdb6a37b11938b791004e3849954f47a88dd1526380f92030a9e10c6e0ad";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''mcap vendor package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ntrip-client/default.nix
+++ b/distros/galactic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ntrip-client";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0f3ec60933148b818edcd25890ff9025decefe67ec8d9ea494da14fd345a9a28";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7570f2721665d8066542644ce300ad0ad2c808e77408395060a70e8040952ef8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/plansys2-bringup/default.nix
+++ b/distros/galactic/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bringup";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "2e2e9c1e9dcec819330320432762e5a2b3ad41846f7c5e12845d04dd9ddfcb7f";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "3de7ae9bdf5c7b253beffeed807dde2ee43c256441b5e8350c647357c4246972";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-bt-actions/default.nix
+++ b/distros/galactic/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bt-actions";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "a9b40b750e71b1ba28271ba7ae4fe528d9ee839fb9766d67d3efbaed7e1653fd";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "00657393e70bbcce1b338284e3f041f050523fdb9c9171d387842f8ab74df6a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-core/default.nix
+++ b/distros/galactic/plansys2-core/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-core";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "b6a3f70da0c71aafb8abf5e3b53d52ec45332fde6d07f2e046e5b98f57a84b3a";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "d15d90a2854e445e9cbbb2b8acbda3a3f20be13f7b7bc91327b05275a5c2b4f1";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ plansys2-msgs plansys2-pddl-parser pluginlib rclcpp rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/plansys2-domain-expert/default.nix
+++ b/distros/galactic/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-domain-expert";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "2972f9835094bacaeb7bedbcb04489fcf97492f794d2af46d14d675bfb9b0a0d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "089da386e6124d605e4d9f7cf30829b00e9fbd38960ea420ecfafbe7f843c5b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-executor/default.nix
+++ b/distros/galactic/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-executor";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "c0edaed5b43d4650bf9b36931860c2d0661600a73ea403f4c80fbfc2618a4827";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "ec1d1c1b5a4dca2e93616354f7e7cab23624a48eb13e280645adf21de7495882";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-lifecycle-manager/default.nix
+++ b/distros/galactic/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-lifecycle-manager";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "5f7a78fa8107ce014792326d65c9f89838b483953e226e86c3545049e1477983";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "92fdc2acaf21df9f0fc6b5ed5b826e524dd3073d8b8f29a30be861d15ad0e41b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-msgs/default.nix
+++ b/distros/galactic/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "d35ed688059a2a25c54d5b6a8a4c9b75e0bbe931f0634ae99c499d855214421f";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "5ad8cede2e8d4a93b577b2e552a79d677cbb4ff59cc21401404685f65f2d1754";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-pddl-parser/default.nix
+++ b/distros/galactic/plansys2-pddl-parser/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-pddl-parser";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "88b2c6abe44d8c92c636fd558b6889e97e9063c57c2f0a276fc88388612780b7";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "a5c1a57e29b045f0512d7b319f1a2317aaf93f835468cde8d128b8210e0588b0";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ plansys2-msgs std-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs rclcpp std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/plansys2-planner/default.nix
+++ b/distros/galactic/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-planner";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "11372fdb90bbda11dcdce91336c0a796493a0fafa978630d64aa5d265598b11a";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "86c66621fdb4edb0fde315e63823f5c654e107c3146a8cf34a4a8b847a2ba3bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-popf-plan-solver/default.nix
+++ b/distros/galactic/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-popf-plan-solver";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "cebb036cdb2633dd49818cce4d84863de6375a228753c0dd12bbae13b05e3e02";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "597da949475b4e76a1ac75cd939d7401d341af58ee7be1eefe2c14c12232f4f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-problem-expert/default.nix
+++ b/distros/galactic/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, qt5, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-problem-expert";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f4d99128bd5dde330e82f4e5325de8270fb17085132de6fde13a9d76065a6d85";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "61e39df4dc7b45d01edcaaab52f8e3742235232a90fde79d44f87a390a4aa950";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-terminal/default.nix
+++ b/distros/galactic/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-terminal";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "213296f5c99afa2dbc6eff8ec385dc0dbe639c54f11462a79c01bf6349a21976";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "34bb43733717959670b003609ae60b0f675bdae9c187742206581b4456eef8d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-tools/default.nix
+++ b/distros/galactic/plansys2-tools/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, qt5, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-tools";
-  version = "2.0.3-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_tools/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "91c4b2e84bb8d13c0329f25f9d22f668011488cb55726de0c7c782a08abd3fa7";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_tools/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "dd66346c9ed4abde3bd14ddd536954d65a6a8acaf2079aa5d761ae0a052edf7b";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ qt5.qtbase ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ plansys2-msgs plansys2-problem-expert qt-gui-cpp rclcpp rclcpp-lifecycle rqt-gui rqt-gui-cpp ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/galactic/rcl-action/default.nix
+++ b/distros/galactic/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rcl-action";
-  version = "3.1.2-r1";
+  version = "3.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl_action/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "e4dbd622bdcf9b6e8626b55f232134b8433034f380cb3bfa7d9ea794cd0c7dbb";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl_action/3.1.3-1.tar.gz";
+    name = "3.1.3-1.tar.gz";
+    sha256 = "fb05cc34f5f08601d0a6ab1b8db5b12573c011468f686f73ae56ffaec6cd2839";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcl-lifecycle/default.nix
+++ b/distros/galactic/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-galactic-rcl-lifecycle";
-  version = "3.1.2-r1";
+  version = "3.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl_lifecycle/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "35842262797f8dc1ea327f75416517fd408b5def01668c8604d8f25b0835bedb";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl_lifecycle/3.1.3-1.tar.gz";
+    name = "3.1.3-1.tar.gz";
+    sha256 = "f6ca48cdefc3c7dbd36fbae5002b627ad64feada2eb90fe4c9a30aeb95af3b2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcl-logging-interface/default.nix
+++ b/distros/galactic/rcl-logging-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-rcl-logging-interface";
-  version = "2.1.2-r2";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_interface/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "48db0998236757694d5e6672486d880f04e97f823ce64adae38d8ba89497636a";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_interface/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "bf5cae9873a7eab2261a331102da5f8e25137e0deb15f14038a3a11550de903f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcl-logging-log4cxx/default.nix
+++ b/distros/galactic/rcl-logging-log4cxx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, log4cxx, python3Packages, rcl-logging-interface, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-rcl-logging-log4cxx";
-  version = "2.1.2-r2";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_log4cxx/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "ccd2ee876612f52a78778b60c337b4adcc05b462099fc7b05632ec69244f7a48";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_log4cxx/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "4b7cb48398670396eb3209addcd6b9a813e8fa75b1ae226f29e9a4c710c2c9b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcl-logging-noop/default.nix
+++ b/distros/galactic/rcl-logging-noop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, python3Packages, rcl-logging-interface, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-rcl-logging-noop";
-  version = "2.1.2-r2";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_noop/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "e2a78caa697f4378627d6f0a20bd60f143612dfe9cb5b8f05da0addb22c3334d";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_noop/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "41188eb1936d4158945bb6267a921ac729df1055c541dacda02a946f6795c21a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcl-logging-spdlog/default.nix
+++ b/distros/galactic/rcl-logging-spdlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcl-logging-interface, rcpputils, rcutils, spdlog, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rcl-logging-spdlog";
-  version = "2.1.2-r2";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_spdlog/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "5f8026a3d694c95bcd1caa98311fdf9212f3875b9547366f951f90258803e255";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/galactic/rcl_logging_spdlog/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "cdf4e078cac5649228f252a0a9d85a839c6f05be7573f04bd721da5d7b31d3d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcl-yaml-param-parser/default.nix
+++ b/distros/galactic/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-galactic-rcl-yaml-param-parser";
-  version = "3.1.2-r1";
+  version = "3.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl_yaml_param_parser/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "978c8c57a22ec88e019204846a52cc8674b8a9d4f7645c85f729a0b48103982d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl_yaml_param_parser/3.1.3-1.tar.gz";
+    name = "3.1.3-1.tar.gz";
+    sha256 = "81014877868e1e097118fc76e6f9c3beb2c6910bb5ec95c82ad8ec26d106ba29";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcl/default.nix
+++ b/distros/galactic/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-galactic-rcl";
-  version = "3.1.2-r1";
+  version = "3.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "e5e5acad6b5a7796a7137e0679b6e11fd86dbf22477f457d2057032993257e88";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/galactic/rcl/3.1.3-1.tar.gz";
+    name = "3.1.3-1.tar.gz";
+    sha256 = "61e245f91a5d292d1e0e2c7f3202a21cdfbbf41682220dabf6f405c8fa0036f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclcpp-action/default.nix
+++ b/distros/galactic/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclcpp-action";
-  version = "9.2.0-r1";
+  version = "9.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp_action/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "7802b7f78f33c851565ef54fe3ca5e2e7201233c0227bc0047a42f9c54ecf0f4";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp_action/9.2.1-1.tar.gz";
+    name = "9.2.1-1.tar.gz";
+    sha256 = "836e1df9ba9899a6ae7cbe0841aa6721279b61cd0b439ebda79528daff666139";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclcpp-components/default.nix
+++ b/distros/galactic/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclcpp-components";
-  version = "9.2.0-r1";
+  version = "9.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp_components/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "6e32912e532d91e1f7a338850114c45dd2c0d6c2450bdda2f6aa79b489752f79";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp_components/9.2.1-1.tar.gz";
+    name = "9.2.1-1.tar.gz";
+    sha256 = "03f71d1524155aa00d937fbdb891edf86ec397340222281023bea9b9805b88d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclcpp-lifecycle/default.nix
+++ b/distros/galactic/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclcpp-lifecycle";
-  version = "9.2.0-r1";
+  version = "9.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp_lifecycle/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "75f233e48292bc0c0bf66d174d6e6e0e1982ac45aaf6ec5996bf8166d36268fc";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp_lifecycle/9.2.1-1.tar.gz";
+    name = "9.2.1-1.tar.gz";
+    sha256 = "9d44cdda3d6977744cb050688211067064bcc2c526c09523c64d583da10cd143";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclcpp/default.nix
+++ b/distros/galactic/rclcpp/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-galactic-rclcpp";
-  version = "9.2.0-r1";
+  version = "9.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "c916b3f55199afaa9797407a0053e98b40f308551d3f98ef2d15c26d5ea57b0c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/galactic/rclcpp/9.2.1-1.tar.gz";
+    name = "9.2.1-1.tar.gz";
+    sha256 = "7c13262b75499606c78a409d9e247d04236e8b7eea2847291c5bbedacf78a808";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor performance-test-fixture rmw rmw-implementation-cmake rosidl-default-generators test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-google-benchmark ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor performance-test-fixture rmw rmw-implementation-cmake rosidl-default-generators test-msgs ];
   propagatedBuildInputs = [ ament-index-cpp builtin-interfaces libstatistics-collector rcl rcl-interfaces rcl-yaml-param-parser rcpputils rcutils rmw rosgraph-msgs rosidl-runtime-cpp rosidl-typesupport-c rosidl-typesupport-cpp statistics-msgs tracetools ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/galactic/rclpy/default.nix
+++ b/distros/galactic/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclpy";
-  version = "1.9.0-r1";
+  version = "1.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/galactic/rclpy/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "6a14b4972bbb03902829fe53292f502a0d44651b73b63772b58e6b9d46d528e7";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/galactic/rclpy/1.9.1-1.tar.gz";
+    name = "1.9.1-1.tar.gz";
+    sha256 = "6c082fe63e3008052ab0fd0c23d8b2f5d4b956d9c584e9ee03e81505f188aa96";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcss3d-agent-basic/default.nix
+++ b/distros/galactic/rcss3d-agent-basic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp-components, rcss3d-agent }:
 buildRosPackage {
   pname = "ros-galactic-rcss3d-agent-basic";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-sports/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_basic/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "325f1353ff8c2f177dd41111e0c9369a0a06c0f2625eb0d3dc5c395ee832b109";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_basic/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "a5dcd6c8b2a9dd072052b173667763ca94f77dfadb267a4b543035874738e83f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcss3d-agent-msgs/default.nix
+++ b/distros/galactic/rcss3d-agent-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rcss3d-agent-msgs";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-sports/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_msgs/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "1524e1d1dda07451f2a9863c6388fb685c40e43848c2de870e34f5185c8dcfb3";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_msgs/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "bf91d94050580c1b32436912a1a42e7fbdebea46ffaee0f159fde3ea3f8a8034";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcss3d-agent/default.nix
+++ b/distros/galactic/rcss3d-agent/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcss3d-agent-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rcss3d-agent";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-sports/rcss3d_agent-release/archive/release/galactic/rcss3d_agent/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "aa978f222139cb2c0ea56ef626131ae5167f0dec8e1f18643a240b03c1ad38d4";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "2e259621ca9bed24e18deba8f487803d52048ace76d469e848e355a5286ec0fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-connextdds-common/default.nix
+++ b/distros/galactic/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module }:
 buildRosPackage {
   pname = "ros-galactic-rmw-connextdds-common";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/galactic/rmw_connextdds_common/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "2de236bb2c1d6305cc9dc02177f04e1cd0bef5383e13013473a066f1932d99dc";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/galactic/rmw_connextdds_common/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "86f220bf31380d861fbb672d47234cae4bdd438c1bcbb085789fdd187270f448";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-connextdds/default.nix
+++ b/distros/galactic/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-galactic-rmw-connextdds";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/galactic/rmw_connextdds/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "3ce418e7df5ef547fe7e86007458a37d7742a141c496f79ecc1c408f1cabba83";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/galactic/rmw_connextdds/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "554094b3dc648f0fc24cc69ff3c8a6814623bcf822f0c109028b7024d9c3d6d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-cyclonedds-cpp/default.nix
+++ b/distros/galactic/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rmw-cyclonedds-cpp";
-  version = "0.22.4-r1";
+  version = "0.22.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.4-1.tar.gz";
-    name = "0.22.4-1.tar.gz";
-    sha256 = "f86f6503f2b9cb5bac39e1582afd46867521eef1ca9266f4944922ba69c8d207";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.5-1.tar.gz";
+    name = "0.22.5-1.tar.gz";
+    sha256 = "9eaf76c4a7d0dc66f55f79b8c2d32e3bc2e8bb30dd188862a89dd60c9b23223e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-fastrtps-cpp/default.nix
+++ b/distros/galactic/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmw-fastrtps-cpp";
-  version = "5.0.1-r1";
+  version = "5.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_cpp/5.0.1-1.tar.gz";
-    name = "5.0.1-1.tar.gz";
-    sha256 = "422dfa6e90794bd8952ca91b28c2e57759d5e29628dea140da49dd9ad1a701fd";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_cpp/5.0.2-1.tar.gz";
+    name = "5.0.2-1.tar.gz";
+    sha256 = "7c1ef4fb2065046853c0e7c7137687702ffa42668e9ede0732b7fb0fcb9e3db9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/galactic/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmw-fastrtps-dynamic-cpp";
-  version = "5.0.1-r1";
+  version = "5.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_dynamic_cpp/5.0.1-1.tar.gz";
-    name = "5.0.1-1.tar.gz";
-    sha256 = "2888703340830792e8b97ae224677621da6f0fe0809cff4cd66d44ccedb7b9c1";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_dynamic_cpp/5.0.2-1.tar.gz";
+    name = "5.0.2-1.tar.gz";
+    sha256 = "5058daf1d884a77e569b17be3777c09d934f541c1a456378e8d581bbe5b2136b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/galactic/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-galactic-rmw-fastrtps-shared-cpp";
-  version = "5.0.1-r1";
+  version = "5.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_shared_cpp/5.0.1-1.tar.gz";
-    name = "5.0.1-1.tar.gz";
-    sha256 = "02b406c5db05b6817f29e540a159dc6284b8bdbe1a507b2cd418e624038a67d7";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_shared_cpp/5.0.2-1.tar.gz";
+    name = "5.0.2-1.tar.gz";
+    sha256 = "12d2040394528d815d9e99a50b9ca48618a24a860585edea804c9cc786fd35d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/robot-upstart/default.nix
+++ b/distros/galactic/robot-upstart/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-robot-upstart";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/galactic/robot_upstart/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "da6d007b9110ea957e9fd9c6b698e494429d47b17c9176b8d433ebb0cf5c4b6f";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/galactic/robot_upstart/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "23415f06e9d88ad1af93bce698c639efb24850d1f528528e4fe4da4b32ecbe9d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control-test-assets";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "fe146bb001f59c8bf9f00d0020476e734a302a0553712c9d033768e3ec96d42e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "74abf7c1ddd5c8f285e67f223c2aea2104a4597c5ce4ec5d78512bb021045a4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "103a4ef57243483d76b6441e06b411563e716dcba599db96f2af5295fec95487";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "5177b0f2eeb9b57302244b65464120ca7af4607a996e35a7a55065efeba696fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2action/default.nix
+++ b/distros/galactic/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2action";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2action/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "256a5966ebdc8ebd11e5e5c3cbf597a7107d3cd5b1d059360cf59f38c437927d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2action/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "ba9acd16b9e2d7492b12c188b3c64d6833cb6088c6e1ec693b3892fc7562a87f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2cli-test-interfaces/default.nix
+++ b/distros/galactic/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-ros2cli-test-interfaces";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli_test_interfaces/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "7884490aab83c6a607b8e04484af2b50dfdc63771d70e10088665b7eb33a7561";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli_test_interfaces/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "ffd03eae7479c064e390b372d3d5cf5dc7b37c8fb155a003c5828a7176bcb191";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2cli/default.nix
+++ b/distros/galactic/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2cli";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "2fe95eb99d64dd3dee6fa7a0fb90f9ee055d564e746d3adfff33608b457b21d5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "9b194da471ef59ac71d2631058be3958b8ae61c6fa28341ad1144feac776052b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2component/default.nix
+++ b/distros/galactic/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-galactic-ros2component";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2component/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "38dfe58c0db061119d6e098b9167004360f19b8707a48f2fb3512c003fff85a6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2component/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "602d902973709fcfc58b23252b50f0228d200a3af3738177c181ab20ef19fa0f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-galactic-ros2controlcli";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "422603a6a081026518aa8725626b81d2b8d424ac6d5bdfc4c3caf152585c5bce";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "100ce7e8b6122f2e31f0e251a356c2e20dbe48aa0327a6fffd04e19537b6931c";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2interface/default.nix
+++ b/distros/galactic/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros-testing, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2interface";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2interface/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "aee58ae4744008b4540b7ee7fc2782403976f8302a16fe618f4f3b03ac57bdf4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2interface/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "d4de78b85d60c2dd13cf7002d69e876c702ab8b706d6d9c65006d360627ec02f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2launch/default.nix
+++ b/distros/galactic/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-galactic-ros2launch";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/galactic/ros2launch/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "e714d60ca9cbce9dedc8832c3295fcd4448a240b3b8ed6e37558eef450118fc3";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/galactic/ros2launch/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "ca7c7c0ed75cff1cd0eb42b7a7acdef66a25c2f5d47c37d77d4ddc8fd686412a";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/galactic/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-ros2lifecycle-test-fixtures";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle_test_fixtures/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "c48f5c453519bd7702b640461b1476cda7699ae04e68cbe097db77153ead5468";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle_test_fixtures/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "c99fc0db9b4de89d150b6276e99904cdcb65fed8adb1f3c2106311b60432005f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2lifecycle/default.nix
+++ b/distros/galactic/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle-msgs, pythonPackages, rclpy, ros-testing, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-galactic-ros2lifecycle";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "39cc87ecdbfe474776286855a1a82b89586a48854c8cc260be7446f8f0a7ffd7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "5dfc438f0d70cbdf5df2535d24b2ee5aa2c010fc7fb6519490283c462f3257c7";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2multicast/default.nix
+++ b/distros/galactic/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-galactic-ros2multicast";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2multicast/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "324fdcc4fdf8abe5ce0d9d649fbcf2179a4c2d36422237bd0d6a7eaac78c580b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2multicast/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "2154f171ddd909dc361d9860ca2a009a5538f1a5cbc2537380e69d3450a92bd3";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2node/default.nix
+++ b/distros/galactic/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2node";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2node/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "9f2f14aefd28ff3274645c3115b63de02940ad611607cbb4a39dae62363d5e16";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2node/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "e784f7c443be0c373f760f02006ab2d4f3a4b8429bc7ae7b6540873130191610";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2param/default.nix
+++ b/distros/galactic/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-galactic-ros2param";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2param/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "49b84c176557340cb446c256bf30aba7352df3256b3c07f39463e9f1e4d9972c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2param/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "a9b3cf5e594f88f3af4d3d09b6769d6ec8465ec12a29f5898bd24f7a8d29f159";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2pkg/default.nix
+++ b/distros/galactic/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros-testing, ros2cli }:
 buildRosPackage {
   pname = "ros-galactic-ros2pkg";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2pkg/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "b421c730272bfeaeb42a06164744d9b685323a8168bc7f773f7a87028fe40859";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2pkg/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "68908331986148ef75968caf4b55bf8f8259f33b84aa53c75409dfbf73f44c8f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2run/default.nix
+++ b/distros/galactic/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-galactic-ros2run";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2run/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "c41e97892532ce8d8cb0fdea92b950b982542c7f5f4ea7ed79eadedb60d102ab";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2run/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "bccb2118c796f36843a8f87e379a495be2ac486fcfb011fb50dd651b5b23bcc4";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2service/default.nix
+++ b/distros/galactic/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2service";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2service/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "151c2cfae0255b630b7ff2366e7e52ed7fc0849f8964191b58f0513662ed38b4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2service/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "8979ec818370497074d500e4e69dec71d09bb580374e8e35774c34491f4ef108";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2topic/default.nix
+++ b/distros/galactic/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2topic";
-  version = "0.13.2-r1";
+  version = "0.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2topic/0.13.2-1.tar.gz";
-    name = "0.13.2-1.tar.gz";
-    sha256 = "74574491d9de0573b48dc0c8e686b20bc50d7a89062ad88cfd375fb97121b33a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2topic/0.13.3-1.tar.gz";
+    name = "0.13.3-1.tar.gz";
+    sha256 = "20966ec44a899c06fd29c2331249374b12527d31e35f542aa41582a9f0ae048f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rosbag2-storage-mcap/default.nix
+++ b/distros/galactic/rosbag2-storage-mcap/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, python3Packages, rcutils, ros-environment, rosbag2-storage }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-storage-mcap";
-  version = "0.1.1-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "add936e76c297124bdc1dab1f588ecc16c0d5ae3c6eb95083afc9e221faabe5f";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "dd309854f8f0e0581b028e8e1cf52c28c6fe9369c663a2ffd386e659a48884ab";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp pluginlib rcutils ros-environment rosbag2-storage ];
-  nativeBuildInputs = [ ament-cmake python3Packages.pip ];
+  propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rosbag2 storage plugin using the MCAP file format'';

--- a/distros/galactic/rosidl-adapter/default.nix
+++ b/distros/galactic/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-adapter";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_adapter/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "2d866590706b67064b4241b50d71d4d81694608738967648f7c72e9d8d428bf6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_adapter/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "055ab655b3438630b934345e75e43c92b819df74b98a067ff850d1d9d5faee9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-cli/default.nix
+++ b/distros/galactic/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-cli";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_cli/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "594496523a8b30380e1757f666682b02a063cb6998aef7ab13a35cc1a6395f0d";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_cli/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "a87336fbf05e74e755d8f1ea81cc2d15df75c51622325ea91cab8009ce5cf9e8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rosidl-cmake/default.nix
+++ b/distros/galactic/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter, rosidl-parser }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-cmake";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_cmake/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "89bc62102d4d4e3059b1b5f5b1a85ad9eb3f8a6d521fa4bf013bd41e1c35bf42";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_cmake/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "a52b303eb5e2a0843b9649fe448403a4952b7e5035edb9d7674e1567429c10c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-generator-c/default.nix
+++ b/distros/galactic/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-interface, test-interface-files }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-generator-c";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_generator_c/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "5dad322027dc8d72b4a9af9201924d29c3c6079460c93830c16c0874adc8d69c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_generator_c/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "8664abdd780cedb263b3114e27db067255bd3c0fde192fdeea3682756c611aae";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-generator-cpp/default.nix
+++ b/distros/galactic/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, test-interface-files }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-generator-cpp";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_generator_cpp/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "d4e59dfb7cee9fcb7399986bc4208a4cad716006c8db22d53dd8ce943779dede";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_generator_cpp/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "577afd82e383fe38e324735475b0d022990b1b2e892f664e30cc0c18d5d44d1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-generator-py/default.nix
+++ b/distros/galactic/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-generator-py";
-  version = "0.11.1-r1";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "ae389bf4aad1ffb74dc5098935fb56f26051ce4c8ca7115e620f896142e1c94c";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "8b1b68d2a58b68e4501069eb05b81136d21feb632a3d60ad952b4743c6c1411a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-parser/default.nix
+++ b/distros/galactic/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-parser";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_parser/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "1de7b1705b510bc98c59a2b6b2e7843933df2a0af6dd2b1a1a2a1cb083c3fd0f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_parser/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "2f70eb5eae2f8da1e5d8fd9795eb68e86f8bf4f9b20c5d0db177cf6f60ef4b2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-runtime-c/default.nix
+++ b/distros/galactic/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-runtime-c";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_runtime_c/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "9586b262cfbaba9c558b97f8faeaf473f530fc343a140c3541c35e10bed70422";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_runtime_c/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "5359235333c69e31e10c4553c5121673fc6a62a5e9a90a8b74b7957ff408b149";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-runtime-cpp/default.nix
+++ b/distros/galactic/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-runtime-cpp";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_runtime_cpp/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "24b8e6a83b3934e03355c1e422528434b12820d055ad4d00fb162885bee68a44";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_runtime_cpp/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "af1d99afa31ba15b85f438a4a6123582a89bc49097e1ca291ea8f4ba4f1f3e9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-typesupport-interface/default.nix
+++ b/distros/galactic/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-typesupport-interface";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_typesupport_interface/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "81e4354d9240b3d1351bd0728ee42fe452519d506a507d89070dde8eef2df142";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_typesupport_interface/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "d8aa86e04fb187562bc3ff4684c30b3a9b4165b661f7350cc7c884d02b8c355e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/galactic/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-typesupport-introspection-c";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_typesupport_introspection_c/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "a04fb45ba5ffcfa08279db6261bec16d51c8464a3e61a1c8fcd1b752135565e0";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_typesupport_introspection_c/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "c766c2bbe88ba1ef6f0573b28d5867764e70185f1591f34100b0159bae1c2cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/galactic/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-typesupport-introspection-cpp";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_typesupport_introspection_cpp/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "43bc1a74fdeb1cf6c77500b543a5d28549b50e40fce40648009c9102c6e0bfdf";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_typesupport_introspection_cpp/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "c0ef2dc9de13fe41d0b202dd60ae579661ec122d33a56a53d03d0ecb715e7c62";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rti-connext-dds-cmake-module/default.nix
+++ b/distros/galactic/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-galactic-rti-connext-dds-cmake-module";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/galactic/rti_connext_dds_cmake_module/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "42a57326c1aa23a3ee53886c528347c68af1612970b0cb11e10807bfa5c9a975";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/galactic/rti_connext_dds_cmake_module/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "a6bcc95b271c577be51d2649e4ca5d7b71eaf625871bdadccee2beb9fdaee11a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-assimp-vendor/default.nix
+++ b/distros/galactic/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-galactic-rviz-assimp-vendor";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_assimp_vendor/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "5036ac1fb289dbc21df026c39bd14c67d5650f69465ce1c90d4c0b5a48a0d01c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_assimp_vendor/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "c0cc6629fde03f4fdc854927c21cdbdd87a5d6dabe26d052a3a173c9f54e7876";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-common/default.nix
+++ b/distros/galactic/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rviz-common";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_common/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "6acbeb1c7d6b1c374312ad901f76759ee442bdad608c73ad8c8e375f37a56587";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_common/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "731e706c2c64d7bd6f53fefd0d8dd7b84b210c51116a027c52b8893d4fc10ecd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-default-plugins/default.nix
+++ b/distros/galactic/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rviz-default-plugins";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_default_plugins/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "714e4bde7fa34ff30f3186e5ba397bf3799edb67c74849ba01e1510264fbd8b5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_default_plugins/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "e1a1e87b7c984b8c8245b71c301d1452e834eea96cbcd7758f351edc50eb862e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-imu-plugin/default.nix
+++ b/distros/galactic/rviz-imu-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, message-filters, pluginlib, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering, sensor-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-rviz-imu-plugin";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/rviz_imu_plugin/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f87d865af4ff5d444bd53f2c8ec6cfdb95c52a8eb47f2202ea2ffb7e08f8f384";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ message-filters pluginlib qt5.qtbase rclcpp rviz-common rviz-ogre-vendor rviz-rendering sensor-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RVIZ plugin for IMU visualization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rviz-ogre-vendor/default.nix
+++ b/distros/galactic/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-galactic-rviz-ogre-vendor";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_ogre_vendor/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "eedeed0285eb9331c568f33935c1c1751bba1bf6411e16b433e5ae71a99836ec";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_ogre_vendor/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "67e45490338df5b421c3e9d04706cdc21f7a4f6ed0864c88f7fe4156400579fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-rendering-tests/default.nix
+++ b/distros/galactic/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-galactic-rviz-rendering-tests";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_rendering_tests/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "60ccbe310e03cd605e831adc51886d784693df2aa8ebf398aad14ee817a88f7b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_rendering_tests/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "dda98747b911ebd2519bdfa4254ab6892d21441023173a7c0ff7d98176102837";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-rendering/default.nix
+++ b/distros/galactic/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rviz-rendering";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_rendering/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "a38656ea85e9c6126100f546681ec1f1263bdcc85565c235e569504345fb31f3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_rendering/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "d8b12eb8cf07ab9e0d00719eb4ad22d603cfad914053362c376177a19aa58268";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-visual-testing-framework/default.nix
+++ b/distros/galactic/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-galactic-rviz-visual-testing-framework";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_visual_testing_framework/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "1f51cb523c19bf4b273d649a9c97161643c02e751d87084b34158aa037db7abb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz_visual_testing_framework/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "a7f39d5402b83fde3a3e1fedd838a31ff2361c2dfbe1ec265b99a05a508dfc91";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz2/default.nix
+++ b/distros/galactic/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rviz2";
-  version = "8.5.0-r3";
+  version = "8.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz2/8.5.0-3.tar.gz";
-    name = "8.5.0-3.tar.gz";
-    sha256 = "9dd77b2ce990c6c7ecc82b6c61290b1d4b5514e69c884777d771cea1182ad397";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/galactic/rviz2/8.5.1-1.tar.gz";
+    name = "8.5.1-1.tar.gz";
+    sha256 = "2cc97d9ac50bd7e195e0baa3c6c381fa5118f6b2008ee001e98497d3fea290b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/septentrio-gnss-driver/default.nix
+++ b/distros/galactic/septentrio-gnss-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-septentrio-gnss-driver";
+  version = "1.2.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/galactic/septentrio_gnss_driver/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "65f0b63d04201e9d9d7c42a791362099122c4c097d025b25102256ab672040e4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ boost diagnostic-msgs geographiclib geometry-msgs gps-msgs libpcap nav-msgs nmea-msgs rclcpp rclcpp-components rosidl-default-runtime sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROSaic: C++ driver for Septentrio's mosaic receivers and beyond'';
+    license = with lib.licenses; [ "BSD-3-Clause-License" ];
+  };
+}

--- a/distros/galactic/simple-launch/default.nix
+++ b/distros/galactic/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-galactic-simple-launch";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/galactic/simple_launch/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "e27bd988f504871bbfddc8c802b77045eb14a23b6e6621de22f8306b09a32c10";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/galactic/simple_launch/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "32f00772530a8edb683687837ca469ddc6dd2b738c6704e2eba49c85124efc0b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/slider-publisher/default.nix
+++ b/distros/galactic/slider-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-galactic-slider-publisher";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/galactic/slider_publisher/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "525137f72228fdee500deeef844d9271be4c543c5442fd7e5107d3d67143ca20";
+    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/galactic/slider_publisher/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "422dac2ae3a2d53b0314e99bf19996c72e7e1f6733dcfa4c87b894407a3a1b38";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/swri-console-util/default.nix
+++ b/distros/galactic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-swri-console-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_console_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "403c7597167446b0862e39f49f58c7aae3107c71851007ca5466127fc51c24c6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_console_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "18b6029c9fae6e54e112049243b768ce7d3419c7887287eeb19fdde00a791357";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-dbw-interface/default.nix
+++ b/distros/galactic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-swri-dbw-interface";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_dbw_interface/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "196c6d5122cb565883af349fe76adca71e0dceb86e32bd408a9c703156fc5c94";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_dbw_interface/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "f682404f333dbb618ba90cbd8f3171d3607e086155e6981c8fc89e2937219457";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-geometry-util/default.nix
+++ b/distros/galactic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-swri-geometry-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_geometry_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "e6a177c737ddc547556e046586c8030fe1d89c9daaa32ae169e5cc1406c3e687";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_geometry_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "c57914b8333ee11726c1e52938e4c394830aed2f635a4d74077ca81912041ac3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-image-util/default.nix
+++ b/distros/galactic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-swri-image-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_image_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "37d8abbc5d824315ebbb7e99135e6cbd6a39a37f267dc7895b0f6f95352a8019";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_image_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "db3f839a52e81a267f0d6dfebed5f03685a848298dc375102b6f8d76ef51d66b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-math-util/default.nix
+++ b/distros/galactic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-swri-math-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_math_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "1c5ee1d7c512420387f83f82ec6af7ec68e18de150deee485fa947e62847925a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_math_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "2288c87b8e22144c57bebef53c9b34a78ce091366d10cad62bca68b0fa240145";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-opencv-util/default.nix
+++ b/distros/galactic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-galactic-swri-opencv-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_opencv_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "4b29bdf2923b95b6992e4848abd37e847076bafd2508fce6128aacbef904c0f3";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_opencv_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "03f0037a97a720c39e9843c8ac52a89e7aa36226b3e8a9c799788e3ef102b7cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-prefix-tools/default.nix
+++ b/distros/galactic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-swri-prefix-tools";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_prefix_tools/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "644c15a3b4a6aa473f59770c1e740237df074b5cc67f012d3c785553b7ae58f6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_prefix_tools/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "0cf820b4e5bce0239a5cfe0f7b785289ecd1eab3fc072682a7cf2c40f21e23aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-roscpp/default.nix
+++ b/distros/galactic/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-swri-roscpp";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_roscpp/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "b7b754aad7a4de40147df74e47ab5225117c692648c055728baf8152686aa605";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_roscpp/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "ba144b703e83c15259f2678924b47a9ee1d405af934dfa2a0c567ac74ba83ae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-route-util/default.nix
+++ b/distros/galactic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-swri-route-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_route_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "5a590f468faded6cbcfb8e089b31e842e04a5ccf875d51d38d65e812531c70fe";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_route_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "eeffd4e7b29f26aa608a5359d831533c16c6bd9040cd30af5ffa80e7a01e3bce";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-serial-util/default.nix
+++ b/distros/galactic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-galactic-swri-serial-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_serial_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "4bc907f422665d03b8a9b99e0833f97019726d79e1824115ffd427746f5f48aa";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_serial_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "ff31c383859f027252ee34826f321db785ff4c2a451631c6d306c5eb0c0ad61b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-system-util/default.nix
+++ b/distros/galactic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-swri-system-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_system_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "6cc3dba9637825817e35ca7515eb407ba70d9d9f8579f2f7557a046b37e3093d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_system_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "3ab5d9d0e5b375f0db3ec0c0278d1e8546a175b9ff741889298bf68e3ed2595e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/swri-transform-util/default.nix
+++ b/distros/galactic/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-swri-transform-util";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_transform_util/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "7d98f6a960869476f2e7fc0f3e3736e6884208fbd00c00a7104510c44e572fb0";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/galactic/swri_transform_util/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "cf562697a64fa9b294f0cd211e625ad29e97398a81e964225e9a860ca40ffdd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tango-icons-vendor/default.nix
+++ b/distros/galactic/tango-icons-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-galactic-tango-icons-vendor";
-  version = "0.1.0-r3";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/galactic/tango_icons_vendor/0.1.0-3.tar.gz";
-    name = "0.1.0-3.tar.gz";
-    sha256 = "661aac9d0a3d032cda959eecfaa71c03a100c212d27f09d5f6f2ac53dfd03480";
+    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/galactic/tango_icons_vendor/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "e55e99c0c1d66102074064f2a41bf432ee579f096c463f5afd671bc4dddc24e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-bullet/default.nix
+++ b/distros/galactic/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-tf2-bullet";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_bullet/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "24f6e8adf5a31008de226fbb6a505a432f1f817cec0d3988a938ae6639accc43";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_bullet/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "e2ddfdb3a018d10f118f1ea2df029903c3fa072e31e93ac038528148242862c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-eigen-kdl/default.nix
+++ b/distros/galactic/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, orocos-kdl, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-tf2-eigen-kdl";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen_kdl/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "153866e62c46b7b63c3d780e3a9ce210985c91ffa820cc269dfc2750623b892c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen_kdl/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "18c4088c08d200e718750f3dc94cf30425037466a9fa7dae4e530906cd554c49";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-eigen/default.nix
+++ b/distros/galactic/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-tf2-eigen";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "3aafa8eece29e1db5d08de0891b8ab7c08ee28be3d89756909f7778fb62725dc";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "22ba59d9a6550f7ecc55f116c9aeec256d15375640108bee809a416b1a9edc52";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-geometry-msgs/default.nix
+++ b/distros/galactic/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-geometry-msgs";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_geometry_msgs/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "a6edf35a3a2240d4d9237efcd03d5cad8c4b76b25168754940db2d26936d7f60";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_geometry_msgs/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "b4560d72ea88f1c87aadb879162a76faedda7333a975c0cc41e904adc34062d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-kdl/default.nix
+++ b/distros/galactic/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-kdl";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_kdl/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "61240279b98c997e0663e80612ebba48818160da374de38690fb67f6539abc6c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_kdl/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "3c3cc075bbcfdb2feffa29a356f2e4a0e06060d87e17b34998695dc5a3ff23a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-msgs/default.nix
+++ b/distros/galactic/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-tf2-msgs";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_msgs/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "92c2814f3cfc8fdc4b8659b7ed564b6239364c08207a6209168ca8e121565be2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_msgs/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "c1fa046fa8f20189db4ec35f979a80d087e7ed205160f3974665c59397a9bf92";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-py/default.nix
+++ b/distros/galactic/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-tf2-py";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_py/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "22ab22a3a92c27ffe3e87f3bf8838ac0684fcae93321e37d130186d5348caba7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_py/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "482b9c9e80afa7a6a1689f8e68a8cbcd4f03b60c0c660e1b4e6801c3f2a16582";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-ros-py/default.nix
+++ b/distros/galactic/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-ros-py";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros_py/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "772d9b9eadb6b28dbab213f4f6c1b338868460c0de3a5216dcec5266e7beb3bb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros_py/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "dd22835487b8605c373a42fc0b8025519ae76776d153876e7b6b4c3ca83f1ab8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/tf2-ros/default.nix
+++ b/distros/galactic/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-tf2-ros";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "6f47bdb0e80108bd75f4932f32f1215287db25af5f6f6ad91137c373d2d6c73b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "35f8a3fdae5237ba01cf75cd730cc230fc755b235ff7d8ac31b12a641e13e286";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-sensor-msgs/default.nix
+++ b/distros/galactic/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-sensor-msgs";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_sensor_msgs/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "80aabbf0502c146cc7f0f24aecf76e68c702777e09d18f853a392501a21ccc5b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_sensor_msgs/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "6665b2e496fffca583eacf90491a587162f74b80771971133bc6ca67bd551569";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-tools/default.nix
+++ b/distros/galactic/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-tools";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_tools/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "596cf6a8b91252fcf7505446a1a8c4177aec2047d576c49f1b7574ff915005c5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_tools/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "a645e7ae59bd5a6b6a97a3cf14dfdb685a2a708e15b55e913ac7d4292549b1d2";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/tf2/default.nix
+++ b/distros/galactic/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, geometry-msgs, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-tf2";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "aab05abae43e5c87e8fbf8fbd961cc57a935c20cb99d6cd5b52f7c77440f6a25";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "e73f8c6868e104d8805a20e09dc7bc5db891130fe3ffb5745758e9e237478a35";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-galactic-transmission-interface";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2e8da6385659ea712ca0cfcbecc44dd54afb0c79d513070722f3c9f1882ad757";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "67a0f8b0b5b864dabbad7698832afaa5e99d45af475a9ce490ef1b6dcb26d26b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-description/default.nix
+++ b/distros/galactic/turtlebot4-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-description, robot-state-publisher, urdf }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-description";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_description/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6f9fb98d371d784f3ff06385bf82dd1b2c69f64aa974658ead54a1f6ad0df63f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ irobot-create-description robot-state-publisher urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Turtlebot4 Description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-desktop/default.nix
+++ b/distros/galactic/turtlebot4-desktop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-viz }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-desktop";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_desktop-release/archive/release/galactic/turtlebot4_desktop/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "790fa5f098fac9803706187bc0a5f83907e5ec4e9e917a5966f999f90755feb0";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ turtlebot4-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Turtlebot4 Desktop Metapackage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-ignition-bringup/default.nix
+++ b/distros/galactic/turtlebot4-ignition-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-toolbox, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs, turtlebot4-description, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-ignition-bringup";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_bringup/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "19411e65888d4cebcb686a5fcb226160dd934f6315cdb22f6268f82c03fe35c7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-bringup irobot-create-ignition-toolbox irobot-create-msgs irobot-create-toolbox ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs turtlebot4-description turtlebot4-ignition-gui-plugins turtlebot4-ignition-toolbox turtlebot4-msgs turtlebot4-navigation turtlebot4-node turtlebot4-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TODO: Package description'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-ignition-toolbox/default.nix
+++ b/distros/galactic/turtlebot4-ignition-toolbox/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, turtlebot4-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-ignition-toolbox";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_toolbox/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "9eaabd5c035e658c8b9e81288d2e4f079d1a7b675391a27963d5a96036a371b6";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-action rcutils ros-ign-interfaces sensor-msgs std-msgs turtlebot4-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Turtlebot4 Ignition Toolbox'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-msgs/default.nix
+++ b/distros/galactic/turtlebot4-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "1c3b89649c5251aab468fc6bcc71b6914cf1290f91b7e1644b938ef93cbfdfd8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Turtlebot4 Messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-navigation/default.nix
+++ b/distros/galactic/turtlebot4-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav2-bringup, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-navigation";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_navigation/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "173e72b8c0b910c817c14632186ebaa04658b5d15981ae2f8819f6a28c5328dc";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ nav2-bringup slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Turtlebot4 Navigation'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-node/default.nix
+++ b/distros/galactic/turtlebot4-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, turtlebot4-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-node";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_node/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "cf5dff74cf226318ca2f7dfa60d081212d2a3479c70b1903e80d59d0c3b06bef";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ irobot-create-msgs rclcpp rclcpp-action rcutils sensor-msgs std-msgs turtlebot4-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Turtlebot4 Node'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-simulator/default.nix
+++ b/distros/galactic/turtlebot4-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-ignition-bringup, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-simulator";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_simulator/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "11de2a7c9481102234c252e0166551791c2bf8d2dd0cee1abf9714b4dc99c044";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ turtlebot4-ignition-bringup turtlebot4-ignition-gui-plugins turtlebot4-ignition-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TODO: Package description'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-viz/default.nix
+++ b/distros/galactic/turtlebot4-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rqt-robot-monitor, rviz2, turtlebot4-description }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-viz";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_desktop-release/archive/release/galactic/turtlebot4_viz/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "bd78e70e6c1b972c95d5d58c9d71f59b1030edde17e17602802fe420ab057baa";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rqt-robot-monitor rviz2 turtlebot4-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Visualization launchers and helpers for Turtlebot4'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlesim/default.nix
+++ b/distros/galactic/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, geometry-msgs, qt5, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-turtlesim";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/galactic/turtlesim/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "e1bab0d23b65b3cc1d88a5d5889120c83dd2636683f0df8245df61a359d11d50";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/galactic/turtlesim/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "3ef3ffd2d5fc8eadf843c3e20db101220abed41e6636eb84533f89bea8f793ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ur-bringup/default.nix
+++ b/distros/galactic/ur-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-publisher, launch, launch-ros, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-description, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-ur-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_bringup/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "39b3ff22e060157bcbeb461225e29c7bd58156cf59c5f105b72a0b579b06faa1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-manager force-torque-sensor-broadcaster joint-state-publisher launch launch-ros rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 ur-description urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Launch file and run-time configurations, e.g. controllers.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/galactic/ur-calibration/default.nix
+++ b/distros/galactic/ur-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
+buildRosPackage {
+  pname = "ros-galactic-ur-calibration";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_calibration/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "27dc3c645a534068c1adaaa0aec805863dfd12fbdefae8597436d1604c491d86";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen libyamlcpp rclcpp ur-client-library ur-robot-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for extracting the factory calibration from a UR robot and change it such that it can be used by ur_description to gain a correct URDF'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/galactic/ur-client-library/default.nix
+++ b/distros/galactic/ur-client-library/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, console-bridge }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-galactic-ur-client-library";
-  version = "1.0.0-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/galactic/ur_client_library/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "b3378b1cfc4478adc8dc336d75c18d547d8ded7fbea268d013e9741e73d01f35";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/galactic/ur_client_library/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d6578b686f968452f71055cb9c20338d14a0f3cc3615e2a9b0b4527e8ab376f3";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake console-bridge ];
+  propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/galactic/ur-controllers/default.nix
+++ b/distros/galactic/ur-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, control-msgs, controller-interface, geometry-msgs, joint-trajectory-controller, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, sensor-msgs, std-msgs, std-srvs, ur-client-library, ur-dashboard-msgs, ur-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ur-controllers";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_controllers/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "995e066d21c126d96a2b8785bac3659a3c36ff756f9e866537ec66d44fa54fa3";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ angles control-msgs controller-interface geometry-msgs joint-trajectory-controller pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs std-msgs std-srvs ur-client-library ur-dashboard-msgs ur-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides controllers that use the speed scaling interface of Universal Robots.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/galactic/ur-dashboard-msgs/default.nix
+++ b/distros/galactic/ur-dashboard-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-ur-dashboard-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_dashboard_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "df30b14e04b9066895a938d3e6d1f068591caba1f2fb40da904670e60071f678";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages around the UR Dashboard server.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/galactic/ur-moveit-config/default.nix
+++ b/distros/galactic/ur-moveit-config/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-ros-move-group, moveit-servo, rviz2, ur-description, urdf, warehouse-ros-mongo, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-ur-moveit-config";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_moveit_config/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "8d777fb4fbb67ec21aed5f83809681118a8b1448d6ef8c63538294ad9d8b1094";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ launch launch-ros moveit-ros-move-group moveit-servo rviz2 ur-description urdf warehouse-ros-mongo xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''An example package with MoveIt2 configurations for UR robots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ur-robot-driver/default.nix
+++ b/distros/galactic/ur-robot-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, launch-testing-ament-cmake, pluginlib, rclcpp, rclpy, std-msgs, std-srvs, tf2-geometry-msgs, ur-bringup, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ur-robot-driver";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_robot_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "0a0cc3540912ba0dfe3f6fae0864ba2e29ed2158b9642f532765dec0fd8a6792";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-manager controller-manager-msgs geometry-msgs hardware-interface launch-testing-ament-cmake pluginlib rclcpp rclpy std-msgs std-srvs tf2-geometry-msgs ur-bringup ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The new driver for Universal Robots UR3, UR5 and UR10 robots with CB3 controllers and the e-series.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/galactic/usb-cam/default.nix
+++ b/distros/galactic/usb-cam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, ffmpeg, image-transport, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-galactic-usb-cam";
-  version = "0.4.0-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/galactic/usb_cam/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "3d526bb3a8559d357e5a30c58a6dbeff14e43ffd52a552210b0dd70b54d5af45";
+    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/galactic/usb_cam/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "6ca56175471c6e497a0d5f4ae8b7fa4a3d2cdd47acd8989b57b9561b9858795d";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces camera-info-manager ffmpeg image-transport rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
+  propagatedBuildInputs = [ builtin-interfaces camera-info-manager ffmpeg image-transport image-transport-plugins rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {

--- a/distros/melodic/aws-common/default.nix
+++ b/distros/melodic/aws-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, curl, gtest, openssl, ros-environment, util-linux, zlib }:
 buildRosPackage {
   pname = "ros-melodic-aws-common";
-  version = "2.2.1-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_common-release/archive/release/melodic/aws_common/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "d432e283db309fa929373f84ea3aa48ce7919caa608ebc5b033b0b55336e8d19";
+    url = "https://github.com/aws-gbp/aws_common-release/archive/release/melodic/aws_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ca6b356a24bbfc7851da14716f3f90cdc751ce5d7620f5eda2401cdfebdddbfe";
   };
 
   buildType = "cmake";

--- a/distros/melodic/aws-ros1-common/default.nix
+++ b/distros/melodic/aws-ros1-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, gtest, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-aws-ros1-common";
-  version = "2.0.3-r1";
+  version = "2.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/melodic/aws_ros1_common/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "24a738e160ad02cdb48e5ff6334739193edc14583b90bce7d77c9f735b00864e";
+    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/melodic/aws_ros1_common/2.0.1-2.tar.gz";
+    name = "2.0.1-2.tar.gz";
+    sha256 = "6ce3c5da6d51c25b2c8453af0a780dbeaa94561baf086346a2fdc2b3ed27caac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-logger/default.nix
+++ b/distros/melodic/cloudwatch-logger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-logs-common, gtest, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logger";
-  version = "2.3.2-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/melodic/cloudwatch_logger/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "a8557c5581e22ba30088f76043c42a5f22e4b7045af5e1ea2b707387c536db1f";
+    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/melodic/cloudwatch_logger/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "b76d61d2863ba0edb061c39e0b0722df5a54f62d0f215dc7f5152fe4850fc871";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-logs-common/default.nix
+++ b/distros/melodic/cloudwatch-logs-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logs-common";
-  version = "1.1.6-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_logs_common/1.1.6-1.tar.gz";
-    name = "1.1.6-1.tar.gz";
-    sha256 = "01b8d478fca24e0c34b62c0c8fdb429081380c4ed368af59f7f2a71b9f6710c7";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_logs_common/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "34f60d17cd9747fc6f691ab0da37a5ae48f19d60e03e21fdf9e30582f625199c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/cloudwatch-metrics-collector/default.nix
+++ b/distros/melodic/cloudwatch-metrics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-collector";
-  version = "2.2.2-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "825b38181077ca024fe497525ec5dd69e3e7eedd662a65bba98c0521e9f5c3c3";
+    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "1c8d20e04ea8096f94cf510c3624385a2b1f8effc03276fe4a0fcd6f6b3fb3f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-metrics-common/default.nix
+++ b/distros/melodic/cloudwatch-metrics-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-common";
-  version = "1.1.6-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_metrics_common/1.1.6-1.tar.gz";
-    name = "1.1.6-1.tar.gz";
-    sha256 = "ffe43bbe3567d57586e1cee957002b8123d07a3d70508081d4e783fccf801d8c";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_metrics_common/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "5bf53ce407e01c6461fb30d1cbb09721c2e452f52751c7bbf3fb0e80f6e10ed7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/dataflow-lite/default.nix
+++ b/distros/melodic/dataflow-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, gtest }:
 buildRosPackage {
   pname = "ros-melodic-dataflow-lite";
-  version = "1.1.6-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/dataflow_lite/1.1.6-1.tar.gz";
-    name = "1.1.6-1.tar.gz";
-    sha256 = "48eee6c7e4843e4e73a2b800d5b59214e15bcfc87157012e79bca5ca968af806";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/dataflow_lite/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "6bd3d571380bb06623afd09ae46e1a0d95368ccafe14416a323fd79ac84e2bed";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "e7f905efc3fe4c02ad5375fe89bdd6932d897349a61ba9f7284e0163b267465d";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "e6f7edf9060c26c59d57b119df1fc730d6aa2e4da0a9074660b77aaa40ccfa7d";
   };
 
   buildType = "cmake";

--- a/distros/melodic/ethercat-manager/default.nix
+++ b/distros/melodic/ethercat-manager/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, roslaunch, rostest, soem }:
+buildRosPackage {
+  pname = "ros-melodic-ethercat-manager";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/minas-release/archive/release/melodic/ethercat_manager/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "de54e41f6f741c656d0b4124f7c9d9b2329e4364efef0463ee32ed2635b7b17f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ roscpp soem ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS-Industrial support stack for facilitating communication with
+EtherCAT networks. The code is mainly copied from https://github.com/ros-industrial/robotiq/blob/jade-devel/robotiq_ethercat/src/ethercat_manager.cpp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/euslime/default.nix
+++ b/distros/melodic/euslime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, roseus, slime-ros }:
 buildRosPackage {
   pname = "ros-melodic-euslime";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/jsk-ros-pkg/euslime-release/archive/release/melodic/euslime/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "7b1218610fe3dcd041423a9651ba5111032e787359bf3c845887f7de2968c3b3";
+    url = "https://github.com/jsk-ros-pkg/euslime-release/archive/release/melodic/euslime/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "7a4181eef5f1c6e75c02f475c13b4b11f31f18ea14b588a62d092cd0a1fab7da";
   };
 
   buildType = "catkin";

--- a/distros/melodic/file-management/default.nix
+++ b/distros/melodic/file-management/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, dataflow-lite, gtest }:
 buildRosPackage {
   pname = "ros-melodic-file-management";
-  version = "1.1.6-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/file_management/1.1.6-1.tar.gz";
-    name = "1.1.6-1.tar.gz";
-    sha256 = "56eb2cea0667a774bc0205104fedbdd3f935968d941ec70a051d52ad7f3cd048";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/file_management/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "ba98a28f68f31e1a51a1fb3de6afc22b8797f88ddeb0416a1d85fdbbc863e51d";
   };
 
   buildType = "cmake";

--- a/distros/melodic/file-uploader-msgs/default.nix
+++ b/distros/melodic/file-uploader-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-file-uploader-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/file_uploader_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "acb003c039995c7b1500acb18f5274fa2aaccb0805141931c5138cedbc731193";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/file_uploader_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "09cb1bb3bd826bc012b149ae435bf76f4d1b9f9dc6efda04fbb57baf476ae2c7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -946,6 +946,8 @@ self: super: {
 
  ethercat-hardware = self.callPackage ./ethercat-hardware {};
 
+ ethercat-manager = self.callPackage ./ethercat-manager {};
+
  ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
 
  eus-assimp = self.callPackage ./eus-assimp {};
@@ -2126,6 +2128,10 @@ self: super: {
 
  mikrotik-swos-tools = self.callPackage ./mikrotik-swos-tools {};
 
+ minas = self.callPackage ./minas {};
+
+ minas-control = self.callPackage ./minas-control {};
+
  mini-maxwell = self.callPackage ./mini-maxwell {};
 
  mir-actions = self.callPackage ./mir-actions {};
@@ -2371,8 +2377,6 @@ self: super: {
  multisense-lib = self.callPackage ./multisense-lib {};
 
  multisense-ros = self.callPackage ./multisense-ros {};
-
- mvsim = self.callPackage ./mvsim {};
 
  nanomsg = self.callPackage ./nanomsg {};
 
@@ -2711,6 +2715,8 @@ self: super: {
  perception = self.callPackage ./perception {};
 
  perception-pcl = self.callPackage ./perception-pcl {};
+
+ pf-description = self.callPackage ./pf-description {};
 
  pf-driver = self.callPackage ./pf-driver {};
 
@@ -4110,6 +4116,8 @@ self: super: {
 
  toposens = self.callPackage ./toposens {};
 
+ toposens-sensor-library = self.callPackage ./toposens-sensor-library {};
+
  toposens-bringup = self.callPackage ./toposens-bringup {};
 
  toposens-description = self.callPackage ./toposens-description {};
@@ -4131,6 +4139,12 @@ self: super: {
  towr = self.callPackage ./towr {};
 
  towr-ros = self.callPackage ./towr-ros {};
+
+ tra1-bringup = self.callPackage ./tra1-bringup {};
+
+ tra1-description = self.callPackage ./tra1-description {};
+
+ tra1-moveit-config = self.callPackage ./tra1-moveit-config {};
 
  trac-ik = self.callPackage ./trac-ik {};
 

--- a/distros/melodic/h264-encoder-core/default.nix
+++ b/distros/melodic/h264-encoder-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, ffmpeg, gtest }:
 buildRosPackage {
   pname = "ros-melodic-h264-encoder-core";
-  version = "2.0.4-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/h264_encoder_core-release/archive/release/melodic/h264_encoder_core/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "bdcf55d6442de34b56bb1e23bbeb4d12f29aaa46a25ac2899ef38b326fc03e6a";
+    url = "https://github.com/aws-gbp/h264_encoder_core-release/archive/release/melodic/h264_encoder_core/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "19f31cb9992ac20374ee457efcac78772598992ad832d31da4c9c23f02029dad";
   };
 
   buildType = "cmake";

--- a/distros/melodic/health-metric-collector/default.nix
+++ b/distros/melodic/health-metric-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, message-generation, message-runtime, ros-monitoring-msgs, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-health-metric-collector";
-  version = "2.0.3-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/melodic/health_metric_collector/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "7bc8f10d1e168870282670c9da976844f48cf49699b064b8b701a1b09da9ef4e";
+    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/melodic/health_metric_collector/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "de3cceb8580f9dea5b9dc921ff1364c6486c89e217ae42ebf5349d67f8668c0c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hri-msgs/default.nix
+++ b/distros/melodic/hri-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hri-msgs";
-  version = "0.4.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/melodic/hri_msgs/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "ed7f9460160ad1b434b0bb4cf9963aeb086500126681e920350849f65198efb9";
+    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/melodic/hri_msgs/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "cac21b2c2d95c7e9c5ec331d0d85367c5bcdaea90f25ec964b70657e7226da20";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hri/default.nix
+++ b/distros/melodic/hri/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, geometry-msgs, hri-msgs, rosconsole, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-hri";
-  version = "0.4.1-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/libhri-release/archive/release/melodic/hri/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "be2ec0e8fe1e453b9ee5e53dd7b47bbaf0b6b8594aac0ddfd5c2d8c33d51c20c";
+    url = "https://github.com/ros4hri/libhri-release/archive/release/melodic/hri/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "81b6bc6d35f6ed7f7e455dc3f2a644642f33889a3aa07fd8a274462996101c3a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kinesis-manager/default.nix
+++ b/distros/melodic/kinesis-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, curl, gtest, log4cplus, openssl, pkg-config }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-manager";
-  version = "2.0.4-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_manager-release/archive/release/melodic/kinesis_manager/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "6f22911e08025ecc3b5f01cb5ae4fe7acd7c9ae49a7470299cb72892ca8b9b08";
+    url = "https://github.com/aws-gbp/kinesis_manager-release/archive/release/melodic/kinesis_manager/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "6db7c90ac6fb345ff10ec737c2f37f5cc6a0f6a6aebf038c852375afd2fb40e2";
   };
 
   buildType = "cmake";

--- a/distros/melodic/kinesis-video-msgs/default.nix
+++ b/distros/melodic/kinesis-video-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-video-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "e857e438116f810e6523c5124130522aae0efb005c5eb615943d0a129554bdaf";
+    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "d3116f1e9c9aea3eeda1de9c5a49056834699356ebdf058f713112425306ca09";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kinesis-video-streamer/default.nix
+++ b/distros/melodic/kinesis-video-streamer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, image-transport, kinesis-manager, kinesis-video-msgs, roscpp, rostest, rostopic, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-video-streamer";
-  version = "2.0.4-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_streamer/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "a64bdfb44fd7078a6fd38b5b311f37132db8339445c11f414d7d9358992b86e2";
+    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/melodic/kinesis_video_streamer/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c9d21edf29f27e1896e428ecabe75be86a821ecb7caa07ff4fd3ffd45c4c1385";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lex-common-msgs/default.nix
+++ b/distros/melodic/lex-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lex-common-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_common_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "185e910bba5ebe7d74453e9c843063c4238cec97dc442617ca47da8ad138372e";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_common_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "ca665d382b0694fc69c410c9b474bffebf278025ac46ac6554488870e94b23c8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lex-common/default.nix
+++ b/distros/melodic/lex-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, gtest, ros-environment }:
 buildRosPackage {
   pname = "ros-melodic-lex-common";
-  version = "1.0.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_common-release/archive/release/melodic/lex_common/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c19408145479820b1c6aac9421d65161786b8e17b679ae4fd6db36a003d3ab52";
+    url = "https://github.com/aws-gbp/lex_common-release/archive/release/melodic/lex_common/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "69a222e4226dfcaf24a2a5c923b70f37b411c95a51ae870b97a6734178cd8536";
   };
 
   buildType = "cmake";

--- a/distros/melodic/lex-node/default.nix
+++ b/distros/melodic/lex-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, lex-common, lex-common-msgs, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lex-node";
-  version = "2.0.3-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_node/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "e7ef63cc1fb0b85d1c3e4c69d8feb4866ba240937ad8e639c7afd8ddf5253a81";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_node/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "24375a02bbf5b57fa1fb9765d43c4cbcf76f7c14e3f250369a738f023ab773e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/minas-control/default.nix
+++ b/distros/melodic/minas-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-updater, ethercat-manager, hardware-interface, joint-limits-interface, realtime-tools, roslaunch, rostest, sensor-msgs, soem, tinyxml, trajectory-msgs, transmission-interface }:
+buildRosPackage {
+  pname = "ros-melodic-minas-control";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/minas-release/archive/release/melodic/minas_control/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b3d7ec61f7f282359cef85b5a974807849ff747f9e2aff0d8589e8a9cbf363b4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ soem ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ controller-manager diagnostic-updater ethercat-manager hardware-interface joint-limits-interface realtime-tools sensor-msgs tinyxml trajectory-msgs transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains ros_control based robot controller for PANASONIC MINAS EtherCAT Motor Driver Control System'';
+    license = with lib.licenses; [ "GPL-2.0-only" bsdOriginal ];
+  };
+}

--- a/distros/melodic/minas/default.nix
+++ b/distros/melodic/minas/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-manager, minas-control, tra1-bringup, tra1-description, tra1-moveit-config }:
+buildRosPackage {
+  pname = "ros-melodic-minas";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/minas-release/archive/release/melodic/minas/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "38395a2295e45d5de7557d8fbaf43d8d8f932f18f423d66c97a21988d9a1297b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ethercat-manager minas-control tra1-bringup tra1-description tra1-moveit-config ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package for minas for PANASONIC MINAS EtherCAT Motor Driver Control System'';
+    license = with lib.licenses; [ "GPL-2.0-only" bsdOriginal "CC-BY-SA" ];
+  };
+}

--- a/distros/melodic/mrpt-bridge/default.nix
+++ b/distros/melodic/mrpt-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gtest, marker-msgs, message-generation, message-runtime, mrpt-msgs, mrpt1, nav-msgs, pcl, pcl-conversions, qt5, roscpp, rosunit, sensor-msgs, std-msgs, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gtest, marker-msgs, message-generation, message-runtime, mrpt-msgs, mrpt2, nav-msgs, pcl, pcl-conversions, qt5, roscpp, rosunit, sensor-msgs, std-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-bridge";
-  version = "0.1.25";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release/archive/release/melodic/mrpt_bridge/0.1.25-0.tar.gz";
-    name = "0.1.25-0.tar.gz";
-    sha256 = "58292956027c9b5bc85b4223fc9ce1220d88b975e68206ad1a963728ca27d396";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release/archive/release/melodic/mrpt_bridge/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b7ddc4f04da6b2785c62e70a39c1d34a9872c2066457c932e17c765978994a4b";
   };
 
   buildType = "catkin";
   buildInputs = [ pcl pcl-conversions qt5.qtbase ];
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs marker-msgs message-generation message-runtime mrpt-msgs mrpt1 nav-msgs roscpp sensor-msgs std-msgs stereo-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs marker-msgs message-generation message-runtime mrpt-msgs mrpt2 nav-msgs roscpp sensor-msgs std-msgs stereo-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-local-obstacles/default.nix
+++ b/distros/melodic/mrpt-local-obstacles/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt1, roscpp, sensor-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt2, roscpp, sensor-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-local-obstacles";
-  version = "0.1.26-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_local_obstacles/0.1.26-1.tar.gz";
-    name = "0.1.26-1.tar.gz";
-    sha256 = "62af298ee1f3352bf32f91529121c5fd2b7976a5c6d9b6e5f0a22cee91dfe9b9";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_local_obstacles/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4a2da9e5d359a399bcc0a1f994efb8a16f9be09175fce08ffdc875c0a5522e26";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt1 roscpp sensor-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt2 roscpp sensor-msgs tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-localization/default.nix
+++ b/distros/melodic/mrpt-localization/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-msgs, mrpt1, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-localization";
-  version = "0.1.26-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_localization/0.1.26-1.tar.gz";
-    name = "0.1.26-1.tar.gz";
-    sha256 = "087d02e1a4dc85b9901bf497f98489920b1f7ba2abcc2fb402ab713ba3641ea1";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_localization/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b58e4b2540affcda0127cf95910f82b86e98747186bcd0d9af350dc59966ca34";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-msgs mrpt1 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-msgs mrpt2 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''Package for robot 2D self-localization using dynamic or static (MRPT or ROS) maps.
-	The interface is similar to amcl (http://wiki.ros.org/amcl)
+	The interface is similar to amcl (https://wiki.ros.org/amcl)
    but supports different particle-filter algorithms, several grid maps at
    different heights, range-only localization, etc.'';
     license = with lib.licenses; [ bsdOriginal bsdOriginal ];

--- a/distros/melodic/mrpt-map/default.nix
+++ b/distros/melodic/mrpt-map/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mrpt-bridge, mrpt1, nav-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-bridge, mrpt2, nav-msgs, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-map";
-  version = "0.1.26-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_map/0.1.26-1.tar.gz";
-    name = "0.1.26-1.tar.gz";
-    sha256 = "1347d1084c5cd1bfbaf3b6fad8db1512c848d49ef81612f5be09837787dcf6a9";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_map/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7af95b573fa3ab1972b6e4ca1b6246c1991a98eff45bb9ba1c4e1b3e46172725";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mrpt-bridge mrpt1 nav-msgs roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ mrpt-bridge mrpt2 nav-msgs roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-navigation/default.nix
+++ b/distros/melodic/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-local-obstacles, mrpt-localization, mrpt-map, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-navigation";
-  version = "0.1.26-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_navigation/0.1.26-1.tar.gz";
-    name = "0.1.26-1.tar.gz";
-    sha256 = "3ff8c916893a54a39c070acc7aaed06abb6ea114504df7e5d9aa8ffa44d6dab1";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_navigation/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "59256dc71fcdaf3d4ea3070a6f811162441316c3bc83f87b501e028456c21d52";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
 
   meta = {
     description = ''Tools related to the Mobile Robot Programming Toolkit (MRPT).
-    Refer to http://wiki.ros.org/mrpt_navigation for further documentation.'';
+    Refer to https://wiki.ros.org/mrpt_navigation for further documentation.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mrpt-rawlog/default.nix
+++ b/distros/melodic/mrpt-rawlog/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-bridge, mrpt-msgs, mrpt1, nav-msgs, rosbag, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-rawlog";
-  version = "0.1.26-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_rawlog/0.1.26-1.tar.gz";
-    name = "0.1.26-1.tar.gz";
-    sha256 = "e71c97fb56f14c6fb15a0cbc6744aa2cd5d16e2a536f39c0ae7c25e209b5bfd3";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_rawlog/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d418ff87ddff3ead415f7c555c2c7ca2caf900f0059d3c2a9be23b3ffb5c1bf7";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-bridge mrpt-msgs mrpt1 nav-msgs rosbag roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-bridge mrpt-msgs mrpt2 nav-msgs rosbag roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-reactivenav2d/default.nix
+++ b/distros/melodic/mrpt-reactivenav2d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-bridge, mrpt1, roscpp, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-bridge, mrpt2, roscpp, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-reactivenav2d";
-  version = "0.1.26-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_reactivenav2d/0.1.26-1.tar.gz";
-    name = "0.1.26-1.tar.gz";
-    sha256 = "6c7352f0b6f9eda20e956b30797e10bb40b0aa1ba0a22be33a872f5d3a2eb47a";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_reactivenav2d/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "679da45a84c04348062a832fc991de4c3ae33c955ebeae73dec5845a0df39eb4";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-bridge mrpt1 roscpp tf visualization-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-bridge mrpt2 roscpp tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-tutorials/default.nix
+++ b/distros/melodic/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-tutorials";
-  version = "0.1.26-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_tutorials/0.1.26-1.tar.gz";
-    name = "0.1.26-1.tar.gz";
-    sha256 = "056e0a6b2e6f66f064975a5d8df023325bc86ac013f6ed4d179b82a3ff369619";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_tutorials/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "01d612ea5a187fb104a8d858af95bf27ba9dacdd49f0c6214889e089bd4e80aa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ntrip-client/default.nix
+++ b/distros/melodic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ntrip-client";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "bd8fa6101b2348b83714b27576dfea851faea7194fc89910a59060912b387220";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0eadc0bcc6f8dd8f6b5c00f6e3c66a9b8ac0eba1c09a4193a0a54179f42866aa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pf-description/default.nix
+++ b/distros/melodic/pf-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-pf-description";
+  version = "1.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/PepperlFuchs/pf_lidar_ros_driver-release/archive/release/melodic/pf_description/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "302e3c7f6a0642e3a8819f56eef5e2c9967c1a93ac1cd3cc3055f21e29852597";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pf_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/pf-driver/default.nix
+++ b/distros/melodic/pf-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, curlpp, dynamic-reconfigure, jsoncpp, laser-geometry, message-generation, message-runtime, pcl, pcl-conversions, pcl-ros, roscpp, roscpp-serialization, roslint, rosunit, rviz, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, curlpp, dynamic-reconfigure, jsoncpp, laser-geometry, message-generation, message-runtime, pcl, pcl-conversions, pcl-ros, pf-description, roscpp, roscpp-serialization, roslint, rosunit, rviz, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-pf-driver";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/PepperlFuchs/pf_lidar_ros_driver-release/archive/release/melodic/pf_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "683c782e779761431a7b5c92768f0c6a48398ea827cb1bfc7cf70f87c845a123";
+    url = "https://github.com/PepperlFuchs/pf_lidar_ros_driver-release/archive/release/melodic/pf_driver/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "a852a67342f0e1f46a313a41a954b1540f8b8af833b23672c3ba80a0bf195706";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation roslint ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ curlpp dynamic-reconfigure jsoncpp laser-geometry message-runtime pcl pcl-conversions pcl-ros roscpp roscpp-serialization rviz sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ curlpp dynamic-reconfigure jsoncpp laser-geometry message-runtime pcl pcl-conversions pcl-ros pf-description roscpp roscpp-serialization rviz sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/pose-cov-ops/default.nix
+++ b/distros/melodic/pose-cov-ops/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt1, roscpp, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt2, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pose-cov-ops";
-  version = "0.2.1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.2.1-0.tar.gz";
-    name = "0.2.1-0.tar.gz";
-    sha256 = "03a6c9edc43d420a3532232fdbd48db4d4bf69acea65d8a5ce153b7f19b6595f";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "794632c6d7d6f755a451573ced192e5f73ac0098b057899ee9226c0c9d3aa5b5";
   };
 
   buildType = "catkin";
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ geometry-msgs mrpt-bridge mrpt1 roscpp ];
+  propagatedBuildInputs = [ geometry-msgs mrpt-bridge mrpt2 roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/recorder-msgs/default.nix
+++ b/distros/melodic/recorder-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-recorder-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/recorder_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "3065e9f7c51beeff9d0e8d10c1cc7b8d3968086a85228cd715c7e29f7cd19503";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/recorder_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f5a741c359bf9420a8bdb479bc65c235a72e3af4f510eb8a8f3716f832019246";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration-msgs/default.nix
+++ b/distros/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.6.5-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.5-1.tar.gz";
-    name = "0.6.5-1.tar.gz";
-    sha256 = "6731bd47372ae3156e9e51bc287328a17b5cbbceeaaf08bdc2451534abe2b41c";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "c56502d5634b26aabfab1a700fa163704139938adfb617975183876517ca5c91";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration/default.nix
+++ b/distros/melodic/robot-calibration/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.6.5-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.5-1.tar.gz";
-    name = "0.6.5-1.tar.gz";
-    sha256 = "220c011cec369940fdb8feec65009fd585da171bec385fd7c37752df40396f08";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "bc802d9ee3d0dc1dc1737c925e8ac21aee07ff1cdc8a08b49c71b507d33c87e2";
   };
 
   buildType = "catkin";
+  buildInputs = [ eigen ];
   checkInputs = [ code-coverage ];
-  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ros-babel-fish-test-msgs/default.nix
+++ b/distros/melodic/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish-test-msgs";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "f13a502ad8757c7101ac8687cc3dd5771b0952ed91275872a7f2b89ab8891bce";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "7f7108fb6abb6252ecbcd985fad242d85b8b61a18626cbed814d93cd363bdf9a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-babel-fish/default.nix
+++ b/distros/melodic/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, rosgraph-msgs, roslib, rostest, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "394a08a9ae770f97183f60302b4a037b9ed207b4480c1937e7e5aa85e62751fb";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "52f42f185f4f8f1a838bdfa1057bbd33d2927b5a24d236fa8bff867dff011a05";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-monitoring-msgs/default.nix
+++ b/distros/melodic/ros-monitoring-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-monitoring-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/ros_monitoring_msgs-release/archive/release/melodic/ros_monitoring_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0f33f8a0c1a4de6309dbbb24d8ab3f0dbb1f7533bb4d956c540dea8235f03a08";
+    url = "https://github.com/aws-gbp/ros_monitoring_msgs-release/archive/release/melodic/ros_monitoring_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d9215590fe7e1d5c0dadd7a19195db12250e64327bd5423ad6292c0a7e920165";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-cloud-recorders/default.nix
+++ b/distros/melodic/rosbag-cloud-recorders/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gtest, recorder-msgs, rosbag-storage, roscpp, roslint, rostest, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-cloud-recorders";
-  version = "1.0.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/rosbag_cloud_recorders/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "35540e67e87bbd85c8311535c8b585de9736b7fb2e640e7b45dcd6d802de098c";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/rosbag_cloud_recorders/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "7558cdb87a1dc7a56a0dc4eaeedc550724cdb293a0b56a7e5a44a707adcb8e9a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/s3-common/default.nix
+++ b/distros/melodic/s3-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, gtest }:
 buildRosPackage {
   pname = "ros-melodic-s3-common";
-  version = "1.0.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_common/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "660dfd0718cfc11abc19f8d61c046f14c85e2c0e6670af3244b8f8776004a9e9";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_common/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "020e7dcb88eb4b7c3efc63814fd190051ca4769345fc180807b576ee018e9bbb";
   };
 
   buildType = "cmake";

--- a/distros/melodic/s3-file-uploader/default.nix
+++ b/distros/melodic/s3-file-uploader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gtest, roscpp, rostest, s3-common }:
 buildRosPackage {
   pname = "ros-melodic-s3-file-uploader";
-  version = "1.0.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_file_uploader/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "160dab31e75756e0997e3589c8281431a33ff4af07c561af0948a2784e622b59";
+    url = "https://github.com/aws-gbp/rosbag_uploader-release/archive/release/melodic/s3_file_uploader/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c0dcc4dbd3ec1ee24590acc7b770caef82b6b4a4434517b277754f5738d6836a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/septentrio-gnss-driver/default.nix
+++ b/distros/melodic/septentrio-gnss-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-septentrio-gnss-driver";
-  version = "1.0.8-r1";
+  version = "1.1.0-r8";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "15b96f4c8e3c695d7bf3da1dc2f356b185ca13ab65539cc75c129b78fbe80a0e";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.1.0-8.tar.gz";
+    name = "1.1.0-8.tar.gz";
+    sha256 = "8e870ed6082be60ffa5b56966dd3396a8ae1e7c46bc37b8f60c3ee16d39b3fea";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ boost cpp-common diagnostic-msgs geometry-msgs gps-common libpcap message-runtime rosconsole roscpp roscpp-serialization rostime sensor-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ boost cpp-common diagnostic-msgs geographiclib geometry-msgs gps-common libpcap message-runtime nav-msgs nmea-msgs rosconsole roscpp roscpp-serialization rostime sensor-msgs tf2 tf2-geometry-msgs tf2-ros xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-sensor-library/default.nix
+++ b/distros/melodic/toposens-sensor-library/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
+buildRosPackage {
+  pname = "ros-melodic-toposens-sensor-library";
+  version = "1.1.4-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/melodic/toposens-sensor-library/1.1.4-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "040af85195cfdb9c9f9be372be53490f54b6998280de3d37f73b72265c993359";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Driver for toposens echo sensor'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/tra1-bringup/default.nix
+++ b/distros/melodic/tra1-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, joint-state-controller, joint-trajectory-controller, minas-control, position-controllers, robot-state-publisher, roslaunch, rostest, tf, tra1-description, tra1-moveit-config }:
+buildRosPackage {
+  pname = "ros-melodic-tra1-bringup";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/minas-release/archive/release/melodic/tra1_bringup/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b26072a45edf374187cbf24fc53bdaa12840abfcd32a5e5a3e78e6d76609f721";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ controller-manager joint-state-controller joint-trajectory-controller minas-control position-controllers robot-state-publisher tf tra1-description tra1-moveit-config ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package contains bringup scripts/config/tools for tra1 robto'';
+    license = with lib.licenses; [ "GPL-2.0-only" ];
+  };
+}

--- a/distros/melodic/tra1-description/default.nix
+++ b/distros/melodic/tra1-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-tra1-description";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/minas-release/archive/release/melodic/tra1_description/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "cecc2bf7664b6d24ccf9783e0955499ca1a7e21b38f7a0ea38b718fe10bf6f1d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the description (mechanical, kinematic, visual,  etc.) of the TRA1 robot. The files in this package are parsed and used by a variety of other components.  Most users will not interact directly with this package.'';
+    license = with lib.licenses; [ "GPL-2.0-only" "CC-BY-SA" ];
+  };
+}

--- a/distros/melodic/tra1-moveit-config/default.nix
+++ b/distros/melodic/tra1-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joy, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rostest, rviz, tra1-description, warehouse-ros, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-tra1-moveit-config";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/minas-release/archive/release/melodic/tra1_moveit_config/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "aae9958445d523413c744f069ca4e973b137a0c3f1c4f8472902c3e6a2467572";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher joy moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-simple-controller-manager robot-state-publisher rviz tra1-description warehouse-ros xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the tra1 with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/tts/default.nix
+++ b/distros/melodic/tts/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, pythonPackages, rospy, rostest, rosunit, sound-play, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, pythonPackages, rospy, rostest, rosunit, sound-play, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-tts";
-  version = "1.0.3-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/tts-release/archive/release/melodic/tts/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "58c5eeaf9d04747a09cdcf3cdadd673b1dcb20afd3173c8d62a090b7b407f172";
+    url = "https://github.com/aws-gbp/tts-release/archive/release/melodic/tts/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ff9513ecc2e040bc38e882badee1407e351c9c1abb6cd8c75ec1ac81dcfe5cd1";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation rostest rosunit ];
   checkInputs = [ pythonPackages.mock ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime pythonPackages.boto3 rospy sound-play std-msgs ];
+  propagatedBuildInputs = [ actionlib-msgs message-runtime pythonPackages.boto3 rospy sound-play std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/camera-aravis/default.nix
+++ b/distros/noetic/camera-aravis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aravis, camera-info-manager, catkin, dynamic-reconfigure, glib, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-camera-aravis";
-  version = "4.0.1-r2";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.1-2.tar.gz";
-    name = "4.0.1-2.tar.gz";
-    sha256 = "7b521ceb0d18a3751afaa1ed5831ab10053c8f512bbbc47a6baa4d9ca7dc60ac";
+    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "a186ad55b2a74110cf821cd72c0fa3de1b8798b8880569d155a3c82637ae9b21";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bringup-sim/default.nix
+++ b/distros/noetic/cob-bringup-sim/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-default-env-config, cob-default-robot-config, cob-gazebo, cob-gazebo-worlds, cob-supported-robots, gazebo-ros, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-cob-bringup-sim";
+  version = "0.7.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_bringup_sim/0.7.5-2.tar.gz";
+    name = "0.7.5-2.tar.gz";
+    sha256 = "7f37d1f5eb547ad959305eb7e6ffb12d8c848a6b57199198fc0a0032100af1aa";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ cob-default-env-config cob-supported-robots roslaunch ];
+  propagatedBuildInputs = [ cob-default-env-config cob-default-robot-config cob-gazebo cob-gazebo-worlds gazebo-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides launch files for starting a simulated Care-O-bot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-bringup/default.nix
+++ b/distros/noetic/cob-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cob-android-script-server, cob-base-controller-utils, cob-base-velocity-smoother, cob-bms-driver, cob-calibration-data, cob-cam3d-throttle, cob-collision-monitor, cob-collision-velocity-filter, cob-command-gui, cob-control-mode-adapter, cob-dashboard, cob-default-env-config, cob-default-robot-behavior, cob-default-robot-config, cob-docker-control, cob-frame-tracker, cob-hand-bridge, cob-hardware-config, cob-helper-tools, cob-image-flip, cob-light, cob-linear-nav, cob-mecanum-controller, cob-mimic, cob-monitoring, cob-moveit-config, cob-obstacle-distance, cob-omni-drive-controller, cob-phidget-em-state, cob-phidget-power-state, cob-phidgets, cob-reflector-referencing, cob-safety-controller, cob-scan-unifier, cob-script-server, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-supported-robots, cob-teleop, cob-twist-controller, cob-voltage-control, compressed-depth-image-transport, compressed-image-transport, controller-manager, costmap-2d, diagnostic-aggregator, generic-throttle, image-proc, joint-state-controller, joint-state-publisher, joint-trajectory-controller, joy, laser-filters, nodelet, openni2-launch, position-controllers, realsense2-camera, rgbd-launch, robot-state-publisher, roslaunch, rosserial-python, rosserial-server, rostopic, rviz, spacenav-node, tf2-ros, theora-image-transport, topic-tools, twist-mux, usb-cam, velocity-controllers }:
+buildRosPackage {
+  pname = "ros-noetic-cob-bringup";
+  version = "0.7.6-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_bringup/0.7.6-4.tar.gz";
+    name = "0.7.6-4.tar.gz";
+    sha256 = "1e48c88721cb3ee02da7e39301e3f813d637131fc18e45e79270cb136b6085a2";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ cob-supported-robots roslaunch ];
+  propagatedBuildInputs = [ canopen-chain-node canopen-motor-node cob-android-script-server cob-base-controller-utils cob-base-velocity-smoother cob-bms-driver cob-calibration-data cob-cam3d-throttle cob-collision-monitor cob-collision-velocity-filter cob-command-gui cob-control-mode-adapter cob-dashboard cob-default-env-config cob-default-robot-behavior cob-default-robot-config cob-docker-control cob-frame-tracker cob-hand-bridge cob-hardware-config cob-helper-tools cob-image-flip cob-light cob-linear-nav cob-mecanum-controller cob-mimic cob-monitoring cob-moveit-config cob-obstacle-distance cob-omni-drive-controller cob-phidget-em-state cob-phidget-power-state cob-phidgets cob-reflector-referencing cob-safety-controller cob-scan-unifier cob-script-server cob-sick-lms1xx cob-sick-s300 cob-sound cob-teleop cob-twist-controller cob-voltage-control compressed-depth-image-transport compressed-image-transport controller-manager costmap-2d diagnostic-aggregator generic-throttle image-proc joint-state-controller joint-state-publisher joint-trajectory-controller joy laser-filters nodelet openni2-launch position-controllers realsense2-camera rgbd-launch robot-state-publisher rosserial-python rosserial-server rostopic rviz spacenav-node tf2-ros theora-image-transport topic-tools twist-mux usb-cam velocity-controllers ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides launch files for operating Care-O-bot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-collision-monitor/default.nix
+++ b/distros/noetic/cob-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-moveit-config, moveit-ros-move-group, moveit-ros-planning, pluginlib, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-monitor";
-  version = "0.7.6-r1";
+  version = "0.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "863695b63278cf0fbcdd2e8d2da5d7475220cced0f8e14e2f2cc5f61bd4bd1bd";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.6-2.tar.gz";
+    name = "0.7.6-2.tar.gz";
+    sha256 = "e1970e334d7bd63e4020fd2513e792bada61910c3561ebc71dfcdf4fdf653154";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-behavior/default.nix
+++ b/distros/noetic/cob-default-robot-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-light, cob-script-server, python3Packages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-behavior";
-  version = "0.7.6-r1";
+  version = "0.7.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "04a3a72c8b8ab058f179a5ce8ef80f7ef7f5d746c4783ce6273d1f1aef22ce07";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.6-4.tar.gz";
+    name = "0.7.6-4.tar.gz";
+    sha256 = "4ac6bc3ee9caeb9d9298eb234290e7f68b6e1581bcaf230db4d5489fad342707";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-config/default.nix
+++ b/distros/noetic/cob-default-robot-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-config";
-  version = "0.7.6-r1";
+  version = "0.7.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "7731694171bcbb7210d7ca97dc6846fa4f7eaccaaca993aae5831274deddcfe5";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.6-4.tar.gz";
+    name = "0.7.6-4.tar.gz";
+    sha256 = "b784b13ad0033bcc9337fa8054809e33b90de0f583268b6a738a1e1d7efd3edf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-objects/default.nix
+++ b/distros/noetic/cob-gazebo-objects/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-objects";
-  version = "0.7.5-r1";
+  version = "0.7.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_objects/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "b3b1bcb5d1137e27c5340a462125ac712f161f3c96d33d749736d6d71471cae0";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_objects/0.7.5-2.tar.gz";
+    name = "0.7.5-2.tar.gz";
+    sha256 = "f9ebb9e972375cabb72ebd0b075ba0c58e102d0415fbd042ed761a6874726dc2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-tools/default.nix
+++ b/distros/noetic/cob-gazebo-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, geometry-msgs, python3Packages, roslib, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-tools";
-  version = "0.7.5-r1";
+  version = "0.7.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_tools/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "6f1d3cb85549ac63c32a6c1915e5308323fd18f740b990ba42dc2fcdb01c7731";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_tools/0.7.5-2.tar.gz";
+    name = "0.7.5-2.tar.gz";
+    sha256 = "8f429c820e04807d1437af5913bf6c681ee1fb7457c43fa9ed24906e51cb54a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-worlds/default.nix
+++ b/distros/noetic/cob-gazebo-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config, controller-manager, gazebo-msgs, gazebo-ros, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rospy, rostest, std-msgs, tf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-worlds";
-  version = "0.7.5-r1";
+  version = "0.7.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_worlds/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "270ee226a2749623bef6b433ff8557835da31482d8c88ee4a54752f066db7575";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_worlds/0.7.5-2.tar.gz";
+    name = "0.7.5-2.tar.gz";
+    sha256 = "200a22d3573d5e4b172e1f1ebc5a45a982a2c558d7574bbe11efca62222ac357";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo/default.nix
+++ b/distros/noetic/cob-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-bringup, cob-default-robot-config, cob-gazebo-ros-control, cob-hardware-config, cob-script-server, cob-supported-robots, control-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, roslaunch, rospy, rostest, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-cob-gazebo";
+  version = "0.7.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo/0.7.5-2.tar.gz";
+    name = "0.7.5-2.tar.gz";
+    sha256 = "aa8890823d1ce3a3beca56e223cde29f9892b53913a73329811e41f669b8bfd0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ cob-supported-robots roslaunch ];
+  propagatedBuildInputs = [ cob-bringup cob-default-robot-config cob-gazebo-ros-control cob-hardware-config cob-script-server control-msgs gazebo-plugins gazebo-ros gazebo-ros-control rospy rostest trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files and tools for 3D simulation of Care-O-bot in gazebo simulator.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-grasp-generation/default.nix
+++ b/distros/noetic/cob-grasp-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-description, cob-manipulation-msgs, geometry-msgs, moveit-msgs, python3Packages, robot-state-publisher, roslib, rospy, rviz, schunk-description, sensor-msgs, std-msgs, tf, tf2-ros, trajectory-msgs, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-grasp-generation";
-  version = "0.7.6-r1";
+  version = "0.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "d7e681a929a37b658d340413be870f05bb558c23b69f0841c6f57515ec117554";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.6-2.tar.gz";
+    name = "0.7.6-2.tar.gz";
+    sha256 = "deb00a4b93f97cc79223f04bcd589dc2da6544751c8f6ad9d14032ab99322bd9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-config/default.nix
+++ b/distros/noetic/cob-hardware-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-calibration-data, cob-description, cob-omni-drive-controller, cob-supported-robots, costmap-2d, diagnostic-aggregator, joint-state-controller, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, laser-filters, position-controllers, raw-description, robot-state-publisher, roslaunch, rostest, rviz, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-config";
-  version = "0.7.6-r1";
+  version = "0.7.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "ff9ea8ffc5394ec5cb5038fb123289b7f1a5a6e7c63923ec845cdb80a4e46bde";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.6-4.tar.gz";
+    name = "0.7.6-4.tar.gz";
+    sha256 = "004e7782371c933b213222f26fcf28d16a643cc0cc1438e70d847396e6eab375";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-lookat-action/default.nix
+++ b/distros/noetic/cob-lookat-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, angles, catkin, control-msgs, geometry-msgs, kdl-conversions, kdl-parser, message-generation, message-runtime, move-base-msgs, orocos-kdl, roscpp, rospy, sensor-msgs, tf, tf-conversions, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-lookat-action";
-  version = "0.7.6-r1";
+  version = "0.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "5db8ba80099a60b1ea42ef11ecc44b788b1fd5018ea1a29a54d6687e29d8a6d5";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.6-2.tar.gz";
+    name = "0.7.6-2.tar.gz";
+    sha256 = "fa11fd115afb0152e90c75d4aea9b4fdc0279a98216e72a84116b7544596cd17";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-manipulation-msgs/default.nix
+++ b/distros/noetic/cob-manipulation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, moveit-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-manipulation-msgs";
-  version = "0.7.6-r1";
+  version = "0.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation_msgs/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "f41e5d52ca49b9b4b7bc8873311574bc23ef5e3c99bbc38e72f76f6dc84ddb25";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation_msgs/0.7.6-2.tar.gz";
+    name = "0.7.6-2.tar.gz";
+    sha256 = "316c86387cf2b7fac6d808ca2ba90f93476576cd36951284e9d7d4223f102231";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-manipulation/default.nix
+++ b/distros/noetic/cob-manipulation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-collision-monitor, cob-grasp-generation, cob-lookat-action, cob-manipulation-msgs, cob-moveit-bringup, cob-moveit-interface }:
+buildRosPackage {
+  pname = "ros-noetic-cob-manipulation";
+  version = "0.7.6-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation/0.7.6-2.tar.gz";
+    name = "0.7.6-2.tar.gz";
+    sha256 = "17578b27ceca783a6f5982bbca3ccf2fec46087ce58295932506c62ab4f4f08c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-collision-monitor cob-grasp-generation cob-lookat-action cob-manipulation-msgs cob-moveit-bringup cob-moveit-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The cob_manipulation stack includes packages that provide manipulation capabilities for Care-O-bot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-moveit-bringup/default.nix
+++ b/distros/noetic/cob-moveit-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-hardware-config, cob-moveit-config, joint-state-publisher, moveit-planners-ompl, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, moveit-setup-assistant, robot-state-publisher, rviz, tf, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-bringup";
-  version = "0.7.6-r1";
+  version = "0.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "aaba22f509827cfdd315e46cd3df66a432fec482fb0e2ddfe0d753dd390b9955";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.6-2.tar.gz";
+    name = "0.7.6-2.tar.gz";
+    sha256 = "32f3c3e7547fb673fada3892f6fffc4ae411a695b9fb32d3b87d0a6dc702d033";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-config/default.nix
+++ b/distros/noetic/cob-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-config";
-  version = "0.7.6-r1";
+  version = "0.7.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "7c00139e3b54bb551daf98b7a15f08ace9bd2936c8fdff1ad74b3d3b69de4d38";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.6-4.tar.gz";
+    name = "0.7.6-4.tar.gz";
+    sha256 = "aae8fb9e574992a4b2657d32106055e4f8133f2aec1a7fc21d8c462573b312cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-interface/default.nix
+++ b/distros/noetic/cob-moveit-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-script-server, geometry-msgs, moveit-commander, python3Packages, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-interface";
-  version = "0.7.6-r1";
+  version = "0.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "0bb73dcafe3ef02ce0678a7d883b6f38e794d6541bbc32b3abd5050615567e7f";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.6-2.tar.gz";
+    name = "0.7.6-2.tar.gz";
+    sha256 = "b23e016544bda94934e7aafc143d32f33be4be7208481755b7ddf0759a9c3144";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-robots/default.nix
+++ b/distros/noetic/cob-robots/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-bringup, cob-default-robot-behavior, cob-default-robot-config, cob-hardware-config, cob-moveit-config }:
+buildRosPackage {
+  pname = "ros-noetic-cob-robots";
+  version = "0.7.6-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_robots/0.7.6-4.tar.gz";
+    name = "0.7.6-4.tar.gz";
+    sha256 = "108d2d5764ed228e6aea25c0a03b4210fd6bf409fe6e55c6ac03767bef409a7f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-bringup cob-default-robot-behavior cob-default-robot-config cob-hardware-config cob-moveit-config ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This stack holds packages for hardware configuration as well as launch files for starting up the basic layer for operating Care-O-bot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-simulation/default.nix
+++ b/distros/noetic/cob-simulation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-bringup-sim, cob-gazebo, cob-gazebo-objects, cob-gazebo-tools, cob-gazebo-worlds }:
+buildRosPackage {
+  pname = "ros-noetic-cob-simulation";
+  version = "0.7.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_simulation/0.7.5-2.tar.gz";
+    name = "0.7.5-2.tar.gz";
+    sha256 = "eddfe760bd0aa94909ece4da9ef0758fdc0e5fc3516f64c279ae8bfa73a08b4a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-bringup-sim cob-gazebo cob-gazebo-objects cob-gazebo-tools cob-gazebo-worlds ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The cob_simulation stack includes packages to work with Care-O-bot within simulation environments, e.g. gazebo.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/dynamic-robot-state-publisher/default.nix
+++ b/distros/noetic/dynamic-robot-state-publisher/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, kdl-parser, robot-state-publisher, roscpp, rostest, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dynamic-robot-state-publisher";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/dynamic_robot_state_publisher-release/archive/release/noetic/dynamic_robot_state_publisher/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2f9f99a40f6371216a634914742c7056dc89aeedd525a09b6289048e1ef0f65d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure kdl-parser robot-state-publisher roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Improved ROS robot_state_publisher which can update the robot model via dynamic_reconfigure.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "f303b60dc5a2132d470d111a83164716ac65647464aeaeb1670d9112abc8e421";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "9eae8aa2ca61fdbcb380ff8c98d3ce4573230d914d5da0c7599703bce44bd8d4";
   };
 
   buildType = "cmake";

--- a/distros/noetic/euslime/default.nix
+++ b/distros/noetic/euslime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, roseus, slime-ros }:
 buildRosPackage {
   pname = "ros-noetic-euslime";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/jsk-ros-pkg/euslime-release/archive/release/noetic/euslime/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "0baa5371b2df2c86936dc54491dcf33357a9bd0c3e6eebc6ff681c476fa9c149";
+    url = "https://github.com/jsk-ros-pkg/euslime-release/archive/release/noetic/euslime/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "9253cf2007e79c6abd81333fca4e042c8a2aad24075d3942cb2c4f993ad84897";
   };
 
   buildType = "catkin";

--- a/distros/noetic/flir-camera-description/default.nix
+++ b/distros/noetic/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-description";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "676469d8c3b0ba4fb88223eb948aaba9ecd1bbf1a74f93fdb12b30c1e36e202a";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_description/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "43776586e031b4be647bbd1231762d465d1e3643dc722b762f7c16ad1fced2ef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/flir-camera-driver/default.nix
+++ b/distros/noetic/flir-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flir-camera-description, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-noetic-flir-camera-driver";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d7c34b9c69f6f63522013884324ee24bf4a372a6e4e9a791f806def69d47ccdd";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/flir_camera_driver/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "327f8ef92766d5cd10aa75ec9a05549509a7d5ef1ca1514f756dd72200c10229";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -242,6 +242,10 @@ self: super: {
 
  cob-bms-driver = self.callPackage ./cob-bms-driver {};
 
+ cob-bringup = self.callPackage ./cob-bringup {};
+
+ cob-bringup-sim = self.callPackage ./cob-bringup-sim {};
+
  cob-calibration-data = self.callPackage ./cob-calibration-data {};
 
  cob-cam3d-throttle = self.callPackage ./cob-cam3d-throttle {};
@@ -290,6 +294,8 @@ self: super: {
 
  cob-frame-tracker = self.callPackage ./cob-frame-tracker {};
 
+ cob-gazebo = self.callPackage ./cob-gazebo {};
+
  cob-gazebo-objects = self.callPackage ./cob-gazebo-objects {};
 
  cob-gazebo-plugins = self.callPackage ./cob-gazebo-plugins {};
@@ -323,6 +329,8 @@ self: super: {
  cob-linear-nav = self.callPackage ./cob-linear-nav {};
 
  cob-lookat-action = self.callPackage ./cob-lookat-action {};
+
+ cob-manipulation = self.callPackage ./cob-manipulation {};
 
  cob-manipulation-msgs = self.callPackage ./cob-manipulation-msgs {};
 
@@ -378,6 +386,8 @@ self: super: {
 
  cob-relayboard = self.callPackage ./cob-relayboard {};
 
+ cob-robots = self.callPackage ./cob-robots {};
+
  cob-safety-controller = self.callPackage ./cob-safety-controller {};
 
  cob-scan-unifier = self.callPackage ./cob-scan-unifier {};
@@ -387,6 +397,8 @@ self: super: {
  cob-sick-lms1xx = self.callPackage ./cob-sick-lms1xx {};
 
  cob-sick-s300 = self.callPackage ./cob-sick-s300 {};
+
+ cob-simulation = self.callPackage ./cob-simulation {};
 
  cob-sound = self.callPackage ./cob-sound {};
 
@@ -639,6 +651,8 @@ self: super: {
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamic-reconfigure = self.callPackage ./dynamic-reconfigure {};
+
+ dynamic-robot-state-publisher = self.callPackage ./dynamic-robot-state-publisher {};
 
  dynamic-tf-publisher = self.callPackage ./dynamic-tf-publisher {};
 
@@ -1822,7 +1836,21 @@ self: super: {
 
  mrpt-bridge = self.callPackage ./mrpt-bridge {};
 
+ mrpt-local-obstacles = self.callPackage ./mrpt-local-obstacles {};
+
+ mrpt-localization = self.callPackage ./mrpt-localization {};
+
+ mrpt-map = self.callPackage ./mrpt-map {};
+
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
+
+ mrpt-navigation = self.callPackage ./mrpt-navigation {};
+
+ mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
+
+ mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
+
+ mrpt-tutorials = self.callPackage ./mrpt-tutorials {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
@@ -1845,8 +1873,6 @@ self: super: {
  multisense-lib = self.callPackage ./multisense-lib {};
 
  multisense-ros = self.callPackage ./multisense-ros {};
-
- mvsim = self.callPackage ./mvsim {};
 
  nav2d = self.callPackage ./nav2d {};
 
@@ -1987,6 +2013,10 @@ self: super: {
  openni2-camera = self.callPackage ./openni2-camera {};
 
  openni2-launch = self.callPackage ./openni2-launch {};
+
+ openni-description = self.callPackage ./openni-description {};
+
+ openni-launch = self.callPackage ./openni-launch {};
 
  openrtm-aist = self.callPackage ./openrtm-aist {};
 
@@ -2311,8 +2341,6 @@ self: super: {
  qb-move-description = self.callPackage ./qb-move-description {};
 
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
-
- qt-advanced-docking = self.callPackage ./qt-advanced-docking {};
 
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
 
@@ -2980,6 +3008,8 @@ self: super: {
 
  stage-ros = self.callPackage ./stage-ros {};
 
+ static-transform-mux = self.callPackage ./static-transform-mux {};
+
  statistics-msgs = self.callPackage ./statistics-msgs {};
 
  std-msgs = self.callPackage ./std-msgs {};
@@ -3104,6 +3134,8 @@ self: super: {
 
  tf-conversions = self.callPackage ./tf-conversions {};
 
+ tf-remapper-cpp = self.callPackage ./tf-remapper-cpp {};
+
  theora-image-transport = self.callPackage ./theora-image-transport {};
 
  thunder-line-follower-pmr3100 = self.callPackage ./thunder-line-follower-pmr3100 {};
@@ -3221,6 +3253,8 @@ self: super: {
  udp-com = self.callPackage ./udp-com {};
 
  ueye-cam = self.callPackage ./ueye-cam {};
+
+ um6 = self.callPackage ./um6 {};
 
  um7 = self.callPackage ./um7 {};
 

--- a/distros/noetic/grepros/default.nix
+++ b/distros/noetic/grepros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, python3Packages, rosbag, roslib, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-grepros";
-  version = "0.4.4-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/suurjaak/grepros-release/archive/release/noetic/grepros/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "2b162595da82c9719e088b15449b86f2804240d03f3adb5328d4a28b10275d1c";
+    url = "https://github.com/suurjaak/grepros-release/archive/release/noetic/grepros/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "173193109603d6ade70ef47923fcfa9b387240ecef48bef7ce52c21fcf3bdc40";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hri-msgs/default.nix
+++ b/distros/noetic/hri-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hri-msgs";
-  version = "0.4.1-r2";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.4.1-2.tar.gz";
-    name = "0.4.1-2.tar.gz";
-    sha256 = "051e170ce939ac91a41085d34dff349c2ba0e08e77baedbf86e995614ec0d30e";
+    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "f8a10c45b41a78bc11d2eec3ae1b11667eae0a8b6a5f26df56ad473ce133f752";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hri/default.nix
+++ b/distros/noetic/hri/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, geometry-msgs, hri-msgs, rosconsole, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-hri";
-  version = "0.4.1-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/libhri-release/archive/release/noetic/hri/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "24b156be2728899d62333ef0bd551207d64a10aad1f6d8220be406c60a693fa9";
+    url = "https://github.com/ros4hri/libhri-release/archive/release/noetic/hri/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "45143e13a6e3690226f5d7b90934882b8664bcd2c9ba1e3c07fdc9e3a2450b14";
   };
 
   buildType = "catkin";

--- a/distros/noetic/knowledge-representation/default.nix
+++ b/distros/noetic/knowledge-representation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, libpqxx, postgresql, python3, python3Packages, roslint, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-knowledge-representation";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/noetic/knowledge_representation/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "3cdbf4f6a2964d8e9dd9e281936f812e4eee24c1936b3d62aa817f1389ef0e07";
+    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/noetic/knowledge_representation/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "fad16bb2d5c4b082e11b1969accdf506789cbc771b76fae614f0fbbf5a2b40c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-bridge/default.nix
+++ b/distros/noetic/mrpt-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gtest, marker-msgs, message-generation, message-runtime, mrpt-msgs, mrpt2, nav-msgs, pcl, pcl-conversions, qt5, roscpp, rosunit, sensor-msgs, std-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-bridge";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release/archive/release/noetic/mrpt_bridge/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e12355e480e0d0894780c09077b348567522f187086170bbc47d54bb045dcfd9";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release/archive/release/noetic/mrpt_bridge/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8344fa904fd7a4ba211cc9d861034f92c4494be9b857d1f64eb54550865671e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-local-obstacles/default.nix
+++ b/distros/noetic/mrpt-local-obstacles/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt2, roscpp, sensor-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-local-obstacles";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c5c40f46c0e038cbff0acfbe206d2b43d43a3ee2606acf02ca3d6c5489e72c92";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt2 roscpp sensor-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Maintains a local obstacle map (point cloud,
+   voxels or occupancy grid) from recent sensor readings within a
+   configurable time window.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-localization/default.nix
+++ b/distros/noetic/mrpt-localization/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-localization";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4f2bbe76c3d9c30e1134e0673d65f2875eabdc5313139df5d2fd37c23018c5d3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-msgs mrpt2 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package for robot 2D self-localization using dynamic or static (MRPT or ROS) maps.
+	The interface is similar to amcl (https://wiki.ros.org/amcl)
+   but supports different particle-filter algorithms, several grid maps at
+   different heights, range-only localization, etc.'';
+    license = with lib.licenses; [ bsdOriginal bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-map/default.nix
+++ b/distros/noetic/mrpt-map/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-bridge, mrpt2, nav-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-map";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e4e657ac8765764b6f8efd661d66102e91391a15cb3655d87b01981799e5e7c0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-bridge mrpt2 nav-msgs roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mrpt_map is able to publish a mrpt map as ros occupancy grid like the map_server'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-navigation/default.nix
+++ b/distros/noetic/mrpt-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-local-obstacles, mrpt-localization, mrpt-map, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-navigation";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "576a3f8930809254bec26794f2a5b53957fb644973dbe1d0adfed70c3ac6d143";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-local-obstacles mrpt-localization mrpt-map mrpt-rawlog mrpt-reactivenav2d mrpt-tutorials ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools related to the Mobile Robot Programming Toolkit (MRPT).
+    Refer to https://wiki.ros.org/mrpt_navigation for further documentation.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-rawlog/default.nix
+++ b/distros/noetic/mrpt-rawlog/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-rawlog";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d7fb9297a5262abbf3b4134468e1d7dc3b295e9dceb65cb229218c71b7e2aba3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-bridge mrpt-msgs mrpt2 nav-msgs rosbag roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package enables you to record a rawlog from a ROS drive robot.
+  At the moment the package is able to deal with odometry and 2d laser scans.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-reactivenav2d/default.nix
+++ b/distros/noetic/mrpt-reactivenav2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-bridge, mrpt2, roscpp, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-reactivenav2d";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "cf9a3bfeb2dd0cea18fc6285c63299860a3773b393b5ee3a808e69d0dfe8ba78";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-bridge mrpt2 roscpp tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Reactive navigation for 2D robots using MRPT navigation algorithms (TP-Space)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-tutorials/default.nix
+++ b/distros/noetic/mrpt-tutorials/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-tutorials";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ce65c0e46bbcad164c62f87d9441a5a242a1d733296acc750deaf56053468818";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ teleop-twist-keyboard tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Example files used as tutorials for MRPT ROS packages'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ntrip-client/default.nix
+++ b/distros/noetic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ntrip-client";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "cf1cf0459dbbd26305989ef21308f7a52c57e6842ab07e651530c8096148fefc";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "580598ce99c0642c956718997d12bfe65ec9966a1f4ef39f434b887103ca98b1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openni-description/default.nix
+++ b/distros/noetic/openni-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rostest, urdf, urdfdom, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-openni-description";
+  version = "1.11.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/openni_camera-release/archive/release/noetic/openni_description/1.11.1-1.tar.gz";
+    name = "1.11.1-1.tar.gz";
+    sha256 = "6cddd77bc3e372d26cdd86c3b17b102b8c061c77f525a5c4c06de907754a27ea";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest urdfdom ];
+  propagatedBuildInputs = [ urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Model files of OpenNI device.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/openni-launch/default.nix
+++ b/distros/noetic/openni-launch/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, openni-camera, rgbd-launch, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-openni-launch";
+  version = "1.11.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/openni_camera-release/archive/release/noetic/openni_launch/1.11.1-1.tar.gz";
+    name = "1.11.1-1.tar.gz";
+    sha256 = "2a09c7c74039e9db76f2b8fe47741e944ca036beabb689802dac06fc09b549fb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ nodelet openni-camera rgbd-launch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files to open an OpenNI device and load all nodelets to 
+     convert raw depth/RGB/IR streams to depth images, disparity images, 
+     and (registered) point clouds.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt2, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-pose-cov-ops";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "2ea9a6b1920a4d26e45ece0f8363b1c95126a2eaa84039dd531631207914f612";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "ceac6165ee9ab4c98c9fdb41e816bb80fa63fa9e5d85929ac1bdf1bf60804a7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-calibration-msgs/default.nix
+++ b/distros/noetic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-calibration-msgs";
-  version = "0.6.5-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.6.5-1.tar.gz";
-    name = "0.6.5-1.tar.gz";
-    sha256 = "dcc0c22d1e110b7eb81658606d1431938b2195c86d95bc8f36ee98aae92d665d";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "b4c71fc3494c5b5107f13be141a132595b12c323d7fa86f0f2239e6399115f68";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-calibration/default.nix
+++ b/distros/noetic/robot-calibration/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-calibration";
-  version = "0.6.5-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.6.5-1.tar.gz";
-    name = "0.6.5-1.tar.gz";
-    sha256 = "02482fe8c6e8ed687cc90c1e67bc3469c049544d0cd05a76c7223270f7d5c4f3";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "c80bb52777ce861d3b2a273cd7f27a955d71ca824effe8d372b16ffb6b738357";
   };
 
   buildType = "catkin";
+  buildInputs = [ eigen ];
   checkInputs = [ code-coverage ];
-  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros-babel-fish-test-msgs/default.nix
+++ b/distros/noetic/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ros-babel-fish-test-msgs";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish_test_msgs/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "67d20d43b351518405030c80ed6e85105980f1f974c23bb371d7144843d8113f";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish_test_msgs/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "23b8229d1479dc91b0e05ec4f536c4f80eb3a529f9aa64ddbedc3107309d846e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-babel-fish/default.nix
+++ b/distros/noetic/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, rosgraph-msgs, roslib, rostest, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ros-babel-fish";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "b744a0b74ee7d6073440f24092a51d614ee1ac29b1653a13d695c27dc0ece8f5";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "a6c044f3285c529be6833c499a7ea5dba2cd99f170c51e9a544b0b1ae0730e03";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-reconfigure/default.nix
+++ b/distros/noetic/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, python-qt-binding, python3Packages, roslint, rospy, rostest, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-reconfigure";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/noetic/rqt_reconfigure/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "128637989a4b312064b75165f0793ef7d3a28b464fe2ba8ac1e5564384267b19";
+    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/noetic/rqt_reconfigure/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "95c072cfd3f2b997083601645e510482b268af1aabb4b0163e697a3cc15a4d94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/septentrio-gnss-driver/default.nix
+++ b/distros/noetic/septentrio-gnss-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-septentrio-gnss-driver";
-  version = "1.0.8-r1";
+  version = "1.1.0-r7";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "4f57d9e9cee6be0f612b13cdfb9b8b958f045d471a1cf095575dc8f7f355bd82";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.1.0-7.tar.gz";
+    name = "1.1.0-7.tar.gz";
+    sha256 = "2f71fe83b75dbaf47065f37e9c4bdcff177ff20e0daa97a541445c15963ed02f";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ boost cpp-common diagnostic-msgs geometry-msgs gps-common libpcap message-runtime rosconsole roscpp roscpp-serialization rostime sensor-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ boost cpp-common diagnostic-msgs geographiclib geometry-msgs gps-common libpcap message-runtime nav-msgs nmea-msgs rosconsole roscpp roscpp-serialization rostime sensor-msgs tf2 tf2-geometry-msgs tf2-ros xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/spinnaker-camera-driver/default.nix
+++ b/distros/noetic/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-noetic-spinnaker-camera-driver";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d011ea1c0289cdf7318a96d0af10c0f23bfb7aad54062ee92d473119ecd7941d";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/noetic/spinnaker_camera_driver/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "2a8560cf47e4b405439333bfea119075f8a617c341056e47e5868685466b7b4c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/static-transform-mux/default.nix
+++ b/distros/noetic/static-transform-mux/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rospy, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-static-transform-mux";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/static_transform_mux-release/archive/release/noetic/static_transform_mux/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f21262353f684f756a1f1ebb9e88e7d335f767843d908267d532fab94ce7e2f1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rospy tf2-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A helper node that makes sure everybody knows about all static transforms, even if they are published by multiple publishers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/tf-remapper-cpp/default.nix
+++ b/distros/noetic/tf-remapper-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rostest, tf, tf2-msgs, xmlrpcpp }:
+buildRosPackage {
+  pname = "ros-noetic-tf-remapper-cpp";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/tf_remapper_cpp-release/archive/release/noetic/tf_remapper_cpp/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "ca712c9318d7ad39dbfa3f8c7736fe7e9600a399177a4a0b6e5c707bbe51e6c1";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest tf ];
+  propagatedBuildInputs = [ roscpp tf2-msgs xmlrpcpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''More efficient version of tf/tf_remap able to handle TFs at kHz with tens of subscribers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-sensor-library/default.nix
+++ b/distros/noetic/toposens-sensor-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-toposens-sensor-library";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/noetic/toposens-sensor-library/1.1.3-1/archive.tar.gz";
+    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/noetic/toposens-sensor-library/1.1.4-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "e17bd3510385845d7038cc633ba4602ee410c6f75b33a09d86944d8fb764091a";
+    sha256 = "83edaf16652efd206c158c95710959da959870520a0212c6116be79bf58d9991";
   };
 
   buildType = "cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''Driver for toposens echo sensor'';
-    license = with lib.licenses; [ bsd3 ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/noetic/um6/default.nix
+++ b/distros/noetic/um6/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, roslint, sensor-msgs, serial }:
+buildRosPackage {
+  pname = "ros-noetic-um6";
+  version = "1.1.3-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/um6-release/archive/release/noetic/um6/1.1.3-4.tar.gz";
+    name = "1.1.3-4.tar.gz";
+    sha256 = "1545b3debade76db6e2955bc6769c6e1eb23c8f4f1d2f6e0a28aee3dbbb97c2b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation roslint ];
+  propagatedBuildInputs = [ message-runtime roscpp sensor-msgs serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The um6 package provides a C++ implementation of the CH Robotics serial protocol, and a
+    corresponding ROS node for publishing standard ROS orientation topics from a UM6.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit e8f302ca29d2d667071932717555447de9726c2c.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *clober-bringup 0.1.0-r2 --> 0.2.0-r5*
* *clober-description 0.1.0-r2 --> 0.2.0-r5*
* *clober-navigation 0.1.0-r2 --> 0.2.0-r5*
* *clober-serial 0.1.0-r2 --> 0.2.0-r5*
* *clober-simulation 0.1.0-r2 --> 0.2.0-r5*
* *clober-slam 0.1.0-r2 --> 0.2.0-r5*
* *eigenpy 2.7.1-r1 --> 2.7.2-r1*
* *foxglove-msgs 1.1.0-r1*
* *grepros 0.4.4-r1 --> 0.4.5-r1*
* *imu-complementary-filter 2.0.1-r1*
* *imu-filter-madgwick 2.0.1-r1*
* *imu-tools 2.0.1-r1*
* *mcap-vendor 0.1.5-r1*
* *ntrip-client 1.0.2-r1 --> 1.1.0-r1*
* *robot-upstart 1.0.1-r1 --> 1.0.2-r1*
* *rosbag2-storage-mcap 0.1.5-r1*
* *rviz-imu-plugin 2.0.1-r1*
* *septentrio-gnss-driver 1.2.0-r2*
* *simple-launch 1.3.0-r1 --> 1.3.1-r1*
* *slider-publisher 2.1.0-r1 --> 2.1.1-r1*
* *swri-console-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-dbw-interface 3.4.0-r1 --> 3.4.1-r1*
* *swri-geometry-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-image-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-math-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-opencv-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-prefix-tools 3.4.0-r1 --> 3.4.1-r1*
* *swri-roscpp 3.4.0-r1 --> 3.4.1-r1*
* *swri-route-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-serial-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-system-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-transform-util 3.4.0-r1 --> 3.4.1-r1*
* *ur-client-library 1.0.0-r1 --> 1.1.0-r1*
* *usb-cam 0.4.1-r1 --> 0.4.2-r1*

Galactic Changes:
-----------------
* *ament-clang-format 0.10.6-r1 --> 0.10.7-r1*
* *ament-clang-tidy 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-clang-format 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-clang-tidy 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-copyright 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-cppcheck 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-cpplint 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-flake8 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-lint-cmake 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-mypy 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-pclint 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-pep257 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-pycodestyle 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-pyflakes 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-uncrustify 0.10.6-r1 --> 0.10.7-r1*
* *ament-cmake-xmllint 0.10.6-r1 --> 0.10.7-r1*
* *ament-copyright 0.10.6-r1 --> 0.10.7-r1*
* *ament-cppcheck 0.10.6-r1 --> 0.10.7-r1*
* *ament-cpplint 0.10.6-r1 --> 0.10.7-r1*
* *ament-flake8 0.10.6-r1 --> 0.10.7-r1*
* *ament-lint 0.10.6-r1 --> 0.10.7-r1*
* *ament-lint-auto 0.10.6-r1 --> 0.10.7-r1*
* *ament-lint-cmake 0.10.6-r1 --> 0.10.7-r1*
* *ament-lint-common 0.10.6-r1 --> 0.10.7-r1*
* *ament-mypy 0.10.6-r1 --> 0.10.7-r1*
* *ament-pclint 0.10.6-r1 --> 0.10.7-r1*
* *ament-pep257 0.10.6-r1 --> 0.10.7-r1*
* *ament-pycodestyle 0.10.6-r1 --> 0.10.7-r1*
* *ament-pyflakes 0.10.6-r1 --> 0.10.7-r1*
* *ament-uncrustify 0.10.6-r1 --> 0.10.7-r1*
* *ament-xmllint 0.10.6-r1 --> 0.10.7-r1*
* *camera-calibration-parsers 2.3.0-r3 --> 2.3.1-r1*
* *camera-info-manager 2.3.0-r3 --> 2.3.1-r1*
* *controller-interface 1.4.0-r1 --> 1.5.0-r1*
* *controller-manager 1.4.0-r1 --> 1.5.0-r1*
* *controller-manager-msgs 1.4.0-r1 --> 1.5.0-r1*
* *examples-tf2-py 0.17.2-r1 --> 0.17.3-r1*
* *foxglove-msgs 1.1.0-r1*
* *geometry2 0.17.2-r1 --> 0.17.3-r1*
* *hardware-interface 1.4.0-r1 --> 1.5.0-r1*
* *image-common 2.3.0-r3 --> 2.3.1-r1*
* *image-transport 2.3.0-r3 --> 2.3.1-r1*
* *imu-complementary-filter 2.0.1-r1*
* *imu-filter-madgwick 2.0.1-r1*
* *imu-tools 2.0.1-r1*
* *irobot-create-common-bringup 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-control 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-description 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-gazebo-bringup 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-gazebo-plugins 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-gazebo-sim 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-ignition-bringup 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-ignition-sim 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-ignition-toolbox 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-nodes 1.0.1-r1 --> 1.0.3-r1*
* *irobot-create-toolbox 1.0.1-r1 --> 1.0.3-r1*
* *launch 0.17.0-r2 --> 0.17.1-r1*
* *launch-ros 0.14.2-r1 --> 0.14.3-r1*
* *launch-testing 0.17.0-r2 --> 0.17.1-r1*
* *launch-testing-ament-cmake 0.17.0-r2 --> 0.17.1-r1*
* *launch-testing-ros 0.14.2-r1 --> 0.14.3-r1*
* *launch-xml 0.17.0-r2 --> 0.17.1-r1*
* *launch-yaml 0.17.0-r2 --> 0.17.1-r1*
* *mcap-vendor 0.1.5-r1*
* *ntrip-client 1.0.2-r1 --> 1.1.0-r1*
* *plansys2-bringup 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-bt-actions 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-core 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-domain-expert 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-executor 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-lifecycle-manager 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-msgs 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-pddl-parser 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-planner 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-popf-plan-solver 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-problem-expert 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-terminal 2.0.3-r1 --> 2.0.8-r1*
* *plansys2-tools 2.0.3-r1 --> 2.0.8-r1*
* *rcl 3.1.2-r1 --> 3.1.3-r1*
* *rcl-action 3.1.2-r1 --> 3.1.3-r1*
* *rcl-lifecycle 3.1.2-r1 --> 3.1.3-r1*
* *rcl-logging-interface 2.1.2-r2 --> 2.1.4-r1*
* *rcl-logging-log4cxx 2.1.2-r2 --> 2.1.4-r1*
* *rcl-logging-noop 2.1.2-r2 --> 2.1.4-r1*
* *rcl-logging-spdlog 2.1.2-r2 --> 2.1.4-r1*
* *rcl-yaml-param-parser 3.1.2-r1 --> 3.1.3-r1*
* *rclcpp 9.2.0-r1 --> 9.2.1-r1*
* *rclcpp-action 9.2.0-r1 --> 9.2.1-r1*
* *rclcpp-components 9.2.0-r1 --> 9.2.1-r1*
* *rclcpp-lifecycle 9.2.0-r1 --> 9.2.1-r1*
* *rclpy 1.9.0-r1 --> 1.9.1-r1*
* *rcss3d-agent 0.0.6-r1 --> 0.0.7-r1*
* *rcss3d-agent-basic 0.0.6-r1 --> 0.0.7-r1*
* *rcss3d-agent-msgs 0.0.6-r1 --> 0.0.7-r1*
* *rmw-connextdds 0.6.2-r1 --> 0.6.3-r1*
* *rmw-connextdds-common 0.6.2-r1 --> 0.6.3-r1*
* *rmw-cyclonedds-cpp 0.22.4-r1 --> 0.22.5-r1*
* *rmw-fastrtps-cpp 5.0.1-r1 --> 5.0.2-r1*
* *rmw-fastrtps-dynamic-cpp 5.0.1-r1 --> 5.0.2-r1*
* *rmw-fastrtps-shared-cpp 5.0.1-r1 --> 5.0.2-r1*
* *robot-upstart 1.0.1-r1 --> 1.0.2-r1*
* *ros2-control 1.4.0-r1 --> 1.5.0-r1*
* *ros2-control-test-assets 1.4.0-r1 --> 1.5.0-r1*
* *ros2action 0.13.2-r1 --> 0.13.3-r1*
* *ros2cli 0.13.2-r1 --> 0.13.3-r1*
* *ros2cli-test-interfaces 0.13.2-r1 --> 0.13.3-r1*
* *ros2component 0.13.2-r1 --> 0.13.3-r1*
* *ros2controlcli 1.4.0-r1 --> 1.5.0-r1*
* *ros2interface 0.13.2-r1 --> 0.13.3-r1*
* *ros2launch 0.14.2-r1 --> 0.14.3-r1*
* *ros2lifecycle 0.13.2-r1 --> 0.13.3-r1*
* *ros2lifecycle-test-fixtures 0.13.2-r1 --> 0.13.3-r1*
* *ros2multicast 0.13.2-r1 --> 0.13.3-r1*
* *ros2node 0.13.2-r1 --> 0.13.3-r1*
* *ros2param 0.13.2-r1 --> 0.13.3-r1*
* *ros2pkg 0.13.2-r1 --> 0.13.3-r1*
* *ros2run 0.13.2-r1 --> 0.13.3-r1*
* *ros2service 0.13.2-r1 --> 0.13.3-r1*
* *ros2topic 0.13.2-r1 --> 0.13.3-r1*
* *rosbag2-storage-mcap 0.1.1-r1 --> 0.1.5-r1*
* *rosidl-adapter 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-cli 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-cmake 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-generator-c 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-generator-cpp 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-generator-py 0.11.1-r1 --> 0.11.2-r1*
* *rosidl-parser 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-runtime-c 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-runtime-cpp 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-typesupport-interface 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-typesupport-introspection-c 2.2.1-r2 --> 2.2.2-r1*
* *rosidl-typesupport-introspection-cpp 2.2.1-r2 --> 2.2.2-r1*
* *rti-connext-dds-cmake-module 0.6.2-r1 --> 0.6.3-r1*
* *rviz-assimp-vendor 8.5.0-r3 --> 8.5.1-r1*
* *rviz-common 8.5.0-r3 --> 8.5.1-r1*
* *rviz-default-plugins 8.5.0-r3 --> 8.5.1-r1*
* *rviz-imu-plugin 2.0.1-r1*
* *rviz-ogre-vendor 8.5.0-r3 --> 8.5.1-r1*
* *rviz-rendering 8.5.0-r3 --> 8.5.1-r1*
* *rviz-rendering-tests 8.5.0-r3 --> 8.5.1-r1*
* *rviz-visual-testing-framework 8.5.0-r3 --> 8.5.1-r1*
* *rviz2 8.5.0-r3 --> 8.5.1-r1*
* *septentrio-gnss-driver 1.2.0-r5*
* *simple-launch 1.3.0-r1 --> 1.3.1-r1*
* *slider-publisher 2.1.0-r1 --> 2.1.1-r1*
* *swri-console-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-dbw-interface 3.4.0-r1 --> 3.4.1-r1*
* *swri-geometry-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-image-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-math-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-opencv-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-prefix-tools 3.4.0-r1 --> 3.4.1-r1*
* *swri-roscpp 3.4.0-r1 --> 3.4.1-r1*
* *swri-route-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-serial-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-system-util 3.4.0-r1 --> 3.4.1-r1*
* *swri-transform-util 3.4.0-r1 --> 3.4.1-r1*
* *tango-icons-vendor 0.1.0-r3 --> 0.1.1-r1*
* *tf2 0.17.2-r1 --> 0.17.3-r1*
* *tf2-bullet 0.17.2-r1 --> 0.17.3-r1*
* *tf2-eigen 0.17.2-r1 --> 0.17.3-r1*
* *tf2-eigen-kdl 0.17.2-r1 --> 0.17.3-r1*
* *tf2-geometry-msgs 0.17.2-r1 --> 0.17.3-r1*
* *tf2-kdl 0.17.2-r1 --> 0.17.3-r1*
* *tf2-msgs 0.17.2-r1 --> 0.17.3-r1*
* *tf2-py 0.17.2-r1 --> 0.17.3-r1*
* *tf2-ros 0.17.2-r1 --> 0.17.3-r1*
* *tf2-ros-py 0.17.2-r1 --> 0.17.3-r1*
* *tf2-sensor-msgs 0.17.2-r1 --> 0.17.3-r1*
* *tf2-tools 0.17.2-r1 --> 0.17.3-r1*
* *transmission-interface 1.4.0-r1 --> 1.5.0-r1*
* *turtlebot4-description 0.1.0-r1*
* *turtlebot4-desktop 0.1.0-r1*
* *turtlebot4-ignition-bringup 0.1.0-r1*
* *turtlebot4-ignition-toolbox 0.1.0-r1*
* *turtlebot4-msgs 0.1.0-r1*
* *turtlebot4-navigation 0.1.0-r1*
* *turtlebot4-node 0.1.0-r1*
* *turtlebot4-simulator 0.1.0-r1*
* *turtlebot4-viz 0.1.0-r1*
* *turtlesim 1.3.3-r1 --> 1.3.4-r1*
* *ur-bringup 2.1.0-r1*
* *ur-calibration 2.1.0-r1*
* *ur-client-library 1.0.0-r3 --> 1.1.0-r1*
* *ur-controllers 2.1.0-r1*
* *ur-dashboard-msgs 2.1.0-r1*
* *ur-moveit-config 2.1.0-r1*
* *ur-robot-driver 2.1.0-r1*
* *usb-cam 0.4.0-r1 --> 0.4.2-r1*

Melodic Changes:
----------------
* *aws-common 2.2.1-r1 --> 2.2.0-r1*
* *aws-ros1-common 2.0.3-r1 --> 2.0.1-r2*
* *cloudwatch-logger 2.3.2-r1 --> 2.3.1-r1*
* *cloudwatch-logs-common 1.1.6-r1 --> 1.1.5-r1*
* *cloudwatch-metrics-collector 2.2.2-r1 --> 2.2.1-r2*
* *cloudwatch-metrics-common 1.1.6-r1 --> 1.1.5-r1*
* *dataflow-lite 1.1.6-r1 --> 1.1.5-r1*
* *eigenpy 2.7.1-r1 --> 2.7.2-r1*
* *ethercat-manager 1.0.10-r1*
* *euslime 1.1.1-r1 --> 1.1.2-r1*
* *file-management 1.1.6-r1 --> 1.1.5-r1*
* *file-uploader-msgs 1.0.2-r1 --> 1.0.1-r1*
* *h264-encoder-core 2.0.4-r1 --> 2.0.3-r1*
* *health-metric-collector 2.0.3-r1 --> 2.0.2-r1*
* *hri 0.4.1-r1 --> 0.4.3-r1*
* *hri-msgs 0.4.1-r1 --> 0.5.2-r1*
* *kinesis-manager 2.0.4-r1 --> 2.0.3-r1*
* *kinesis-video-msgs 2.0.4-r1 --> 2.0.3-r1*
* *kinesis-video-streamer 2.0.4-r1 --> 2.0.3-r1*
* *lex-common 1.0.1-r1 --> 1.0.0-r1*
* *lex-common-msgs 2.0.3-r1 --> 2.0.2-r1*
* *lex-node 2.0.3-r1 --> 2.0.2-r1*
* *minas 1.0.10-r1*
* *minas-control 1.0.10-r1*
* *mrpt-bridge 0.1.25 --> 1.0.1-r1*
* *mrpt-local-obstacles 0.1.26-r1 --> 1.0.0-r1*
* *mrpt-localization 0.1.26-r1 --> 1.0.0-r1*
* *mrpt-map 0.1.26-r1 --> 1.0.0-r1*
* *mrpt-navigation 0.1.26-r1 --> 1.0.0-r1*
* *mrpt-rawlog 0.1.26-r1 --> 1.0.0-r1*
* *mrpt-reactivenav2d 0.1.26-r1 --> 1.0.0-r1*
* *mrpt-tutorials 0.1.26-r1 --> 1.0.0-r1*
* *ntrip-client 1.0.1-r1 --> 1.1.0-r1*
* *pf-description 1.2.0-r2*
* *pf-driver 1.1.1-r1 --> 1.2.0-r2*
* *pose-cov-ops 0.2.1 --> 0.3.1-r1*
* *recorder-msgs 1.0.2-r1 --> 1.0.1-r1*
* *robot-calibration 0.6.5-r1 --> 0.7.0-r1*
* *robot-calibration-msgs 0.6.5-r1 --> 0.7.0-r1*
* *ros-babel-fish 0.9.2-r1 --> 0.9.3-r1*
* *ros-babel-fish-test-msgs 0.9.2-r1 --> 0.9.3-r1*
* *ros-monitoring-msgs 1.0.2-r1 --> 1.0.1-r1*
* *rosbag-cloud-recorders 1.0.2-r1 --> 1.0.1-r1*
* *s3-common 1.0.2-r1 --> 1.0.1-r1*
* *s3-file-uploader 1.0.2-r1 --> 1.0.1-r1*
* *septentrio-gnss-driver 1.0.8-r1 --> 1.1.0-r8*
* *toposens-sensor-library 1.1.4-r1*
* *tra1-bringup 1.0.10-r1*
* *tra1-description 1.0.10-r1*
* *tra1-moveit-config 1.0.10-r1*
* *tts 1.0.3-r1 --> 1.0.2-r1*

Noetic Changes:
---------------
* *camera-aravis 4.0.1-r2 --> 4.0.2-r1*
* *cob-bringup 0.7.6-r4*
* *cob-bringup-sim 0.7.5-r2*
* *cob-collision-monitor 0.7.6-r1 --> 0.7.6-r2*
* *cob-default-robot-behavior 0.7.6-r1 --> 0.7.6-r4*
* *cob-default-robot-config 0.7.6-r1 --> 0.7.6-r4*
* *cob-gazebo 0.7.5-r2*
* *cob-gazebo-objects 0.7.5-r1 --> 0.7.5-r2*
* *cob-gazebo-tools 0.7.5-r1 --> 0.7.5-r2*
* *cob-gazebo-worlds 0.7.5-r1 --> 0.7.5-r2*
* *cob-grasp-generation 0.7.6-r1 --> 0.7.6-r2*
* *cob-hardware-config 0.7.6-r1 --> 0.7.6-r4*
* *cob-lookat-action 0.7.6-r1 --> 0.7.6-r2*
* *cob-manipulation 0.7.6-r2*
* *cob-manipulation-msgs 0.7.6-r1 --> 0.7.6-r2*
* *cob-moveit-bringup 0.7.6-r1 --> 0.7.6-r2*
* *cob-moveit-config 0.7.6-r1 --> 0.7.6-r4*
* *cob-moveit-interface 0.7.6-r1 --> 0.7.6-r2*
* *cob-robots 0.7.6-r4*
* *cob-simulation 0.7.5-r2*
* *dynamic-robot-state-publisher 1.2.0-r1*
* *eigenpy 2.7.1-r1 --> 2.7.2-r1*
* *euslime 1.1.1-r1 --> 1.1.2-r1*
* *flir-camera-description 0.2.2-r1 --> 0.2.3-r1*
* *flir-camera-driver 0.2.2-r1 --> 0.2.3-r1*
* *grepros 0.4.4-r1 --> 0.4.5-r1*
* *hri 0.4.1-r1 --> 0.4.3-r1*
* *hri-msgs 0.4.1-r2 --> 0.5.2-r1*
* *knowledge-representation 0.9.5-r1 --> 0.9.6-r1*
* *mrpt-bridge 1.0.0-r1 --> 1.0.1-r1*
* *mrpt-local-obstacles 1.0.0-r1*
* *mrpt-localization 1.0.0-r1*
* *mrpt-map 1.0.0-r1*
* *mrpt-navigation 1.0.0-r1*
* *mrpt-rawlog 1.0.0-r1*
* *mrpt-reactivenav2d 1.0.0-r1*
* *mrpt-tutorials 1.0.0-r1*
* *ntrip-client 1.0.1-r1 --> 1.1.0-r1*
* *openni-description 1.11.1-r1*
* *openni-launch 1.11.1-r1*
* *pose-cov-ops 0.3.0-r1 --> 0.3.1-r1*
* *robot-calibration 0.6.5-r1 --> 0.7.0-r1*
* *robot-calibration-msgs 0.6.5-r1 --> 0.7.0-r1*
* *ros-babel-fish 0.9.2-r1 --> 0.9.3-r1*
* *ros-babel-fish-test-msgs 0.9.2-r1 --> 0.9.3-r1*
* *rqt-reconfigure 0.5.4-r1 --> 0.5.5-r1*
* *septentrio-gnss-driver 1.0.8-r1 --> 1.1.0-r7*
* *spinnaker-camera-driver 0.2.2-r1 --> 0.2.3-r1*
* *static-transform-mux 1.1.0-r1*
* *tf-remapper-cpp 1.1.1-r1*
* *toposens-sensor-library 1.1.3-r1 --> 1.1.4-r1*
* *um6 1.1.3-r4*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

