### PR TITLE
rosdistro sync, Fri May 20 13:47:27 2022

### DIFF
--- a/distros/foxy/depthai/default.nix
+++ b/distros/foxy/depthai/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv }:
+buildRosPackage {
+  pname = "ros-foxy-depthai";
+  version = "2.15.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "88d84cdcc15e90cf05e45bfb7ef6336a13609f98bc006681c237219bbf5f515c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ libusb1 nlohmann_json opencv ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''DepthAI core is a C++ library which comes with firmware and an API to interact with OAK Platform'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/dynamic-edt-3d/default.nix
+++ b/distros/foxy/dynamic-edt-3d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, octomap }:
+{ lib, buildRosPackage, fetchurl, cmake, octomap }:
 buildRosPackage {
   pname = "ros-foxy-dynamic-edt-3d";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/dynamic_edt_3d/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "875f29170fcf67ae8c6cdafe91baea41b258714a4eae930eb7c4ae712d731523";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/dynamic_edt_3d/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "836454d9a8fae684a72f309cafcc841ff7d5c4615c9d732d9030c4070fbd1864";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake octomap ];
+  propagatedBuildInputs = [ octomap ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "212b9bf6732e306bb1e300ed9c42bb136b95166e0d51ae294dc9e045ec8db425";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "b784f6a28d3c19779124fe7e36216c05a8417e9ce70fe791e7017a17a4d06ad0";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -310,6 +310,8 @@ self: super: {
 
  depth-image-proc = self.callPackage ./depth-image-proc {};
 
+ depthai = self.callPackage ./depthai {};
+
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
  derived-object-msgs = self.callPackage ./derived-object-msgs {};
@@ -573,6 +575,26 @@ self: super: {
  hardware-interface = self.callPackage ./hardware-interface {};
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
+
+ husky-base = self.callPackage ./husky-base {};
+
+ husky-bringup = self.callPackage ./husky-bringup {};
+
+ husky-control = self.callPackage ./husky-control {};
+
+ husky-description = self.callPackage ./husky-description {};
+
+ husky-desktop = self.callPackage ./husky-desktop {};
+
+ husky-gazebo = self.callPackage ./husky-gazebo {};
+
+ husky-msgs = self.callPackage ./husky-msgs {};
+
+ husky-robot = self.callPackage ./husky-robot {};
+
+ husky-simulator = self.callPackage ./husky-simulator {};
+
+ husky-viz = self.callPackage ./husky-viz {};
 
  ibeo-msgs = self.callPackage ./ibeo-msgs {};
 
@@ -859,6 +881,8 @@ self: super: {
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
  mppic = self.callPackage ./mppic {};
+
+ mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 

--- a/distros/foxy/husky-base/default.nix
+++ b/distros/foxy/husky-base/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, husky-msgs, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-husky-base";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_base/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "45abe0eb40c34cb0ff2f5966e1eace952d7a66627d5b77156597aca9bb8c3a6f";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs geometry-msgs hardware-interface husky-msgs nav-msgs pluginlib rclcpp sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Clearpath Husky robot driver'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-bringup/default.nix
+++ b/distros/foxy/husky-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, husky-base, husky-control, husky-description, microstrain-inertial-driver, robot-upstart, urg-node, velodyne-driver, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-foxy-husky-bringup";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_bringup/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "08cc70dab9604cee4bd0fc04d347bd3879457d470b5355a539f0b550329ea09b";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ husky-base husky-control husky-description microstrain-inertial-driver robot-upstart urg-node velodyne-driver velodyne-pointcloud ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Clearpath Husky installation and integration package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-control/default.nix
+++ b/distros/foxy/husky-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, husky-description, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
+buildRosPackage {
+  pname = "ros-foxy-husky-control";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_control/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "885573fcb0d1e63219747c38757d1965669f205e2f490b12c84cb8b46b01e175";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller husky-description imu-filter-madgwick interactive-marker-twist-server joint-state-broadcaster joint-trajectory-controller joy robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Clearpath Husky controller configurations'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-description/default.nix
+++ b/distros/foxy/husky-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, urdf }:
+buildRosPackage {
+  pname = "ros-foxy-husky-description";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_description/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "19b1e057c9aab1660f2a9f61b28839133c44a463c6ce66f3ae6955762b7efa44";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Clearpath Husky URDF description'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-desktop/default.nix
+++ b/distros/foxy/husky-desktop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, husky-msgs, husky-viz }:
+buildRosPackage {
+  pname = "ros-foxy-husky-desktop";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_desktop/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "21560266da1399025db0d84dc90a708c4208dddf47d5d01419759e82fae8b5c5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ husky-msgs husky-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for Clearpath Husky visualization software'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-gazebo/default.nix
+++ b/distros/foxy/husky-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, husky-control, husky-description, ros2launch, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-husky-gazebo";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_gazebo/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "ad1860accae9114da1ed658e87dd300e18db34d585e2c8f02435d49f1d427914";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control husky-control husky-description ros2launch urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Clearpath Husky Simulator bringup'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-msgs/default.nix
+++ b/distros/foxy/husky-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-husky-msgs";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_msgs/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "cf1c9adc08628160bd622271b3a89e37f7ae2e9ab011e86bc46be108317cd787";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages for Clearpath Husky'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-robot/default.nix
+++ b/distros/foxy/husky-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, husky-base, husky-bringup }:
+buildRosPackage {
+  pname = "ros-foxy-husky-robot";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_robot/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a6826b911a5a541bc8338d44e701e82e752346112bae45e66bb1578f548b7180";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ husky-base husky-bringup ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for Clearpath Husky robot software'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-simulator/default.nix
+++ b/distros/foxy/husky-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, husky-gazebo }:
+buildRosPackage {
+  pname = "ros-foxy-husky-simulator";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_simulator/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "72c78817ea2df607e2f22da6b35cca5f6a91c8b760ba0e9160f48427acd2c29a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ husky-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for Clearpath Husky simulation software'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/husky-viz/default.nix
+++ b/distros/foxy/husky-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, husky-description, joint-state-publisher, joint-state-publisher-gui, launch-ros, robot-state-publisher, rviz2 }:
+buildRosPackage {
+  pname = "ros-foxy-husky-viz";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/foxy/husky_viz/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "6fe27fd6224aacd509ac4357d84243c6c2306f3b724c8b4f883c3e1255cf39e7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ husky-description joint-state-publisher joint-state-publisher-gui launch-ros robot-state-publisher rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Visualization configuration for Clearpath Husky'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/mrpt-msgs/default.nix
+++ b/distros/foxy/mrpt-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-mrpt-msgs";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/foxy/mrpt_msgs/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "bbf371cba2231b1a56f67dd4d37434431cf5385e5894f9640ab781d04094bfb8";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-cppcheck ament-cpplint ament-lint-auto ament-lint-cmake ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for MRPT classes and objects'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/octomap-ros/default.nix
+++ b/distros/foxy/octomap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-octomap-ros";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/foxy/octomap_ros/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "2156e374f7e49071993af1d13ac2e552961b5fe0d5777551a452a45c844f6d70";
+    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/foxy/octomap_ros/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "71a489c497eab3b8ebaa254356272247db3be9bb554fec5654b0cd1f0dcfc58c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/octomap/default.nix
+++ b/distros/foxy/octomap/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-foxy-octomap";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octomap/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "98bf2fe150437da7c6438b4936778889dbea3400775c90195c7916f7c83d28a2";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octomap/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "3c87ff348c5a0afd6f96c0f1ac077fecaccfc82d1fcd5f93ef2d1358dbba671f";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/octovis/default.nix
+++ b/distros/foxy/octovis/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, libsForQt5, octomap, qt5 }:
+{ lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-octovis";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octovis/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "792c48dc5943a326194f72f5efa22cd37f4dd4c8e073e659e599a09e8f4be52e";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octovis/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "c3d44b01d9b95bbeaffa4fb05e1fd789658d3db59e1320e481a1abbbbbd8ae8b";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake libsForQt5.libqglviewer octomap qt5.qtbase ];
+  propagatedBuildInputs = [ libsForQt5.libqglviewer octomap qt5.qtbase ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.4.3-r1";
+  version = "3.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.3-1.tar.gz";
-    name = "3.4.3-1.tar.gz";
-    sha256 = "be3ba195a60718a5080a63e34385447a84daba6f8d74c15a771652321bb6f502";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.4-1.tar.gz";
+    name = "3.4.4-1.tar.gz";
+    sha256 = "6bb6146e85d7123619641f3e4788fd85282ef3289756ef2238324dadd8977c12";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras ];
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/septentrio-gnss-driver/default.nix
+++ b/distros/foxy/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-septentrio-gnss-driver";
-  version = "1.2.0-r6";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/foxy/septentrio_gnss_driver/1.2.0-6.tar.gz";
-    name = "1.2.0-6.tar.gz";
-    sha256 = "b0959ad4bdb9d44e4060b46f11e1c3c5b99c708d29b181748ef04939c0e79844";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/foxy/septentrio_gnss_driver/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "408f55ee7502c416b78cdbf45daba222bb6e917792da8d28090e8cfaea048eed";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/costmap-queue/default.nix
+++ b/distros/galactic/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-costmap-queue";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f5a30727da14f9ca35bf9201713b0b04e14b343e5e348cdcf8813c6d0490f6c9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "2c37c92750548b77438ea60bedb0a39e108e6325288e8e5ded66fe460bac6aae";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai/default.nix
+++ b/distros/galactic/depthai/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv }:
+buildRosPackage {
+  pname = "ros-galactic-depthai";
+  version = "2.15.4-r2";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.15.4-2.tar.gz";
+    name = "2.15.4-2.tar.gz";
+    sha256 = "556938d97b747462ec3a797080f9b5eae8d3fc5ff9132a55e7ddd0816d778848";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ libusb1 nlohmann_json opencv ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''DepthAI core is a C++ library which comes with firmware and an API to interact with OAK Platform'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/dwb-core/default.nix
+++ b/distros/galactic/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-core";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a235446c09026926ceff194ee2d5e293243ad955e6c4b68ccdeeda8ee9a21420";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "5f37823566c17f1e3f5f69d28305022310a6cffa1f2e5e487310f6af3b7f9500";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-critics/default.nix
+++ b/distros/galactic/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-critics";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f25995f98819094c57215367afcc7f925e6863b2481fd6779c9a84b950e98cec";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "fecda736d8e76548b4c34cf98ccfa1259f3e5d993cd028ec5dd51e73e0046cd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-msgs/default.nix
+++ b/distros/galactic/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "30277a37d9e05119bbb6c5fd8f452b5b49e587f4015b65a598ef0caac3a5f51a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "b2ca84d5e5f2bad9f9d46a044b85fa7f815a2019ee2e4aa1cbd3537ccb2c065f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-plugins/default.nix
+++ b/distros/galactic/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-dwb-plugins";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "334ea6849dfdd1b0eec10bb78b7a6bbca2c64dee907f9d816b5868120ac6963a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "169e59b2ff0bea76fa4ff5aacce060fd7fc798917a2de3c0632e7264da858e6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dynamic-edt-3d/default.nix
+++ b/distros/galactic/dynamic-edt-3d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, octomap }:
+{ lib, buildRosPackage, fetchurl, cmake, octomap }:
 buildRosPackage {
   pname = "ros-galactic-dynamic-edt-3d";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/galactic/dynamic_edt_3d/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "e040644fd6d15b95839cca5b37d695d2283cd3ca9614d62b6ff753320c86703a";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/galactic/dynamic_edt_3d/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "7978860470859665103211ff214abe844d51042785a403dd8e65b36fa66f334e";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake octomap ];
+  propagatedBuildInputs = [ octomap ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/galactic/ecl-build/default.nix
+++ b/distros/galactic/ecl-build/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ecl-license }:
+buildRosPackage {
+  pname = "ros-galactic-ecl-build";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/galactic/ecl_build/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "b271994c98220314058318d97437e67e5a9bd74d2fea771f10fb767448d57ad5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-license ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Collection of cmake/make build tools primarily for ecl development itself, but also
+     contains a few cmake modules useful outside of the ecl.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/ecl-license/default.nix
+++ b/distros/galactic/ecl-license/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-ecl-license";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/galactic/ecl_license/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "36e8c7129becc9aeaa626649b15e7a6364cdf8f571db75c7a1e1bf62aece2378";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maintains the ecl licenses and also provides an install
+     target for deploying licenses with the ecl libraries.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/ecl-tools/default.nix
+++ b/distros/galactic/ecl-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ecl-build, ecl-license }:
+buildRosPackage {
+  pname = "ros-galactic-ecl-tools";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/galactic/ecl_tools/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "f4634517727d175721d93980cbc75acbe2bb9af3999958f5eaf6d958feee114e";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-build ecl-license ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Tools and utilities for ecl development.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -230,6 +230,8 @@ self: super: {
 
  depth-image-proc = self.callPackage ./depth-image-proc {};
 
+ depthai = self.callPackage ./depthai {};
+
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
  desktop = self.callPackage ./desktop {};
@@ -275,6 +277,12 @@ self: super: {
  dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
 
  dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
+ ecl-build = self.callPackage ./ecl-build {};
+
+ ecl-license = self.callPackage ./ecl-license {};
+
+ ecl-tools = self.callPackage ./ecl-tools {};
 
  effort-controllers = self.callPackage ./effort-controllers {};
 
@@ -1749,6 +1757,8 @@ self: super: {
  xacro = self.callPackage ./xacro {};
 
  yaml-cpp-vendor = self.callPackage ./yaml-cpp-vendor {};
+
+ zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
 
  zstd-vendor = self.callPackage ./zstd-vendor {};
 

--- a/distros/galactic/nav-2d-msgs/default.nix
+++ b/distros/galactic/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "49bc935d02cbb89d03abd0ec1dab1424166b5caad9d60d9735a1d71ffb589dd0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "38a054e3821fed50571d3447c89b66c4b99809f52a247d81a360dd865a3ba1df";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav-2d-utils/default.nix
+++ b/distros/galactic/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-utils";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "3c13c283edf395d08424ab5f9a7a8d0d87c31f0e7c889752bc2d9e96b29856b8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "9671cc7a50446d5dd729df858108725ddb83d84454bef1d6613f4bb6e9e9abb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-amcl/default.nix
+++ b/distros/galactic/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-amcl";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "efe0cf6c1c2c112065891a4b5ad12a133a2cf8a960bcf65a6766700b2910549a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "c32cbd13a62a34eb56e870439cc9e08714a1e4e88af03430022a0449b085dff6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-behavior-tree/default.nix
+++ b/distros/galactic/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-behavior-tree";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "53b520748d8b317ecbaf6335f30b2eaebd3b824875e71a221180c7ba04724841";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "ce3007b0385c0c42e0890009f25c73acf2f6a137dd751c13c9ad271f120047c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bringup/default.nix
+++ b/distros/galactic/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bringup";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "2d49b9631632977540f7d91345d31ace377195b705540073b18d398728c86fc5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "fe5e3228a31137da9a74251d7f5ef3a318fa524da5ed8eb1b8fab215778940d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bt-navigator/default.nix
+++ b/distros/galactic/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bt-navigator";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "c4aecce353863f99c12e6855e0092e06f730f325e480fd1f31f96638eb7b34e2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "edf708268248be5313c9ad10ce9bfa5a61e5e762fa84375fe7d81d5f4e2d92ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-common/default.nix
+++ b/distros/galactic/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-common";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a23d5360fd4b1a21c540e5ed51c14701b5ccee010a2fd6d957df3675b83ef31c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "197efdc63bd761783b46a4b76767ece88514832254968a2a815258e0fb1cd9e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-controller/default.nix
+++ b/distros/galactic/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-controller";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1799230a535bf116a2c6637883c54ec36a5944883cab57f56408473bb6923023";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "25f0fdfe9e5cb3b397366aeaf4c00a9dff790e4e4375a84b8daa4571d3e98517";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-core/default.nix
+++ b/distros/galactic/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-core";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f381ac7d274f15680f9c3824b1dc0de53d77decb3cec36fdcfd1480b8bac579d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "be354e3bbe418536e390ad8850d3b9c0c77b245249816e489c87d24b7aa382a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-costmap-2d/default.nix
+++ b/distros/galactic/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-costmap-2d";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "30b00ee13cb65fcd10e76c80e3213a1a7909b28500b9463e5756af4124a6c6c9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "63d9c3984bd4c2eeada63d9c0e5ee8a9a99ec74dae43bf654ed2c8d4965f1afe";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-dwb-controller/default.nix
+++ b/distros/galactic/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-galactic-nav2-dwb-controller";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "b021b4c71f600092d8dee8d6db8f927ce968cd271f66c09c822d835454f5c25d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "b11dedfb6c062f7e5d27446febc6eec6170b1b9621c484c96764735cb267c5a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-gazebo-spawner/default.nix
+++ b/distros/galactic/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-gazebo-spawner";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0127e75064ab655841813c745dd8d423dafc4dd8877913d7c46185a2e9b22bb9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "c3ef6355ec97588e7e9c8421d301d457113b694b475e21a3b9a3ece69c51b525";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-lifecycle-manager/default.nix
+++ b/distros/galactic/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-lifecycle-manager";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "d45928cbf7ededd041ecde3149882196203ba97fcb9463e22bbcba59dfe70f32";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "3295f2d0fbf9ce378849cd267a53d9be4e00008a41c9a8aba9ed9251b571ee85";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-map-server/default.nix
+++ b/distros/galactic/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-nav2-map-server";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "642607bfb94cce6b766a0e1369a40e9999b9cfef658e3e59d539fadac81736ca";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "8d3d2c267d84581c5485227687e3cf5c7602c3a7ea69d1675177989c0f880f51";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-msgs/default.nix
+++ b/distros/galactic/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "4f7946653eca774cabc0868fcef181f859caa774b81e3a6bad5e0df241205b3e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "23c34edc0b4059b7384feff6cb786ce15e3ca18cc4922da35ab43a34b8aceae9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-navfn-planner/default.nix
+++ b/distros/galactic/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-navfn-planner";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "7c780bb4443eff7174a45079e5cd8084b494a63229a681f5851d033bc6b7b92c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "8fc955ec4170ab18f11a4d2ee6fed94a965e107b16873aa82a76023ed04c65ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-planner/default.nix
+++ b/distros/galactic/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-planner";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f84e977ade147658aff385e45e391bbadb586cb01468ff2f65ad05519fa23d0b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "34f1fd619fcb5993858986dabe327fc826f4dfa6d6c53b5f40090169b52d0f0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-recoveries/default.nix
+++ b/distros/galactic/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-recoveries";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "ef6939f24a19506046d30582762d161fbb787ee5c39c5b0d2057c2a6f1c429a2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "b6dd74fedf5ae36abfec7799b57c6375227b760734cf5742e463d3a40bc77bc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-regulated-pure-pursuit-controller";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a9e3830d1791dcd1cd72c23c800ab0a81bfcf7b52270e2263f46f6dc3bf2766a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "51ce72e46c1c1604549734527b732faae0ea4317fedcf7eaca67506dce945793";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rotation-shim-controller/default.nix
+++ b/distros/galactic/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rotation-shim-controller";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "d431c0831a564ecab12885895b405a78ee7a6818aa7499d6aaeb157a72e34a59";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "fb9721a63c3c00204187cedcdbde6e60558d5cd41605a2c48518119c003e4978";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rviz-plugins/default.nix
+++ b/distros/galactic/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rviz-plugins";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "83e74d17a90a923fd8be0dd7966ffb9695cf79bd256c73d4a36f89fcd05ac5dc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "aa8dbc35259b8ed0ce9ca9e30607d43d353b78ca08f8833bf88474221d5835ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-simple-commander/default.nix
+++ b/distros/galactic/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-simple-commander";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f195205c4009f180eab8644181269c53c2af30da6a3700eb17641412be4ca104";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "fbddc7ed655af8fc30e5defb0f25a6499d921577f19ececaefa3956c545a7ae3";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-smac-planner/default.nix
+++ b/distros/galactic/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-smac-planner";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "cab9755f1d8cea4bd38aef51b5b9c7b654390efffd125d7ff5d1a9b3a4f3d0c6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "c3d79de924b04ab4769c151fbf1afc3c05b336a0d2b9962fc6c94852bd4d4a07";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-system-tests/default.nix
+++ b/distros/galactic/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-system-tests";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "960c7bc2f951099f1c8c451197969ca98916f98127194c40519e66743fd9e57c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "2d5d86a8d1f0ded55f09b260736e3627ec2aca092e9449d623b819d9f03b30f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-theta-star-planner/default.nix
+++ b/distros/galactic/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-theta-star-planner";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f449828277e48a103387c50906d3bffea8c81c90a0b338046da22739ae05a69b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "1fd908a17bdf363c238087f412de17250bb812e32d8cb03b9670e2adbf27f69c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-util/default.nix
+++ b/distros/galactic/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-util";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "dc6772ec22df2c7805b1cc373a8f22f21b8b585e29f492045fcd761ac8f93410";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "83795bc7bacf58fe5d0da3549c5db1ae911cd609829af535908ab2da13647b24";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-voxel-grid/default.nix
+++ b/distros/galactic/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nav2-voxel-grid";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "9d92352f4a77ea6aee0094a717dc8c398e254b29205502a8b690392a4a08a719";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "4969999af3228c8b5e2e3cf9ff3b51f4dabbcc7e42cf5f1f08b4e9f7aabc2109";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-waypoint-follower/default.nix
+++ b/distros/galactic/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-waypoint-follower";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "cc7f712412b1a01c43b26e74fdd2b54dacd7c16411a3add5f39e513beac77e51";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "1c10c3531708238e5a07bcccc17a6175c167a7c03d2330ae7b6649c0b91e8f79";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/navigation2/default.nix
+++ b/distros/galactic/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-theta-star-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-galactic-navigation2";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a5d681f28ebb9501870f1a1b77395bdbef6366e9aa5cb63a31a5af830eba9d2c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "f7e531233ce4136bd2441aa542b392a90c486c9aec7267edff70017b305a383a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/octomap-ros/default.nix
+++ b/distros/galactic/octomap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, octomap, octomap-msgs, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-octomap-ros";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/galactic/octomap_ros/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "8c4842e8369ac1c1fcc29d4347724c4630a219df1b76d3ec1e56de28757225b7";
+    url = "https://github.com/ros2-gbp/octomap_ros-release/archive/release/galactic/octomap_ros/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "c7d5ffb76aff85d914469f2c65b765702dcc88aa33b26fdef724055beaf58d07";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/octomap/default.nix
+++ b/distros/galactic/octomap/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-galactic-octomap";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/galactic/octomap/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "ea2e2eaae831141197472500cd15eca755310804022399a6f95e6c50f825b5ff";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/galactic/octomap/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "63f2be49d860a8f7971d384788ae7d14294591e5d96dfb7111d462ccddc9a806";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/galactic/octovis/default.nix
+++ b/distros/galactic/octovis/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, libsForQt5, octomap, qt5 }:
+{ lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-galactic-octovis";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/galactic/octovis/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "06e6523f0fd18be71735ae45910cbfce375069c179503121d1369c56b0cbbebe";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/galactic/octovis/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "c85f90f5b2d37cf5ff1b29a87b5f811bb7e0a9fabce8325d1c0653a432212ad1";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ ament-cmake libsForQt5.libqglviewer octomap qt5.qtbase ];
+  propagatedBuildInputs = [ libsForQt5.libqglviewer octomap qt5.qtbase ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.4.2-r1";
+  version = "3.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "917322dd3b9ef735c0db860c71ff7f3ce09f47cc9dad98b8ddbf4f5d583a223f";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.4.4-1.tar.gz";
+    name = "3.4.4-1.tar.gz";
+    sha256 = "bbb66613ad9ef0d3a49f89618a2ec8f8e84b576ee79938d3c07d17cd1525d956";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras ];
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/septentrio-gnss-driver/default.nix
+++ b/distros/galactic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-septentrio-gnss-driver";
-  version = "1.2.0-r5";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/galactic/septentrio_gnss_driver/1.2.0-5.tar.gz";
-    name = "1.2.0-5.tar.gz";
-    sha256 = "65f0b63d04201e9d9d7c42a791362099122c4c097d025b25102256ab672040e4";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/galactic/septentrio_gnss_driver/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "0698eb2849cb3773cde7a84c8285d3fc2dc8bdef2994f282187abeac1eddc664";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-ignition-bringup/default.nix
+++ b/distros/galactic/turtlebot4-ignition-bringup/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-toolbox, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs, turtlebot4-description, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-nodes, irobot-create-toolbox, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs, turtlebot4-description, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-ignition-bringup";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_bringup/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "19411e65888d4cebcb686a5fcb226160dd934f6315cdb22f6268f82c03fe35c7";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_bringup/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b939dfd8547d72ae2c13b879c38875aeb1257f645e8226d71020bd37c5bdd749";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-bringup irobot-create-ignition-toolbox irobot-create-msgs irobot-create-toolbox ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs turtlebot4-description turtlebot4-ignition-gui-plugins turtlebot4-ignition-toolbox turtlebot4-msgs turtlebot4-navigation turtlebot4-node turtlebot4-viz ];
+  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-bringup irobot-create-ignition-toolbox irobot-create-msgs irobot-create-nodes irobot-create-toolbox ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs turtlebot4-description turtlebot4-ignition-gui-plugins turtlebot4-ignition-toolbox turtlebot4-msgs turtlebot4-navigation turtlebot4-node turtlebot4-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''TurtleBot 4 Ignition Simulator bringup'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/turtlebot4-ignition-toolbox/default.nix
+++ b/distros/galactic/turtlebot4-ignition-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-ignition-toolbox";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_toolbox/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "9eaabd5c035e658c8b9e81288d2e4f079d1a7b675391a27963d5a96036a371b6";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_ignition_toolbox/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "5672e2506144558a54d65922946036f5ad427f913adc655e11577cb675572c9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-simulator/default.nix
+++ b/distros/galactic/turtlebot4-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-ignition-bringup, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-simulator";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_simulator/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "11de2a7c9481102234c252e0166551791c2bf8d2dd0cee1abf9714b4dc99c044";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/galactic/turtlebot4_simulator/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "2721b40c617b6a564a7b36ba9312e37a6fff3870806eda9991c5c80ceced0e7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/zmqpp-vendor/default.nix
+++ b/distros/galactic/zmqpp-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cppzmq }:
+buildRosPackage {
+  pname = "ros-galactic-zmqpp-vendor";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tier4/zmqpp_vendor-release/archive/release/galactic/zmqpp_vendor/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "d399685344debd3bfc100cc85a98510db16cd7dc655d5edc3195405ab89779a4";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cppzmq ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Vendor package for zmqpp'';
+    license = with lib.licenses; [ asl20 "Mozilla-Public-License-2.0" ];
+  };
+}

--- a/distros/melodic/aques-talk/default.nix
+++ b/distros/melodic/aques-talk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-aques-talk";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "82869afa17eba0e36a858850f810ec92304ee2332d37868e5c03cd20fa399fe6";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "7191cc0e6140068f22c72a4b7e86b33bdcbce88621a32d2d0acdee3139638533";
   };
 
   buildType = "catkin";

--- a/distros/melodic/assimp-devel/default.nix
+++ b/distros/melodic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-melodic-assimp-devel";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "f1fc13d561d14a433023f924c829f39097608b7aa28f3947214cc89c3fb176b2";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "eadd07bbf3ac87aebd166a7972f6a81786d77d6e859310dccb21f248821ccf44";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bayesian-belief-networks/default.nix
+++ b/distros/melodic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-melodic-bayesian-belief-networks";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "e1b42c1dfb5284eed1db5beb5ea6c769ebc2cbef17b89674d95eed6e15936f12";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "6d1673ffd1144446dd32eda73d25e4885dccce3f4c922e4a2ec9fb9214310af8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/chaplus-ros/default.nix
+++ b/distros/melodic/chaplus-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-chaplus-ros";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "39bb3f7e562d4f135fd6281b7abf4b71e20bdbf7559aa56909093bb446fba75e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "d606d591bf48e7447ed61a3141dfd244bdc9c1560d81648504a05ca8de8fcfb8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/control-toolbox/default.nix
+++ b/distros/melodic/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, control-msgs, dynamic-reconfigure, message-generation, message-runtime, realtime-tools, roscpp, rosunit, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-control-toolbox";
-  version = "1.18.2-r1";
+  version = "1.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/melodic/control_toolbox/1.18.2-1.tar.gz";
-    name = "1.18.2-1.tar.gz";
-    sha256 = "35b286163116a3ba5e016f9e970ece963de8711cb3fae2b1cccb7dcb1c32f55a";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/melodic/control_toolbox/1.19.0-1.tar.gz";
+    name = "1.19.0-1.tar.gz";
+    sha256 = "f1c7f00c8c9e32db695503d01ab129c915dd47cb1f1468535e2086dd6b9ecaf2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "671675984156c172450732e1cf53dd4c477b2e7df3280ef2b9c7e682f4c95eb6";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "3f25e8c54a57cefba0cb7fb12968f553d4b307b93749694d948ac5df789b406e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "79b3e3015c6819d91db0000f8ff3877731b111b9245e304fafb69f27bcb034f5";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "6b3bb0a5f5024f163d7498bdb1dbdbd8b1d7af30a0e2c9a2dc406534e8cbcfb3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "e4822a65d81656b3e248a1eaf98204a9d03cf4d7d0d56b61c962e41366050022";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "d9288339a3cb2f2814cd28a0314f7840d8fefe9182a5945af938224953099c9b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "a4e94d20963dd88256b78523d8570f0409ebb333f3aefee0bb203e1a56825c1d";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "9dc5fd85ce150c8ff2a149cb509e32deb79fb2225ac31b940199bc38686fd9f7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/downward/default.nix
+++ b/distros/melodic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python, rostest, time }:
 buildRosPackage {
   pname = "ros-melodic-downward";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "2ff442d942c92ae15b01fe6a41549dde0ad83877bafd1ae83e5a28c2431f32b2";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "9fe3d8f1499291060044573cdd470514331ebe1f4297b3c8de8eede9a49959ed";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamic-edt-3d/default.nix
+++ b/distros/melodic/dynamic-edt-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, octomap }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-edt-3d";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/dynamic_edt_3d/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "b716b393f7a79fbcf653cb96ed7ce995ef0d02f29653db7ecf7087259a31322d";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/dynamic_edt_3d/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "03b45d87c83b117ff3202a82849b1f7cc07c2d0a4624c2b001abb92539330a55";
   };
 
   buildType = "cmake";

--- a/distros/melodic/dynamic-reconfigure/default.nix
+++ b/distros/melodic/dynamic-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, roscpp, roscpp-serialization, roslib, rospy, rosservice, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-reconfigure";
-  version = "1.6.4-r1";
+  version = "1.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/melodic/dynamic_reconfigure/1.6.4-1.tar.gz";
-    name = "1.6.4-1.tar.gz";
-    sha256 = "30e130c37526441336a00f251d9484378f476ecb497548ad7925faf246c3e5ca";
+    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/melodic/dynamic_reconfigure/1.6.5-1.tar.gz";
+    name = "1.6.5-1.tar.gz";
+    sha256 = "5e609322e2ed6ab0698b93ffa4fd89c7fee57f5e08ec4cc881e5f8246e9707b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "e6f7edf9060c26c59d57b119df1fc730d6aa2e4da0a9074660b77aaa40ccfa7d";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "3664e366f7ebd962056f104b284f8933eeee40c14a35371a30e6594c0e014959";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eus-assimp/default.nix
+++ b/distros/melodic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-melodic-eus-assimp";
-  version = "0.4.3";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eus_assimp/0.4.3-0.tar.gz";
-    name = "0.4.3-0.tar.gz";
-    sha256 = "c82e9cbb4c4fd87a20d1c6a596293aed0dbc8661a1ccb4f57f4637cc688b8548";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eus_assimp/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "d94c8c3950538e07a3d17c344f0d25aa7ce89081991c80b3200fcd90b6077e06";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eusurdf/default.nix
+++ b/distros/melodic/eusurdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, pythonPackages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-melodic-eusurdf";
-  version = "0.4.3";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eusurdf/0.4.3-0.tar.gz";
-    name = "0.4.3-0.tar.gz";
-    sha256 = "47f6b8cfb42f9516ed0993922e6f3059cb387fa533cda56fed5e2fb81937f395";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/eusurdf/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "e65fe8bb4fa58516ec9b7833d07302ee91b8283808e5fe7f18c31db1f974722f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ff/default.nix
+++ b/distros/melodic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-melodic-ff";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "4009d2758aa8c4dde3c4a850ab68854d90928c8bd8f0033c8c323597339de767";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "13dfc86b59d80bef612a14e95788d35e583bd0f6caec9a61ec443ca57ef03fc4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ffha/default.nix
+++ b/distros/melodic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-melodic-ffha";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "dd6a5b76ff585b5fcd82a8f2b641f9ed35d0787535866027d563cb1ea312f8e0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "cf98d5edbe4df60e5c37270f7a830cdf00fcee43004e8d5f743adc5e6c717ab4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/filters/default.nix
+++ b/distros/melodic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, rosconsole, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-melodic-filters";
-  version = "1.8.2-r1";
+  version = "1.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.2-1.tar.gz";
-    name = "1.8.2-1.tar.gz";
-    sha256 = "b88bbcf6eb05e6297b7026ce3e6ab28bf80612b7f4059519e8c01f12fb1ac794";
+    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.3-1.tar.gz";
+    name = "1.8.3-1.tar.gz";
+    sha256 = "8cd183df34d0c9458e0a3f90d5a1d2885aa9363978347e3e3cfc3d01ec709261";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1832,8 +1832,6 @@ self: super: {
 
  laser-filters = self.callPackage ./laser-filters {};
 
- laser-filters-jsk-patch = self.callPackage ./laser-filters-jsk-patch {};
-
  laser-geometry = self.callPackage ./laser-geometry {};
 
  laser-joint-processor = self.callPackage ./laser-joint-processor {};
@@ -4505,6 +4503,8 @@ self: super: {
  wamv-gazebo = self.callPackage ./wamv-gazebo {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
 
  warthog-control = self.callPackage ./warthog-control {};
 

--- a/distros/melodic/jsk-3rdparty/default.nix
+++ b/distros/melodic/jsk-3rdparty/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, google-cloud-texttospeech, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
 buildRosPackage {
   pname = "ros-melodic-jsk-3rdparty";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "1450a9afeb52fdb7ef609eb251583bfd59ea3986b4388fd915f1e89e6bbb69a6";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "d689658c87a23f49a5956e6a7832213d3f80c0572a5e5946b2fe762ac90578b1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-model-tools/default.nix
+++ b/distros/melodic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-melodic-jsk-model-tools";
-  version = "0.4.3";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/jsk_model_tools/0.4.3-0.tar.gz";
-    name = "0.4.3-0.tar.gz";
-    sha256 = "41abafed65016c7f1f4825f689b95a45fcf1d8d93eeec12752ea0f1f728521a2";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/jsk_model_tools/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "7d67e14898a9a2dc4d8c0db7b9cb584f5f541de477f336ed63bbf74c7c76a1bf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/julius/default.nix
+++ b/distros/melodic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-melodic-julius";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "e9584e6b499d9efac760ae114e921b80a72304897d4ccb4d1e41fb6521d460ce";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "c729762c703fad77210f45279b17b1e807fe9e48bff481fa5a321f1099ad1da0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libcmt/default.nix
+++ b/distros/melodic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-melodic-libcmt";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "e0ece8617dc15630f1584003705c73484db1f27123b3dc943d31d2878bd0cfc4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "27528289685effa72e038798c91577ca99ed3ce45912e4cb25ed10bc23554f30";
   };
 
   buildType = "cmake";

--- a/distros/melodic/libsiftfast/default.nix
+++ b/distros/melodic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, pythonPackages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-melodic-libsiftfast";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "87761a5a4f4feb68f17e309768ff3868e1b3f2a24f06885671321a289406bbaa";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "e58938eb8fb2959ca83ccff2ca6d3b44f8d09b99fdd3809f47d087c9dfef2613";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lpg-planner/default.nix
+++ b/distros/melodic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-lpg-planner";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "ddb8d29035bc8e74460123650bc23d69b87b9802fe1f9fcfd20249e784bd7fd0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "03da06db41df77b0f6d5537e2af8be4ef6895858dc32b1cc375d9c5bbdf8bd16";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mini-maxwell/default.nix
+++ b/distros/melodic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-melodic-mini-maxwell";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "ba44f36b1f096aae97a143170235999f251fb121b66792fe6d05106722b9d8c3";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "d2673819f9a22a3ecdb132d8e154ce27047b60962473b51ed8b1246826269e59";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mrpt-msgs/default.nix
+++ b/distros/melodic/mrpt-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-msgs";
-  version = "0.2.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "0160776a2d1aaf5360e5a76730dee50a1077ba77fb006aa0378fea3aed1b505e";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "fc307fe3df5c94c3e163021ccabe4cc435c035e732f200b94ea8967aa72954ee";
   };
 
-  buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildType = "cmake";
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/nlopt/default.nix
+++ b/distros/melodic/nlopt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libtool, mk, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-melodic-nlopt";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "738644a604b580b7ee9fe3df9332558d7fe29559e68d7d4ab3d4c129dcda8ae0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "f9128eae806b05a44d01a1e3ce57cf0e9690a0fa14a810dad22877a49383da0c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/octomap/default.nix
+++ b/distros/melodic/octomap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-melodic-octomap";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octomap/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "4e0637858158938f744a53cbbfaa410f5d67d103cdd78cfc759d86321877a8fd";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octomap/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "deed4682029157898edbe591eada25b7c2acdef246d5097343ef79cc4f137245";
   };
 
   buildType = "cmake";

--- a/distros/melodic/octovis/default.nix
+++ b/distros/melodic/octovis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-melodic-octovis";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octovis/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "5b0d576647416126ae201c21e66e734bc9587766dfff31de44bca12bd5a024fc";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octovis/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "ea018124bcf6f33cf750c056ff7ca5b8ebcc069b807e5b02df09db2768db27f7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/opt-camera/default.nix
+++ b/distros/melodic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-opt-camera";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "bb1aedce31c9f6efeca26bbe59e5139fae1218d0b1591d6e4fd34646cea4020f";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "30a71fe885a1d964a1b369c180a6644a6e92f17f0530f6eadd15e19fad2d3551";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pose-cov-ops/default.nix
+++ b/distros/melodic/pose-cov-ops/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt2, roscpp, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pose-cov-ops";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "794632c6d7d6f755a451573ced192e5f73ac0098b057899ee9226c0c9d3aa5b5";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "ac4c22782f5b83108c80988bd6077869e5c9f88a0aeaabb58dfc3b03e547f71e";
   };
 
-  buildType = "catkin";
+  buildType = "cmake";
+  buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ geometry-msgs mrpt-bridge mrpt2 roscpp ];
-  nativeBuildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];
+  nativeBuildInputs = [ catkin cmake ];
 
   meta = {
-    description = ''C++ library for SE(2/3) pose and 2D/3D point
-    composition operations with uncertainty'';
+    description = ''C++ library for SE(2)/SE(3) pose composition operations with uncertainty'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/ridgeback-control/default.nix
+++ b/distros/melodic/ridgeback-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, urdf }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, twist-mux, urdf }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-control";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "08547888015f3a2b37c26a66654b23adf741d755aad3efe47f88971422a1eb30";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "cf97c8e257c9bf8b9a6bf864c5fa95a74a8d6806ddecdd4d729a0e3756258839";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ controller-interface controller-manager interactive-marker-twist-server joint-state-controller joy nav-msgs realtime-tools robot-localization teleop-twist-joy tf topic-tools urdf ];
+  propagatedBuildInputs = [ controller-interface controller-manager interactive-marker-twist-server joint-state-controller joy nav-msgs realtime-tools robot-localization teleop-twist-joy tf topic-tools twist-mux urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ridgeback-description/default.nix
+++ b/distros/melodic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-description";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "c8ebf4371f0ccd63db91fee284f6cf4aab99fe6e28bcbdbf8fbdbf2162dccdb6";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "1c00ca0f22cf8185c034c172bff114c9380a54253663a56b4c3908c1410274bf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-msgs/default.nix
+++ b/distros/melodic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-msgs";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "25bbaf64c4391f1d7cb16fc8217f9d47fe35895e62b1cab3128a2d77ebb629e0";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "88ea366355a09e1704a4ee00f5fd8dbf6150209651e5ee960d066f114a8c7f9f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-navigation/default.nix
+++ b/distros/melodic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-navigation";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "5b58af5e4a32ffe7cc45b55abf896c410c23e508ea81eb45d05e79738ece2752";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "638bc9dc6920e842218860fdb839489729c727d1bafc7f5b1c73b55713fe525c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospatlite/default.nix
+++ b/distros/melodic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospatlite";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "26cb5bd321426b71aa3e2f6c1818ee7a029422a6818b9e47bd39896c76cad17d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "9f38ca446c4aaaaa6fc430c796304b3040ad049416e28857e2622bbafbfeffb4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosping/default.nix
+++ b/distros/melodic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosping";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "bc920068e908068eea5789b1cfbacda7e48872836c845c47cae6e7aff6b27334";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "d0a34e3eb3d8bd83f9c2adbf15c35b2a9c476969bbdf6653fc139e0c8b25de84";
   };
 
   buildType = "catkin";

--- a/distros/melodic/septentrio-gnss-driver/default.nix
+++ b/distros/melodic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-septentrio-gnss-driver";
-  version = "1.1.0-r8";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.1.0-8.tar.gz";
-    name = "1.1.0-8.tar.gz";
-    sha256 = "8e870ed6082be60ffa5b56966dd3396a8ae1e7c46bc37b8f60c3ee16d39b3fea";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "f1f2e70d210988a9ab33a3ee66081b69dbaf837e2749127a66921db14b60e23a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sesame-ros/default.nix
+++ b/distros/melodic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-melodic-sesame-ros";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "d066f569e031178d47310e1b7761bd1f7e9d038843876838cb1fdc167e7b99ac";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "50245aa61649961bd2fd9ebd7b9c8a71548b362ad1d35a9e80cec7641b9b298b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slic/default.nix
+++ b/distros/melodic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv, openssl }:
 buildRosPackage {
   pname = "ros-melodic-slic";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "e007e40244375ee5d06d9d254db91c142349edfb218b6b12fe76fd84297eb9bf";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "9520a466a57433c5f8f949ecd9337e2f30038b298d793af438747f22d9d22ab1";
   };
 
   buildType = "cmake";

--- a/distros/melodic/switchbot-ros/default.nix
+++ b/distros/melodic/switchbot-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-runtime, pythonPackages, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-switchbot-ros";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/switchbot_ros/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "328df93d029dd75726982089e88ce3112d497a3ec7c2df4bfd5e8c8b8035ff08";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/switchbot_ros/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "4395f8e6fa9575450e9fbdae009e49c674c1cf7d4c1420129b256b4031f73dd9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-sensor-library/default.nix
+++ b/distros/melodic/toposens-sensor-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
 buildRosPackage {
   pname = "ros-melodic-toposens-sensor-library";
-  version = "1.1.4-r1";
+  version = "1.2.4-r4";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/melodic/toposens-sensor-library/1.1.4-1/archive.tar.gz";
+    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/melodic/toposens-sensor-library/1.2.4-4/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "040af85195cfdb9c9f9be372be53490f54b6998280de3d37f73b72265c993359";
+    sha256 = "c2388a269c1a3e4afa77bbfc7c683140d2ccf61bdd150e952cfa9d40662fd80e";
   };
 
   buildType = "cmake";

--- a/distros/melodic/voice-text/default.nix
+++ b/distros/melodic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-voice-text";
-  version = "2.1.24-r1";
+  version = "2.1.24-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.24-1.tar.gz";
-    name = "2.1.24-1.tar.gz";
-    sha256 = "8e17878d8972cc45282d3d10ff334d242e8e49c568bf02e01960d8bd13a911e0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.24-2.tar.gz";
+    name = "2.1.24-2.tar.gz";
+    sha256 = "be625a2d0c79a132c7f14afdaa7c31051f581c974fb414a9dbefed7b36ac7892";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warehouse-ros-sqlite/default.nix
+++ b/distros/melodic/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, roscpp, rostest, rostime, sqlite, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-melodic-warehouse-ros-sqlite";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/warehouse_ros_sqlite-release/archive/release/melodic/warehouse_ros_sqlite/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "dcdad8deebb3ee56669b1e27bbde2bb3d923937108b0a590ede4b69eab89e181";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ class-loader roscpp rostime sqlite warehouse-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/warehouse-ros/default.nix
+++ b/distros/melodic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, gtest, pluginlib, roscpp, rostest, rostime, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-warehouse-ros";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/melodic/warehouse_ros/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "30ead0eff97639e117939b3dbf2a7310e922dfe53ce2963591e2fb20976a27e7";
+    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/melodic/warehouse_ros/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "5ca7ab01596b0a016cd246426d942d88e503ebbcf407e379589560459a64f88d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ackermann-steering-controller/default.nix
+++ b/distros/noetic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, controller-manager-msgs, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, std-msgs, std-srvs, tf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ackermann-steering-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "23f563369e94501bb09f64ed544b80ed071630d5aeb8001f54da0e1237b5093e";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "58506e4644b956f71b96fae9bae470062fb74482bfb9749db057b8a7cb3bd402";
   };
 
   buildType = "catkin";

--- a/distros/noetic/control-toolbox/default.nix
+++ b/distros/noetic/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, control-msgs, dynamic-reconfigure, message-generation, message-runtime, realtime-tools, roscpp, rosunit, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-control-toolbox";
-  version = "1.18.2-r1";
+  version = "1.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.18.2-1.tar.gz";
-    name = "1.18.2-1.tar.gz";
-    sha256 = "f0cfd52a0e7ecb256997808fd3caa730e31ddfe2e9404174d875f13100caaae2";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.19.0-1.tar.gz";
+    name = "1.19.0-1.tar.gz";
+    sha256 = "64f03769fcf0512c51bca4e1cc1278d05dfee163887a851b48f83b5c30524cfe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diff-drive-controller/default.nix
+++ b/distros/noetic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, rostopic, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-diff-drive-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "8cf5a8da963e16139d510f77d4c5b302f443f8eff85efe8e47200bef4ad5c044";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "03c536a0d01ebddff96e04db85e7107f5163c03f4b26bc3949139d16f34b2c39";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamic-edt-3d/default.nix
+++ b/distros/noetic/dynamic-edt-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, octomap }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-edt-3d";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "233899b5ed9f3422daa94d4fbd8ab3069ed7dc18a4d16504daccac0eb240bda4";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "bd1c960ffca2b94e4ee4501d83af1d11a7848d15842a689ce482733744efd81b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-reconfigure/default.nix
+++ b/distros/noetic/dynamic-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, roscpp, roscpp-serialization, roslib, rospy, rosservice, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-reconfigure";
-  version = "1.7.2-r1";
+  version = "1.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/noetic/dynamic_reconfigure/1.7.2-1.tar.gz";
-    name = "1.7.2-1.tar.gz";
-    sha256 = "d413788e97245a877c314523b4c6524c6e3aec180ec9361ca4294ad7ee982210";
+    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/noetic/dynamic_reconfigure/1.7.3-1.tar.gz";
+    name = "1.7.3-1.tar.gz";
+    sha256 = "bb4e9834fe4b0da8a503c8060a5f4780ac29f4192b0f889a07be6362176b41f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/effort-controllers/default.nix
+++ b/distros/noetic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, joint-state-controller, pluginlib, realtime-tools, robot-state-publisher, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-effort-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "48eab98ddf97ac7e2adee655d4c1ce4c9d3fbd152bd7fe980feb8cd1746606ca";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "e4cbcb3236d71d04d94a5b81c18e872097d699c09d978fb0f890ed1167209fce";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "9eae8aa2ca61fdbcb380ff8c98d3ce4573230d914d5da0c7599703bce44bd8d4";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "c56ab85eaf5e7c4a0895b548aeccc81c210cca1e9ccd5fca9e4c4179bce1f23d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-noetic-eus-assimp";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "a77826bcb3b116fb363b1747899a6b7e845ae8cd311d07d09d2548beb754c8a4";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "f166cf1a93f42fc5f713ab98b2048206a69fefd26cebafeb45b9da845cd8317e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, pythonPackages, roseus, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, python3Packages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-noetic-eusurdf";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "b74f03dfd5d156cbf563c1ef108d74b646563d325141765ad541ec7defb63f86";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "45ce43d84f15082ea736caa61f9bc71503b97b54e5c7c6f6b479eeb7f9bf4131";
   };
 
   buildType = "catkin";
   buildInputs = [ roseus ];
-  propagatedBuildInputs = [ collada-urdf-jsk-patch gazebo-ros pythonPackages.lxml rostest ];
+  propagatedBuildInputs = [ collada-urdf-jsk-patch gazebo-ros python3Packages.lxml rostest ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/filters/default.nix
+++ b/distros/noetic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, pluginlib, rosconsole, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-filters";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/filters-release/archive/release/noetic/filters/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "a8a2088bfcc4b02644c20627bdc445b36443fc4c2c5c1a9f7e0ce8dc4764bb11";
+    url = "https://github.com/ros-gbp/filters-release/archive/release/noetic/filters/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "7cfca50e56f78921bf185fd6dd7d3fe614b2daee6e326a96307776ad3aad8fe6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/force-torque-sensor-controller/default.nix
+++ b/distros/noetic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-force-torque-sensor-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "118b2a5754ef2839be99ec0bc90e71651dd3d67ac62328830715941c538ce3ae";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "4f323c720b5d6cc09278570b7b135d3ae06a33b04a8c31a2c0f6050d432e335d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/forward-command-controller/default.nix
+++ b/distros/noetic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-forward-command-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "add33ba307dbd9f4a90192dda911ec466d854e7774cd199489afaad75c83f4f8";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "24ac6b8c48c223a7c0dfa07220349e6f7ef5c970c7bba150d60d7ef8d0d7c7df";
   };
 
   buildType = "catkin";

--- a/distros/noetic/four-wheel-steering-controller/default.nix
+++ b/distros/noetic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rosgraph-msgs, rostest, std-msgs, std-srvs, tf, urdf-geometry-parser, xacro }:
 buildRosPackage {
   pname = "ros-noetic-four-wheel-steering-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "d3a724bac511e84f4d1ffd046cf5ba0006a6adf5fcbef6888ca8c5fccc9968e0";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "2f57408975c161779d4c095d68b2a4b96f4fe861a38dbec12fd65d467c05160f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1504,6 +1504,8 @@ self: super: {
 
  laser-scan-splitter = self.callPackage ./laser-scan-splitter {};
 
+ laser-tilt-controller-filter = self.callPackage ./laser-tilt-controller-filter {};
+
  led-msgs = self.callPackage ./led-msgs {};
 
  leo = self.callPackage ./leo {};
@@ -2080,6 +2082,10 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ pf-description = self.callPackage ./pf-description {};
+
+ pf-driver = self.callPackage ./pf-driver {};
+
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
 
  phidgets-analog-inputs = self.callPackage ./phidgets-analog-inputs {};
@@ -2266,7 +2272,25 @@ self: super: {
 
  pr2-motor-diagnostic-tool = self.callPackage ./pr2-motor-diagnostic-tool {};
 
+ pr2-move-base = self.callPackage ./pr2-move-base {};
+
  pr2-msgs = self.callPackage ./pr2-msgs {};
+
+ pr2-navigation = self.callPackage ./pr2-navigation {};
+
+ pr2-navigation-config = self.callPackage ./pr2-navigation-config {};
+
+ pr2-navigation-global = self.callPackage ./pr2-navigation-global {};
+
+ pr2-navigation-local = self.callPackage ./pr2-navigation-local {};
+
+ pr2-navigation-perception = self.callPackage ./pr2-navigation-perception {};
+
+ pr2-navigation-self-filter = self.callPackage ./pr2-navigation-self-filter {};
+
+ pr2-navigation-slam = self.callPackage ./pr2-navigation-slam {};
+
+ pr2-navigation-teleop = self.callPackage ./pr2-navigation-teleop {};
 
  pr2-position-scripts = self.callPackage ./pr2-position-scripts {};
 
@@ -2539,6 +2563,8 @@ self: super: {
  ros-emacs-utils = self.callPackage ./ros-emacs-utils {};
 
  ros-environment = self.callPackage ./ros-environment {};
+
+ ros-ethercat-eml = self.callPackage ./ros-ethercat-eml {};
 
  ros-ign = self.callPackage ./ros-ign {};
 
@@ -2913,6 +2939,8 @@ self: super: {
  sdhlibrary-cpp = self.callPackage ./sdhlibrary-cpp {};
 
  self-test = self.callPackage ./self-test {};
+
+ semantic-point-annotator = self.callPackage ./semantic-point-annotator {};
 
  sensor-filters = self.callPackage ./sensor-filters {};
 
@@ -3387,6 +3415,8 @@ self: super: {
  vrpn-client-ros = self.callPackage ./vrpn-client-ros {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
 
  warthog-control = self.callPackage ./warthog-control {};
 

--- a/distros/noetic/gripper-action-controller/default.nix
+++ b/distros/noetic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gripper-action-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "8a308353861c5fa7b1cf374b0d88eca845621cf3bf430229e649732f8e13de21";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "dd0b17dbed1ac9d78f5079838be10d158ac81a7fbc0ff954363acccd941aa5c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-control/default.nix
+++ b/distros/noetic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-husky-control";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "efd3033e019a3262c8653390ba34b2933cf5f88fcea1d439fa54723ef5b1514f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "9966a4304e61c68b5d2056d5fb94460bd80ffcaa750f76985792f1387337db79";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-description/default.nix
+++ b/distros/noetic/husky-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, flir-camera-description, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-husky-description";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "8f335ec34e1831ff0be69850d67a75730e973c150340b05e64e1e598a8e5c20b";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "370ca36ae053b2c82658b56e94d96ed8d7cfbf620aab1a8fd151391ff766641d";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ lms1xx realsense2-description urdf velodyne-description xacro ];
+  propagatedBuildInputs = [ flir-camera-description lms1xx realsense2-description urdf velodyne-description xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/husky-desktop/default.nix
+++ b/distros/noetic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-noetic-husky-desktop";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "d9eb767589795f5e848b0cef73f96f45c9ff066439626686f53103f685045749";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "34ea1bf27ab789439da80491dffb9edb825c72cf91b10a1b3893f8240fd2a28a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-gazebo/default.nix
+++ b/distros/noetic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-husky-gazebo";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "9d243e1af40acf3683331ed65cfcd2dd262b9fc632072b907d8e93b6aca752a6";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "5f61a79cf313359e882853e9c36d3787d3ca5785e26d6f1ea2580a9c8da01032";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-msgs/default.nix
+++ b/distros/noetic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-husky-msgs";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "6de2ebf432e6585b1b3b6fee258a7da36c6dbc89339fb6094604299e39d84064";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "0a28e9b15d0fc29732c086911837fd69c8e86fe4b6251f569756d7654f8b09a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-navigation/default.nix
+++ b/distros/noetic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-husky-navigation";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "c39aeb9bfa3ce058c79e61b48f12ceef93a4aa0f544bdb96565ac09ab2a0dc67";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "e9b274a28c8f9dd20c145e2d0be3a4d12ad5625c89c35a461577be4776ec7969";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-simulator/default.nix
+++ b/distros/noetic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-noetic-husky-simulator";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "89a6fb7ec65c7c1ffeabb82086155027cd96f326c1c72caac0261133f8ae4a64";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "96c15f21e9674dac759904c2d81d957d126c7def7e1edf95f27634b8ea901310";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-viz/default.nix
+++ b/distros/noetic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-noetic-husky-viz";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "50323e6030035e6cc0570711b693ed2390f60ccb44faac2930fcf99619beba0f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "8096e5f4f238880e988801f59af0491269696faa21d62669c7dce305601d2eb2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-sensor-controller/default.nix
+++ b/distros/noetic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-imu-sensor-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "d5aa66065b7e8637f293704b830e157a4b4e36b17b671c775ca35934d5a6cefc";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "42a959e2c576dcb463e6ee7bb1889454c9fe5e4a9f37c1514bf25a2f2d70d4d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-control/default.nix
+++ b/distros/noetic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-jackal-control";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "a01d15d776eaabad0d76456846ae88bce29df2ba8f6444cc17aaf8a8c17584ca";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "f27cd628301a00b3061bf3a64168789e2111adec14298b401ba2b470703f4825";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-description/default.nix
+++ b/distros/noetic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, sick-tim, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-description";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "fafb0d5f722af145a6a75146954a0726479b216a38af040d760c9885fe3aa222";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "7347a36fc46adac2412a6aaf01ace5a09e6a96023566de9d653397f7c6b91d57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-msgs/default.nix
+++ b/distros/noetic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jackal-msgs";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "aca1a9ae52c82428c22c005347d3a499a3c19bcb38208c2029d0c17e5a414607";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "21f185d7e136914a452295a3a92eb6d9dfc1de405ec22103dd682b86ce66de3f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-navigation/default.nix
+++ b/distros/noetic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-navigation";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "f91d8e845e0415299b5800912139f6c8e16a31d6c07d66fbc6495f634366448d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "ae93f55028496ee7f3218ba1a0a6074ab719b3af57f8bd7ae3ebd73a46002bd9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-tutorials/default.nix
+++ b/distros/noetic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-noetic-jackal-tutorials";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "6a10adef088e593f1d733c9a31704b747169d9ca3cbaf32d403d97c1cc1080bd";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "de3bf47b83262b81d62a543987bb9cefc43f558dd836a28212fd8043f4c29784";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-controller/default.nix
+++ b/distros/noetic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "e0968620e901d8ca8a2e1a4d032d5afde60acdbf61440a63073483c008c093ba";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "b3a8ee2feecf31dfae9823e093e41f72941dac919e5566945d9f6ec25769590b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-trajectory-controller/default.nix
+++ b/distros/noetic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, boost, catkin, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, std-msgs, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-joint-trajectory-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "53720e691240d1a87f4d8b1829207a3345ef6928db56de85d62cee6b95edf322";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "dcc6f8449207dbc2576025355bf51f71c84d3f58f66e601b39bba9ef6738db09";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-noetic-jsk-model-tools";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "1629e8ab27a3570996b0dda67032e3cfc6ce2467dbc0512cc90984e8f51aeeeb";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "a98c65b7bd5eae30a78d619e77f7c5ea47c1910f4d2b9ddd524b7888783a9108";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-tilt-controller-filter/default.nix
+++ b/distros/noetic/laser-tilt-controller-filter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, filters, pluginlib, pr2-msgs, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-laser-tilt-controller-filter";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/laser_tilt_controller_filter/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "41f120ac8c70022e91763ef75c1fb26fbd594c3e8115439aa55dacbf37e6df76";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ filters pluginlib pr2-msgs roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''laser_tilt_controller_filter'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mocap-nokov/default.nix
+++ b/distros/noetic/mocap-nokov/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/noetic/mocap_nokov/0.0.1-1.tar.gz";
     name = "0.0.1-1.tar.gz";
-    sha256 = "23fc5402d82811d8eb216a60838c170533e8a9bc8726849f62b66c2d33362132";
+    sha256 = "59aabc6a6fe038462221dc84bdb2f5f1b3562b194c7467740782b6c9519e4e72";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-msgs/default.nix
+++ b/distros/noetic/mrpt-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs";
-  version = "0.2.0-r2";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.2.0-2.tar.gz";
-    name = "0.2.0-2.tar.gz";
-    sha256 = "4e19f99e5c7510dc49b081269f50518b26904f96300ed11cda4af31daa56aad2";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "57974058d5f4a98b8c9bfc7866bde56095a3d186b5e2edc20bdf1d50bbc6bbae";
   };
 
-  buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildType = "cmake";
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/octomap/default.nix
+++ b/distros/noetic/octomap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-octomap";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "070c0eb719b120814c7ab76ec0f38ba46e924bac8b5415080bc080fa3aeb404f";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "b8e00029f05725f6367a03e337c5c2ffd2c7a140fa5e78a7f1ee4417e249a83b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/octovis/default.nix
+++ b/distros/noetic/octovis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-noetic-octovis";
-  version = "1.9.7-r1";
+  version = "1.9.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.7-1.tar.gz";
-    name = "1.9.7-1.tar.gz";
-    sha256 = "c04e15284a47d6e952f0d9ab9670cad38ee45287d200fbe3a7c50149126f3d1c";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.8-1.tar.gz";
+    name = "1.9.8-1.tar.gz";
+    sha256 = "2a72bc352c76f646762c18d9aa04f5bd99ab5356086fe78269789a994b116fce";
   };
 
   buildType = "cmake";

--- a/distros/noetic/openrtm-aist/default.nix
+++ b/distros/noetic/openrtm-aist/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automake, catkin, cmake, doxygen, libtool, omniorb, pkg-config, pythonPackages, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-openrtm-aist";
-  version = "1.1.2-r2";
+  version = "1.1.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/openrtm_aist-release/archive/release/noetic/openrtm_aist/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "cf609f4f2f92ea3c3542391b6b73eb9e032e0ec1e4bdac3a3327100c06f910f6";
+    url = "https://github.com/tork-a/openrtm_aist-release/archive/release/noetic/openrtm_aist/1.1.2-4.tar.gz";
+    name = "1.1.2-4.tar.gz";
+    sha256 = "61a7a22fbfbf87fff5685a08bde398fc1523e543865f24fe3bacc6f83afc341b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pf-description/default.nix
+++ b/distros/noetic/pf-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-pf-description";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PepperlFuchs/pf_lidar_ros_driver-release/archive/release/noetic/pf_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e3dbb3a0801529e49456c53545ef3e6ed84b607cd28872d4152ec4b45d12624e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pf_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pf-driver/default.nix
+++ b/distros/noetic/pf-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, curlpp, dynamic-reconfigure, jsoncpp, laser-geometry, message-generation, message-runtime, pcl, pcl-conversions, pcl-ros, pf-description, roscpp, roscpp-serialization, roslint, rosunit, rviz, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-pf-driver";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PepperlFuchs/pf_lidar_ros_driver-release/archive/release/noetic/pf_driver/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5cf437f193925c44f47c36c345ad605e4e6161d016ff9778ed89c8f21a5dcae0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ curlpp dynamic-reconfigure jsoncpp laser-geometry message-runtime pcl pcl-conversions pcl-ros pf-description roscpp roscpp-serialization rviz sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Pepperl+Fuchs LiDAR package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, mrpt-bridge, mrpt2, roscpp, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-pose-cov-ops";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "ceac6165ee9ab4c98c9fdb41e816bb80fa63fa9e5d85929ac1bdf1bf60804a7a";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "a39bd4d3350f24be404f95c4e4e524b4dfa68cc05aa67f6bf0152d1286daa921";
   };
 
-  buildType = "catkin";
+  buildType = "cmake";
+  buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ geometry-msgs mrpt-bridge mrpt2 roscpp ];
-  nativeBuildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];
+  nativeBuildInputs = [ catkin cmake ];
 
   meta = {
-    description = ''C++ library for SE(2/3) pose and 2D/3D point
-    composition operations with uncertainty'';
+    description = ''C++ library for SE(2)/SE(3) pose composition operations with uncertainty'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/position-controllers/default.nix
+++ b/distros/noetic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-position-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "eb065ab91e1908cb598cf0ad100582163e0b99d4ddc7790568a99ffa4ff176b4";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "73ed1c9e8d03e2565928ecfe15daf1b5de9e58fda1f5b731203c38b5ee8ada90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-move-base/default.nix
+++ b/distros/noetic/pr2-move-base/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, move-base-msgs, pr2-common-action-msgs, pr2-controllers-msgs, pr2-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-move-base";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_move_base/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "92f10f4bbf993c229a8336a93fdb0868e835a43ad4b5ef42a890c21e8006bff5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure move-base-msgs pr2-common-action-msgs pr2-controllers-msgs pr2-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''pr2_move_base'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation-config/default.nix
+++ b/distros/noetic/pr2-navigation-config/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, move-base }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation-config";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation_config/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "b93b69cdb3b11916f3c40e2c93abf035e0dfc9e4a694d528a86c0d0a01403001";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package holds common configuration files for running the'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation-global/default.nix
+++ b/distros/noetic/pr2-navigation-global/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, joint-trajectory-generator, move-base, pr2-machine, pr2-move-base, pr2-navigation-config, pr2-tuck-arms-action, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation-global";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation_global/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "3b31ef840cf89724d95f86964134f7289b3133a5875a1e2c212ba4c0b8f2d2e3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl joint-trajectory-generator move-base pr2-machine pr2-move-base pr2-navigation-config pr2-tuck-arms-action topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package holds XML files for running the'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation-local/default.nix
+++ b/distros/noetic/pr2-navigation-local/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-trajectory-generator, move-base, pr2-machine, pr2-move-base, pr2-navigation-config, pr2-tuck-arms-action, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation-local";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation_local/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "ce2e8ccda502ac1b7396baa5c530da99d172d76f2fc6f675d9a62c4a0f6ed595";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-trajectory-generator move-base pr2-machine pr2-move-base pr2-navigation-config pr2-tuck-arms-action topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package holds xml files for running the'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation-perception/default.nix
+++ b/distros/noetic/pr2-navigation-perception/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, filters, geometry-msgs, laser-filters, laser-geometry, laser-tilt-controller-filter, message-filters, pcl-ros, pr2-machine, pr2-navigation-self-filter, roscpp, semantic-point-annotator, sensor-msgs, tf, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation-perception";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation_perception/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "0e26ff63d508ade9c80bf615bd9dd535dc25a600b816868fc6175e2566268501";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure filters geometry-msgs laser-filters laser-geometry laser-tilt-controller-filter message-filters pcl-ros pr2-machine pr2-navigation-self-filter roscpp semantic-point-annotator sensor-msgs tf topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package holds navigation-specific sensor configuration options and launch files for the PR2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation-self-filter/default.nix
+++ b/distros/noetic/pr2-navigation-self-filter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, bullet, catkin, filters, pcl-ros, resource-retriever, roscpp, sensor-msgs, tf, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation-self-filter";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation_self_filter/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "3b8177bfe8da07b2600f7bc0c01f73c33686a4411f1a669e52bf425376b350f1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ assimp bullet filters pcl-ros resource-retriever roscpp sensor-msgs tf urdf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Filters the robot's body out of point clouds.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation-slam/default.nix
+++ b/distros/noetic/pr2-navigation-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gmapping, joint-trajectory-generator, move-base, pr2-machine, pr2-move-base, pr2-navigation-config, pr2-tuck-arms-action, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation-slam";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation_slam/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "9ddc0197025fbd2f56d9269dc5bebd9f159d94e50ebf4ac6ed0ebd56488809db";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gmapping joint-trajectory-generator move-base pr2-machine pr2-move-base pr2-navigation-config pr2-tuck-arms-action topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package holds launch files for running the'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation-teleop/default.nix
+++ b/distros/noetic/pr2-navigation-teleop/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-machine, pr2-teleop, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation-teleop";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation_teleop/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "c00e9f1cec35b615a2bf681214efbbd39d7983a9a3fae4f435ff130ef732d887";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pr2-machine pr2-teleop topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package holds a special teleop configuration for the PR2 robot that
+     should be used when running applications that use autonomous navigation.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-navigation/default.nix
+++ b/distros/noetic/pr2-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dwa-local-planner, laser-tilt-controller-filter, pr2-move-base, pr2-navigation-config, pr2-navigation-global, pr2-navigation-local, pr2-navigation-perception, pr2-navigation-self-filter, pr2-navigation-slam, pr2-navigation-teleop, semantic-point-annotator }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-navigation";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/pr2_navigation/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "32ecc115470f2967e47b0f707f075e4e60fbb1c762f1adb9f57ae412e846d21f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dwa-local-planner laser-tilt-controller-filter pr2-move-base pr2-navigation-config pr2-navigation-global pr2-navigation-local pr2-navigation-perception pr2-navigation-self-filter pr2-navigation-slam pr2-navigation-teleop semantic-point-annotator ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_navigation stack holds common configuration options for running the'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ridgeback-control/default.nix
+++ b/distros/noetic/ridgeback-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, urdf }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, twist-mux, urdf }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-control";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_control/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "0332e62492bba9f6db8b7fa9b17800917d9cc147939a3af1a56d3d575c0cee99";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_control/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "66527dfd93b88a9b621ff58a3f9206a7341c7fb104d7c008aacd8e3dcbe534f9";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ controller-interface controller-manager interactive-marker-twist-server joint-state-controller joy nav-msgs realtime-tools robot-localization teleop-twist-joy tf topic-tools urdf ];
+  propagatedBuildInputs = [ controller-interface controller-manager interactive-marker-twist-server joint-state-controller joy nav-msgs realtime-tools robot-localization teleop-twist-joy tf topic-tools twist-mux urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ridgeback-description/default.nix
+++ b/distros/noetic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-description";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_description/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "9eb55c5e1e4795b357cab278cfe06e6f50d291deb60e0743a4fe5eb80f0b0c4e";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_description/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "b1c54aac8759b04ce003d2639ef3ad5058c858db73cf986a7e3cdd8ba7b5d887";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-msgs/default.nix
+++ b/distros/noetic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-msgs";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "84cd40f1bb1832e3b4a13409873904ea749c6743b30aac8aeabcec818d658ff1";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_msgs/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "b861ea515733bd8c57a7facd666157dc9b310d45256fea511e650c83f6640c3c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-navigation/default.nix
+++ b/distros/noetic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-navigation";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_navigation/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "54aac94db8046adba7fd59dad20125a637eca2dacc3604b379ceb20a49238b95";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_navigation/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "1bc1dd7dd3ddcbe355de1f8448ef688204efe9382c0c3b10a0284f11be46c90a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-controllers/default.nix
+++ b/distros/noetic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "7ad4a7b2a5a080efc80f130f2b25b20fb61a87b7dcf8234962d861a0e84c889e";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "be08d48674def6cab1ff7d3c9336505a31c657d3975b73d72a33b6b1898fb86f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-ethercat-eml/default.nix
+++ b/distros/noetic/ros-ethercat-eml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-ros-ethercat-eml";
+  version = "0.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/shadow-robot/ros_ethercat_eml-release/archive/release/noetic/ros_ethercat_eml/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "82e7e9d697778090cfb63e386c64b3877dd085382dd55b3b05fa3eb48399495f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This is an implementation of the EtherCAT master protocol for use wiht ros_ethercar package
+      based on the work done at Flanders' Mechatronics Technology Centre and Willow Garage.'';
+    license = with lib.licenses; [ "GPL" ];
+  };
+}

--- a/distros/noetic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/noetic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-joint-trajectory-controller";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "68fe23d5f1543ca1aaea9774afcef57f3563303be6ca59bb43fda925c66c3551";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "8fddd3a83221fbf0b3d3b142bf2fd98d1e113d5806ca381ecceb86f051346196";
   };
 
   buildType = "catkin";

--- a/distros/noetic/semantic-point-annotator/default.nix
+++ b/distros/noetic/semantic-point-annotator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, pcl-ros, roscpp, tf }:
+buildRosPackage {
+  pname = "ros-noetic-semantic-point-annotator";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_navigation-release/archive/release/noetic/semantic_point_annotator/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "c87f87e059bee66848d92f71e78ec1dbf239f5ed7a8425b6a8a115848070031b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen pcl-ros roscpp tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A node which annotates 3D point cloud data with semantic labels.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/septentrio-gnss-driver/default.nix
+++ b/distros/noetic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-septentrio-gnss-driver";
-  version = "1.1.0-r7";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.1.0-7.tar.gz";
-    name = "1.1.0-7.tar.gz";
-    sha256 = "2f71fe83b75dbaf47065f37e9c4bdcff177ff20e0daa97a541445c15963ed02f";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d94097675afc971808cecc27c6ea9fea074bdcb3c8512eca4a7ec505f589cf23";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-sensor-library/default.nix
+++ b/distros/noetic/toposens-sensor-library/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-toposens-sensor-library";
-  version = "1.1.4-r1";
+  version = "1.2.4-r4";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/noetic/toposens-sensor-library/1.1.4-1/archive.tar.gz";
+    url = "https://gitlab.com/toposens/public/toposens-library-release/-/archive/release/noetic/toposens-sensor-library/1.2.4-4/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "83edaf16652efd206c158c95710959da959870520a0212c6116be79bf58d9991";
+    sha256 = "39671f17d25ef7add7279a4e55fc6bfa70f8bd47c22fa39fdc7ac123ad8dddd2";
   };
 
   buildType = "cmake";
+  buildInputs = [ python3Packages.cffi ];
   propagatedBuildInputs = [ boost catkin ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/velocity-controllers/default.nix
+++ b/distros/noetic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, roscpp, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-velocity-controllers";
-  version = "0.19.0-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "5281f0510e937a8ce981053f9bbc4c9c81ea84254b097fb6df2481edf4963fed";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "fc5bc1a35bc54c54fdb2bbd535058e0cf693a767db14293dbcaae0e12bef76c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/warehouse-ros-sqlite/default.nix
+++ b/distros/noetic/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, roscpp, rostest, rostime, sqlite, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-noetic-warehouse-ros-sqlite";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/warehouse_ros_sqlite-release/archive/release/noetic/warehouse_ros_sqlite/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "55c1b940c50612b756897cd167512990caad3e2f26b79f7f20574fb0e49616fe";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ class-loader roscpp rostime sqlite warehouse-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/warehouse-ros/default.nix
+++ b/distros/noetic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, gtest, pluginlib, roscpp, rostest, rostime, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-warehouse-ros";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/noetic/warehouse_ros/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "e13a08e95124d32895d6182a372c459102e2181b68ac72f31cb1bf595ccd4c34";
+    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/noetic/warehouse_ros/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "f3ea5eab008525e1e38cdbaffb5b43fa4db549a217abda35e8fb39111281ba91";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 4284c676a6ca7fe38863b92047b5eb8c1a1ec64b.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *depthai 2.15.4-r1*
* *dynamic-edt-3d 1.9.7-r1 --> 1.9.8-r1*
* *eigenpy 2.7.2-r1 --> 2.7.4-r1*
* *husky-base 1.0.7-r1*
* *husky-bringup 1.0.7-r1*
* *husky-control 1.0.7-r1*
* *husky-description 1.0.7-r1*
* *husky-desktop 1.0.7-r1*
* *husky-gazebo 1.0.7-r1*
* *husky-msgs 1.0.7-r1*
* *husky-robot 1.0.7-r1*
* *husky-simulator 1.0.7-r1*
* *husky-viz 1.0.7-r1*
* *mrpt-msgs 0.4.2-r1*
* *octomap 1.9.7-r1 --> 1.9.8-r1*
* *octomap-ros 0.4.2-r1 --> 0.4.3-r1*
* *octovis 1.9.7-r1 --> 1.9.8-r1*
* *plotjuggler 3.4.3-r1 --> 3.4.4-r1*
* *septentrio-gnss-driver 1.2.0-r6 --> 1.2.1-r1*

Galactic Changes:
-----------------
* *costmap-queue 1.0.9-r1 --> 1.0.11-r1*
* *depthai 2.15.4-r2*
* *dwb-core 1.0.9-r1 --> 1.0.11-r1*
* *dwb-critics 1.0.9-r1 --> 1.0.11-r1*
* *dwb-msgs 1.0.9-r1 --> 1.0.11-r1*
* *dwb-plugins 1.0.9-r1 --> 1.0.11-r1*
* *dynamic-edt-3d 1.9.7-r1 --> 1.9.8-r1*
* *ecl-build 1.0.2-r1*
* *ecl-license 1.0.2-r1*
* *ecl-tools 1.0.2-r1*
* *nav-2d-msgs 1.0.9-r1 --> 1.0.11-r1*
* *nav-2d-utils 1.0.9-r1 --> 1.0.11-r1*
* *nav2-amcl 1.0.9-r1 --> 1.0.11-r1*
* *nav2-behavior-tree 1.0.9-r1 --> 1.0.11-r1*
* *nav2-bringup 1.0.9-r1 --> 1.0.11-r1*
* *nav2-bt-navigator 1.0.9-r1 --> 1.0.11-r1*
* *nav2-common 1.0.9-r1 --> 1.0.11-r1*
* *nav2-controller 1.0.9-r1 --> 1.0.11-r1*
* *nav2-core 1.0.9-r1 --> 1.0.11-r1*
* *nav2-costmap-2d 1.0.9-r1 --> 1.0.11-r1*
* *nav2-dwb-controller 1.0.9-r1 --> 1.0.11-r1*
* *nav2-gazebo-spawner 1.0.9-r1 --> 1.0.11-r1*
* *nav2-lifecycle-manager 1.0.9-r1 --> 1.0.11-r1*
* *nav2-map-server 1.0.9-r1 --> 1.0.11-r1*
* *nav2-msgs 1.0.9-r1 --> 1.0.11-r1*
* *nav2-navfn-planner 1.0.9-r1 --> 1.0.11-r1*
* *nav2-planner 1.0.9-r1 --> 1.0.11-r1*
* *nav2-recoveries 1.0.9-r1 --> 1.0.11-r1*
* *nav2-regulated-pure-pursuit-controller 1.0.9-r1 --> 1.0.11-r1*
* *nav2-rotation-shim-controller 1.0.9-r1 --> 1.0.11-r1*
* *nav2-rviz-plugins 1.0.9-r1 --> 1.0.11-r1*
* *nav2-simple-commander 1.0.9-r1 --> 1.0.11-r1*
* *nav2-smac-planner 1.0.9-r1 --> 1.0.11-r1*
* *nav2-system-tests 1.0.9-r1 --> 1.0.11-r1*
* *nav2-theta-star-planner 1.0.9-r1 --> 1.0.11-r1*
* *nav2-util 1.0.9-r1 --> 1.0.11-r1*
* *nav2-voxel-grid 1.0.9-r1 --> 1.0.11-r1*
* *nav2-waypoint-follower 1.0.9-r1 --> 1.0.11-r1*
* *navigation2 1.0.9-r1 --> 1.0.11-r1*
* *octomap 1.9.7-r1 --> 1.9.8-r1*
* *octomap-ros 0.4.2-r1 --> 0.4.3-r1*
* *octovis 1.9.7-r1 --> 1.9.8-r1*
* *plotjuggler 3.4.2-r1 --> 3.4.4-r1*
* *septentrio-gnss-driver 1.2.0-r5 --> 1.2.1-r1*
* *turtlebot4-ignition-bringup 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-ignition-toolbox 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-simulator 0.1.0-r1 --> 0.1.1-r1*
* *zmqpp-vendor 0.0.1-r2*

Melodic Changes:
----------------
* *aques-talk 2.1.24-r1 --> 2.1.24-r2*
* *assimp-devel 2.1.24-r1 --> 2.1.24-r2*
* *bayesian-belief-networks 2.1.24-r1 --> 2.1.24-r2*
* *chaplus-ros 2.1.24-r1 --> 2.1.24-r2*
* *control-toolbox 1.18.2-r1 --> 1.19.0-r1*
* *dingo-control 0.1.10-r1 --> 0.1.11-r1*
* *dingo-description 0.1.10-r1 --> 0.1.11-r1*
* *dingo-msgs 0.1.10-r1 --> 0.1.11-r1*
* *dingo-navigation 0.1.10-r1 --> 0.1.11-r1*
* *downward 2.1.24-r1 --> 2.1.24-r2*
* *dynamic-edt-3d 1.9.7-r1 --> 1.9.8-r1*
* *dynamic-reconfigure 1.6.4-r1 --> 1.6.5-r1*
* *eigenpy 2.7.2-r1 --> 2.7.4-r1*
* *eus-assimp 0.4.3 --> 0.4.4-r1*
* *eusurdf 0.4.3 --> 0.4.4-r1*
* *ff 2.1.24-r1 --> 2.1.24-r2*
* *ffha 2.1.24-r1 --> 2.1.24-r2*
* *filters 1.8.2-r1 --> 1.8.3-r1*
* *jsk-3rdparty 2.1.24-r1 --> 2.1.24-r2*
* *jsk-model-tools 0.4.3 --> 0.4.4-r1*
* *julius 2.1.24-r1 --> 2.1.24-r2*
* *libcmt 2.1.24-r1 --> 2.1.24-r2*
* *libsiftfast 2.1.24-r1 --> 2.1.24-r2*
* *lpg-planner 2.1.24-r1 --> 2.1.24-r2*
* *mini-maxwell 2.1.24-r1 --> 2.1.24-r2*
* *mrpt-msgs 0.2.0-r1 --> 0.4.0-r1*
* *nlopt 2.1.24-r1 --> 2.1.24-r2*
* *octomap 1.9.7-r1 --> 1.9.8-r1*
* *octovis 1.9.7-r1 --> 1.9.8-r1*
* *opt-camera 2.1.24-r1 --> 2.1.24-r2*
* *pose-cov-ops 0.3.1-r1 --> 0.3.2-r1*
* *ridgeback-control 0.3.1-r1 --> 0.3.2-r1*
* *ridgeback-description 0.3.1-r1 --> 0.3.2-r1*
* *ridgeback-msgs 0.3.1-r1 --> 0.3.2-r1*
* *ridgeback-navigation 0.3.1-r1 --> 0.3.2-r1*
* *rospatlite 2.1.24-r1 --> 2.1.24-r2*
* *rosping 2.1.24-r1 --> 2.1.24-r2*
* *septentrio-gnss-driver 1.1.0-r8 --> 1.1.1-r1*
* *sesame-ros 2.1.24-r1 --> 2.1.24-r2*
* *slic 2.1.24-r1 --> 2.1.24-r2*
* *switchbot-ros 2.1.24-r1 --> 2.1.24-r2*
* *toposens-sensor-library 1.1.4-r1 --> 1.2.4-r4*
* *voice-text 2.1.24-r1 --> 2.1.24-r2*
* *warehouse-ros 0.9.4-r1 --> 0.9.5-r1*
* *warehouse-ros-sqlite 0.9.0-r1*

Noetic Changes:
---------------
* *ackermann-steering-controller 0.19.0-r1 --> 0.20.0-r1*
* *control-toolbox 1.18.2-r1 --> 1.19.0-r1*
* *diff-drive-controller 0.19.0-r1 --> 0.20.0-r1*
* *dynamic-edt-3d 1.9.7-r1 --> 1.9.8-r1*
* *dynamic-reconfigure 1.7.2-r1 --> 1.7.3-r1*
* *effort-controllers 0.19.0-r1 --> 0.20.0-r1*
* *eigenpy 2.7.2-r1 --> 2.7.4-r1*
* *eus-assimp 0.4.3-r1 --> 0.4.4-r1*
* *eusurdf 0.4.3-r1 --> 0.4.4-r1*
* *filters 1.9.1-r1 --> 1.9.2-r1*
* *force-torque-sensor-controller 0.19.0-r1 --> 0.20.0-r1*
* *forward-command-controller 0.19.0-r1 --> 0.20.0-r1*
* *four-wheel-steering-controller 0.19.0-r1 --> 0.20.0-r1*
* *gripper-action-controller 0.19.0-r1 --> 0.20.0-r1*
* *husky-control 0.6.2-r1 --> 0.6.3-r1*
* *husky-description 0.6.2-r1 --> 0.6.3-r1*
* *husky-desktop 0.6.2-r1 --> 0.6.3-r1*
* *husky-gazebo 0.6.2-r1 --> 0.6.3-r1*
* *husky-msgs 0.6.2-r1 --> 0.6.3-r1*
* *husky-navigation 0.6.2-r1 --> 0.6.3-r1*
* *husky-simulator 0.6.2-r1 --> 0.6.3-r1*
* *husky-viz 0.6.2-r1 --> 0.6.3-r1*
* *imu-sensor-controller 0.19.0-r1 --> 0.20.0-r1*
* *jackal-control 0.8.3-r1 --> 0.8.4-r1*
* *jackal-description 0.8.3-r1 --> 0.8.4-r1*
* *jackal-msgs 0.8.3-r1 --> 0.8.4-r1*
* *jackal-navigation 0.8.3-r1 --> 0.8.4-r1*
* *jackal-tutorials 0.8.3-r1 --> 0.8.4-r1*
* *joint-state-controller 0.19.0-r1 --> 0.20.0-r1*
* *joint-trajectory-controller 0.19.0-r1 --> 0.20.0-r1*
* *jsk-model-tools 0.4.3-r1 --> 0.4.4-r1*
* *laser-tilt-controller-filter 0.2.0-r1*
* *mrpt-msgs 0.2.0-r2 --> 0.4.0-r1*
* *octomap 1.9.7-r1 --> 1.9.8-r1*
* *octovis 1.9.7-r1 --> 1.9.8-r1*
* *openrtm-aist 1.1.2-r2 --> 1.1.2-r4*
* *pf-description 1.2.0-r1*
* *pf-driver 1.2.0-r1*
* *pose-cov-ops 0.3.1-r1 --> 0.3.2-r1*
* *position-controllers 0.19.0-r1 --> 0.20.0-r1*
* *pr2-move-base 0.2.0-r1*
* *pr2-navigation 0.2.0-r1*
* *pr2-navigation-config 0.2.0-r1*
* *pr2-navigation-global 0.2.0-r1*
* *pr2-navigation-local 0.2.0-r1*
* *pr2-navigation-perception 0.2.0-r1*
* *pr2-navigation-self-filter 0.2.0-r1*
* *pr2-navigation-slam 0.2.0-r1*
* *pr2-navigation-teleop 0.2.0-r1*
* *ridgeback-control 0.3.1-r1 --> 0.3.2-r1*
* *ridgeback-description 0.3.1-r1 --> 0.3.2-r1*
* *ridgeback-msgs 0.3.1-r1 --> 0.3.2-r1*
* *ridgeback-navigation 0.3.1-r1 --> 0.3.2-r1*
* *ros-controllers 0.19.0-r1 --> 0.20.0-r1*
* *ros-ethercat-eml 0.4.0-r2*
* *rqt-joint-trajectory-controller 0.19.0-r1 --> 0.20.0-r1*
* *semantic-point-annotator 0.2.0-r1*
* *septentrio-gnss-driver 1.1.0-r7 --> 1.1.1-r1*
* *toposens-sensor-library 1.1.4-r1 --> 1.2.4-r4*
* *velocity-controllers 0.19.0-r1 --> 0.20.0-r1*
* *warehouse-ros 0.9.4-r1 --> 0.9.5-r1*
* *warehouse-ros-sqlite 0.9.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] clpe
 * [ ] clpe_ros_msgs
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-wstool
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

