### PR TITLE
rosdistro sync, Fri May 13 13:36:13 2022

### DIFF
--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "212b9bf6732e306bb1e300ed9c42bb136b95166e0d51ae294dc9e045ec8db425";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "b784f6a28d3c19779124fe7e36216c05a8417e9ce70fe791e7017a17a4d06ad0";
   };
 
   buildType = "cmake";

--- a/distros/foxy/octomap-ros/default.nix
+++ b/distros/foxy/octomap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-octomap-ros";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/foxy/octomap_ros/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "2156e374f7e49071993af1d13ac2e552961b5fe0d5777551a452a45c844f6d70";
+    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/foxy/octomap_ros/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "71a489c497eab3b8ebaa254356272247db3be9bb554fec5654b0cd1f0dcfc58c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/costmap-queue/default.nix
+++ b/distros/galactic/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-costmap-queue";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f5a30727da14f9ca35bf9201713b0b04e14b343e5e348cdcf8813c6d0490f6c9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "227a7e0cda4a0a5fcb066319dd1c6566574bb3bc2bb3bffae3c6afc004cf1b60";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai/default.nix
+++ b/distros/galactic/depthai/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv }:
+buildRosPackage {
+  pname = "ros-galactic-depthai";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "59d1a880410829ea6df58495a578aecf7341fe4a6ab2108ad64fc9461d2025f5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ libusb1 nlohmann_json opencv ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''DepthAI core is a C++ library which comes with firmware and an API to interact with OAK Platform'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/dwb-core/default.nix
+++ b/distros/galactic/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-core";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a235446c09026926ceff194ee2d5e293243ad955e6c4b68ccdeeda8ee9a21420";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "950e2b1e316baaebbcc7e09002f196e49fcbc3eb8708ec57b4f4ec48090d99b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-critics/default.nix
+++ b/distros/galactic/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-critics";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f25995f98819094c57215367afcc7f925e6863b2481fd6779c9a84b950e98cec";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1ae2bd65fb0731797404e2093818500ec6f1db88f3b0df07279d59ee324dcfee";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-msgs/default.nix
+++ b/distros/galactic/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "30277a37d9e05119bbb6c5fd8f452b5b49e587f4015b65a598ef0caac3a5f51a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "d1edc99b59c41954f7ef43cfe3789108041031f9a5a32906b0765e666f397538";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-plugins/default.nix
+++ b/distros/galactic/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-dwb-plugins";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "334ea6849dfdd1b0eec10bb78b7a6bbca2c64dee907f9d816b5868120ac6963a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "fb4665f3200a43de252b5b5dfbc236e3722fa51131030079cf14a1c7062b432b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -230,6 +230,8 @@ self: super: {
 
  depth-image-proc = self.callPackage ./depth-image-proc {};
 
+ depthai = self.callPackage ./depthai {};
+
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
  desktop = self.callPackage ./desktop {};

--- a/distros/galactic/nav-2d-msgs/default.nix
+++ b/distros/galactic/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "49bc935d02cbb89d03abd0ec1dab1424166b5caad9d60d9735a1d71ffb589dd0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "8848b5b2e617f7c302f06799505623d56ac66ce9fc4b51bd35c51c3f6b2a6dea";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav-2d-utils/default.nix
+++ b/distros/galactic/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-utils";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "3c13c283edf395d08424ab5f9a7a8d0d87c31f0e7c889752bc2d9e96b29856b8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "49663348d60924a6f381644b0812418af144a75fddd8e2ce75389fe24cef4c93";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-amcl/default.nix
+++ b/distros/galactic/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-amcl";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "efe0cf6c1c2c112065891a4b5ad12a133a2cf8a960bcf65a6766700b2910549a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "f7adcc119ed1173fb34b885a9a238a21f0e67dae82fec9fdc2ddca7b4c2aa948";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-behavior-tree/default.nix
+++ b/distros/galactic/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-behavior-tree";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "53b520748d8b317ecbaf6335f30b2eaebd3b824875e71a221180c7ba04724841";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "7617a8a8c6d661c2c44f056e0dde06fd41fc945b2424da81dc02ea0bc4875689";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bringup/default.nix
+++ b/distros/galactic/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bringup";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "2d49b9631632977540f7d91345d31ace377195b705540073b18d398728c86fc5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1bcbc337c5bf6775ccf7b9c231149958a271a93d1c5cc9d5a7d4e5e25dc2ffdc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bt-navigator/default.nix
+++ b/distros/galactic/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bt-navigator";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "c4aecce353863f99c12e6855e0092e06f730f325e480fd1f31f96638eb7b34e2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b892cdf37cb7fd85472885401252427360a2d35db732bdd05819da96b0c0dcd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-common/default.nix
+++ b/distros/galactic/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-common";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a23d5360fd4b1a21c540e5ed51c14701b5ccee010a2fd6d957df3675b83ef31c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "ff8947fcbd0540f7aefce59b0d7e5e0c7e93a4892ac8cb480125636fb35d0b84";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-controller/default.nix
+++ b/distros/galactic/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-controller";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1799230a535bf116a2c6637883c54ec36a5944883cab57f56408473bb6923023";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "8bd40271aca53becc576ba07226068de0596d64aedffa52f66df676b33a05118";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-core/default.nix
+++ b/distros/galactic/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-core";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f381ac7d274f15680f9c3824b1dc0de53d77decb3cec36fdcfd1480b8bac579d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1c7a899db880e4d15e28a5fa7e37a8d0a815e987ce90583eea8341995535253f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-costmap-2d/default.nix
+++ b/distros/galactic/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-costmap-2d";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "30b00ee13cb65fcd10e76c80e3213a1a7909b28500b9463e5756af4124a6c6c9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "fa4ef57dfb224cfc4b317cfc29a01ee539a696b2ab2990c98df2e229f2263919";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-dwb-controller/default.nix
+++ b/distros/galactic/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-galactic-nav2-dwb-controller";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "b021b4c71f600092d8dee8d6db8f927ce968cd271f66c09c822d835454f5c25d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b464973623b7225bea330cb8d138d8f81e2cbf6ca71ff5dd6940f8289bef3b50";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-gazebo-spawner/default.nix
+++ b/distros/galactic/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-gazebo-spawner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0127e75064ab655841813c745dd8d423dafc4dd8877913d7c46185a2e9b22bb9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1930cf2a4ad3e9e8f73043b273549cb43e0e0ec26eaef6375f316b1ea7fa1fdc";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-lifecycle-manager/default.nix
+++ b/distros/galactic/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-lifecycle-manager";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "d45928cbf7ededd041ecde3149882196203ba97fcb9463e22bbcba59dfe70f32";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "0f67dc18acac92bf662fb1b2acf4a3e019cf95dbfe12978cd82e7e1aff109292";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-map-server/default.nix
+++ b/distros/galactic/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-nav2-map-server";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "642607bfb94cce6b766a0e1369a40e9999b9cfef658e3e59d539fadac81736ca";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "a42063092e1c63f1b1e181f3a80333810587908cf128defa539eaaebb82fd837";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-msgs/default.nix
+++ b/distros/galactic/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "4f7946653eca774cabc0868fcef181f859caa774b81e3a6bad5e0df241205b3e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1f46c6e12b5f2ee63e49c9282b51c8ff11677e61985b7ab4ddb5c4d4696eb75d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-navfn-planner/default.nix
+++ b/distros/galactic/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-navfn-planner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "7c780bb4443eff7174a45079e5cd8084b494a63229a681f5851d033bc6b7b92c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "f9ad45037cdae3351cb9b7e68801cfa2925fac59d8471e9f3668f23a4bfa2ab0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-planner/default.nix
+++ b/distros/galactic/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-planner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f84e977ade147658aff385e45e391bbadb586cb01468ff2f65ad05519fa23d0b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "fcb499688aa8f94141e220fe5344be0835eee5ed21e5b61e06fed7402fecf32d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-recoveries/default.nix
+++ b/distros/galactic/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-recoveries";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "ef6939f24a19506046d30582762d161fbb787ee5c39c5b0d2057c2a6f1c429a2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "ec3ce9ce0da57cfaee5e3a546e18a20fa3c476ad4c0b1667b5e67d239fa9dcda";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-regulated-pure-pursuit-controller";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a9e3830d1791dcd1cd72c23c800ab0a81bfcf7b52270e2263f46f6dc3bf2766a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b5c481965ed0966829edd2c1294e5487ae3b67bd7da88afdc38f4e789e461a27";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rotation-shim-controller/default.nix
+++ b/distros/galactic/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rotation-shim-controller";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "d431c0831a564ecab12885895b405a78ee7a6818aa7499d6aaeb157a72e34a59";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "12e3998cc1a8857163639e04421d685dfc824b0a34efaac6a814f88fde36a6e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rviz-plugins/default.nix
+++ b/distros/galactic/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rviz-plugins";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "83e74d17a90a923fd8be0dd7966ffb9695cf79bd256c73d4a36f89fcd05ac5dc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "35b0e01c982df4a69ccc2b4f1513bf3d3c6f8486d9482d9574b9ee8e82f97e90";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-simple-commander/default.nix
+++ b/distros/galactic/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-simple-commander";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f195205c4009f180eab8644181269c53c2af30da6a3700eb17641412be4ca104";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "a29bbd6aed118add6a31aad49caee86135dcb8518fa18e49028ba0a089df4e41";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-smac-planner/default.nix
+++ b/distros/galactic/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-smac-planner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "cab9755f1d8cea4bd38aef51b5b9c7b654390efffd125d7ff5d1a9b3a4f3d0c6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "6a1ff7b8f2d3dec3099a680bb305c9540e4760a39a3cfb2a273d799f632b9ac5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-system-tests/default.nix
+++ b/distros/galactic/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-system-tests";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "960c7bc2f951099f1c8c451197969ca98916f98127194c40519e66743fd9e57c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b291483e9ddee4072b3e444db8a21d2cfbbd432e1a16a09eb1c15e810585a1ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-theta-star-planner/default.nix
+++ b/distros/galactic/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-theta-star-planner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f449828277e48a103387c50906d3bffea8c81c90a0b338046da22739ae05a69b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "8e55470dd017bd8ee9994eff1e9388cbe8ea6021b285a11f49472b82e84501a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-util/default.nix
+++ b/distros/galactic/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-util";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "dc6772ec22df2c7805b1cc373a8f22f21b8b585e29f492045fcd761ac8f93410";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "9cfa8747b535f04953d0ca921942189cee447fe1ab44b29e4d6fb1a32181c5f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-voxel-grid/default.nix
+++ b/distros/galactic/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nav2-voxel-grid";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "9d92352f4a77ea6aee0094a717dc8c398e254b29205502a8b690392a4a08a719";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "59ddb6f01b33172b18880a172726cc8c657e1a44a484a211d579e11a07f32687";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-waypoint-follower/default.nix
+++ b/distros/galactic/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-waypoint-follower";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "cc7f712412b1a01c43b26e74fdd2b54dacd7c16411a3add5f39e513beac77e51";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1f50eccba7e3ac575a1e50d83bb0fcbcd308d25128588775ce62d3b9f33f7ef6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/navigation2/default.nix
+++ b/distros/galactic/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-theta-star-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-galactic-navigation2";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a5d681f28ebb9501870f1a1b77395bdbef6366e9aa5cb63a31a5af830eba9d2c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "ab4a33f8ae23a90c2ddb3b6cd6374aa3f2cfdca9ae4607a93a192c0d2163e35d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/octomap-ros/default.nix
+++ b/distros/galactic/octomap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-octomap-ros";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/galactic/octomap_ros/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "8c4842e8369ac1c1fcc29d4347724c4630a219df1b76d3ec1e56de28757225b7";
+    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/galactic/octomap_ros/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "c7d5ffb76aff85d914469f2c65b765702dcc88aa33b26fdef724055beaf58d07";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-ignition-bringup/default.nix
+++ b/distros/galactic/turtlebot4-ignition-bringup/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-toolbox, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs, turtlebot4-description, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-nodes, irobot-create-toolbox, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs, turtlebot4-description, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-ignition-bringup";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_bringup/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "19411e65888d4cebcb686a5fcb226160dd934f6315cdb22f6268f82c03fe35c7";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_bringup/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b939dfd8547d72ae2c13b879c38875aeb1257f645e8226d71020bd37c5bdd749";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-bringup irobot-create-ignition-toolbox irobot-create-msgs irobot-create-toolbox ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs turtlebot4-description turtlebot4-ignition-gui-plugins turtlebot4-ignition-toolbox turtlebot4-msgs turtlebot4-navigation turtlebot4-node turtlebot4-viz ];
+  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-bringup irobot-create-ignition-toolbox irobot-create-msgs irobot-create-nodes irobot-create-toolbox ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs turtlebot4-description turtlebot4-ignition-gui-plugins turtlebot4-ignition-toolbox turtlebot4-msgs turtlebot4-navigation turtlebot4-node turtlebot4-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''TurtleBot 4 Ignition Simulator bringup'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/turtlebot4-ignition-toolbox/default.nix
+++ b/distros/galactic/turtlebot4-ignition-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-ignition-toolbox";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_toolbox/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "9eaabd5c035e658c8b9e81288d2e4f079d1a7b675391a27963d5a96036a371b6";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_toolbox/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "5672e2506144558a54d65922946036f5ad427f913adc655e11577cb675572c9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-simulator/default.nix
+++ b/distros/galactic/turtlebot4-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-ignition-bringup, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-simulator";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_simulator/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "11de2a7c9481102234c252e0166551791c2bf8d2dd0cee1abf9714b4dc99c044";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_simulator/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "2721b40c617b6a564a7b36ba9312e37a6fff3870806eda9991c5c80ceced0e7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/control-toolbox/default.nix
+++ b/distros/melodic/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, control-msgs, dynamic-reconfigure, message-generation, message-runtime, realtime-tools, roscpp, rosunit, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-control-toolbox";
-  version = "1.18.2-r1";
+  version = "1.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/melodic/control_toolbox/1.18.2-1.tar.gz";
-    name = "1.18.2-1.tar.gz";
-    sha256 = "35b286163116a3ba5e016f9e970ece963de8711cb3fae2b1cccb7dcb1c32f55a";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/melodic/control_toolbox/1.19.0-1.tar.gz";
+    name = "1.19.0-1.tar.gz";
+    sha256 = "f1c7f00c8c9e32db695503d01ab129c915dd47cb1f1468535e2086dd6b9ecaf2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "e6f7edf9060c26c59d57b119df1fc730d6aa2e4da0a9074660b77aaa40ccfa7d";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "3664e366f7ebd962056f104b284f8933eeee40c14a35371a30e6594c0e014959";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eus-assimp/default.nix
+++ b/distros/melodic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-melodic-eus-assimp";
-  version = "0.4.3";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eus_assimp/0.4.3-0.tar.gz";
-    name = "0.4.3-0.tar.gz";
-    sha256 = "c82e9cbb4c4fd87a20d1c6a596293aed0dbc8661a1ccb4f57f4637cc688b8548";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eus_assimp/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "d94c8c3950538e07a3d17c344f0d25aa7ce89081991c80b3200fcd90b6077e06";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eusurdf/default.nix
+++ b/distros/melodic/eusurdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, pythonPackages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-melodic-eusurdf";
-  version = "0.4.3";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eusurdf/0.4.3-0.tar.gz";
-    name = "0.4.3-0.tar.gz";
-    sha256 = "47f6b8cfb42f9516ed0993922e6f3059cb387fa533cda56fed5e2fb81937f395";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eusurdf/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "e65fe8bb4fa58516ec9b7833d07302ee91b8283808e5fe7f18c31db1f974722f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/filters/default.nix
+++ b/distros/melodic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, rosconsole, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-melodic-filters";
-  version = "1.8.2-r1";
+  version = "1.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.2-1.tar.gz";
-    name = "1.8.2-1.tar.gz";
-    sha256 = "b88bbcf6eb05e6297b7026ce3e6ab28bf80612b7f4059519e8c01f12fb1ac794";
+    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.3-1.tar.gz";
+    name = "1.8.3-1.tar.gz";
+    sha256 = "8cd183df34d0c9458e0a3f90d5a1d2885aa9363978347e3e3cfc3d01ec709261";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -4506,6 +4506,8 @@ self: super: {
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
 
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
+
  warthog-control = self.callPackage ./warthog-control {};
 
  warthog-description = self.callPackage ./warthog-description {};

--- a/distros/melodic/jsk-model-tools/default.nix
+++ b/distros/melodic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-melodic-jsk-model-tools";
-  version = "0.4.3";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/jsk_model_tools/0.4.3-0.tar.gz";
-    name = "0.4.3-0.tar.gz";
-    sha256 = "41abafed65016c7f1f4825f689b95a45fcf1d8d93eeec12752ea0f1f728521a2";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/jsk_model_tools/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "7d67e14898a9a2dc4d8c0db7b9cb584f5f541de477f336ed63bbf74c7c76a1bf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pose-cov-ops/default.nix
+++ b/distros/melodic/pose-cov-ops/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt2, roscpp, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pose-cov-ops";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "794632c6d7d6f755a451573ced192e5f73ac0098b057899ee9226c0c9d3aa5b5";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "ac4c22782f5b83108c80988bd6077869e5c9f88a0aeaabb58dfc3b03e547f71e";
   };
 
-  buildType = "catkin";
+  buildType = "cmake";
+  buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ geometry-msgs mrpt-bridge mrpt2 roscpp ];
-  nativeBuildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];
+  nativeBuildInputs = [ catkin cmake ];
 
   meta = {
-    description = ''C++ library for SE(2/3) pose and 2D/3D point
-    composition operations with uncertainty'';
+    description = ''C++ library for SE(2)/SE(3) pose composition operations with uncertainty'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/warehouse-ros-sqlite/default.nix
+++ b/distros/melodic/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, roscpp, rostest, rostime, sqlite, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-melodic-warehouse-ros-sqlite";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/warehouse_ros_sqlite-release/archive/release/melodic/warehouse_ros_sqlite/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "dcdad8deebb3ee56669b1e27bbde2bb3d923937108b0a590ede4b69eab89e181";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ class-loader roscpp rostime sqlite warehouse-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/warehouse-ros/default.nix
+++ b/distros/melodic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, gtest, pluginlib, roscpp, rostest, rostime, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-warehouse-ros";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/melodic/warehouse_ros/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "30ead0eff97639e117939b3dbf2a7310e922dfe53ce2963591e2fb20976a27e7";
+    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/melodic/warehouse_ros/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "5ca7ab01596b0a016cd246426d942d88e503ebbcf407e379589560459a64f88d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ackermann-steering-controller/default.nix
+++ b/distros/noetic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, controller-manager-msgs, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, std-msgs, std-srvs, tf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ackermann-steering-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "23f563369e94501bb09f64ed544b80ed071630d5aeb8001f54da0e1237b5093e";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "58506e4644b956f71b96fae9bae470062fb74482bfb9749db057b8a7cb3bd402";
   };
 
   buildType = "catkin";

--- a/distros/noetic/control-toolbox/default.nix
+++ b/distros/noetic/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, control-msgs, dynamic-reconfigure, message-generation, message-runtime, realtime-tools, roscpp, rosunit, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-control-toolbox";
-  version = "1.18.2-r1";
+  version = "1.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.18.2-1.tar.gz";
-    name = "1.18.2-1.tar.gz";
-    sha256 = "f0cfd52a0e7ecb256997808fd3caa730e31ddfe2e9404174d875f13100caaae2";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.19.0-1.tar.gz";
+    name = "1.19.0-1.tar.gz";
+    sha256 = "64f03769fcf0512c51bca4e1cc1278d05dfee163887a851b48f83b5c30524cfe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diff-drive-controller/default.nix
+++ b/distros/noetic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, rostopic, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-diff-drive-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "8cf5a8da963e16139d510f77d4c5b302f443f8eff85efe8e47200bef4ad5c044";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "03c536a0d01ebddff96e04db85e7107f5163c03f4b26bc3949139d16f34b2c39";
   };
 
   buildType = "catkin";

--- a/distros/noetic/effort-controllers/default.nix
+++ b/distros/noetic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, joint-state-controller, pluginlib, realtime-tools, robot-state-publisher, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-effort-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "48eab98ddf97ac7e2adee655d4c1ce4c9d3fbd152bd7fe980feb8cd1746606ca";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "e4cbcb3236d71d04d94a5b81c18e872097d699c09d978fb0f890ed1167209fce";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "9eae8aa2ca61fdbcb380ff8c98d3ce4573230d914d5da0c7599703bce44bd8d4";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "c56ab85eaf5e7c4a0895b548aeccc81c210cca1e9ccd5fca9e4c4179bce1f23d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-noetic-eus-assimp";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "a77826bcb3b116fb363b1747899a6b7e845ae8cd311d07d09d2548beb754c8a4";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "f166cf1a93f42fc5f713ab98b2048206a69fefd26cebafeb45b9da845cd8317e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, pythonPackages, roseus, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, python3Packages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-noetic-eusurdf";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "b74f03dfd5d156cbf563c1ef108d74b646563d325141765ad541ec7defb63f86";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "45ce43d84f15082ea736caa61f9bc71503b97b54e5c7c6f6b479eeb7f9bf4131";
   };
 
   buildType = "catkin";
   buildInputs = [ roseus ];
-  propagatedBuildInputs = [ collada-urdf-jsk-patch gazebo-ros pythonPackages.lxml rostest ];
+  propagatedBuildInputs = [ collada-urdf-jsk-patch gazebo-ros python3Packages.lxml rostest ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/filters/default.nix
+++ b/distros/noetic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, pluginlib, rosconsole, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-filters";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/filters-release/archive/release/noetic/filters/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "a8a2088bfcc4b02644c20627bdc445b36443fc4c2c5c1a9f7e0ce8dc4764bb11";
+    url = "https://github.com/ros-gbp/filters-release/archive/release/noetic/filters/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "7cfca50e56f78921bf185fd6dd7d3fe614b2daee6e326a96307776ad3aad8fe6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/force-torque-sensor-controller/default.nix
+++ b/distros/noetic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-force-torque-sensor-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "118b2a5754ef2839be99ec0bc90e71651dd3d67ac62328830715941c538ce3ae";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "4f323c720b5d6cc09278570b7b135d3ae06a33b04a8c31a2c0f6050d432e335d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/forward-command-controller/default.nix
+++ b/distros/noetic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-forward-command-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "add33ba307dbd9f4a90192dda911ec466d854e7774cd199489afaad75c83f4f8";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "24ac6b8c48c223a7c0dfa07220349e6f7ef5c970c7bba150d60d7ef8d0d7c7df";
   };
 
   buildType = "catkin";

--- a/distros/noetic/four-wheel-steering-controller/default.nix
+++ b/distros/noetic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rosgraph-msgs, rostest, std-msgs, std-srvs, tf, urdf-geometry-parser, xacro }:
 buildRosPackage {
   pname = "ros-noetic-four-wheel-steering-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "d3a724bac511e84f4d1ffd046cf5ba0006a6adf5fcbef6888ca8c5fccc9968e0";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "2f57408975c161779d4c095d68b2a4b96f4fe861a38dbec12fd65d467c05160f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -2080,6 +2080,10 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ pf-description = self.callPackage ./pf-description {};
+
+ pf-driver = self.callPackage ./pf-driver {};
+
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
 
  phidgets-analog-inputs = self.callPackage ./phidgets-analog-inputs {};
@@ -3387,6 +3391,8 @@ self: super: {
  vrpn-client-ros = self.callPackage ./vrpn-client-ros {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
 
  warthog-control = self.callPackage ./warthog-control {};
 

--- a/distros/noetic/gripper-action-controller/default.nix
+++ b/distros/noetic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gripper-action-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "8a308353861c5fa7b1cf374b0d88eca845621cf3bf430229e649732f8e13de21";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "dd0b17dbed1ac9d78f5079838be10d158ac81a7fbc0ff954363acccd941aa5c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-sensor-controller/default.nix
+++ b/distros/noetic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-imu-sensor-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "d5aa66065b7e8637f293704b830e157a4b4e36b17b671c775ca35934d5a6cefc";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "42a959e2c576dcb463e6ee7bb1889454c9fe5e4a9f37c1514bf25a2f2d70d4d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-control/default.nix
+++ b/distros/noetic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-jackal-control";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "a01d15d776eaabad0d76456846ae88bce29df2ba8f6444cc17aaf8a8c17584ca";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "f27cd628301a00b3061bf3a64168789e2111adec14298b401ba2b470703f4825";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-description/default.nix
+++ b/distros/noetic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, sick-tim, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-description";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "fafb0d5f722af145a6a75146954a0726479b216a38af040d760c9885fe3aa222";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "7347a36fc46adac2412a6aaf01ace5a09e6a96023566de9d653397f7c6b91d57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-msgs/default.nix
+++ b/distros/noetic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jackal-msgs";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "aca1a9ae52c82428c22c005347d3a499a3c19bcb38208c2029d0c17e5a414607";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "21f185d7e136914a452295a3a92eb6d9dfc1de405ec22103dd682b86ce66de3f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-navigation/default.nix
+++ b/distros/noetic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-navigation";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "f91d8e845e0415299b5800912139f6c8e16a31d6c07d66fbc6495f634366448d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "ae93f55028496ee7f3218ba1a0a6074ab719b3af57f8bd7ae3ebd73a46002bd9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-tutorials/default.nix
+++ b/distros/noetic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-noetic-jackal-tutorials";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "6a10adef088e593f1d733c9a31704b747169d9ca3cbaf32d403d97c1cc1080bd";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "de3bf47b83262b81d62a543987bb9cefc43f558dd836a28212fd8043f4c29784";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-controller/default.nix
+++ b/distros/noetic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "e0968620e901d8ca8a2e1a4d032d5afde60acdbf61440a63073483c008c093ba";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "b3a8ee2feecf31dfae9823e093e41f72941dac919e5566945d9f6ec25769590b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-trajectory-controller/default.nix
+++ b/distros/noetic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, boost, catkin, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, std-msgs, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-joint-trajectory-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "53720e691240d1a87f4d8b1829207a3345ef6928db56de85d62cee6b95edf322";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "dcc6f8449207dbc2576025355bf51f71c84d3f58f66e601b39bba9ef6738db09";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-noetic-jsk-model-tools";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "1629e8ab27a3570996b0dda67032e3cfc6ce2467dbc0512cc90984e8f51aeeeb";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "a98c65b7bd5eae30a78d619e77f7c5ea47c1910f4d2b9ddd524b7888783a9108";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mocap-nokov/default.nix
+++ b/distros/noetic/mocap-nokov/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/noetic/mocap_nokov/0.0.1-1.tar.gz";
     name = "0.0.1-1.tar.gz";
-    sha256 = "23fc5402d82811d8eb216a60838c170533e8a9bc8726849f62b66c2d33362132";
+    sha256 = "59aabc6a6fe038462221dc84bdb2f5f1b3562b194c7467740782b6c9519e4e72";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pf-description/default.nix
+++ b/distros/noetic/pf-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-pf-description";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PepperlFuchs/pf_lidar_ros_driver-release/archive/release/noetic/pf_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e3dbb3a0801529e49456c53545ef3e6ed84b607cd28872d4152ec4b45d12624e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pf_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pf-driver/default.nix
+++ b/distros/noetic/pf-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, curlpp, dynamic-reconfigure, jsoncpp, laser-geometry, message-generation, message-runtime, pcl, pcl-conversions, pcl-ros, pf-description, roscpp, roscpp-serialization, roslint, rosunit, rviz, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-pf-driver";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PepperlFuchs/pf_lidar_ros_driver-release/archive/release/noetic/pf_driver/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5cf437f193925c44f47c36c345ad605e4e6161d016ff9778ed89c8f21a5dcae0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ curlpp dynamic-reconfigure jsoncpp laser-geometry message-runtime pcl pcl-conversions pcl-ros pf-description roscpp roscpp-serialization rviz sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Pepperl+Fuchs LiDAR package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt2, roscpp, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-pose-cov-ops";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "ceac6165ee9ab4c98c9fdb41e816bb80fa63fa9e5d85929ac1bdf1bf60804a7a";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "a39bd4d3350f24be404f95c4e4e524b4dfa68cc05aa67f6bf0152d1286daa921";
   };
 
-  buildType = "catkin";
+  buildType = "cmake";
+  buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ geometry-msgs mrpt-bridge mrpt2 roscpp ];
-  nativeBuildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];
+  nativeBuildInputs = [ catkin cmake ];
 
   meta = {
-    description = ''C++ library for SE(2/3) pose and 2D/3D point
-    composition operations with uncertainty'';
+    description = ''C++ library for SE(2)/SE(3) pose composition operations with uncertainty'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/position-controllers/default.nix
+++ b/distros/noetic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-position-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "eb065ab91e1908cb598cf0ad100582163e0b99d4ddc7790568a99ffa4ff176b4";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "73ed1c9e8d03e2565928ecfe15daf1b5de9e58fda1f5b731203c38b5ee8ada90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-controllers/default.nix
+++ b/distros/noetic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "7ad4a7b2a5a080efc80f130f2b25b20fb61a87b7dcf8234962d861a0e84c889e";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "be08d48674def6cab1ff7d3c9336505a31c657d3975b73d72a33b6b1898fb86f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/noetic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-joint-trajectory-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "68fe23d5f1543ca1aaea9774afcef57f3563303be6ca59bb43fda925c66c3551";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "8fddd3a83221fbf0b3d3b142bf2fd98d1e113d5806ca381ecceb86f051346196";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velocity-controllers/default.nix
+++ b/distros/noetic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, roscpp, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-velocity-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "5281f0510e937a8ce981053f9bbc4c9c81ea84254b097fb6df2481edf4963fed";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "fc5bc1a35bc54c54fdb2bbd535058e0cf693a767db14293dbcaae0e12bef76c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/warehouse-ros-sqlite/default.nix
+++ b/distros/noetic/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, roscpp, rostest, rostime, sqlite, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-noetic-warehouse-ros-sqlite";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/warehouse_ros_sqlite-release/archive/release/noetic/warehouse_ros_sqlite/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "55c1b940c50612b756897cd167512990caad3e2f26b79f7f20574fb0e49616fe";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ class-loader roscpp rostime sqlite warehouse-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/warehouse-ros/default.nix
+++ b/distros/noetic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, gtest, pluginlib, roscpp, rostest, rostime, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-warehouse-ros";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/noetic/warehouse_ros/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "e13a08e95124d32895d6182a372c459102e2181b68ac72f31cb1bf595ccd4c34";
+    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/noetic/warehouse_ros/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "f3ea5eab008525e1e38cdbaffb5b43fa4db549a217abda35e8fb39111281ba91";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 4284c676a6ca7fe38863b92047b5eb8c1a1ec64b.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *eigenpy 2.7.2-r1 --> 2.7.4-r1*
* *octomap-ros 0.4.2-r1 --> 0.4.3-r1*

Galactic Changes:
-----------------
* *costmap-queue 1.0.9-r1 --> 1.0.10-r1*
* *depthai 1.5.0-r1*
* *dwb-core 1.0.9-r1 --> 1.0.10-r1*
* *dwb-critics 1.0.9-r1 --> 1.0.10-r1*
* *dwb-msgs 1.0.9-r1 --> 1.0.10-r1*
* *dwb-plugins 1.0.9-r1 --> 1.0.10-r1*
* *nav-2d-msgs 1.0.9-r1 --> 1.0.10-r1*
* *nav-2d-utils 1.0.9-r1 --> 1.0.10-r1*
* *nav2-amcl 1.0.9-r1 --> 1.0.10-r1*
* *nav2-behavior-tree 1.0.9-r1 --> 1.0.10-r1*
* *nav2-bringup 1.0.9-r1 --> 1.0.10-r1*
* *nav2-bt-navigator 1.0.9-r1 --> 1.0.10-r1*
* *nav2-common 1.0.9-r1 --> 1.0.10-r1*
* *nav2-controller 1.0.9-r1 --> 1.0.10-r1*
* *nav2-core 1.0.9-r1 --> 1.0.10-r1*
* *nav2-costmap-2d 1.0.9-r1 --> 1.0.10-r1*
* *nav2-dwb-controller 1.0.9-r1 --> 1.0.10-r1*
* *nav2-gazebo-spawner 1.0.9-r1 --> 1.0.10-r1*
* *nav2-lifecycle-manager 1.0.9-r1 --> 1.0.10-r1*
* *nav2-map-server 1.0.9-r1 --> 1.0.10-r1*
* *nav2-msgs 1.0.9-r1 --> 1.0.10-r1*
* *nav2-navfn-planner 1.0.9-r1 --> 1.0.10-r1*
* *nav2-planner 1.0.9-r1 --> 1.0.10-r1*
* *nav2-recoveries 1.0.9-r1 --> 1.0.10-r1*
* *nav2-regulated-pure-pursuit-controller 1.0.9-r1 --> 1.0.10-r1*
* *nav2-rotation-shim-controller 1.0.9-r1 --> 1.0.10-r1*
* *nav2-rviz-plugins 1.0.9-r1 --> 1.0.10-r1*
* *nav2-simple-commander 1.0.9-r1 --> 1.0.10-r1*
* *nav2-smac-planner 1.0.9-r1 --> 1.0.10-r1*
* *nav2-system-tests 1.0.9-r1 --> 1.0.10-r1*
* *nav2-theta-star-planner 1.0.9-r1 --> 1.0.10-r1*
* *nav2-util 1.0.9-r1 --> 1.0.10-r1*
* *nav2-voxel-grid 1.0.9-r1 --> 1.0.10-r1*
* *nav2-waypoint-follower 1.0.9-r1 --> 1.0.10-r1*
* *navigation2 1.0.9-r1 --> 1.0.10-r1*
* *octomap-ros 0.4.2-r1 --> 0.4.3-r1*
* *turtlebot4-ignition-bringup 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-ignition-toolbox 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-simulator 0.1.0-r1 --> 0.1.1-r1*

Melodic Changes:
----------------
* *control-toolbox 1.18.2-r1 --> 1.19.0-r1*
* *eigenpy 2.7.2-r1 --> 2.7.4-r1*
* *eus-assimp 0.4.3 --> 0.4.4-r1*
* *eusurdf 0.4.3 --> 0.4.4-r1*
* *filters 1.8.2-r1 --> 1.8.3-r1*
* *jsk-model-tools 0.4.3 --> 0.4.4-r1*
* *pose-cov-ops 0.3.1-r1 --> 0.3.2-r1*
* *warehouse-ros 0.9.4-r1 --> 0.9.5-r1*
* *warehouse-ros-sqlite 0.9.0-r1*

Noetic Changes:
---------------
* *ackermann-steering-controller 0.19.0-r1 --> 0.20.0-r1*
* *control-toolbox 1.18.2-r1 --> 1.19.0-r1*
* *diff-drive-controller 0.19.0-r1 --> 0.20.0-r1*
* *effort-controllers 0.19.0-r1 --> 0.20.0-r1*
* *eigenpy 2.7.2-r1 --> 2.7.4-r1*
* *eus-assimp 0.4.3-r1 --> 0.4.4-r1*
* *eusurdf 0.4.3-r1 --> 0.4.4-r1*
* *filters 1.9.1-r1 --> 1.9.2-r1*
* *force-torque-sensor-controller 0.19.0-r1 --> 0.20.0-r1*
* *forward-command-controller 0.19.0-r1 --> 0.20.0-r1*
* *four-wheel-steering-controller 0.19.0-r1 --> 0.20.0-r1*
* *gripper-action-controller 0.19.0-r1 --> 0.20.0-r1*
* *imu-sensor-controller 0.19.0-r1 --> 0.20.0-r1*
* *jackal-control 0.8.3-r1 --> 0.8.4-r1*
* *jackal-description 0.8.3-r1 --> 0.8.4-r1*
* *jackal-msgs 0.8.3-r1 --> 0.8.4-r1*
* *jackal-navigation 0.8.3-r1 --> 0.8.4-r1*
* *jackal-tutorials 0.8.3-r1 --> 0.8.4-r1*
* *joint-state-controller 0.19.0-r1 --> 0.20.0-r1*
* *joint-trajectory-controller 0.19.0-r1 --> 0.20.0-r1*
* *jsk-model-tools 0.4.3-r1 --> 0.4.4-r1*
* *pf-description 1.2.0-r1*
* *pf-driver 1.2.0-r1*
* *pose-cov-ops 0.3.1-r1 --> 0.3.2-r1*
* *position-controllers 0.19.0-r1 --> 0.20.0-r1*
* *ros-controllers 0.19.0-r1 --> 0.20.0-r1*
* *rqt-joint-trajectory-controller 0.19.0-r1 --> 0.20.0-r1*
* *velocity-controllers 0.19.0-r1 --> 0.20.0-r1*
* *warehouse-ros 0.9.4-r1 --> 0.9.5-r1*
* *warehouse-ros-sqlite 0.9.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-wstool
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

