### PR TITLE
rosdistro sync, Fri Jun 17 13:47:36 2022

### DIFF
--- a/distros/foxy/bosch-locator-bridge/default.nix
+++ b/distros/foxy/bosch-locator-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-srvs, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-bosch-locator-bridge";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "56154d58494f9a6c219470b658bb30c4a7b1acfd7f5f817a70fd568fedffced8";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "9e6f267e4f89e4a3a14f4a4bc7b88dbfe9acb31ee089d5de3258b3b063a3ef2e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs launch-xml nav-msgs pcl-conversions poco rclcpp rosidl-default-runtime std-srvs tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs launch-xml nav-msgs pcl-conversions poco rclcpp rosidl-default-runtime sensor-msgs std-srvs tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/depthai/default.nix
+++ b/distros/foxy/depthai/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-depthai";
-  version = "2.15.4-r1";
+  version = "2.15.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.15.4-1.tar.gz";
-    name = "2.15.4-1.tar.gz";
-    sha256 = "88d84cdcc15e90cf05e45bfb7ef6336a13609f98bc006681c237219bbf5f515c";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.15.5-1.tar.gz";
+    name = "2.15.5-1.tar.gz";
+    sha256 = "687fd898f762a61c98888ca56f81ff4b4dd6cdfceb6b893aca8a01ad50b50845";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
   propagatedBuildInputs = [ libusb1 nlohmann_json opencv ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "b784f6a28d3c19779124fe7e36216c05a8417e9ce70fe791e7017a17a4d06ad0";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "9b96e2ca134cbf95c31400f5ae7862e5e79b36a6133630079083734a461aa2c2";
   };
 
   buildType = "cmake";

--- a/distros/foxy/foxglove-msgs/default.nix
+++ b/distros/foxy/foxglove-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-foxglove-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/foxy/foxglove_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "66c303fdfa86acd2216a77601f039f1bd864ed22b6c7fa2d47ffe70a7058ec00";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/foxy/foxglove_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "21ed8c1eb314f12467a00e273f506b2ec7b2f75689b610495b4b31f8f3421b34";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -312,6 +312,14 @@ self: super: {
 
  depthai = self.callPackage ./depthai {};
 
+ depthai-ros = self.callPackage ./depthai-ros {};
+
+ depthai-bridge = self.callPackage ./depthai-bridge {};
+
+ depthai-examples = self.callPackage ./depthai-examples {};
+
+ depthai-ros-msgs = self.callPackage ./depthai-ros-msgs {};
+
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
  derived-object-msgs = self.callPackage ./derived-object-msgs {};
@@ -451,6 +459,8 @@ self: super: {
  eiquadprog = self.callPackage ./eiquadprog {};
 
  embree-vendor = self.callPackage ./embree-vendor {};
+
+ end-effector = self.callPackage ./end-effector {};
 
  espeak-interfaces = self.callPackage ./espeak-interfaces {};
 
@@ -754,6 +764,20 @@ self: super: {
 
  lusb = self.callPackage ./lusb {};
 
+ maliput = self.callPackage ./maliput {};
+
+ maliput-dragway = self.callPackage ./maliput-dragway {};
+
+ maliput-drake = self.callPackage ./maliput-drake {};
+
+ maliput-malidrive = self.callPackage ./maliput-malidrive {};
+
+ maliput-multilane = self.callPackage ./maliput-multilane {};
+
+ maliput-object = self.callPackage ./maliput-object {};
+
+ maliput-py = self.callPackage ./maliput-py {};
+
  map-msgs = self.callPackage ./map-msgs {};
 
  map-transformer = self.callPackage ./map-transformer {};
@@ -1018,6 +1042,8 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ performance-test = self.callPackage ./performance-test {};
+
  performance-test-fixture = self.callPackage ./performance-test-fixture {};
 
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
@@ -1105,6 +1131,8 @@ self: super: {
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
+
+ pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
  position-controllers = self.callPackage ./position-controllers {};
 
@@ -1453,6 +1481,8 @@ self: super: {
  rosbridge-suite = self.callPackage ./rosbridge-suite {};
 
  rosbridge-test-msgs = self.callPackage ./rosbridge-test-msgs {};
+
+ rosee-msg = self.callPackage ./rosee-msg {};
 
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
 
@@ -1929,6 +1959,8 @@ self: super: {
  xacro-live = self.callPackage ./xacro-live {};
 
  yaml-cpp-vendor = self.callPackage ./yaml-cpp-vendor {};
+
+ zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
 
  zstd-vendor = self.callPackage ./zstd-vendor {};
 

--- a/distros/foxy/maliput-dragway/default.nix
+++ b/distros/foxy/maliput-dragway/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, pybind11 }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-dragway";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "712a1f3b5af0faa0d7fe3d8070f03aa1f29ed68ce1c63770512670f804cfd2f8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-cmake-pytest ];
+  propagatedBuildInputs = [ maliput maliput-py pybind11 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Dragway.'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-drake/default.nix
+++ b/distros/foxy/maliput-drake/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, fmt }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-drake";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_drake-release/archive/release/foxy/maliput_drake/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "62c1eb10211bb8818d8593cbaa3e759763c4d5e52432445b8423f2c2272b1a7c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ eigen eigen3-cmake-module fmt ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''Maliput drake extraction to provide trajectory integration support'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-malidrive/default.nix
+++ b/distros/foxy/maliput-malidrive/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, fmt, maliput, maliput-drake, tinyxml-2 }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-malidrive";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "f643c9761b5333d6cc0856263e49ef2931b4820f5b141f800639a2d800276971";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ];
+  propagatedBuildInputs = [ fmt maliput maliput-drake tinyxml-2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''maliput_malidrive backend'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-multilane";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "527698d08a50d9a49c0d3382e62f2854ebb5e02dee52873dfd3668f25c16e55f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-cmake-gtest ];
+  propagatedBuildInputs = [ fmt libyamlcpp maliput maliput-drake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Multilane.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/maliput-object/default.nix
+++ b/distros/foxy/maliput-object/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp, maliput }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-object";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_object-release/archive/release/foxy/maliput_object/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "8f4fd69d2d26d24259b724032fbc85a826fe2475722bbffe390a4ae110bd71b8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-cmake-gtest ];
+  propagatedBuildInputs = [ fmt gflags libyamlcpp maliput ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Object'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-py/default.nix
+++ b/distros/foxy/maliput-py/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput, pybind11, python3 }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-py";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_py-release/archive/release/foxy/maliput_py/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "2bc757970ac2532515772d7a2f7494c43938c8e36ee7a3281a61da6c8b9b49a1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ python3 ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-pytest ];
+  propagatedBuildInputs = [ maliput pybind11 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput bindings'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput/default.nix
+++ b/distros/foxy/maliput/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp }:
 buildRosPackage {
   pname = "ros-foxy-maliput";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "bf062af6c12f5280931c07623b7d0a590daf3ed158460930cdfb22ea3a623c6b";
+    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "fbb5918c21d8a93b9cca9e5a74e929c10bc8d9d0cb762e47585eb3f60b4ac316";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mrpt-msgs/default.nix
+++ b/distros/foxy/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mrpt-msgs";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/foxy/mrpt_msgs/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "bbf371cba2231b1a56f67dd4d37434431cf5385e5894f9640ab781d04094bfb8";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/foxy/mrpt_msgs/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "9e224e5920e7cf9479af30d712767db0921e687365f9bc89f02eaf29c504980b";
   };
 
   buildType = "cmake";

--- a/distros/galactic/costmap-queue/default.nix
+++ b/distros/galactic/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-costmap-queue";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "2c37c92750548b77438ea60bedb0a39e108e6325288e8e5ded66fe460bac6aae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "eace4bc202c703bea555c1fc9278e429c2a377143dc8748175971a615c8682bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai/default.nix
+++ b/distros/galactic/depthai/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-depthai";
-  version = "2.15.4-r2";
+  version = "2.15.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.15.4-2.tar.gz";
-    name = "2.15.4-2.tar.gz";
-    sha256 = "556938d97b747462ec3a797080f9b5eae8d3fc5ff9132a55e7ddd0816d778848";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.15.5-1.tar.gz";
+    name = "2.15.5-1.tar.gz";
+    sha256 = "4986156602eab268b763908b1c26d67e4404f43476a61a026ddd6c6b95b901fe";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
   propagatedBuildInputs = [ libusb1 nlohmann_json opencv ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/dwb-core/default.nix
+++ b/distros/galactic/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-core";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "5f37823566c17f1e3f5f69d28305022310a6cffa1f2e5e487310f6af3b7f9500";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "a183c107ab0edb87290647f4333a259da8a3bff19aa462ef180ae83038d38f6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-critics/default.nix
+++ b/distros/galactic/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-critics";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fecda736d8e76548b4c34cf98ccfa1259f3e5d993cd028ec5dd51e73e0046cd5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "798c23c6be0837cda89372cd5e4612e163b343a48fe524b0a13517082823c92a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-msgs/default.nix
+++ b/distros/galactic/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-msgs";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "b2ca84d5e5f2bad9f9d46a044b85fa7f815a2019ee2e4aa1cbd3537ccb2c065f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "f4700ca459805066a26d4c388b33f62be0a4678681c6604d8e261e2c56d88354";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-plugins/default.nix
+++ b/distros/galactic/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-dwb-plugins";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "169e59b2ff0bea76fa4ff5aacce060fd7fc798917a2de3c0632e7264da858e6b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "892479c0c1daa707be18db68cabfa65af61e9305d59d2815b9e43775b7c515c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/foxglove-msgs/default.nix
+++ b/distros/galactic/foxglove-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-foxglove-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/galactic/foxglove_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "6a9ff07622083559177d8b0912cd63dc7057e5c1df1690bc8a2778b7fdb5a117";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/galactic/foxglove_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e8e81d56cd17a73f6a2ab55780aa20aa5e466832bf2b5b0bcfd3f884ff7f0c31";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  ament-cmake-auto = self.callPackage ./ament-cmake-auto {};
 
+ ament-cmake-black = self.callPackage ./ament-cmake-black {};
+
  ament-cmake-catch2 = self.callPackage ./ament-cmake-catch2 {};
 
  ament-cmake-clang-format = self.callPackage ./ament-cmake-clang-format {};
@@ -234,6 +236,14 @@ self: super: {
 
  depthai = self.callPackage ./depthai {};
 
+ depthai-ros = self.callPackage ./depthai-ros {};
+
+ depthai-bridge = self.callPackage ./depthai-bridge {};
+
+ depthai-examples = self.callPackage ./depthai-examples {};
+
+ depthai-ros-msgs = self.callPackage ./depthai-ros-msgs {};
+
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
  desktop = self.callPackage ./desktop {};
@@ -282,9 +292,75 @@ self: super: {
 
  ecl-build = self.callPackage ./ecl-build {};
 
+ ecl-command-line = self.callPackage ./ecl-command-line {};
+
+ ecl-concepts = self.callPackage ./ecl-concepts {};
+
+ ecl-config = self.callPackage ./ecl-config {};
+
+ ecl-console = self.callPackage ./ecl-console {};
+
+ ecl-containers = self.callPackage ./ecl-containers {};
+
+ ecl-converters = self.callPackage ./ecl-converters {};
+
+ ecl-converters-lite = self.callPackage ./ecl-converters-lite {};
+
+ ecl-core = self.callPackage ./ecl-core {};
+
+ ecl-core-apps = self.callPackage ./ecl-core-apps {};
+
+ ecl-devices = self.callPackage ./ecl-devices {};
+
+ ecl-eigen = self.callPackage ./ecl-eigen {};
+
+ ecl-errors = self.callPackage ./ecl-errors {};
+
+ ecl-exceptions = self.callPackage ./ecl-exceptions {};
+
+ ecl-filesystem = self.callPackage ./ecl-filesystem {};
+
+ ecl-formatters = self.callPackage ./ecl-formatters {};
+
+ ecl-geometry = self.callPackage ./ecl-geometry {};
+
+ ecl-io = self.callPackage ./ecl-io {};
+
+ ecl-ipc = self.callPackage ./ecl-ipc {};
+
  ecl-license = self.callPackage ./ecl-license {};
 
+ ecl-linear-algebra = self.callPackage ./ecl-linear-algebra {};
+
+ ecl-lite = self.callPackage ./ecl-lite {};
+
+ ecl-manipulators = self.callPackage ./ecl-manipulators {};
+
+ ecl-math = self.callPackage ./ecl-math {};
+
+ ecl-mobile-robot = self.callPackage ./ecl-mobile-robot {};
+
+ ecl-mpl = self.callPackage ./ecl-mpl {};
+
+ ecl-sigslots = self.callPackage ./ecl-sigslots {};
+
+ ecl-sigslots-lite = self.callPackage ./ecl-sigslots-lite {};
+
+ ecl-statistics = self.callPackage ./ecl-statistics {};
+
+ ecl-streams = self.callPackage ./ecl-streams {};
+
+ ecl-threads = self.callPackage ./ecl-threads {};
+
+ ecl-time = self.callPackage ./ecl-time {};
+
+ ecl-time-lite = self.callPackage ./ecl-time-lite {};
+
  ecl-tools = self.callPackage ./ecl-tools {};
+
+ ecl-type-traits = self.callPackage ./ecl-type-traits {};
+
+ ecl-utilities = self.callPackage ./ecl-utilities {};
 
  effort-controllers = self.callPackage ./effort-controllers {};
 
@@ -341,6 +417,8 @@ self: super: {
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
  filters = self.callPackage ./filters {};
+
+ fluent-rviz = self.callPackage ./fluent-rviz {};
 
  fmi-adapter = self.callPackage ./fmi-adapter {};
 
@@ -710,6 +788,8 @@ self: super: {
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
+ mrpt-msgs = self.callPackage ./mrpt-msgs {};
+
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
  multires-image = self.callPackage ./multires-image {};
@@ -854,6 +934,8 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ performance-test = self.callPackage ./performance-test {};
+
  performance-test-fixture = self.callPackage ./performance-test-fixture {};
 
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
@@ -928,7 +1010,11 @@ self: super: {
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
+ pose-cov-ops = self.callPackage ./pose-cov-ops {};
+
  position-controllers = self.callPackage ./position-controllers {};
+
+ py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
 
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
 
@@ -1444,6 +1530,8 @@ self: super: {
 
  sol-vendor = self.callPackage ./sol-vendor {};
 
+ sophus = self.callPackage ./sophus {};
+
  spacenav = self.callPackage ./spacenav {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
@@ -1519,8 +1607,6 @@ self: super: {
  test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
-
- test-launch-system-modes = self.callPackage ./test-launch-system-modes {};
 
  test-msgs = self.callPackage ./test-msgs {};
 
@@ -1608,9 +1694,19 @@ self: super: {
 
  turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
+ turtlebot4-bringup = self.callPackage ./turtlebot4-bringup {};
+
+ turtlebot4-cpp-examples = self.callPackage ./turtlebot4-cpp-examples {};
+
+ turtlebot4-cpp-tutorials = self.callPackage ./turtlebot4-cpp-tutorials {};
+
  turtlebot4-description = self.callPackage ./turtlebot4-description {};
 
  turtlebot4-desktop = self.callPackage ./turtlebot4-desktop {};
+
+ turtlebot4-diagnostics = self.callPackage ./turtlebot4-diagnostics {};
+
+ turtlebot4-examples = self.callPackage ./turtlebot4-examples {};
 
  turtlebot4-ignition-bringup = self.callPackage ./turtlebot4-ignition-bringup {};
 
@@ -1622,7 +1718,17 @@ self: super: {
 
  turtlebot4-node = self.callPackage ./turtlebot4-node {};
 
+ turtlebot4-python-examples = self.callPackage ./turtlebot4-python-examples {};
+
+ turtlebot4-python-tutorials = self.callPackage ./turtlebot4-python-tutorials {};
+
+ turtlebot4-robot = self.callPackage ./turtlebot4-robot {};
+
  turtlebot4-simulator = self.callPackage ./turtlebot4-simulator {};
+
+ turtlebot4-tests = self.callPackage ./turtlebot4-tests {};
+
+ turtlebot4-tutorials = self.callPackage ./turtlebot4-tutorials {};
 
  turtlebot4-viz = self.callPackage ./turtlebot4-viz {};
 

--- a/distros/galactic/nav-2d-msgs/default.nix
+++ b/distros/galactic/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-msgs";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "38a054e3821fed50571d3447c89b66c4b99809f52a247d81a360dd865a3ba1df";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "b34381dd3f3098bc343cd51202075b98f996109eb1dfcd61224322d7454fea4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav-2d-utils/default.nix
+++ b/distros/galactic/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-utils";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "9671cc7a50446d5dd729df858108725ddb83d84454bef1d6613f4bb6e9e9abb3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "6577cfad6839eb9a3d83c3921a64cc02d12caae79ac03d6b800bc2177348da05";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-amcl/default.nix
+++ b/distros/galactic/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-amcl";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "c32cbd13a62a34eb56e870439cc9e08714a1e4e88af03430022a0449b085dff6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "20fe3f869f4c75e595396e041b6d56275bd39674fa8d70d8a85ff818f3053f7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-behavior-tree/default.nix
+++ b/distros/galactic/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-behavior-tree";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "ce3007b0385c0c42e0890009f25c73acf2f6a137dd751c13c9ad271f120047c2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "bcb28a37c795bddb4bec5776f603bd3286af09387d4b8e457ca143beafbd7a90";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bringup/default.nix
+++ b/distros/galactic/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bringup";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fe5e3228a31137da9a74251d7f5ef3a318fa524da5ed8eb1b8fab215778940d3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "4f16762450ad6a9935d52f13a00b3381af3342a1281818f89dbc6305c8149077";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bt-navigator/default.nix
+++ b/distros/galactic/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bt-navigator";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "edf708268248be5313c9ad10ce9bfa5a61e5e762fa84375fe7d81d5f4e2d92ee";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "fc2b76a6f1055215f0ccd3f243e39707d9044648a46f46836079e4eae9c722b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-common/default.nix
+++ b/distros/galactic/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-common";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "197efdc63bd761783b46a4b76767ece88514832254968a2a815258e0fb1cd9e8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "3390f2a003fae30e5fb82b9b15e7d604bf9efcc976f40a832c425ae4b2a32f28";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-controller/default.nix
+++ b/distros/galactic/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "25f0fdfe9e5cb3b397366aeaf4c00a9dff790e4e4375a84b8daa4571d3e98517";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "bb79380fc77cd1ec4dfe3fc95b036c3ec1ba35437205a252f9cd20d379e31726";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-core/default.nix
+++ b/distros/galactic/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-core";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "be354e3bbe418536e390ad8850d3b9c0c77b245249816e489c87d24b7aa382a5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "bca1ef2ee4db9e1e68276b572906b9dfa1383c6cf9b62535e63e0acaae7b974b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-costmap-2d/default.nix
+++ b/distros/galactic/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-costmap-2d";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "63d9c3984bd4c2eeada63d9c0e5ee8a9a99ec74dae43bf654ed2c8d4965f1afe";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "cce941aa526e0d5aa402c7611eea065a09ca65370b970c6eaad37bec8ba4c300";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-dwb-controller/default.nix
+++ b/distros/galactic/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-galactic-nav2-dwb-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "b11dedfb6c062f7e5d27446febc6eec6170b1b9621c484c96764735cb267c5a1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "e8482a6d2443302054d8a5ce1b2e1578ccdd6c8a88f88d1bded6ecf027065436";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-gazebo-spawner/default.nix
+++ b/distros/galactic/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-gazebo-spawner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "c3ef6355ec97588e7e9c8421d301d457113b694b475e21a3b9a3ece69c51b525";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "1348fcbf2e7025737da0c4a9add065633590cb9e28821e81c01e97f290625806";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-lifecycle-manager/default.nix
+++ b/distros/galactic/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-lifecycle-manager";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "3295f2d0fbf9ce378849cd267a53d9be4e00008a41c9a8aba9ed9251b571ee85";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "7c7026dfd4b750518f0baa676c471f913cce3b5d549080637c131ae727673440";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-map-server/default.nix
+++ b/distros/galactic/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-nav2-map-server";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "8d3d2c267d84581c5485227687e3cf5c7602c3a7ea69d1675177989c0f880f51";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "811d9854add038969da27f275ddde870b01077a6d37d9abc51796778f621ef09";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-msgs/default.nix
+++ b/distros/galactic/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-msgs";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "23c34edc0b4059b7384feff6cb786ce15e3ca18cc4922da35ab43a34b8aceae9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "07c3c19ca5fc4a8f4016ae9aeeb8eda00a314a5355deb3eddd234d56a6abb22e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-navfn-planner/default.nix
+++ b/distros/galactic/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-navfn-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "8fc955ec4170ab18f11a4d2ee6fed94a965e107b16873aa82a76023ed04c65ac";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "e77760025dc5a91a7d3e733ff1a913c99790ec25767e92fa3e95bd07ef7ea7bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-planner/default.nix
+++ b/distros/galactic/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "34f1fd619fcb5993858986dabe327fc826f4dfa6d6c53b5f40090169b52d0f0f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "2b929c9aebd1cf1d6538b62bcfa270d151949e10a119297190d88ad33fa39b85";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-recoveries/default.nix
+++ b/distros/galactic/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-recoveries";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "b6dd74fedf5ae36abfec7799b57c6375227b760734cf5742e463d3a40bc77bc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "267672750dc19cb2b5eb1d88eaa65b470111737781a9d6f05fbf2dcf048b6928";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-regulated-pure-pursuit-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "51ce72e46c1c1604549734527b732faae0ea4317fedcf7eaca67506dce945793";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "843e9fadc756207394c3170ed709930f7c4063eb12c3700d6f7a3e8e2b65bdbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rotation-shim-controller/default.nix
+++ b/distros/galactic/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rotation-shim-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fb9721a63c3c00204187cedcdbde6e60558d5cd41605a2c48518119c003e4978";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "ceb2346ea6f6e0a4c3ff60de292d6e3269157cd3a09ea3701167de9368fad565";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rviz-plugins/default.nix
+++ b/distros/galactic/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rviz-plugins";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "aa8dbc35259b8ed0ce9ca9e30607d43d353b78ca08f8833bf88474221d5835ae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "d33f957539bbdec66081ce8df83487bf7d89b700583696a1ae22d7e8fe4c4cee";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-simple-commander/default.nix
+++ b/distros/galactic/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-simple-commander";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fbddc7ed655af8fc30e5defb0f25a6499d921577f19ececaefa3956c545a7ae3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "d582ede409d515cd0baa48001c95ba9307cdc4f2f5acf5992c49403c80d7090a";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-smac-planner/default.nix
+++ b/distros/galactic/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-smac-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "c3d79de924b04ab4769c151fbf1afc3c05b336a0d2b9962fc6c94852bd4d4a07";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "5a0438afe92f63ca64cd043afa7d736feeb87f1f2586fa5a4c6cf6503877280e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-system-tests/default.nix
+++ b/distros/galactic/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-system-tests";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "2d5d86a8d1f0ded55f09b260736e3627ec2aca092e9449d623b819d9f03b30f1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "eafb86033015cb54239a81bf76a8e0edfffdb1e4646d487805a2f952b920924a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-theta-star-planner/default.nix
+++ b/distros/galactic/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-theta-star-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "1fd908a17bdf363c238087f412de17250bb812e32d8cb03b9670e2adbf27f69c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "f5c78bf161d62ea9ae300f3327dcb1c3565df948c378bf6e0f5ce2495853fb09";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-util/default.nix
+++ b/distros/galactic/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-util";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "83795bc7bacf58fe5d0da3549c5db1ae911cd609829af535908ab2da13647b24";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "04642e089eb5b1689fbdb84f845f443e7ae2505c1492735fe3024cc3bceab050";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-voxel-grid/default.nix
+++ b/distros/galactic/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nav2-voxel-grid";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "4969999af3228c8b5e2e3cf9ff3b51f4dabbcc7e42cf5f1f08b4e9f7aabc2109";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "d1a24f7db607fbac85f895ce83fce3e369da655a446b7cc361db9d95416a0e70";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-waypoint-follower/default.nix
+++ b/distros/galactic/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-waypoint-follower";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "1c10c3531708238e5a07bcccc17a6175c167a7c03d2330ae7b6649c0b91e8f79";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "ed5ac03b406b8a45e501ee909266e72b325c5c1aaf11175c8e8f3480b0783089";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/navigation2/default.nix
+++ b/distros/galactic/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-theta-star-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-galactic-navigation2";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "f7e531233ce4136bd2441aa542b392a90c486c9aec7267edff70017b305a383a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "3208d18f9c1aa932a7a7e587b7d221ddfd5a01cf667bea516e2d527753002569";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/zmqpp-vendor/default.nix
+++ b/distros/galactic/zmqpp-vendor/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cppzmq }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cppzmq, git }:
 buildRosPackage {
   pname = "ros-galactic-zmqpp-vendor";
-  version = "0.0.1-r2";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/zmqpp_vendor-release/archive/release/galactic/zmqpp_vendor/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "d399685344debd3bfc100cc85a98510db16cd7dc655d5edc3195405ab89779a4";
+    url = "https://github.com/tier4/zmqpp_vendor-release/archive/release/galactic/zmqpp_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "d161406de0515cd02b1d3c0ba9b89e0bf081ffb54ded21f1727c0e262ff33379";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cppzmq ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''Vendor package for zmqpp'';

--- a/distros/humble/diagnostic-aggregator/default.nix
+++ b/distros/humble/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-aggregator";
-  version = "2.1.3-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/2.1.3-3.tar.gz";
-    name = "2.1.3-3.tar.gz";
-    sha256 = "33453341c6e711d393b2e5be831fbbf9acda211653a1369f7ab36d21392bf747";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "2fecf33067be564781b0efb26e815457a51523c52eeb680725b4e3d77026952d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-updater/default.nix
+++ b/distros/humble/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-updater";
-  version = "2.1.3-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/2.1.3-3.tar.gz";
-    name = "2.1.3-3.tar.gz";
-    sha256 = "a8167dc1f9810bc10f8da37e134da1aa9622da83b8b768b38ccf8b1167a290b3";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "5d2f40a7d3119f3f4b645e8f51e3c499d3931dafdb5bac3dd19db43f69d7bacf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fogros2-examples/default.nix
+++ b/distros/humble/fogros2-examples/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, fogros2, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-fogros2-examples";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fogros2-release/archive/release/humble/fogros2_examples/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "67f26be1f643fa7c9edfb626dcf106a97d0076bfba550e7c7a5390f91c7a06f8";
+    url = "https://github.com/ros2-gbp/fogros2-release/archive/release/humble/fogros2_examples/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "6613e0d7877aac0bf0707e68f296bd3960db395f53b1ec0485d60187b53567d6";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ fogros2 ];
 
   meta = {
     description = ''Examples using FogROS2'';

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -846,6 +846,10 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ performance-report = self.callPackage ./performance-report {};
+
+ performance-test = self.callPackage ./performance-test {};
+
  performance-test-fixture = self.callPackage ./performance-test-fixture {};
 
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
@@ -1102,6 +1106,12 @@ self: super: {
 
  rmw-implementation-cmake = self.callPackage ./rmw-implementation-cmake {};
 
+ robot-controllers = self.callPackage ./robot-controllers {};
+
+ robot-controllers-interface = self.callPackage ./robot-controllers-interface {};
+
+ robot-controllers-msgs = self.callPackage ./robot-controllers-msgs {};
+
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
@@ -1329,6 +1339,8 @@ self: super: {
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
  sdl2-vendor = self.callPackage ./sdl2-vendor {};
+
+ self-test = self.callPackage ./self-test {};
 
  sensor-msgs = self.callPackage ./sensor-msgs {};
 

--- a/distros/humble/orocos-kdl-vendor/default.nix
+++ b/distros/humble/orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, git, orocos-kdl }:
 buildRosPackage {
   pname = "ros-humble-orocos-kdl-vendor";
-  version = "0.2.2-r3";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/orocos_kdl_vendor/0.2.2-3.tar.gz";
-    name = "0.2.2-3.tar.gz";
-    sha256 = "31de19ed029028bdad7eb5c0db32485108e00ba9bdc32dbd06f931659309508b";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/orocos_kdl_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "16b43362fa4ac66f83e3e10f09b4fcfdb994152a8b7e0f0ccd5a10022c0d4696";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/performance-report/default.nix
+++ b/distros/humble/performance-report/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, chromium, performance-test, python3Packages, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-performance-report";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_report/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "dcb7eed87c7a7cc4506451c3aa1e6ee6cfd9baf0eecda56cccc772b1768fa38f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pyyaml pythonPackages.pytest ];
+  propagatedBuildInputs = [ chromium performance-test python3Packages.pandas python3Packages.selenium rclpy ];
+
+  meta = {
+    description = ''Apex.AI performance_test runner, plotter, and reporter'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/performance-test/default.nix
+++ b/distros/humble/performance-test/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-performance-test";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_test/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "86837cb1939cb826de597334ba5d7653deafbcf42a572ab28c7b45406d94ef1e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ osrf-testing-tools-cpp ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing rmw-implementation-cmake ];
+  propagatedBuildInputs = [ rclcpp rmw-implementation rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Tool to test performance of ROS2 and DDS data layers and communication.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/pose-cov-ops/default.nix
+++ b/distros/humble/pose-cov-ops/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-pose-cov-ops";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "47629a776d64c1cf59d61570b18f1fc22fab5a94386f78e19bd4e92006b0fc5e";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "6cbdb83ba2163e3e5ddc61281854db1f8857177a72d64c57f673c563abebd306";
   };
 
   buildType = "cmake";

--- a/distros/humble/pybind11-vendor/default.nix
+++ b/distros/humble/pybind11-vendor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, pybind11 }:
 buildRosPackage {
   pname = "ros-humble-pybind11-vendor";
   version = "2.4.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ pythonPackages.pybind11 ];
+  propagatedBuildInputs = [ pybind11 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/python-orocos-kdl-vendor/default.nix
+++ b/distros/humble/python-orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, orocos-kdl-vendor, pybind11-vendor, python-cmake-module, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-python-orocos-kdl-vendor";
-  version = "0.2.2-r3";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/python_orocos_kdl_vendor/0.2.2-3.tar.gz";
-    name = "0.2.2-3.tar.gz";
-    sha256 = "8568fe986677ac102c94958763484aa46006521329a940aa2a74727da510ef5b";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/python_orocos_kdl_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "72815f58f8cb90a0e7d1c62a6a63a5f86a09bd51addf098d482f6f214becebde";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-controllers-interface/default.nix
+++ b/distros/humble/robot-controllers-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, pluginlib, rclcpp, rclcpp-action, robot-controllers-msgs }:
+buildRosPackage {
+  pname = "ros-humble-robot-controllers-interface";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_interface/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "fa0b921a6a77464174a56b6605722ce4bfab9ef5db7b9368289ed482a9c3d549";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cpplint ];
+  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-action robot-controllers-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic framework for robot controls.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/robot-controllers-msgs/default.nix
+++ b/distros/humble/robot-controllers-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-robot-controllers-msgs";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "6168c20282d5df0cdb2fa9aaa08b9ac684e0413c74831dad9a4127cb1499eaeb";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-generators rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for use with robot_controllers framework.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/robot-controllers/default.nix
+++ b/distros/humble/robot-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-gtest, angles, control-msgs, geometry-msgs, kdl-parser, nav-msgs, orocos-kdl, pluginlib, rclcpp, rclcpp-action, robot-controllers-interface, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-humble-robot-controllers";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "2af7614debde55931e933e9ca4b1c2ab5a7e79bec8c729824935c9e116a78ce0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cpplint ament-cmake-gtest ];
+  propagatedBuildInputs = [ angles control-msgs geometry-msgs kdl-parser nav-msgs orocos-kdl pluginlib rclcpp rclcpp-action robot-controllers-interface sensor-msgs std-msgs tf2-geometry-msgs tf2-ros trajectory-msgs urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Some basic robot controllers for use with robot_controllers_interface.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/self-test/default.nix
+++ b/distros/humble/self-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-self-test";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "8acb8d00b7710ecd2f1a5e0242c132953f85934edde4f7c41ca39774fbfda3dd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''self_test'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/simple-launch/default.nix
+++ b/distros/humble/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-simple-launch";
-  version = "1.3.1-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "6f206b0b2cc556f302be38eb11509f0a0b27288cecd72a21302146e2af01d7af";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "323335217360f26bea3981863b5848e0c0c1a953a5441bb2a2a3b8c6e2027c09";
   };
 
   buildType = "ament_python";

--- a/distros/melodic/autoware-can-msgs/default.nix
+++ b/distros/melodic/autoware-can-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_can_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "073221a49f18b6ec6f8c9212fbb04e741c50df80a186cc35844a16d15d99fb41";
+    sha256 = "1e50f649b44dc8ad43ccada6bec907f06e81e1568b12ae5141f2e0ff3967f8e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-config-msgs/default.nix
+++ b/distros/melodic/autoware-config-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_config_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "8ddf21ec12618481606bec665161d5baf3000d258ad46e7970ebd38838680f96";
+    sha256 = "d60ba3433659548c626d654074c19395ac5ec153efc98ae862fdd521170a950a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-external-msgs/default.nix
+++ b/distros/melodic/autoware-external-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_external_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "5c63a69ac01afaf5e14e3bafd269dd84cc39da498ec765a90c3c87868a5a4f1a";
+    sha256 = "7c79c2c05eccebce61b3be3fd3c13d440c9014b5e1425d752732ff557e402543";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-lanelet2-msgs/default.nix
+++ b/distros/melodic/autoware-lanelet2-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_lanelet2_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "a7a1ac35c328f23be34a4c3a48dbd7fcf0398469fdef47e0e5e778e0fb5b81ac";
+    sha256 = "499647b4641b7b3894314e2b1855809983b2c25787db20187b41cdb0d2cd5c12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-map-msgs/default.nix
+++ b/distros/melodic/autoware-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "d5fe344b85d8e5b0fc01fc3375a8fb47ef62e04733457d503c142ad059e5f88d";
+    sha256 = "657e98a615e03cabd4a43531f59636f763b69c1ed17e083bdcba0cb54f756967";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-msgs/default.nix
+++ b/distros/melodic/autoware-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "44ecb84a0ea81721e4b7efac8c258bfabfeec1859e081770a6518f8b3bcbd460";
+    sha256 = "565ea9d118130516a2c35ef6a701b65b72ea89941c21349544dc57be3ebe782b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-system-msgs/default.nix
+++ b/distros/melodic/autoware-system-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_system_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "38acd44d460adf08104f65df50ca6b1f25ee7d1a09bb9f482700e74e862f2e20";
+    sha256 = "45baf85696feee43e02e8d82ddc2ee9e75199c6996b7635f68c78074be0b25f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "3664e366f7ebd962056f104b284f8933eeee40c14a35371a30e6594c0e014959";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "47858bb6feda73d45f258f788360159c31fdcb1f4547a1324c9a1bc7e402acb1";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mrpt-msgs/default.nix
+++ b/distros/melodic/mrpt-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "fc307fe3df5c94c3e163021ccabe4cc435c035e732f200b94ea8967aa72954ee";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "71c42945e7dc24d7a6600f9d069f1657fa5b04ed5e1a7d23c7054e5dc742eb4c";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/pose-cov-ops/default.nix
+++ b/distros/melodic/pose-cov-ops/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pose-cov-ops";
-  version = "0.3.2-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ac4c22782f5b83108c80988bd6077869e5c9f88a0aeaabb58dfc3b03e547f71e";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "12b468ceb6498588d1b5367da27c2fe2cbedb65be23cdd563e02d6be5446fae0";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
   propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];

--- a/distros/melodic/rosapi/default.nix
+++ b/distros/melodic/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosapi";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "8dd2d89502c76eb8a847aad9f578066d61f410b80d56e373c009eca14593d480";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "b939e2ea599570df602a3994b0cd7e3555b2b307e147727433141211451a01b9";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   propagatedBuildInputs = [ message-runtime rosbridge-library rosgraph rosnode rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Provides service calls for getting ros meta-information, like list of

--- a/distros/melodic/rosbridge-library/default.nix
+++ b/distros/melodic/rosbridge-library/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, rosunit, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-library";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "bab43201a6930ad627b5d150e943ac8f2bee4872d854a2acc5372abff437a507";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "b7ae2c4e2b41d4252bb47d57064a9e0f4067609f723d75845b06fd7691845481";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest rosunit sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ geometry-msgs message-runtime pythonPackages.bson pythonPackages.future pythonPackages.pillow roscpp rosgraph rospy rosservice rostopic std-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''The core rosbridge package, responsible for interpreting JSON and performing

--- a/distros/melodic/rosbridge-msgs/default.nix
+++ b/distros/melodic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-msgs";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "8daceccd6f43239a3e76d0a360370be56146dcb8c37b4f554b99fc63ca8732ff";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "507e1ede4d358eff7204455099bc2ddc1cb813bc0f5a0b871c253388a59004e9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-server/default.nix
+++ b/distros/melodic/rosbridge-server/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-server";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "d699e369ab5377894f549cc369194340d97185b362a9e685f2ede6d4e9c9fcfc";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "f4930786659ffde8fa7b30bb69093d05be004b59117841f5dd0536471b5a22bc";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ pythonPackages.autobahn pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''A WebSocket interface to rosbridge.'';

--- a/distros/melodic/rosbridge-suite/default.nix
+++ b/distros/melodic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-suite";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "cc42c8d4a63e7fdf1ca54c691cdab84d6807fec6c86845d50d2dcc948c6c0833";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "5692c065bca1dae9c1986bb94afedad08112e8ea21b2c40966551098d46f9887";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tablet-socket-msgs/default.nix
+++ b/distros/melodic/tablet-socket-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/tablet_socket_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "c9de9912c721e5d0440d175016ffe402f207fd0f4347aaa2d85a4359d0f40327";
+    sha256 = "46866d3f0916a650ea03de6f93ad4f7488b1c2d79c48bd87112d8c6b04573e1d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/vector-map-msgs/default.nix
+++ b/distros/melodic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "121a81bc986a40e9e83e28737b74241bdf9332c0f95e1ea42c3deb03aeb4a8b7";
+    sha256 = "116c8842e3f610f9c6c59fe5db04d2f6cf998a11fb1f85bcb8748cfe247490ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-can-msgs/default.nix
+++ b/distros/noetic/autoware-can-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_can_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "f7b4868e4fb6ce3d591b53a3f9e744e9a1a3194ccba26b63dc4540ad5491f0b3";
+    sha256 = "5748fa3830917c00b34adc2d5e3873b259807230d05cd8469ad99ae0a547e6c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-config-msgs/default.nix
+++ b/distros/noetic/autoware-config-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_config_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "eafaea3c8e37f57ddb46a1f4b9cb3152ba49dec22a3cf4b13e538c70c2947ccf";
+    sha256 = "6ed8afd9b570d46d1957fd3aa581d9cc0fc16ada8f3d826c5c488d60957b39a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-external-msgs/default.nix
+++ b/distros/noetic/autoware-external-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_external_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "9e46e8c0fb4b274a632a42d058fe1b33b556a809f602ec8a9567c468c719b2a6";
+    sha256 = "b9437beeb25e6a7ced4e934c7b4f959ddadd62ce1e29c27142f4b693137052be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-lanelet2-msgs/default.nix
+++ b/distros/noetic/autoware-lanelet2-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_lanelet2_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "fa2a058aa23ed50120b0e7ac33a75dfe637ea301578124929ab0126de9f61f43";
+    sha256 = "3c187aaea630f63cb1c0988407ffd065bd2fc5c393e4ca0d27acbad5f2bd8c75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-map-msgs/default.nix
+++ b/distros/noetic/autoware-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "dfea163b4bd892c5a7cbd519885e309449e6a0f21fe088bd91ce9836b0b68247";
+    sha256 = "766ca0323e7e168b4ff3bf6f748df6ebb1dcd55f9e2f76c05138492fa3a59af6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-msgs/default.nix
+++ b/distros/noetic/autoware-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "f445a6713e8764e34e58f34fc1f8ad56637b3699546b7912baba2cd05c7b31ee";
+    sha256 = "c5016d542bf88e545096e2fef89cb49ee05afe6dde62c3da59df33a11d02444f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-system-msgs/default.nix
+++ b/distros/noetic/autoware-system-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_system_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "7bc5e114a49f6224db2da7cba91ce2e05baf589858391e1366616066a8ded740";
+    sha256 = "04c9598cea451a0f0f7aea0480985b8f3d23c89c3bdc50f4596c51b9b5301a1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "c56ab85eaf5e7c4a0895b548aeccc81c210cca1e9ccd5fca9e4c4179bce1f23d";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "20f26008a32add65e560c36ba04ca221c7d96025e9828f4d52a291b6dd86e1a2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/foxglove-msgs/default.nix
+++ b/distros/noetic/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "c6643f8a3f6c772b1b6049af88567e15001fe53e75e37ce1b289dbe0a137daea";
+    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "1c6e26e9ae43492fa69865d5ccccdea346c5121a80bc6c017cddc2a49c50a951";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1064,6 +1064,8 @@ self: super: {
 
  goal-passer = self.callPackage ./goal-passer {};
 
+ gpio-controller = self.callPackage ./gpio-controller {};
+
  gpp-interface = self.callPackage ./gpp-interface {};
 
  gpp-plugin = self.callPackage ./gpp-plugin {};
@@ -1733,6 +1735,8 @@ self: super: {
  microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
 
  mikrotik-swos-tools = self.callPackage ./mikrotik-swos-tools {};
+
+ mimic-joint-controller = self.callPackage ./mimic-joint-controller {};
 
  mini-maxwell = self.callPackage ./mini-maxwell {};
 

--- a/distros/noetic/gpio-controller/default.nix
+++ b/distros/noetic/gpio-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-gpio-controller";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/gpio_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "6e41a2493b047162393cf144c616cfcc5875fd3eb7f4369ded498abde3b23781";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The gpio_controller package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mimic-joint-controller/default.nix
+++ b/distros/noetic/mimic-joint-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-mimic-joint-controller";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/mimic_joint_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "b3eedf1cfefd8d05f5a2a9ab7c40c9c87fc6a2208da6f3cb46c71322e306e170";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface hardware-interface pluginlib roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mimic_joint_controller package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-msgs/default.nix
+++ b/distros/noetic/mrpt-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "57974058d5f4a98b8c9bfc7866bde56095a3d186b5e2edc20bdf1d50bbc6bbae";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "28ed29f25f7680e838c0d3066e6e3a3ed0c673e1efa590eba163e380299a125b";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-pose-cov-ops";
-  version = "0.3.2-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "a39bd4d3350f24be404f95c4e4e524b4dfa68cc05aa67f6bf0152d1286daa921";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "e6a0f5144c5ec536c35a4407bdcf8f78fd6bc74ef414300677663c85430f565f";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
   propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];

--- a/distros/noetic/rm-calibration-controllers/default.nix
+++ b/distros/noetic/rm-calibration-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, effort-controllers, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-calibration-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "3b66b04c5521583c0d8698b69578ae5ab520ab6216d11fdf1b635dce840197b1";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "fd88731b495674968c92a0b97e9af484f2c00b715fe1b19f92bd613ce813bd85";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-chassis-controllers/default.nix
+++ b/distros/noetic/rm-chassis-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, nav-msgs, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-chassis-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "a68edec6acb1bc0073560a8ee0e63ae205000ba6015214c98f050ec8191ae00b";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "51104a57ca6d339eeb3fba735592430ce710dab5f326a0c1b67128cb05ea68c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, imu-complementary-filter, imu-filter-madgwick, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "6d8ef6bb2d532672d6bd4736b0eb67f7166a33b4cb92f90e135cf23edbb66bbd";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "acd6500480193a21f7f726a694c2d8fbb77634c9b219a07e3448984b0512637d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, rm-dbus, rm-description, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "d87e8ee13e677baab8320bf6e3f340ee2b22abc085b0def23a126e204eec0d09";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "32b4894122ec106292b595ec710c372a95b96c509eaf2915de63e49a7a7dd543";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-controllers/default.nix
+++ b/distros/noetic/rm-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rm-calibration-controllers, rm-chassis-controllers, rm-gimbal-controllers, rm-orientation-controller, rm-shooter-controllers, robot-state-controller, tof-sensor-controller }:
+{ lib, buildRosPackage, fetchurl, catkin, gpio-controller, mimic-joint-controller, rm-calibration-controllers, rm-chassis-controllers, rm-gimbal-controllers, rm-orientation-controller, rm-shooter-controllers, robot-state-controller, tof-sensor-controller }:
 buildRosPackage {
   pname = "ros-noetic-rm-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "88c6a49a51cba27838ef00d2a5f5623fc4a3efcfd7473eb6cb34bec0d8edf04b";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "88b28ad85a307d3e429e5fda647ff71fd7df08abdc7c91fb65559db822629e68";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rm-calibration-controllers rm-chassis-controllers rm-gimbal-controllers rm-orientation-controller rm-shooter-controllers robot-state-controller tof-sensor-controller ];
+  propagatedBuildInputs = [ gpio-controller mimic-joint-controller rm-calibration-controllers rm-chassis-controllers rm-gimbal-controllers rm-orientation-controller rm-shooter-controllers robot-state-controller tof-sensor-controller ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "403fb7f9e910b555337cfbeae1e4217202db0e7aa17e4d5c2e9890841979381c";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "3970f914fefb1865e1ba6805dc546e104106366fb818c438820c6ac75cb2f96d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "649fa3b863a9fab84ac7275ecab74ec165325a1a53c9614cf271f41c037e4a0b";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "fadc636dbb602f42d78a0ef14b86d3eaebf1b375dedd3ffc98896fb2071e8ec0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gimbal-controllers/default.nix
+++ b/distros/noetic/rm-gimbal-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-eigen, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-gimbal-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "7f9539163424ec2c1e8819e7d81ec0fa606b415554a4e9f514f9d7bddce9ba83";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "bafa8c534faf6970c510e9e2256f402cbaf8a7e9815e1a22b4b0b26e768de408";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "536a4b3b4514401c93cb1bf2671d769d3971e61dea6cf2ce129f2313c7854633";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "6db581b3793c26a2add3cbbb9b291716fd403667249b658e1ed4a785503bbb7d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "92c5a64870baa96396bfe47fb2b536ed83d4e4b5504f6faa90928d9564659643";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "84d51eba57e6ba8fc9cf7ba6488def3ccbc1e5b82f2227440f8495ca749dead4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-orientation-controller/default.nix
+++ b/distros/noetic/rm-orientation-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-orientation-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_orientation_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "c33e18f1b6bc67e127e0d35f5485da9d9a61d8b7899d5b45856ad32d16da06cc";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_orientation_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "c5bdefd94013ce7d7c5d8c90f7af5b47d61a842961e6ed0bf080007906c059c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-shooter-controllers/default.nix
+++ b/distros/noetic/rm-shooter-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-shooter-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "5bbfaee47610ef6066a73d13de234d363fceca38c75571fd096f3a3d1aab8305";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "d540be1f264d25d78c0af5ad5144ccdb046f340ba2acc22804efdee4afa3e903";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-state-controller/default.nix
+++ b/distros/noetic/robot-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, kdl-parser, pluginlib, realtime-tools, rm-common, roscpp, roslint, tf2-kdl, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "d4871215d719822b637e070802843bab2c10e0fcb5e2c854fb86096c1ca52b31";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "0bc69ea2aeb3ed0b870613fe331adb3647150469405d53e1088774833d4c7015";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosapi/default.nix
+++ b/distros/noetic/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosapi";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosapi/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "7f6c99d9bf84c75f396ddc7ce31bcea6d9ef5a3f92f1819c10a010cd9b260f62";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosapi/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "7eed9ef3333837df51f12c4ee571b3329030b437b9341d81ade34b7fb1840cf0";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   propagatedBuildInputs = [ message-runtime rosbridge-library rosgraph rosnode rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''Provides service calls for getting ros meta-information, like list of

--- a/distros/noetic/rosbridge-library/default.nix
+++ b/distros/noetic/rosbridge-library/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, python3Packages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, python3Packages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, rosunit, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-library";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_library/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "7dd8d20143d1f25edd3a4712168e4784a94ff65c4ee24e2601d1810675f886c0";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_library/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "5402e1a9596229104dc4cf6973439ba860a6e09bb1a65d3aaadc01bed14534ee";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest rosunit sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ geometry-msgs message-runtime python3Packages.bson python3Packages.pillow roscpp rosgraph rospy rosservice rostopic std-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''The core rosbridge package, responsible for interpreting JSON and performing

--- a/distros/noetic/rosbridge-msgs/default.nix
+++ b/distros/noetic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-msgs";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_msgs/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "1e9f6b9cf45ea986f00fe0a40b8864125f91481011ad6b987d3984f8cabdfa2b";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_msgs/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "def6afc928622244bb2572c7c3ffdfb25c910c54c02a37377e96225dd74f5a74";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbridge-server/default.nix
+++ b/distros/noetic/rosbridge-server/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-server";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_server/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "33e04c5be92316b620a92933d1ad6b171a9b9fe859d3c4a2ef521535625ae26d";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_server/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "f8b64e0a923e542d0b801dea40772778701bf5db532640506341a6f9d5cfa054";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ python3Packages.autobahn python3Packages.tornado python3Packages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''A WebSocket interface to rosbridge.'';

--- a/distros/noetic/rosbridge-suite/default.nix
+++ b/distros/noetic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-suite";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_suite/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "fc10627e5ccda12582d057a6dc6e319fcf42d7090454777b4fddbe14f7cd155e";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_suite/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "401e1fb55db4bdd458647d1c39ebf4ddcafe4f974edccbafd28d1bcdf42db4eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tablet-socket-msgs/default.nix
+++ b/distros/noetic/tablet-socket-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/tablet_socket_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "6bf111b0e4f1332a69414b38dbed9f61247e048b4018e882997ad99a93fd90f8";
+    sha256 = "65f6bd52a23f56ee5ff3e096b3d56feb572123ab4e9961e3616df395ba59e949";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-server/default.nix
+++ b/distros/noetic/tf2-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, message-generation, message-runtime, nodelet, python3Packages, roscpp, rospy, rostest, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-server";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/tf2_server-release/archive/release/noetic/tf2_server/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "7b473444ace213203c6d276cdb7ef2f37794da2187901cdfdbb6d68b59746f8a";
+    url = "https://github.com/peci1/tf2_server-release/archive/release/noetic/tf2_server/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "0ec115bae4a412ef6d2ffb78be3ac3eaf93d84afba296b398c3253447f5c120d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tof-sensor-controller/default.nix
+++ b/distros/noetic/tof-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-tof-sensor-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/tof_sensor_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "9915f2cc49f0b8b47642f2ff1278478467f846bc0bc110439f032992a6f1453b";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/tof_sensor_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "f661879fbed2c87d9d3a8320b8179bb0f164cfc6f5c05f041d56d3f69a171cbf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vector-map-msgs/default.nix
+++ b/distros/noetic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "4132fc88a828774dc43bac8d108aed130622159af96ab717a8a0c8464929a65f";
+    sha256 = "870df6369942aa12d4c13eca898c481571bb2464d0333c56258e2f2498c8eded";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit 68e5c22d987e1eb391c04ad303ba8391e866b911.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *bosch-locator-bridge 2.0.6-r1 --> 2.0.7-r1*
* *depthai 2.15.4-r1 --> 2.15.5-r1*
* *eigenpy 2.7.4-r1 --> 2.7.5-r1*
* *foxglove-msgs 1.2.1-r1 --> 1.2.2-r1*
* *maliput 1.0.3-r1 --> 1.0.4-r1*
* *maliput-dragway 0.1.0-r1*
* *maliput-drake 0.1.1-r1*
* *maliput-malidrive 0.1.1-r1*
* *maliput-multilane 0.1.0-r1*
* *maliput-object 0.1.0-r1*
* *maliput-py 0.1.1-r1*
* *mrpt-msgs 0.4.2-r1 --> 0.4.3-r1*

Galactic Changes:
-----------------
* *costmap-queue 1.0.11-r1 --> 1.0.12-r1*
* *depthai 2.15.4-r2 --> 2.15.5-r1*
* *dwb-core 1.0.11-r1 --> 1.0.12-r1*
* *dwb-critics 1.0.11-r1 --> 1.0.12-r1*
* *dwb-msgs 1.0.11-r1 --> 1.0.12-r1*
* *dwb-plugins 1.0.11-r1 --> 1.0.12-r1*
* *foxglove-msgs 1.2.1-r1 --> 1.2.2-r1*
* *nav-2d-msgs 1.0.11-r1 --> 1.0.12-r1*
* *nav-2d-utils 1.0.11-r1 --> 1.0.12-r1*
* *nav2-amcl 1.0.11-r1 --> 1.0.12-r1*
* *nav2-behavior-tree 1.0.11-r1 --> 1.0.12-r1*
* *nav2-bringup 1.0.11-r1 --> 1.0.12-r1*
* *nav2-bt-navigator 1.0.11-r1 --> 1.0.12-r1*
* *nav2-common 1.0.11-r1 --> 1.0.12-r1*
* *nav2-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-core 1.0.11-r1 --> 1.0.12-r1*
* *nav2-costmap-2d 1.0.11-r1 --> 1.0.12-r1*
* *nav2-dwb-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-gazebo-spawner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-lifecycle-manager 1.0.11-r1 --> 1.0.12-r1*
* *nav2-map-server 1.0.11-r1 --> 1.0.12-r1*
* *nav2-msgs 1.0.11-r1 --> 1.0.12-r1*
* *nav2-navfn-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-recoveries 1.0.11-r1 --> 1.0.12-r1*
* *nav2-regulated-pure-pursuit-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-rotation-shim-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-rviz-plugins 1.0.11-r1 --> 1.0.12-r1*
* *nav2-simple-commander 1.0.11-r1 --> 1.0.12-r1*
* *nav2-smac-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-system-tests 1.0.11-r1 --> 1.0.12-r1*
* *nav2-theta-star-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-util 1.0.11-r1 --> 1.0.12-r1*
* *nav2-voxel-grid 1.0.11-r1 --> 1.0.12-r1*
* *nav2-waypoint-follower 1.0.11-r1 --> 1.0.12-r1*
* *navigation2 1.0.11-r1 --> 1.0.12-r1*
* *zmqpp-vendor 0.0.1-r2 --> 0.0.2-r1*

Humble Changes:
---------------
* *diagnostic-aggregator 2.1.3-r3 --> 3.0.0-r1*
* *diagnostic-updater 2.1.3-r3 --> 3.0.0-r1*
* *fogros2-examples 0.1.4-r1 --> 0.1.5-r1*
* *orocos-kdl-vendor 0.2.2-r3 --> 0.2.3-r1*
* *performance-report 1.1.0-r1*
* *performance-test 1.1.0-r1*
* *pose-cov-ops 0.3.4-r1 --> 0.3.5-r1*
* *python-orocos-kdl-vendor 0.2.2-r3 --> 0.2.3-r1*
* *robot-controllers 0.9.0-r1*
* *robot-controllers-interface 0.9.0-r1*
* *robot-controllers-msgs 0.9.0-r1*
* *self-test 3.0.0-r1*
* *simple-launch 1.3.1-r1 --> 1.4.1-r1*

Melodic Changes:
----------------
* *eigenpy 2.7.4-r1 --> 2.7.5-r1*
* *mrpt-msgs 0.4.0-r1 --> 0.4.4-r1*
* *pose-cov-ops 0.3.2-r1 --> 0.3.6-r1*
* *rosapi 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-library 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-msgs 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-server 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-suite 0.11.13-r1 --> 0.11.14-r1*

Noetic Changes:
---------------
* *eigenpy 2.7.4-r1 --> 2.7.5-r1*
* *foxglove-msgs 1.2.1-r1 --> 1.2.2-r1*
* *gpio-controller 0.1.5-r1*
* *mimic-joint-controller 0.1.5-r1*
* *mrpt-msgs 0.4.0-r1 --> 0.4.4-r1*
* *pose-cov-ops 0.3.2-r1 --> 0.3.6-r1*
* *rm-calibration-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-chassis-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-common 0.1.10-r2 --> 0.1.13-r1*
* *rm-control 0.1.10-r2 --> 0.1.13-r1*
* *rm-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-dbus 0.1.10-r2 --> 0.1.13-r1*
* *rm-gazebo 0.1.10-r2 --> 0.1.13-r1*
* *rm-gimbal-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-hw 0.1.10-r2 --> 0.1.13-r1*
* *rm-msgs 0.1.10-r2 --> 0.1.13-r1*
* *rm-orientation-controller 0.1.4-r1 --> 0.1.5-r1*
* *rm-shooter-controllers 0.1.4-r1 --> 0.1.5-r1*
* *robot-state-controller 0.1.4-r1 --> 0.1.5-r1*
* *rosapi 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-library 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-msgs 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-server 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-suite 0.11.13-r1 --> 0.11.14-r1*
* *tf2-server 1.1.1-r1 --> 1.1.2-r1*
* *tof-sensor-controller 0.1.4-r1 --> 0.1.5-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] camera_info_manager_py
 * [ ] cargo
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] iputils-ping
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libabsl-dev
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] libgpiod-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bokeh-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pytest-timeout
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] wiimote

