### PR TITLE
rosdistro sync, Fri Jul  1 13:52:00 2022

### DIFF
--- a/distros/foxy/ament-download/default.nix
+++ b/distros/foxy/ament-download/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-foxy-ament-download";
+  version = "0.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/samsung-ros/ament_download-release/archive/release/foxy/ament_download/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "b85972b56f2b369c2007a178b7e1c8e4896c5873dc0c9ae8b029d68cf2ce8cb9";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CMake macros for downloading files with ament'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/boost-geometry-util/default.nix
+++ b/distros/foxy/boost-geometry-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, boost, geometry-msgs, ouxt-common, rclcpp }:
+buildRosPackage {
+  pname = "ros-foxy-boost-geometry-util";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/boost_geometry_util-release/archive/release/foxy/boost_geometry_util/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "d7ad6dcb6393aec4180fde2d45138d4f7d73798d1eccdb57973e116311b2e8a5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-common ];
+  propagatedBuildInputs = [ boost geometry-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''Utility library for boost geometry'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/bosch-locator-bridge/default.nix
+++ b/distros/foxy/bosch-locator-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-srvs, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-bosch-locator-bridge";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "56154d58494f9a6c219470b658bb30c4a7b1acfd7f5f817a70fd568fedffced8";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "9e6f267e4f89e4a3a14f4a4bc7b88dbfe9acb31ee089d5de3258b3b063a3ef2e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs launch-xml nav-msgs pcl-conversions poco rclcpp rosidl-default-runtime std-srvs tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs launch-xml nav-msgs pcl-conversions poco rclcpp rosidl-default-runtime sensor-msgs std-srvs tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/crane-plus-control/default.nix
+++ b/distros/foxy/crane-plus-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, crane-plus-description, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, ros2-controllers, ros2controlcli, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-crane-plus-control";
+  version = "1.0.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_control/1.0.0-5.tar.gz";
+    name = "1.0.0-5.tar.gz";
+    sha256 = "1f5882cc2e87191c137c572e1f1bb1bf9d73364c4fc7ad64f1ee56bcd48606f1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager crane-plus-description dynamixel-sdk hardware-interface pluginlib rclcpp ros2-controllers ros2controlcli xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+V2 control package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/crane-plus-description/default.nix
+++ b/distros/foxy/crane-plus-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-ros2-control, ign-ros2-control, joint-state-publisher-gui, launch, robot-state-publisher, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-crane-plus-description";
+  version = "1.0.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_description/1.0.0-5.tar.gz";
+    name = "1.0.0-5.tar.gz";
+    sha256 = "f7bf068aacdbc11478e87d09e286c19f4547e821944015f1b64c6df1ea832753";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gazebo-ros2-control ign-ros2-control joint-state-publisher-gui launch robot-state-publisher rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''CRANE+V2 description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/crane-plus-examples/default.nix
+++ b/distros/foxy/crane-plus-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, crane-plus-control, crane-plus-description, crane-plus-moveit-config, geometry-msgs, moveit-ros-planning-interface, rclcpp, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-crane-plus-examples";
+  version = "1.0.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_examples/1.0.0-5.tar.gz";
+    name = "1.0.0-5.tar.gz";
+    sha256 = "d6c55bae50f52d25bcf4022e959372dc13737d1412836b91ba63e65108ce1033";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-moveit-config geometry-msgs moveit-ros-planning-interface rclcpp tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+V2 examples package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/crane-plus-gazebo/default.nix
+++ b/distros/foxy/crane-plus-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, crane-plus-description, crane-plus-moveit-config, gazebo-ros-pkgs }:
+buildRosPackage {
+  pname = "ros-foxy-crane-plus-gazebo";
+  version = "1.0.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_gazebo/1.0.0-5.tar.gz";
+    name = "1.0.0-5.tar.gz";
+    sha256 = "98f37c57f24200ccd4ae3d01e9ec57c1b30a4507fa78f2fc6a0e2757ec744916";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ crane-plus-description crane-plus-moveit-config gazebo-ros-pkgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+V2 gazebo simulation package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/crane-plus-ignition/default.nix
+++ b/distros/foxy/crane-plus-ignition/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, ros-ign }:
+buildRosPackage {
+  pname = "ros-foxy-crane-plus-ignition";
+  version = "1.0.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_ignition/1.0.0-5.tar.gz";
+    name = "1.0.0-5.tar.gz";
+    sha256 = "e42e517d714f6c34fabf011ba942157d83272080e6f480e533abc2fb4cefe47b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ robot-state-publisher ros-ign ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+V2 ignition gazebo simulation package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/crane-plus-moveit-config/default.nix
+++ b/distros/foxy/crane-plus-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit, robot-state-publisher, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-crane-plus-moveit-config";
+  version = "1.0.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_moveit_config/1.0.0-5.tar.gz";
+    name = "1.0.0-5.tar.gz";
+    sha256 = "90ec7de52429a07afb6af56af934b7c65da4316551b1aaedb8cdf9c812c68ecd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit robot-state-publisher rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+V2 move_group config package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/crane-plus/default.nix
+++ b/distros/foxy/crane-plus/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, crane-plus-control, crane-plus-description, crane-plus-examples, crane-plus-gazebo, crane-plus-moveit-config }:
+buildRosPackage {
+  pname = "ros-foxy-crane-plus";
+  version = "1.0.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus/1.0.0-5.tar.gz";
+    name = "1.0.0-5.tar.gz";
+    sha256 = "62208f3af5c1a99c12b7153d15a1eef0b42d8c377dd2fddba05eaae9c31cc357";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-examples crane-plus-gazebo crane-plus-moveit-config ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 package suite of CRANE+V2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/depthai/default.nix
+++ b/distros/foxy/depthai/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-depthai";
-  version = "2.15.4-r1";
+  version = "2.15.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.15.4-1.tar.gz";
-    name = "2.15.4-1.tar.gz";
-    sha256 = "88d84cdcc15e90cf05e45bfb7ef6336a13609f98bc006681c237219bbf5f515c";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.15.5-1.tar.gz";
+    name = "2.15.5-1.tar.gz";
+    sha256 = "687fd898f762a61c98888ca56f81ff4b4dd6cdfceb6b893aca8a01ad50b50845";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
   propagatedBuildInputs = [ libusb1 nlohmann_json opencv ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "b784f6a28d3c19779124fe7e36216c05a8417e9ce70fe791e7017a17a4d06ad0";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "9b96e2ca134cbf95c31400f5ae7862e5e79b36a6133630079083734a461aa2c2";
   };
 
   buildType = "cmake";

--- a/distros/foxy/fluent-rviz/default.nix
+++ b/distros/foxy/fluent-rviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, geometry-msgs, ouxt-lint-common, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-fluent-rviz";
+  version = "0.0.3-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/fluent_rviz-release/archive/release/foxy/fluent_rviz/0.0.3-3.tar.gz";
+    name = "0.0.3-3.tar.gz";
+    sha256 = "e3f3ecfeedfe1b1123ef79cd67577a226d680e2a28af3246b5863106d619104e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''A library which makes Rviz fluent. Powered by C++17'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/foxglove-msgs/default.nix
+++ b/distros/foxy/foxglove-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-foxglove-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/foxy/foxglove_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "66c303fdfa86acd2216a77601f039f1bd864ed22b6c7fa2d47ffe70a7058ec00";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/foxy/foxglove_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "21ed8c1eb314f12467a00e273f506b2ec7b2f75689b610495b4b31f8f3421b34";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/gc-spl-2022/default.nix
+++ b/distros/foxy/gc-spl-2022/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rcgcd-spl-14, rcgcd-spl-14-conversion, rcgcrd-spl-4, rcgcrd-spl-4-conversion, rclpy }:
+buildRosPackage {
+  pname = "ros-foxy-gc-spl-2022";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/foxy/gc_spl_2022/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "15a5f4197725b8a783b37e20e999b3e2f18b2f6aec7edef2c112465acc7ef175";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ rcgcd-spl-14 rcgcd-spl-14-conversion rcgcrd-spl-4 rcgcrd-spl-4-conversion rclpy ];
+
+  meta = {
+    description = ''GameController-Robot communication in RoboCup SPL at RoboCup2022'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -102,6 +102,8 @@ self: super: {
 
  ament-cpplint = self.callPackage ./ament-cpplint {};
 
+ ament-download = self.callPackage ./ament-download {};
+
  ament-flake8 = self.callPackage ./ament-flake8 {};
 
  ament-index-cpp = self.callPackage ./ament-index-cpp {};
@@ -171,6 +173,8 @@ self: super: {
  bond-core = self.callPackage ./bond-core {};
 
  bondcpp = self.callPackage ./bondcpp {};
+
+ boost-geometry-util = self.callPackage ./boost-geometry-util {};
 
  bosch-locator-bridge = self.callPackage ./bosch-locator-bridge {};
 
@@ -244,6 +248,20 @@ self: super: {
 
  costmap-queue = self.callPackage ./costmap-queue {};
 
+ crane-plus = self.callPackage ./crane-plus {};
+
+ crane-plus-control = self.callPackage ./crane-plus-control {};
+
+ crane-plus-description = self.callPackage ./crane-plus-description {};
+
+ crane-plus-examples = self.callPackage ./crane-plus-examples {};
+
+ crane-plus-gazebo = self.callPackage ./crane-plus-gazebo {};
+
+ crane-plus-ignition = self.callPackage ./crane-plus-ignition {};
+
+ crane-plus-moveit-config = self.callPackage ./crane-plus-moveit-config {};
+
  cv-bridge = self.callPackage ./cv-bridge {};
 
  cyclonedds = self.callPackage ./cyclonedds {};
@@ -311,6 +329,14 @@ self: super: {
  depth-image-proc = self.callPackage ./depth-image-proc {};
 
  depthai = self.callPackage ./depthai {};
+
+ depthai-ros = self.callPackage ./depthai-ros {};
+
+ depthai-bridge = self.callPackage ./depthai-bridge {};
+
+ depthai-examples = self.callPackage ./depthai-examples {};
+
+ depthai-ros-msgs = self.callPackage ./depthai-ros-msgs {};
 
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
@@ -452,6 +478,8 @@ self: super: {
 
  embree-vendor = self.callPackage ./embree-vendor {};
 
+ end-effector = self.callPackage ./end-effector {};
+
  espeak-interfaces = self.callPackage ./espeak-interfaces {};
 
  espeak-ros = self.callPackage ./espeak-ros {};
@@ -500,6 +528,8 @@ self: super: {
 
  filters = self.callPackage ./filters {};
 
+ fluent-rviz = self.callPackage ./fluent-rviz {};
+
  fmi-adapter = self.callPackage ./fmi-adapter {};
 
  fmi-adapter-examples = self.callPackage ./fmi-adapter-examples {};
@@ -529,6 +559,8 @@ self: super: {
  gazebo-ros2-control-demos = self.callPackage ./gazebo-ros2-control-demos {};
 
  gazebo-ros-pkgs = self.callPackage ./gazebo-ros-pkgs {};
+
+ gc-spl-2022 = self.callPackage ./gc-spl-2022 {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -753,6 +785,24 @@ self: super: {
  lua-vendor = self.callPackage ./lua-vendor {};
 
  lusb = self.callPackage ./lusb {};
+
+ maliput = self.callPackage ./maliput {};
+
+ maliput-dragway = self.callPackage ./maliput-dragway {};
+
+ maliput-drake = self.callPackage ./maliput-drake {};
+
+ maliput-integration = self.callPackage ./maliput-integration {};
+
+ maliput-malidrive = self.callPackage ./maliput-malidrive {};
+
+ maliput-multilane = self.callPackage ./maliput-multilane {};
+
+ maliput-object = self.callPackage ./maliput-object {};
+
+ maliput-object-py = self.callPackage ./maliput-object-py {};
+
+ maliput-py = self.callPackage ./maliput-py {};
 
  map-msgs = self.callPackage ./map-msgs {};
 
@@ -1018,6 +1068,8 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ performance-test = self.callPackage ./performance-test {};
+
  performance-test-fixture = self.callPackage ./performance-test-fixture {};
 
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
@@ -1106,6 +1158,8 @@ self: super: {
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
+ pose-cov-ops = self.callPackage ./pose-cov-ops {};
+
  position-controllers = self.callPackage ./position-controllers {};
 
  psen-scan-v2 = self.callPackage ./psen-scan-v2 {};
@@ -1140,6 +1194,8 @@ self: super: {
 
  quaternion-operation = self.callPackage ./quaternion-operation {};
 
+ r2r-spl-7 = self.callPackage ./r2r-spl-7 {};
+
  radar-msgs = self.callPackage ./radar-msgs {};
 
  random-numbers = self.callPackage ./random-numbers {};
@@ -1171,6 +1227,14 @@ self: super: {
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
 
  rcdiscover = self.callPackage ./rcdiscover {};
+
+ rcgcd-spl-14 = self.callPackage ./rcgcd-spl-14 {};
+
+ rcgcd-spl-14-conversion = self.callPackage ./rcgcd-spl-14-conversion {};
+
+ rcgcrd-spl-4 = self.callPackage ./rcgcrd-spl-4 {};
+
+ rcgcrd-spl-4-conversion = self.callPackage ./rcgcrd-spl-4-conversion {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -1454,6 +1518,8 @@ self: super: {
 
  rosbridge-test-msgs = self.callPackage ./rosbridge-test-msgs {};
 
+ rosee-msg = self.callPackage ./rosee-msg {};
+
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
 
  rosidl-adapter = self.callPackage ./rosidl-adapter {};
@@ -1572,6 +1638,10 @@ self: super: {
 
  rqt-topic = self.callPackage ./rqt-topic {};
 
+ rt-manipulators-cpp = self.callPackage ./rt-manipulators-cpp {};
+
+ rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
+
  rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
 
  rtabmap-ros = self.callPackage ./rtabmap-ros {};
@@ -1659,6 +1729,10 @@ self: super: {
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ splsm-7 = self.callPackage ./splsm-7 {};
+
+ splsm-7-conversion = self.callPackage ./splsm-7-conversion {};
 
  sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
 
@@ -1776,6 +1850,8 @@ self: super: {
 
  tracetools = self.callPackage ./tracetools {};
 
+ tracetools-analysis = self.callPackage ./tracetools-analysis {};
+
  tracetools-launch = self.callPackage ./tracetools-launch {};
 
  tracetools-test = self.callPackage ./tracetools-test {};
@@ -1836,9 +1912,21 @@ self: super: {
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
+ ur-bringup = self.callPackage ./ur-bringup {};
+
  ur-client-library = self.callPackage ./ur-client-library {};
 
+ ur-controllers = self.callPackage ./ur-controllers {};
+
+ ur-dashboard-msgs = self.callPackage ./ur-dashboard-msgs {};
+
+ ur-description = self.callPackage ./ur-description {};
+
+ ur-moveit-config = self.callPackage ./ur-moveit-config {};
+
  ur-msgs = self.callPackage ./ur-msgs {};
+
+ ur-robot-driver = self.callPackage ./ur-robot-driver {};
 
  urdf = self.callPackage ./urdf {};
 
@@ -1929,6 +2017,8 @@ self: super: {
  xacro-live = self.callPackage ./xacro-live {};
 
  yaml-cpp-vendor = self.callPackage ./yaml-cpp-vendor {};
+
+ zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
 
  zstd-vendor = self.callPackage ./zstd-vendor {};
 

--- a/distros/foxy/grepros/default.nix
+++ b/distros/foxy/grepros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, builtin-interfaces, python3Packages, pythonPackages, rclpy, rosidl-parser, rosidl-runtime-py, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-grepros";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/suurjaak/grepros-release/archive/release/foxy/grepros/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "138aba5c7d32e7711febb964506dfa701d9ede55a0c1e45ffd873c1f2f40cc31";
+    url = "https://github.com/suurjaak/grepros-release/archive/release/foxy/grepros/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "bb680ab17867ee0880289347733dcf7ae56d8c056f75815a57a7f6cc97577a25";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/gscam/default.nix
+++ b/distros/foxy/gscam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, class-loader, cv-bridge, gst_all_1, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gscam";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gscam-release/archive/release/foxy/gscam/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "5f2b7b23e6286011a20d42dd460dd08acdbf70ba0a3d29b8da3ebc2745de88ba";
+    url = "https://github.com/ros2-gbp/gscam-release/archive/release/foxy/gscam/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "f2539ee337ae0b3a0ae099b825ec4db091154beb68c118a9f3df53cba7d8d1f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-dragway/default.nix
+++ b/distros/foxy/maliput-dragway/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, pybind11, python3 }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-dragway";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "748dd0110dc11469dc428ebc8d18e9262ee8f3b528be3b9f945bcdd8bb0c6d21";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-cmake-pytest ];
+  propagatedBuildInputs = [ maliput maliput-py pybind11 python3 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Dragway.'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-drake/default.nix
+++ b/distros/foxy/maliput-drake/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, fmt }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-drake";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_drake-release/archive/release/foxy/maliput_drake/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "62c1eb10211bb8818d8593cbaa3e759763c4d5e52432445b8423f2c2272b1a7c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ eigen eigen3-cmake-module fmt ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''Maliput drake extraction to provide trajectory integration support'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-integration/default.nix
+++ b/distros/foxy/maliput-integration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-pytest, gflags, libyamlcpp, maliput, maliput-dragway, maliput-malidrive, maliput-multilane, maliput-object, maliput-py }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-integration";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "54e86e33967c31a35f8e9cf103ca887fa1e6009d714e3c17f8a639d7f5814861";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-gtest ament-cmake-pytest ];
+  propagatedBuildInputs = [ gflags libyamlcpp maliput maliput-dragway maliput-malidrive maliput-multilane maliput-object maliput-py ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Integration.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/maliput-malidrive/default.nix
+++ b/distros/foxy/maliput-malidrive/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, fmt, maliput, maliput-drake, tinyxml-2 }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-malidrive";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "f643c9761b5333d6cc0856263e49ef2931b4820f5b141f800639a2d800276971";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ];
+  propagatedBuildInputs = [ fmt maliput maliput-drake tinyxml-2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''maliput_malidrive backend'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-multilane";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "527698d08a50d9a49c0d3382e62f2854ebb5e02dee52873dfd3668f25c16e55f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-cmake-gtest ];
+  propagatedBuildInputs = [ fmt libyamlcpp maliput maliput-drake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Multilane.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/maliput-object-py/default.nix
+++ b/distros/foxy/maliput-object-py/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput-object, pybind11, python3 }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-object-py";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_object_py-release/archive/release/foxy/maliput_object_py/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "ea15fa26b9356f0634a11133d38b71c877ee6c147a0d30861a8df91ec005e5c8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ python3 ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-pytest ];
+  propagatedBuildInputs = [ maliput-object pybind11 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Object bindings'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-object/default.nix
+++ b/distros/foxy/maliput-object/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp, maliput }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-object";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_object-release/archive/release/foxy/maliput_object/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "d487931ef4294cd8b3bff7dfdc18e3dccb67e71ab5894a1d3b35818c05f2cb48";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-cmake-gtest ];
+  propagatedBuildInputs = [ fmt gflags libyamlcpp maliput ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput Object'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput-py/default.nix
+++ b/distros/foxy/maliput-py/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput, pybind11, python3 }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-py";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_py-release/archive/release/foxy/maliput_py/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "2bc757970ac2532515772d7a2f7494c43938c8e36ee7a3281a61da6c8b9b49a1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ python3 ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-pytest ];
+  propagatedBuildInputs = [ maliput pybind11 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maliput bindings'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/foxy/maliput/default.nix
+++ b/distros/foxy/maliput/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp }:
 buildRosPackage {
   pname = "ros-foxy-maliput";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "bf062af6c12f5280931c07623b7d0a590daf3ed158460930cdfb22ea3a623c6b";
+    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "fbb5918c21d8a93b9cca9e5a74e929c10bc8d9d0cb762e47585eb3f60b4ac316";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mrpt-msgs/default.nix
+++ b/distros/foxy/mrpt-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mrpt-msgs";
-  version = "0.4.2-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/foxy/mrpt_msgs/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "bbf371cba2231b1a56f67dd4d37434431cf5385e5894f9640ab781d04094bfb8";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/foxy/mrpt_msgs/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "f7ca85feb2d8c0c0268f6ce4cdb78fe5e459f6bf3202e6ef6b7947b18de2deeb";
   };
 
-  buildType = "cmake";
+  buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cppcheck ament-cpplint ament-lint-auto ament-lint-cmake ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];

--- a/distros/foxy/nerian-stereo/default.nix
+++ b/distros/foxy/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nerian-stereo";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "05e71aa04a65bab2517eec019ff8e82b91c030e39092c08c903e037e254392c3";
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "16ae46284080599ab25f9ab506f11696fefefe00f6bf598dde4a82a134a9318d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.4.4-r1";
+  version = "3.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.4-1.tar.gz";
-    name = "3.4.4-1.tar.gz";
-    sha256 = "6bb6146e85d7123619641f3e4788fd85282ef3289756ef2238324dadd8977c12";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.5-1.tar.gz";
+    name = "3.4.5-1.tar.gz";
+    sha256 = "9c260ad1a41cd500a74c037b76e1604f5accda21d4dddc9067db2243caebfe77";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pose-cov-ops/default.nix
+++ b/distros/foxy/pose-cov-ops/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-pose-cov-ops";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/foxy/pose_cov_ops/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "b369cbc479aca44dca05947266890f5370850009c81e9e9b1ae94f4130bdc847";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/foxy/pose_cov_ops/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "e80d740474f638f97e0114004df1a00ebfd0d169e13058e99c91f72d8402c17e";
   };
 
-  buildType = "cmake";
+  buildType = "ament_cmake";
   buildInputs = [ ament-cmake-xmllint ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common gtest ];
   propagatedBuildInputs = [ geometry-msgs mrpt2 ];

--- a/distros/foxy/r2r-spl-7/default.nix
+++ b/distros/foxy/r2r-spl-7/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, splsm-7-conversion }:
+buildRosPackage {
+  pname = "ros-foxy-r2r-spl-7";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/r2r_spl_7/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "c2348077462eff96b3e9976066da446704e1df6879e492f8e9856685809a0920";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ rclpy splsm-7-conversion ];
+
+  meta = {
+    description = ''Robot-To-Robot communication in RoboCup SPL using SPLSM V7'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rcgcd-spl-14-conversion/default.nix
+++ b/distros/foxy/rcgcd-spl-14-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rcgcd-spl-14 }:
+buildRosPackage {
+  pname = "ros-foxy-rcgcd-spl-14-conversion";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/foxy/rcgcd_spl_14_conversion/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "2895bdf6b6130e14a8daf05c52a77dfd61c44342852bc36cd19e534b1956f69f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct rcgcd-spl-14 ];
+
+  meta = {
+    description = ''Converts RoboCup SPL GameController Data V14 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rcgcd-spl-14/default.nix
+++ b/distros/foxy/rcgcd-spl-14/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rcgcd-spl-14";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/foxy/rcgcd_spl_14/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "83e8aaf6e0f29ef91261e5ba11996ceae30ba80eab29065b00969a76d0245efa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup SPL GameController Data V14 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rcgcrd-spl-4-conversion/default.nix
+++ b/distros/foxy/rcgcrd-spl-4-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rcgcrd-spl-4 }:
+buildRosPackage {
+  pname = "ros-foxy-rcgcrd-spl-4-conversion";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/foxy/rcgcrd_spl_4_conversion/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "b0b528744b54bf9aa53ce17f70f00cc2e11e7e0b8b355fb032ad52f75fcf9275";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct rcgcrd-spl-4 ];
+
+  meta = {
+    description = ''Converts RoboCup SPL GameController Return Data V4 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rcgcrd-spl-4/default.nix
+++ b/distros/foxy/rcgcrd-spl-4/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rcgcrd-spl-4";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/foxy/rcgcrd_spl_4/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "aa5453ef8ed730eb4eea66c67ac3a374f1e713d5d69f5fcbdb15b37a9fa29a51";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup SPL GameController Return Data V4 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rt-manipulators-cpp/default.nix
+++ b/distros/foxy/rt-manipulators-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, libyamlcpp, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-foxy-rt-manipulators-cpp";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/rt_manipulators_cpp-release/archive/release/foxy/rt_manipulators_cpp/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e10b6a350ba61762f678f070614f15e70d1141684dffb02a3fadd00c7da519aa";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module libyamlcpp yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RT Manipulators C++ Library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rt-manipulators-examples/default.nix
+++ b/distros/foxy/rt-manipulators-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rt-manipulators-cpp }:
+buildRosPackage {
+  pname = "ros-foxy-rt-manipulators-examples";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/rt_manipulators_cpp-release/archive/release/foxy/rt_manipulators_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8f3b1ee3e5aafaa221f3ffe7bdacf16ebf4764c69527782de1b6bb601ae608d0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rt-manipulators-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Examples for RT Manipulators C++ Library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/septentrio-gnss-driver/default.nix
+++ b/distros/foxy/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-septentrio-gnss-driver";
-  version = "1.2.1-r1";
+  version = "1.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/foxy/septentrio_gnss_driver/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "408f55ee7502c416b78cdbf45daba222bb6e917792da8d28090e8cfaea048eed";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/foxy/septentrio_gnss_driver/1.2.2-2.tar.gz";
+    name = "1.2.2-2.tar.gz";
+    sha256 = "573448c6757e598b42e40e104c6ef5252c7eb23ef6282e5bedfe7d8b09f6c824";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/splsm-7-conversion/default.nix
+++ b/distros/foxy/splsm-7-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, splsm-7 }:
+buildRosPackage {
+  pname = "ros-foxy-splsm-7-conversion";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/splsm_7_conversion/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "647f7ebe1e0192a54fb31c3f25c492fb47331a4e9d57a268fe536547687d43fd";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct splsm-7 ];
+
+  meta = {
+    description = ''Converts Standard Platform League Standard Message V7 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/splsm-7/default.nix
+++ b/distros/foxy/splsm-7/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-splsm-7";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/splsm_7/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "9a9f8090ce847e013a4e4cf3763b84a2abca6ff033c78e59d2a5752ed3a9f611";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup Standard Platform League Standard Message V7 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/tracetools-analysis/default.nix
+++ b/distros/foxy/tracetools-analysis/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, jupyter, python3Packages, pythonPackages, tracetools-read }:
+buildRosPackage {
+  pname = "ros-foxy-tracetools-analysis";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/ros-tracing/tracetools_analysis-release/-/archive/release/foxy/tracetools_analysis/1.0.3-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "19e6106ad2961799bf245d98ca8ba77a9e9eeae5e95116f63467420d02800e25";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ jupyter python3Packages.pandas tracetools-read ];
+
+  meta = {
+    description = ''Tools for analysing trace data.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ur-bringup/default.nix
+++ b/distros/foxy/ur-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, controller-manager, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, moveit-ros-move-group, moveit-simple-controller-manager, robot-state-publisher, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, warehouse-ros-mongo, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-ur-bringup";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_bringup/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "e70163dce9e7974137f91459f542ceaf7f670a13ad7e4b1b41c27cea99b24c7a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-index-python controller-manager joint-state-broadcaster joint-trajectory-controller launch launch-ros moveit-ros-move-group moveit-simple-controller-manager robot-state-publisher rviz2 ur-controllers ur-description ur-moveit-config urdf warehouse-ros-mongo xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch file and run-time configurations, e.g. controllers.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ur-controllers/default.nix
+++ b/distros/foxy/ur-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, ur-dashboard-msgs, ur-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-ur-controllers";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_controllers/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "67b2398dda46eb9e32ecda788cf65efc559e43534849a22ad32161246f3b64cf";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-interface joint-trajectory-controller lifecycle-msgs pluginlib rclcpp-lifecycle rcutils realtime-tools std-msgs ur-dashboard-msgs ur-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides controllers that use the speed scaling interface of Universal Robots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ur-dashboard-msgs/default.nix
+++ b/distros/foxy/ur-dashboard-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-ur-dashboard-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_dashboard_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8f8322e2c48bd8d7be981d119b0dc52783cdfe4a562b2caf02e81001c6859e86";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages around the UR Dashboard server.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ur-description/default.nix
+++ b/distros/foxy/ur-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, launch, launch-ros, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-ur-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "9f1d52bce3d024f6fdfc54a9a33151fabf820ef2cfe5c453355dfeabc079f855";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher launch launch-ros robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF description for Universal Robots'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ur-moveit-config/default.nix
+++ b/distros/foxy/ur-moveit-config/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-kinematics, moveit-planners-ompl, moveit-ros-visualization, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-ur-moveit-config";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_moveit_config/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "571964e3b94d01486f041aeb45faf7963b653c629a3177df49c2fa361ac1816d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ moveit-kinematics moveit-planners-ompl moveit-ros-visualization rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An example package with MoveIt2 configurations for UR robots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ur-robot-driver/default.nix
+++ b/distros/foxy/ur-robot-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, rclpy, std-msgs, std-srvs, ur-bringup, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-ur-robot-driver";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_robot_driver/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "ef2983d39583f206c6c2ecede5dab1b71da7a78d62f3cdaab8f6571cd7255a26";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ launch-testing-ament-cmake rclpy ];
+  propagatedBuildInputs = [ controller-manager controller-manager-msgs geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle std-msgs std-srvs ur-bringup ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The new driver for Universal Robots UR3, UR5 and UR10 robots with CB3 controllers and the e-series.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/boost-geometry-util/default.nix
+++ b/distros/galactic/boost-geometry-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, boost, geometry-msgs, ouxt-common, rclcpp }:
+buildRosPackage {
+  pname = "ros-galactic-boost-geometry-util";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/boost_geometry_util-release/archive/release/galactic/boost_geometry_util/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "e9bc02c696dd24b78bd6f12aa34645f723a421c3bc250dccd9a05d75afe2a596";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-common ];
+  propagatedBuildInputs = [ boost geometry-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''Utility library for boost geometry'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/control-toolbox/default.nix
+++ b/distros/galactic/control-toolbox/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-galactic-control-toolbox";
-  version = "2.0.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/galactic/control_toolbox/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "6e5f25cbfe125a745a4a7ae9f8d43160fe1cb8969ffe084a854d3acbecf3484b";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/galactic/control_toolbox/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "5ca8a402474b999e41344847cec932fefabff28aa3a6855784299fb5339436ec";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest rclcpp-lifecycle ];
   propagatedBuildInputs = [ control-msgs rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''The control toolbox contains modules that are useful across all controllers.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/galactic/costmap-queue/default.nix
+++ b/distros/galactic/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-costmap-queue";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "2c37c92750548b77438ea60bedb0a39e108e6325288e8e5ded66fe460bac6aae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "eace4bc202c703bea555c1fc9278e429c2a377143dc8748175971a615c8682bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai/default.nix
+++ b/distros/galactic/depthai/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-depthai";
-  version = "2.15.4-r2";
+  version = "2.15.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.15.4-2.tar.gz";
-    name = "2.15.4-2.tar.gz";
-    sha256 = "556938d97b747462ec3a797080f9b5eae8d3fc5ff9132a55e7ddd0816d778848";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.15.5-1.tar.gz";
+    name = "2.15.5-1.tar.gz";
+    sha256 = "4986156602eab268b763908b1c26d67e4404f43476a61a026ddd6c6b95b901fe";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
   propagatedBuildInputs = [ libusb1 nlohmann_json opencv ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/dwb-core/default.nix
+++ b/distros/galactic/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-core";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "5f37823566c17f1e3f5f69d28305022310a6cffa1f2e5e487310f6af3b7f9500";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "a183c107ab0edb87290647f4333a259da8a3bff19aa462ef180ae83038d38f6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-critics/default.nix
+++ b/distros/galactic/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-critics";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fecda736d8e76548b4c34cf98ccfa1259f3e5d993cd028ec5dd51e73e0046cd5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "798c23c6be0837cda89372cd5e4612e163b343a48fe524b0a13517082823c92a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-msgs/default.nix
+++ b/distros/galactic/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-msgs";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "b2ca84d5e5f2bad9f9d46a044b85fa7f815a2019ee2e4aa1cbd3537ccb2c065f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "f4700ca459805066a26d4c388b33f62be0a4678681c6604d8e261e2c56d88354";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-plugins/default.nix
+++ b/distros/galactic/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-dwb-plugins";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "169e59b2ff0bea76fa4ff5aacce060fd7fc798917a2de3c0632e7264da858e6b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "892479c0c1daa707be18db68cabfa65af61e9305d59d2815b9e43775b7c515c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/examples-tf2-py/default.nix
+++ b/distros/galactic/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-examples-tf2-py";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/examples_tf2_py/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "36dbdc9c6a5dd2b66af43e8162bb16e8e5d542e12c9042eaf8930fffed535684";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/examples_tf2_py/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "2651700c95d5de463910710dd67ae50052d0a77a276ab112670b64307eea26a8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/fluent-rviz/default.nix
+++ b/distros/galactic/fluent-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, geometry-msgs, ouxt-lint-common, rclcpp, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-fluent-rviz";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fluent_rviz-release/archive/release/galactic/fluent_rviz/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "00855cded4d1983fe976b0cfc99187503dca9e5583aee875eb5a19c02d061807";
+    url = "https://github.com/ros2-gbp/fluent_rviz-release/archive/release/galactic/fluent_rviz/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "61441e2726c330cc04965f807a4df8bc0ba0dc03496ba41807d4712858a809c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/foxglove-msgs/default.nix
+++ b/distros/galactic/foxglove-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-foxglove-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/galactic/foxglove_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "6a9ff07622083559177d8b0912cd63dc7057e5c1df1690bc8a2778b7fdb5a117";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/galactic/foxglove_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e8e81d56cd17a73f6a2ab55780aa20aa5e466832bf2b5b0bcfd3f884ff7f0c31";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/gc-spl-2022/default.nix
+++ b/distros/galactic/gc-spl-2022/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rcgcd-spl-14, rcgcd-spl-14-conversion, rcgcrd-spl-4, rcgcrd-spl-4-conversion, rclpy }:
+buildRosPackage {
+  pname = "ros-galactic-gc-spl-2022";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/galactic/gc_spl_2022/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2dc6f5216ca0b559ef267113b07c6667c06276149f9512bc509d8c4ebf972a03";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ rcgcd-spl-14 rcgcd-spl-14-conversion rcgcrd-spl-4 rcgcrd-spl-4-conversion rclpy ];
+
+  meta = {
+    description = ''GameController-Robot communication in RoboCup SPL at RoboCup2022'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  ament-cmake-auto = self.callPackage ./ament-cmake-auto {};
 
+ ament-cmake-black = self.callPackage ./ament-cmake-black {};
+
  ament-cmake-catch2 = self.callPackage ./ament-cmake-catch2 {};
 
  ament-cmake-clang-format = self.callPackage ./ament-cmake-clang-format {};
@@ -170,6 +172,8 @@ self: super: {
 
  bondcpp = self.callPackage ./bondcpp {};
 
+ boost-geometry-util = self.callPackage ./boost-geometry-util {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -234,6 +238,14 @@ self: super: {
 
  depthai = self.callPackage ./depthai {};
 
+ depthai-ros = self.callPackage ./depthai-ros {};
+
+ depthai-bridge = self.callPackage ./depthai-bridge {};
+
+ depthai-examples = self.callPackage ./depthai-examples {};
+
+ depthai-ros-msgs = self.callPackage ./depthai-ros-msgs {};
+
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
  desktop = self.callPackage ./desktop {};
@@ -282,9 +294,75 @@ self: super: {
 
  ecl-build = self.callPackage ./ecl-build {};
 
+ ecl-command-line = self.callPackage ./ecl-command-line {};
+
+ ecl-concepts = self.callPackage ./ecl-concepts {};
+
+ ecl-config = self.callPackage ./ecl-config {};
+
+ ecl-console = self.callPackage ./ecl-console {};
+
+ ecl-containers = self.callPackage ./ecl-containers {};
+
+ ecl-converters = self.callPackage ./ecl-converters {};
+
+ ecl-converters-lite = self.callPackage ./ecl-converters-lite {};
+
+ ecl-core = self.callPackage ./ecl-core {};
+
+ ecl-core-apps = self.callPackage ./ecl-core-apps {};
+
+ ecl-devices = self.callPackage ./ecl-devices {};
+
+ ecl-eigen = self.callPackage ./ecl-eigen {};
+
+ ecl-errors = self.callPackage ./ecl-errors {};
+
+ ecl-exceptions = self.callPackage ./ecl-exceptions {};
+
+ ecl-filesystem = self.callPackage ./ecl-filesystem {};
+
+ ecl-formatters = self.callPackage ./ecl-formatters {};
+
+ ecl-geometry = self.callPackage ./ecl-geometry {};
+
+ ecl-io = self.callPackage ./ecl-io {};
+
+ ecl-ipc = self.callPackage ./ecl-ipc {};
+
  ecl-license = self.callPackage ./ecl-license {};
 
+ ecl-linear-algebra = self.callPackage ./ecl-linear-algebra {};
+
+ ecl-lite = self.callPackage ./ecl-lite {};
+
+ ecl-manipulators = self.callPackage ./ecl-manipulators {};
+
+ ecl-math = self.callPackage ./ecl-math {};
+
+ ecl-mobile-robot = self.callPackage ./ecl-mobile-robot {};
+
+ ecl-mpl = self.callPackage ./ecl-mpl {};
+
+ ecl-sigslots = self.callPackage ./ecl-sigslots {};
+
+ ecl-sigslots-lite = self.callPackage ./ecl-sigslots-lite {};
+
+ ecl-statistics = self.callPackage ./ecl-statistics {};
+
+ ecl-streams = self.callPackage ./ecl-streams {};
+
+ ecl-threads = self.callPackage ./ecl-threads {};
+
+ ecl-time = self.callPackage ./ecl-time {};
+
+ ecl-time-lite = self.callPackage ./ecl-time-lite {};
+
  ecl-tools = self.callPackage ./ecl-tools {};
+
+ ecl-type-traits = self.callPackage ./ecl-type-traits {};
+
+ ecl-utilities = self.callPackage ./ecl-utilities {};
 
  effort-controllers = self.callPackage ./effort-controllers {};
 
@@ -342,6 +420,8 @@ self: super: {
 
  filters = self.callPackage ./filters {};
 
+ fluent-rviz = self.callPackage ./fluent-rviz {};
+
  fmi-adapter = self.callPackage ./fmi-adapter {};
 
  fmi-adapter-examples = self.callPackage ./fmi-adapter-examples {};
@@ -371,6 +451,8 @@ self: super: {
  gazebo-ros2-control-demos = self.callPackage ./gazebo-ros2-control-demos {};
 
  gazebo-ros-pkgs = self.callPackage ./gazebo-ros-pkgs {};
+
+ gc-spl-2022 = self.callPackage ./gc-spl-2022 {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -710,6 +792,8 @@ self: super: {
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
+ mrpt-msgs = self.callPackage ./mrpt-msgs {};
+
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
  multires-image = self.callPackage ./multires-image {};
@@ -854,6 +938,8 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ performance-test = self.callPackage ./performance-test {};
+
  performance-test-fixture = self.callPackage ./performance-test-fixture {};
 
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
@@ -928,7 +1014,11 @@ self: super: {
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
+ pose-cov-ops = self.callPackage ./pose-cov-ops {};
+
  position-controllers = self.callPackage ./position-controllers {};
+
+ py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
 
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
 
@@ -956,6 +1046,8 @@ self: super: {
 
  quaternion-operation = self.callPackage ./quaternion-operation {};
 
+ r2r-spl-7 = self.callPackage ./r2r-spl-7 {};
+
  radar-msgs = self.callPackage ./radar-msgs {};
 
  random-numbers = self.callPackage ./random-numbers {};
@@ -973,6 +1065,14 @@ self: super: {
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
 
  rcdiscover = self.callPackage ./rcdiscover {};
+
+ rcgcd-spl-14 = self.callPackage ./rcgcd-spl-14 {};
+
+ rcgcd-spl-14-conversion = self.callPackage ./rcgcd-spl-14-conversion {};
+
+ rcgcrd-spl-4 = self.callPackage ./rcgcrd-spl-4 {};
+
+ rcgcrd-spl-4-conversion = self.callPackage ./rcgcrd-spl-4-conversion {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -1368,6 +1468,10 @@ self: super: {
 
  rslidar-sdk = self.callPackage ./rslidar-sdk {};
 
+ rt-manipulators-cpp = self.callPackage ./rt-manipulators-cpp {};
+
+ rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
+
  rtabmap-ros = self.callPackage ./rtabmap-ros {};
 
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
@@ -1444,11 +1548,17 @@ self: super: {
 
  sol-vendor = self.callPackage ./sol-vendor {};
 
+ sophus = self.callPackage ./sophus {};
+
  spacenav = self.callPackage ./spacenav {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ splsm-7 = self.callPackage ./splsm-7 {};
+
+ splsm-7-conversion = self.callPackage ./splsm-7-conversion {};
 
  sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
 
@@ -1520,8 +1630,6 @@ self: super: {
 
  test-interface-files = self.callPackage ./test-interface-files {};
 
- test-launch-system-modes = self.callPackage ./test-launch-system-modes {};
-
  test-msgs = self.callPackage ./test-msgs {};
 
  tf2 = self.callPackage ./tf2 {};
@@ -1572,6 +1680,8 @@ self: super: {
 
  tracetools = self.callPackage ./tracetools {};
 
+ tracetools-analysis = self.callPackage ./tracetools-analysis {};
+
  tracetools-launch = self.callPackage ./tracetools-launch {};
 
  tracetools-test = self.callPackage ./tracetools-test {};
@@ -1608,9 +1718,21 @@ self: super: {
 
  turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
+ turtlebot4-base = self.callPackage ./turtlebot4-base {};
+
+ turtlebot4-bringup = self.callPackage ./turtlebot4-bringup {};
+
+ turtlebot4-cpp-examples = self.callPackage ./turtlebot4-cpp-examples {};
+
+ turtlebot4-cpp-tutorials = self.callPackage ./turtlebot4-cpp-tutorials {};
+
  turtlebot4-description = self.callPackage ./turtlebot4-description {};
 
  turtlebot4-desktop = self.callPackage ./turtlebot4-desktop {};
+
+ turtlebot4-diagnostics = self.callPackage ./turtlebot4-diagnostics {};
+
+ turtlebot4-examples = self.callPackage ./turtlebot4-examples {};
 
  turtlebot4-ignition-bringup = self.callPackage ./turtlebot4-ignition-bringup {};
 
@@ -1622,7 +1744,17 @@ self: super: {
 
  turtlebot4-node = self.callPackage ./turtlebot4-node {};
 
+ turtlebot4-python-examples = self.callPackage ./turtlebot4-python-examples {};
+
+ turtlebot4-python-tutorials = self.callPackage ./turtlebot4-python-tutorials {};
+
+ turtlebot4-robot = self.callPackage ./turtlebot4-robot {};
+
  turtlebot4-simulator = self.callPackage ./turtlebot4-simulator {};
+
+ turtlebot4-tests = self.callPackage ./turtlebot4-tests {};
+
+ turtlebot4-tutorials = self.callPackage ./turtlebot4-tutorials {};
 
  turtlebot4-viz = self.callPackage ./turtlebot4-viz {};
 

--- a/distros/galactic/geometry2/default.nix
+++ b/distros/galactic/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-galactic-geometry2";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/geometry2/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "1a9c4fa0bf03c2c15c5e54e62448a2963b8336e9bb273e823bf1480fec5f3de1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/geometry2/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "2a6748be037b3b67c7023037458eea41dc3ad41078e01f7b9b569f9eb8da7acc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gscam/default.nix
+++ b/distros/galactic/gscam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, class-loader, cv-bridge, gst_all_1, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-gscam";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gscam-release/archive/release/galactic/gscam/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "25e99d587c1e7eefa7a2d4b862fe8deb48ea0685dce5148e8796380074d4935d";
+    url = "https://github.com/ros2-gbp/gscam-release/archive/release/galactic/gscam/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "ef9212c01b23bcd431ddff80b64ca533143d048973cadfe6043cb4e4aa92b897";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mrpt-msgs/default.nix
+++ b/distros/galactic/mrpt-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-mrpt-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/galactic/mrpt_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "bd118141337a5a914f1be81d1c85e6f18a04789c8640b7dcf4f648874546f80b";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/galactic/mrpt_msgs/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "7d37ac5cc7d7d9d50b7ad1724dad268f9916de505c3245c7290a1850b2f99b9d";
   };
 
-  buildType = "cmake";
+  buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cppcheck ament-cpplint ament-lint-auto ament-lint-cmake ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];

--- a/distros/galactic/nav-2d-msgs/default.nix
+++ b/distros/galactic/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-msgs";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "38a054e3821fed50571d3447c89b66c4b99809f52a247d81a360dd865a3ba1df";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "b34381dd3f3098bc343cd51202075b98f996109eb1dfcd61224322d7454fea4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav-2d-utils/default.nix
+++ b/distros/galactic/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-utils";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "9671cc7a50446d5dd729df858108725ddb83d84454bef1d6613f4bb6e9e9abb3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "6577cfad6839eb9a3d83c3921a64cc02d12caae79ac03d6b800bc2177348da05";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-amcl/default.nix
+++ b/distros/galactic/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-amcl";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "c32cbd13a62a34eb56e870439cc9e08714a1e4e88af03430022a0449b085dff6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "20fe3f869f4c75e595396e041b6d56275bd39674fa8d70d8a85ff818f3053f7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-behavior-tree/default.nix
+++ b/distros/galactic/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-behavior-tree";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "ce3007b0385c0c42e0890009f25c73acf2f6a137dd751c13c9ad271f120047c2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "bcb28a37c795bddb4bec5776f603bd3286af09387d4b8e457ca143beafbd7a90";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bringup/default.nix
+++ b/distros/galactic/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bringup";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fe5e3228a31137da9a74251d7f5ef3a318fa524da5ed8eb1b8fab215778940d3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "4f16762450ad6a9935d52f13a00b3381af3342a1281818f89dbc6305c8149077";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bt-navigator/default.nix
+++ b/distros/galactic/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bt-navigator";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "edf708268248be5313c9ad10ce9bfa5a61e5e762fa84375fe7d81d5f4e2d92ee";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "fc2b76a6f1055215f0ccd3f243e39707d9044648a46f46836079e4eae9c722b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-common/default.nix
+++ b/distros/galactic/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-common";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "197efdc63bd761783b46a4b76767ece88514832254968a2a815258e0fb1cd9e8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "3390f2a003fae30e5fb82b9b15e7d604bf9efcc976f40a832c425ae4b2a32f28";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-controller/default.nix
+++ b/distros/galactic/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "25f0fdfe9e5cb3b397366aeaf4c00a9dff790e4e4375a84b8daa4571d3e98517";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "bb79380fc77cd1ec4dfe3fc95b036c3ec1ba35437205a252f9cd20d379e31726";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-core/default.nix
+++ b/distros/galactic/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-core";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "be354e3bbe418536e390ad8850d3b9c0c77b245249816e489c87d24b7aa382a5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "bca1ef2ee4db9e1e68276b572906b9dfa1383c6cf9b62535e63e0acaae7b974b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-costmap-2d/default.nix
+++ b/distros/galactic/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-costmap-2d";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "63d9c3984bd4c2eeada63d9c0e5ee8a9a99ec74dae43bf654ed2c8d4965f1afe";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "cce941aa526e0d5aa402c7611eea065a09ca65370b970c6eaad37bec8ba4c300";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-dwb-controller/default.nix
+++ b/distros/galactic/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-galactic-nav2-dwb-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "b11dedfb6c062f7e5d27446febc6eec6170b1b9621c484c96764735cb267c5a1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "e8482a6d2443302054d8a5ce1b2e1578ccdd6c8a88f88d1bded6ecf027065436";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-gazebo-spawner/default.nix
+++ b/distros/galactic/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-gazebo-spawner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "c3ef6355ec97588e7e9c8421d301d457113b694b475e21a3b9a3ece69c51b525";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "1348fcbf2e7025737da0c4a9add065633590cb9e28821e81c01e97f290625806";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-lifecycle-manager/default.nix
+++ b/distros/galactic/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-lifecycle-manager";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "3295f2d0fbf9ce378849cd267a53d9be4e00008a41c9a8aba9ed9251b571ee85";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "7c7026dfd4b750518f0baa676c471f913cce3b5d549080637c131ae727673440";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-map-server/default.nix
+++ b/distros/galactic/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-nav2-map-server";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "8d3d2c267d84581c5485227687e3cf5c7602c3a7ea69d1675177989c0f880f51";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "811d9854add038969da27f275ddde870b01077a6d37d9abc51796778f621ef09";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-msgs/default.nix
+++ b/distros/galactic/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-msgs";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "23c34edc0b4059b7384feff6cb786ce15e3ca18cc4922da35ab43a34b8aceae9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "07c3c19ca5fc4a8f4016ae9aeeb8eda00a314a5355deb3eddd234d56a6abb22e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-navfn-planner/default.nix
+++ b/distros/galactic/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-navfn-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "8fc955ec4170ab18f11a4d2ee6fed94a965e107b16873aa82a76023ed04c65ac";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "e77760025dc5a91a7d3e733ff1a913c99790ec25767e92fa3e95bd07ef7ea7bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-planner/default.nix
+++ b/distros/galactic/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "34f1fd619fcb5993858986dabe327fc826f4dfa6d6c53b5f40090169b52d0f0f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "2b929c9aebd1cf1d6538b62bcfa270d151949e10a119297190d88ad33fa39b85";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-recoveries/default.nix
+++ b/distros/galactic/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-recoveries";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "b6dd74fedf5ae36abfec7799b57c6375227b760734cf5742e463d3a40bc77bc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "267672750dc19cb2b5eb1d88eaa65b470111737781a9d6f05fbf2dcf048b6928";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-regulated-pure-pursuit-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "51ce72e46c1c1604549734527b732faae0ea4317fedcf7eaca67506dce945793";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "843e9fadc756207394c3170ed709930f7c4063eb12c3700d6f7a3e8e2b65bdbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rotation-shim-controller/default.nix
+++ b/distros/galactic/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rotation-shim-controller";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fb9721a63c3c00204187cedcdbde6e60558d5cd41605a2c48518119c003e4978";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rotation_shim_controller/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "ceb2346ea6f6e0a4c3ff60de292d6e3269157cd3a09ea3701167de9368fad565";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rviz-plugins/default.nix
+++ b/distros/galactic/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rviz-plugins";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "aa8dbc35259b8ed0ce9ca9e30607d43d353b78ca08f8833bf88474221d5835ae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "d33f957539bbdec66081ce8df83487bf7d89b700583696a1ae22d7e8fe4c4cee";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-simple-commander/default.nix
+++ b/distros/galactic/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-simple-commander";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "fbddc7ed655af8fc30e5defb0f25a6499d921577f19ececaefa3956c545a7ae3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_simple_commander/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "d582ede409d515cd0baa48001c95ba9307cdc4f2f5acf5992c49403c80d7090a";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-smac-planner/default.nix
+++ b/distros/galactic/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-smac-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "c3d79de924b04ab4769c151fbf1afc3c05b336a0d2b9962fc6c94852bd4d4a07";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "5a0438afe92f63ca64cd043afa7d736feeb87f1f2586fa5a4c6cf6503877280e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-system-tests/default.nix
+++ b/distros/galactic/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-system-tests";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "2d5d86a8d1f0ded55f09b260736e3627ec2aca092e9449d623b819d9f03b30f1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "eafb86033015cb54239a81bf76a8e0edfffdb1e4646d487805a2f952b920924a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-theta-star-planner/default.nix
+++ b/distros/galactic/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-theta-star-planner";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "1fd908a17bdf363c238087f412de17250bb812e32d8cb03b9670e2adbf27f69c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_theta_star_planner/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "f5c78bf161d62ea9ae300f3327dcb1c3565df948c378bf6e0f5ce2495853fb09";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-util/default.nix
+++ b/distros/galactic/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-util";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "83795bc7bacf58fe5d0da3549c5db1ae911cd609829af535908ab2da13647b24";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "04642e089eb5b1689fbdb84f845f443e7ae2505c1492735fe3024cc3bceab050";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-voxel-grid/default.nix
+++ b/distros/galactic/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nav2-voxel-grid";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "4969999af3228c8b5e2e3cf9ff3b51f4dabbcc7e42cf5f1f08b4e9f7aabc2109";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "d1a24f7db607fbac85f895ce83fce3e369da655a446b7cc361db9d95416a0e70";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-waypoint-follower/default.nix
+++ b/distros/galactic/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-waypoint-follower";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "1c10c3531708238e5a07bcccc17a6175c167a7c03d2330ae7b6649c0b91e8f79";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "ed5ac03b406b8a45e501ee909266e72b325c5c1aaf11175c8e8f3480b0783089";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/navigation2/default.nix
+++ b/distros/galactic/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-theta-star-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-galactic-navigation2";
-  version = "1.0.11-r1";
+  version = "1.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "f7e531233ce4136bd2441aa542b392a90c486c9aec7267edff70017b305a383a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.12-1.tar.gz";
+    name = "1.0.12-1.tar.gz";
+    sha256 = "3208d18f9c1aa932a7a7e587b7d221ddfd5a01cf667bea516e2d527753002569";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.4.4-r1";
+  version = "3.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.4.4-1.tar.gz";
-    name = "3.4.4-1.tar.gz";
-    sha256 = "bbb66613ad9ef0d3a49f89618a2ec8f8e84b576ee79938d3c07d17cd1525d956";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.4.5-1.tar.gz";
+    name = "3.4.5-1.tar.gz";
+    sha256 = "f81e9ee36e799cba846e96439f43e1b60af3d85325b57b03b5d6c1b42a474992";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/pose-cov-ops/default.nix
+++ b/distros/galactic/pose-cov-ops/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-pose-cov-ops";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/galactic/pose_cov_ops/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "a8c00418faf3dc70656add5ee3a60c3ca821cb0df2e342333e6f22527bade77a";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/galactic/pose_cov_ops/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "2406d466b109c64d2ef3c4496b69d620119438382c7af94ab926bbde91413842";
   };
 
-  buildType = "cmake";
+  buildType = "ament_cmake";
   buildInputs = [ ament-cmake-xmllint ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common gtest ];
   propagatedBuildInputs = [ geometry-msgs mrpt2 ];

--- a/distros/galactic/r2r-spl-7/default.nix
+++ b/distros/galactic/r2r-spl-7/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, splsm-7-conversion }:
+buildRosPackage {
+  pname = "ros-galactic-r2r-spl-7";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/r2r_spl_7/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b88780b8ba42db5986f23f7e3fe9244f24cbe3edad56b75868fdd1c4be128585";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ rclpy splsm-7-conversion ];
+
+  meta = {
+    description = ''Robot-To-Robot communication in RoboCup SPL using SPLSM V7'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rcgcd-spl-14-conversion/default.nix
+++ b/distros/galactic/rcgcd-spl-14-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rcgcd-spl-14 }:
+buildRosPackage {
+  pname = "ros-galactic-rcgcd-spl-14-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/galactic/rcgcd_spl_14_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "cdae7d1bd76c0b23ab984697e135bd596ae91d1cb3da0fd7ffcaf0b12a7d024d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct rcgcd-spl-14 ];
+
+  meta = {
+    description = ''Converts RoboCup SPL GameController Data V14 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rcgcd-spl-14/default.nix
+++ b/distros/galactic/rcgcd-spl-14/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rcgcd-spl-14";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/galactic/rcgcd_spl_14/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c7ab3fa03b13e2b1dbfd641c0ff90ee047e9d96802ed67bf9d9c2cd8c3e61773";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup SPL GameController Data V14 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rcgcrd-spl-4-conversion/default.nix
+++ b/distros/galactic/rcgcrd-spl-4-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rcgcrd-spl-4 }:
+buildRosPackage {
+  pname = "ros-galactic-rcgcrd-spl-4-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/galactic/rcgcrd_spl_4_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0dbeb342f4357e15d8cbe5e9644ca4f3a277d43757033b5d046b4b7014774ace";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct rcgcrd-spl-4 ];
+
+  meta = {
+    description = ''Converts RoboCup SPL GameController Return Data V4 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rcgcrd-spl-4/default.nix
+++ b/distros/galactic/rcgcrd-spl-4/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rcgcrd-spl-4";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/galactic/rcgcrd_spl_4/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1f5c1eaf4ad83f06423c047ba37a45964c2ba53f4ba6d60c06efac5ded32d406";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup SPL GameController Return Data V4 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rclpy/default.nix
+++ b/distros/galactic/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclpy";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/galactic/rclpy/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "6c082fe63e3008052ab0fd0c23d8b2f5d4b956d9c584e9ee03e81505f188aa96";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/galactic/rclpy/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "ee9ae4aed61fa4486c1d585464a25b059fff049ddd0267b751d6b89d8f3d5cf2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcss3d-agent-basic/default.nix
+++ b/distros/galactic/rcss3d-agent-basic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp-components, rcss3d-agent }:
 buildRosPackage {
   pname = "ros-galactic-rcss3d-agent-basic";
-  version = "0.0.7-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_basic/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "a5dcd6c8b2a9dd072052b173667763ca94f77dfadb267a4b543035874738e83f";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_basic/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "c26749823a502ff01415f3746ee939638fefe5cc8d9951c4e7dadcff58fdd5ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcss3d-agent-msgs/default.nix
+++ b/distros/galactic/rcss3d-agent-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rcss3d-agent-msgs";
-  version = "0.0.7-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_msgs/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "bf91d94050580c1b32436912a1a42e7fbdebea46ffaee0f159fde3ea3f8a8034";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "1f97978b886ab5c50becadbc04781e17604fbbd46eda5b241486ad6404f95d6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcss3d-agent/default.nix
+++ b/distros/galactic/rcss3d-agent/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcss3d-agent-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rcss3d-agent";
-  version = "0.0.7-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "2e259621ca9bed24e18deba8f487803d52048ace76d469e848e355a5286ec0fa";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/galactic/rcss3d_agent/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "44cc4a665f915883d3543d7f1eec844b3d12f2a3d29fecb00ba21a750f2d1128";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcutils/default.nix
+++ b/distros/galactic/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-rcutils";
-  version = "4.0.2-r2";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/galactic/rcutils/4.0.2-2.tar.gz";
-    name = "4.0.2-2.tar.gz";
-    sha256 = "afe979208f0510ed365ea45b5d151f68a66497a972aaff8bab9d799c1ee46718";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/galactic/rcutils/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "8752afbefe05ac191fad55b65e85e6a83c443ef2d68f0eb00e757e07f47d542a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-image-to-qimage/default.nix
+++ b/distros/galactic/ros-image-to-qimage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, qt5, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros-image-to-qimage";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-sports/ros_image_to_qimage-release/archive/release/galactic/ros_image_to_qimage/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "df859dc610b2e7ef43e847b133b72289c7219d6d7d05e1ef0f7f2d3417f4b52c";
+    url = "https://github.com/ros2-gbp/ros_image_to_qimage-release/archive/release/galactic/ros_image_to_qimage/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "53f38fc3a197011cbe0978745d73f38f5943fbeb86d253530dbd11696ec8c8f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2action/default.nix
+++ b/distros/galactic/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2action";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2action/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "ba9acd16b9e2d7492b12c188b3c64d6833cb6088c6e1ec693b3892fc7562a87f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2action/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "f5a34a47439f98f6f20044701122fcb43773adc7b47ff51e9eb048dfafed155f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2cli-test-interfaces/default.nix
+++ b/distros/galactic/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-ros2cli-test-interfaces";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli_test_interfaces/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "ffd03eae7479c064e390b372d3d5cf5dc7b37c8fb155a003c5828a7176bcb191";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli_test_interfaces/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "3c690fa7412b317311a57abe257fb76607ad7b1d9b957abde77498e7336d501b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2cli/default.nix
+++ b/distros/galactic/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2cli";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "9b194da471ef59ac71d2631058be3958b8ae61c6fa28341ad1144feac776052b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "748f1ee571ea245c84691dbc405838aa518acf1f5ceb8ccdb24b934414c0ba96";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2component/default.nix
+++ b/distros/galactic/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-galactic-ros2component";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2component/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "602d902973709fcfc58b23252b50f0228d200a3af3738177c181ab20ef19fa0f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2component/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "c43777479419354b13c54b98c7bb74e4b5f218935007e34c7c4fe96944c7728f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2interface/default.nix
+++ b/distros/galactic/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros-testing, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2interface";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2interface/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "d4de78b85d60c2dd13cf7002d69e876c702ab8b706d6d9c65006d360627ec02f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2interface/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "5bbcb23c5d175c890f7808965e24624414e28b44cb4c2363361b74be020d35bf";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/galactic/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-ros2lifecycle-test-fixtures";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle_test_fixtures/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "c99fc0db9b4de89d150b6276e99904cdcb65fed8adb1f3c2106311b60432005f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle_test_fixtures/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "e959a34c3635d23c6bbc48adc038b5a8ac37917de53f774524bbd595c1cec0cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2lifecycle/default.nix
+++ b/distros/galactic/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle-msgs, pythonPackages, rclpy, ros-testing, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-galactic-ros2lifecycle";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "5dfc438f0d70cbdf5df2535d24b2ee5aa2c010fc7fb6519490283c462f3257c7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2lifecycle/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "b0585480151293cf27b7b6eb7920acf5a5714903cbaaf41b659fe5a839bf396d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2multicast/default.nix
+++ b/distros/galactic/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-galactic-ros2multicast";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2multicast/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "2154f171ddd909dc361d9860ca2a009a5538f1a5cbc2537380e69d3450a92bd3";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2multicast/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "ad486fde2a9d1504ad379a0c559cafd38533498be8707dc3613ed7bfc0fbd2ca";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2node/default.nix
+++ b/distros/galactic/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2node";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2node/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "e784f7c443be0c373f760f02006ab2d4f3a4b8429bc7ae7b6540873130191610";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2node/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "4fc3f5ad85b60cad7c4df02b42a4f7822a0de4ca54efdc9ef8d802933598236e";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2param/default.nix
+++ b/distros/galactic/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-galactic-ros2param";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2param/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "a9b3cf5e594f88f3af4d3d09b6769d6ec8465ec12a29f5898bd24f7a8d29f159";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2param/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "5331f18543e7ee9c4c6dbc1c222b157d32925266bc27828d35ff7ee46d2a4c37";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2pkg/default.nix
+++ b/distros/galactic/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros-testing, ros2cli }:
 buildRosPackage {
   pname = "ros-galactic-ros2pkg";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2pkg/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "68908331986148ef75968caf4b55bf8f8259f33b84aa53c75409dfbf73f44c8f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2pkg/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "6bdb6cc2a6691b0174067237ad6bb8b7c3aa7f8991e0775c012ae29eae33cd91";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2run/default.nix
+++ b/distros/galactic/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-galactic-ros2run";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2run/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "bccb2118c796f36843a8f87e379a495be2ac486fcfb011fb50dd651b5b23bcc4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2run/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "ad5ccb0193dfcfe2dc45ee82ec238fa4f7a6c665ac046d0d444af31a7fc010f0";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2service/default.nix
+++ b/distros/galactic/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2service";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2service/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "8979ec818370497074d500e4e69dec71d09bb580374e8e35774c34491f4ef108";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2service/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "d429d5be1b351fad629c886685dfcc6497df0c07b25eb57ccc67201f3ad7a44b";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2topic/default.nix
+++ b/distros/galactic/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2topic";
-  version = "0.13.3-r1";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2topic/0.13.3-1.tar.gz";
-    name = "0.13.3-1.tar.gz";
-    sha256 = "20966ec44a899c06fd29c2331249374b12527d31e35f542aa41582a9f0ae048f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2topic/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "219ebc40cf01620cbe8ea824238da7ffe2a9a1ae719e05e744af99c5dbc81dc6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-image-overlay-layer/default.nix
+++ b/distros/galactic/rqt-image-overlay-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, message-filters, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rqt-image-overlay-layer";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "0ca4c5fa2eb66e86e9b72004315fbab5d487a09317a2f7eb93c195b9bbba8598";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "a65a299e252ed5703a06ff96682392554b008f0cdffc8ea67b2cff433a243739";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-image-overlay/default.nix
+++ b/distros/galactic/rqt-image-overlay/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs, theora-image-transport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, compressed-image-transport, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rqt-image-overlay";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "b6294f9c8499d264f7fc8eafe337b19fda0a38c256377dfee617beb07779acfb";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "415c0090251217dd9503669119a722c040de91193ceebef6fc4437cb6c151170";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common std-msgs theora-image-transport ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common compressed-image-transport std-msgs ];
   propagatedBuildInputs = [ image-transport pluginlib qt5.qtbase rclcpp ros-image-to-qimage rqt-gui-cpp rqt-image-overlay-layer ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/rt-manipulators-cpp/default.nix
+++ b/distros/galactic/rt-manipulators-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, libyamlcpp, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-galactic-rt-manipulators-cpp";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/rt_manipulators_cpp-release/archive/release/galactic/rt_manipulators_cpp/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e5a71a06f9591ef8365c02999c0efaf4e4f2c954c0c669959b56b5bb4804e681";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module libyamlcpp yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RT Manipulators C++ Library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rt-manipulators-examples/default.nix
+++ b/distros/galactic/rt-manipulators-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rt-manipulators-cpp }:
+buildRosPackage {
+  pname = "ros-galactic-rt-manipulators-examples";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/rt_manipulators_cpp-release/archive/release/galactic/rt_manipulators_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1f9114b20b8336de6c2e70152ce97c702e83bc880d1b3c6d07bb6aecdf4aeb79";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rt-manipulators-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Examples for RT Manipulators C++ Library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/septentrio-gnss-driver/default.nix
+++ b/distros/galactic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-septentrio-gnss-driver";
-  version = "1.2.1-r1";
+  version = "1.2.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/galactic/septentrio_gnss_driver/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "0698eb2849cb3773cde7a84c8285d3fc2dc8bdef2994f282187abeac1eddc664";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/galactic/septentrio_gnss_driver/1.2.2-3.tar.gz";
+    name = "1.2.2-3.tar.gz";
+    sha256 = "e00f05c7f96da3faf7175036c1f3659ec76f829ba695c05289a88d41ea105429";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/splsm-7-conversion/default.nix
+++ b/distros/galactic/splsm-7-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, splsm-7 }:
+buildRosPackage {
+  pname = "ros-galactic-splsm-7-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/splsm_7_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ae32436a045de9b5bed13dfe71949c70f0e5051bdd5a7678558b7689a09108e5";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct splsm-7 ];
+
+  meta = {
+    description = ''Converts Standard Platform League Standard Message V7 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/splsm-7/default.nix
+++ b/distros/galactic/splsm-7/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-splsm-7";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/splsm_7/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "db5d85eec05a8dc47f9b6dca33f40941bf66eb2653cca957d88346ec9a6a86ff";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup Standard Platform League Standard Message V7 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/tensorrt-cmake-module/default.nix
+++ b/distros/galactic/tensorrt-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-galactic-tensorrt-cmake-module";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/galactic/tensorrt_cmake_module/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "96ef9c79cb6176306acf96ff30215ddbe4a745218c4491de19d4ebe695e42c53";
+    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/galactic/tensorrt_cmake_module/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "df27e5c5fd88a1ee3c38b767e61f8c73bc7332432cfd2aad87f93be1b593c39d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-bullet/default.nix
+++ b/distros/galactic/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-tf2-bullet";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_bullet/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "e2ddfdb3a018d10f118f1ea2df029903c3fa072e31e93ac038528148242862c4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_bullet/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "ba8ebba5248456deb140bb3b4ef5cd86f29770b73ae844fde0eeeb20605c3dd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-eigen-kdl/default.nix
+++ b/distros/galactic/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, orocos-kdl, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-tf2-eigen-kdl";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen_kdl/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "18c4088c08d200e718750f3dc94cf30425037466a9fa7dae4e530906cd554c49";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen_kdl/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "77a566a7a4d8f879309cfcf4f28dceb18af70168d4bc863a4063db0fa6d18e83";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-eigen/default.nix
+++ b/distros/galactic/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-tf2-eigen";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "22ba59d9a6550f7ecc55f116c9aeec256d15375640108bee809a416b1a9edc52";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_eigen/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "e2b04857359e9ad64ee14775ee1624849da0d08581961e11c49138d5a6e1b770";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-geometry-msgs/default.nix
+++ b/distros/galactic/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-geometry-msgs";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_geometry_msgs/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "b4560d72ea88f1c87aadb879162a76faedda7333a975c0cc41e904adc34062d4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_geometry_msgs/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "ea630e1f1dcc0b10eda044bd007d10f3a1a83fb824519cb2b02863f76ab37c2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-kdl/default.nix
+++ b/distros/galactic/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-kdl";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_kdl/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "3c3cc075bbcfdb2feffa29a356f2e4a0e06060d87e17b34998695dc5a3ff23a4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_kdl/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "2bd46fe8273aa19de9a235674bf1563b2190abe1f009a83f0d65568942fccbdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-msgs/default.nix
+++ b/distros/galactic/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-tf2-msgs";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_msgs/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "c1fa046fa8f20189db4ec35f979a80d087e7ed205160f3974665c59397a9bf92";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_msgs/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "020ee47cc9fd7e8ceba1db71ecb433cb26dda239d3d576c772e91cf55241fa2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-py/default.nix
+++ b/distros/galactic/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-tf2-py";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_py/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "482b9c9e80afa7a6a1689f8e68a8cbcd4f03b60c0c660e1b4e6801c3f2a16582";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_py/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "a05d4171167b74f87e42dc9682dda8ca08800ccad75561bf1a183f9be0255f32";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-ros-py/default.nix
+++ b/distros/galactic/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-ros-py";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros_py/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "dd22835487b8605c373a42fc0b8025519ae76776d153876e7b6b4c3ca83f1ab8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros_py/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "31ba1feb43eaf63c62591812dfc0af758ca50de65bf9b07d1670ca1dd6fe234d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/tf2-ros/default.nix
+++ b/distros/galactic/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-tf2-ros";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "35f8a3fdae5237ba01cf75cd730cc230fc755b235ff7d8ac31b12a641e13e286";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_ros/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "f46e962895f8c99bd5e0002bfe9146b5301f506a871fd96cff3c9d699e38b879";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-sensor-msgs/default.nix
+++ b/distros/galactic/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-sensor-msgs";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_sensor_msgs/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "6665b2e496fffca583eacf90491a587162f74b80771971133bc6ca67bd551569";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_sensor_msgs/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "8eed080a4b723ff4c8ce9b8bce4673a04ef5a7e3059eafb2e82cd6330ef84601";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tf2-tools/default.nix
+++ b/distros/galactic/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-galactic-tf2-tools";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_tools/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "a645e7ae59bd5a6b6a97a3cf14dfdb685a2a708e15b55e913ac7d4292549b1d2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2_tools/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "8b8f56a5a4a1115720eb95e1f795d7108b6346ab4b30dfe4bc4ad656339f7e94";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/tf2/default.nix
+++ b/distros/galactic/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, geometry-msgs, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-tf2";
-  version = "0.17.3-r1";
+  version = "0.17.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2/0.17.3-1.tar.gz";
-    name = "0.17.3-1.tar.gz";
-    sha256 = "e73f8c6868e104d8805a20e09dc7bc5db891130fe3ffb5745758e9e237478a35";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/galactic/tf2/0.17.4-1.tar.gz";
+    name = "0.17.4-1.tar.gz";
+    sha256 = "10517a3f33bad04cbafb7fcf5acc01f63b1595dd1ba95725db2e9f55a92547e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/tracetools-analysis/default.nix
+++ b/distros/galactic/tracetools-analysis/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, jupyter, python3Packages, pythonPackages, tracetools-read }:
+buildRosPackage {
+  pname = "ros-galactic-tracetools-analysis";
+  version = "2.0.3-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tracetools_analysis-release/archive/release/galactic/tracetools_analysis/2.0.3-4.tar.gz";
+    name = "2.0.3-4.tar.gz";
+    sha256 = "57d940923ce99db4f1c45e905811c18f3d4857fc4eb0b86e39d508e912628681";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ jupyter python3Packages.pandas tracetools-read ];
+
+  meta = {
+    description = ''Tools for analysing trace data.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot4-base/default.nix
+++ b/distros/galactic/turtlebot4-base/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, libgpiod, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, turtlebot4-msgs, turtlebot4-node }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot4-base";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/galactic/turtlebot4_base/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "7b2663cb054c1aacb40b5360f2f6a1e8ceffc67879971930aed94a8aa70a9a7d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ irobot-create-msgs libgpiod rclcpp rclcpp-action rcutils sensor-msgs std-msgs turtlebot4-msgs turtlebot4-node ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Turtlebot4 Base Node'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/zmqpp-vendor/default.nix
+++ b/distros/galactic/zmqpp-vendor/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cppzmq }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cppzmq, git }:
 buildRosPackage {
   pname = "ros-galactic-zmqpp-vendor";
-  version = "0.0.1-r2";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/zmqpp_vendor-release/archive/release/galactic/zmqpp_vendor/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "d399685344debd3bfc100cc85a98510db16cd7dc655d5edc3195405ab89779a4";
+    url = "https://github.com/tier4/zmqpp_vendor-release/archive/release/galactic/zmqpp_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "d161406de0515cd02b1d3c0ba9b89e0bf081ffb54ded21f1727c0e262ff33379";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cppzmq ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''Vendor package for zmqpp'';

--- a/distros/humble/ament-download/default.nix
+++ b/distros/humble/ament-download/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-ament-download";
+  version = "0.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/samsung-ros/ament_download-release/archive/release/humble/ament_download/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "531c9b9a5ec77687257edfc3bf46cbc17458c596eda66f434974c38f9a4945e1";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CMake macros for downloading files with ament'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/humble/aws-robomaker-small-warehouse-world/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
+buildRosPackage {
+  pname = "ros-humble-aws-robomaker-small-warehouse-world";
+  version = "1.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release/archive/release/humble/aws_robomaker_small_warehouse_world/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "65dfe041bacd9e53224fef4ea1c98b594c9d6e78e2c88e018b5fca1982292de1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo gazebo-plugins gazebo-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''AWS RoboMaker package for a warehouse world to use in manufacturing and logistics robot applications.'';
+    license = with lib.licenses; [ "MIT-0" ];
+  };
+}

--- a/distros/humble/boost-geometry-util/default.nix
+++ b/distros/humble/boost-geometry-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, boost, geometry-msgs, ouxt-common, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-boost-geometry-util";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/boost_geometry_util-release/archive/release/humble/boost_geometry_util/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "3054977c41c7664c8e4c412abaaf49933b4ce3bf732691fa81e83e60378888a7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-common ];
+  propagatedBuildInputs = [ boost geometry-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''Utility library for boost geometry'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cartographer-ros/default.nix
+++ b/distros/humble/cartographer-ros/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, builtin-interfaces, cartographer, cartographer-ros-msgs, eigen, geometry-msgs, gflags, glog, gtest, launch, nav-msgs, pcl, pcl-conversions, python3Packages, rclcpp, robot-state-publisher, rosbag2-cpp, rosbag2-storage, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-cartographer-ros";
+  version = "2.0.9000-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_ros/2.0.9000-2.tar.gz";
+    name = "2.0.9000-2.tar.gz";
+    sha256 = "b6e2e164edc8518b4e0b5d0085004537e44c7ebcd1c5c13065b057431c3797ba";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ gtest python3Packages.sphinx ];
+  propagatedBuildInputs = [ abseil-cpp builtin-interfaces cartographer cartographer-ros-msgs eigen geometry-msgs gflags glog launch nav-msgs pcl pcl-conversions rclcpp robot-state-publisher rosbag2-cpp rosbag2-storage sensor-msgs std-msgs tf2 tf2-eigen tf2-msgs tf2-ros urdf visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Cartographer is a system that provides real-time simultaneous localization
+    and mapping (SLAM) in 2D and 3D across multiple platforms and sensor
+    configurations. This package provides Cartographer's ROS integration.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cartographer-rviz/default.nix
+++ b/distros/humble/cartographer-rviz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, boost, cartographer, cartographer-ros, cartographer-ros-msgs, eigen, pluginlib, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering }:
+buildRosPackage {
+  pname = "ros-humble-cartographer-rviz";
+  version = "2.0.9000-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_rviz/2.0.9000-2.tar.gz";
+    name = "2.0.9000-2.tar.gz";
+    sha256 = "44cdae3209cad289d23c68c52065cfc6f3ac6a4b3642025f50a1e68a0b7cbae1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ abseil-cpp boost cartographer cartographer-ros cartographer-ros-msgs eigen pluginlib rclcpp rviz-common rviz-ogre-vendor rviz-rendering ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Cartographer is a system that provides real-time simultaneous localization
+    and mapping (SLAM) in 2D and 3D across multiple platforms and sensor
+    configurations. This package provides Cartographer's RViz integration.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cartographer/default.nix
+++ b/distros/humble/cartographer/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abseil-cpp, boost, cairo, ceres-solver, cmake, eigen, gflags, git, glog, gtest, lua5, protobuf, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-cartographer";
+  version = "2.0.9002-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/cartographer-release/archive/release/humble/cartographer/2.0.9002-2.tar.gz";
+    name = "2.0.9002-2.tar.gz";
+    sha256 = "ee74f0e0d86be3b0c946edf63212372e6420861713cce3b79955c2d1eb9c0cca";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ git gtest python3Packages.sphinx ];
+  propagatedBuildInputs = [ abseil-cpp boost cairo ceres-solver eigen gflags glog lua5 protobuf ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Cartographer is a system that provides real-time simultaneous localization
+    and mapping (SLAM) in 2D and 3D across multiple platforms and sensor
+    configurations.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/control-toolbox/default.nix
+++ b/distros/humble/control-toolbox/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-humble-control-toolbox";
-  version = "2.0.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/2.0.2-3.tar.gz";
-    name = "2.0.2-3.tar.gz";
-    sha256 = "24b485bd841c3c8983894e85aae34f913ad260e48fcd5a30c254d218c443ede6";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "1be3c3ffccf588fe727570554d000b2b3e1536f93bc4dc039a4e0e0441837112";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest rclcpp-lifecycle ];
   propagatedBuildInputs = [ control-msgs rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''The control toolbox contains modules that are useful across all controllers.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "c792bd6b1df55e4a3ce2e2a0f924c439245fbf17f773f1191209469b543a1a4d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "da02ea88c85592d1fd49d2413f9e5559f2f1a63708c8a37289c03f9774b78702";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "aebab13897d391b71e2a34da40ca23f771a5963fa3a6b3359dbceca34c1b22d9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "e89206b5b735ad6dbb5fdccc9b9e0f20a14ba23e4157e8e108b3bb1168b75988";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "80ddbaa72419c59e44e96cbd056a727e03023cfb9f6ebed2a42770828ac43e87";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "0e497ae8cbcf367e9518113551a0b6146ac3aa3503e79701356f40ba177218a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-aggregator/default.nix
+++ b/distros/humble/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-aggregator";
-  version = "2.1.3-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/2.1.3-3.tar.gz";
-    name = "2.1.3-3.tar.gz";
-    sha256 = "33453341c6e711d393b2e5be831fbbf9acda211653a1369f7ab36d21392bf747";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "2fecf33067be564781b0efb26e815457a51523c52eeb680725b4e3d77026952d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-updater/default.nix
+++ b/distros/humble/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-updater";
-  version = "2.1.3-r3";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/2.1.3-3.tar.gz";
-    name = "2.1.3-3.tar.gz";
-    sha256 = "a8167dc1f9810bc10f8da37e134da1aa9622da83b8b768b38ccf8b1167a290b3";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "5d2f40a7d3119f3f4b645e8f51e3c499d3931dafdb5bac3dd19db43f69d7bacf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "abaa29a3579db8484d82837237e3cc1b110c5168c7b030798a40340706e9e7dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "8d3ad011895aa982b63e3b6d538cabe8cec2b6234f8cf5f129e20f18d24fb93d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "6d075d70d7ea04eb343e424134251a3cd40298f27886f089d86706e11b970bf9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "4b5d59637695d9ac321935e91a72ee9fa5a0eb1dbb23792c7ab92d9fa1741413";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fastrtps";
-  version = "2.6.0-r3";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.0-3.tar.gz";
-    name = "2.6.0-3.tar.gz";
-    sha256 = "c794075a661ca2346d85fe6f8dd83221326a122e286e3f5f449196d5cc6795d9";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "4f948972b61e7da146517b5e27e1821634e40187879504a7d5fbc4550eea7909";
   };
 
   buildType = "cmake";

--- a/distros/humble/fluent-rviz/default.nix
+++ b/distros/humble/fluent-rviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, geometry-msgs, ouxt-lint-common, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-fluent-rviz";
+  version = "0.0.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/fluent_rviz-release/archive/release/humble/fluent_rviz/0.0.3-2.tar.gz";
+    name = "0.0.3-2.tar.gz";
+    sha256 = "79ccc7501cd98044007c166be8ba13ddeb1f13214b2c47de059dbb2500d87aa9";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ouxt-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''A library which makes Rviz fluent. Powered by C++17'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/fogros2-examples/default.nix
+++ b/distros/humble/fogros2-examples/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, fogros2, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-fogros2-examples";
-  version = "0.1.4-r1";
+  version = "0.1.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fogros2-release/archive/release/humble/fogros2_examples/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "67f26be1f643fa7c9edfb626dcf106a97d0076bfba550e7c7a5390f91c7a06f8";
+    url = "https://github.com/ros2-gbp/fogros2-release/archive/release/humble/fogros2_examples/0.1.6-3.tar.gz";
+    name = "0.1.6-3.tar.gz";
+    sha256 = "b85aecd15e3e9df1eb973162f632b32313bdac7ea88daed79daf9e438111055a";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ fogros2 ];
 
   meta = {
     description = ''Examples using FogROS2'';

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "f9f87b07da5c018dadce735dfdd7e58d699f919abdc1e1bbfd7a3d0cc234cc82";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "0a66cfd0d15adce846a70ad75760d6f8c2a9dfa48d7d566dd2e44db019cc15d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "6b5ae95c59d78acb8528ac0e53d770f9676791cfacec95958e112b4b5c919fb4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "bc71e32986238aa890af5292b3277a218de36bfff01dfa0d5572bec88de6ea83";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-msgs/default.nix
+++ b/distros/humble/foxglove-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-foxglove-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/humble/foxglove_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "fc483942c422a57649f01ca2526dc31da32a825db0a78add39403dc6d2b389df";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/humble/foxglove_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "3d4874e7d7aefac1ea20ce159024052e8b0dd7f9788c5d649d9e29dc29e82cf4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/gazebo-dev/default.nix
+++ b/distros/humble/gazebo-dev/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo_11 }:
 buildRosPackage {
   pname = "ros-humble-gazebo-dev";
-  version = "3.6.0-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_dev/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "a7ccdad257957f75ab5ee8bc95be33f2782d54df8bc43b0a4cbebf38c81d3e13";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_dev/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "b88bb4ca62bab49d30260b178c01b46dd9cfcfea1684a12ec691dbaec33c0ade";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-msgs/default.nix
+++ b/distros/humble/gazebo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-gazebo-msgs";
-  version = "3.6.0-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_msgs/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "7f491edc55cdfceda029d78f4eb4350303d29d9d68e31d5fb1ad8b8e7b87342d";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_msgs/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "43f032d5771c8fd3d5f68ca9fe7f31377f60e22b801b8703fd8d5e6b5b41b6f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-plugins/default.nix
+++ b/distros/humble/gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, gazebo-dev, gazebo-msgs, gazebo-ros, geometry-msgs, image-transport, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-gazebo-plugins";
-  version = "3.6.0-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_plugins/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "09d2244f9614cb8a7774da1fa011a98cfb86e58b55524a05962b1c7dd1f8b645";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_plugins/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "726072c2dd5544400795096c4b5de8acb2bfd5c1f570a3d87bea6403032fd417";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-ros-pkgs/default.nix
+++ b/distros/humble/gazebo-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros-pkgs";
-  version = "3.6.0-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_ros_pkgs/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "593ace42739a7d5075e0fa3daa40cc9f12702a438fde88672fa65bc75bab6fd4";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_ros_pkgs/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "84581e2c7e3cafef31fcd0f2cee1d81c5ecb43534d53b6a7a363dfe9c93da3bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-ros/default.nix
+++ b/distros/humble/gazebo-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, gazebo-dev, gazebo-msgs, geometry-msgs, launch-ros, launch-testing-ament-cmake, python3Packages, rcl, rclcpp, rclpy, rmw, ros2run, sensor-msgs, std-msgs, std-srvs, tinyxml-vendor }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros";
-  version = "3.6.0-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_ros/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "d9f22e7105effe57a87568347fbc5e0e33f19d75af5484aed5863057ef202ea5";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/humble/gazebo_ros/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "23a08d7e0590603b0908f9aa4687f7f21d8eab72c30c93a491fb92835f3f7bdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gc-spl-2022/default.nix
+++ b/distros/humble/gc-spl-2022/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rcgcd-spl-14, rcgcd-spl-14-conversion, rcgcrd-spl-4, rcgcrd-spl-4-conversion, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-gc-spl-2022";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/humble/gc_spl_2022/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "00e8107a6ea051aa197d838b816025b39e139496b2d1934f94b71b5654e6d53c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ rcgcd-spl-14 rcgcd-spl-14-conversion rcgcrd-spl-4 rcgcrd-spl-4-conversion rclpy ];
+
+  meta = {
+    description = ''GameController-Robot communication in RoboCup SPL at RoboCup2022'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -108,6 +108,8 @@ self: super: {
 
  ament-cpplint = self.callPackage ./ament-cpplint {};
 
+ ament-download = self.callPackage ./ament-download {};
+
  ament-flake8 = self.callPackage ./ament-flake8 {};
 
  ament-index-cpp = self.callPackage ./ament-index-cpp {};
@@ -162,6 +164,8 @@ self: super: {
 
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
 
+ aws-robomaker-small-warehouse-world = self.callPackage ./aws-robomaker-small-warehouse-world {};
+
  backward-ros = self.callPackage ./backward-ros {};
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
@@ -173,6 +177,8 @@ self: super: {
  bond-core = self.callPackage ./bond-core {};
 
  bondcpp = self.callPackage ./bondcpp {};
+
+ boost-geometry-util = self.callPackage ./boost-geometry-util {};
 
  bosch-locator-bridge = self.callPackage ./bosch-locator-bridge {};
 
@@ -186,7 +192,13 @@ self: super: {
 
  can-msgs = self.callPackage ./can-msgs {};
 
+ cartographer = self.callPackage ./cartographer {};
+
+ cartographer-ros = self.callPackage ./cartographer-ros {};
+
  cartographer-ros-msgs = self.callPackage ./cartographer-ros-msgs {};
+
+ cartographer-rviz = self.callPackage ./cartographer-rviz {};
 
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
@@ -352,6 +364,8 @@ self: super: {
 
  filters = self.callPackage ./filters {};
 
+ fluent-rviz = self.callPackage ./fluent-rviz {};
+
  fmi-adapter = self.callPackage ./fmi-adapter {};
 
  fmi-adapter-examples = self.callPackage ./fmi-adapter-examples {};
@@ -384,6 +398,8 @@ self: super: {
 
  gazebo-ros-pkgs = self.callPackage ./gazebo-ros-pkgs {};
 
+ gc-spl-2022 = self.callPackage ./gc-spl-2022 {};
+
  geodesy = self.callPackage ./geodesy {};
 
  geographic-info = self.callPackage ./geographic-info {};
@@ -411,6 +427,8 @@ self: super: {
  gpsd-client = self.callPackage ./gpsd-client {};
 
  graph-msgs = self.callPackage ./graph-msgs {};
+
+ grasping-msgs = self.callPackage ./grasping-msgs {};
 
  grbl-msgs = self.callPackage ./grbl-msgs {};
 
@@ -846,6 +864,10 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ performance-report = self.callPackage ./performance-report {};
+
+ performance-test = self.callPackage ./performance-test {};
+
  performance-test-fixture = self.callPackage ./performance-test-fixture {};
 
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
@@ -928,6 +950,8 @@ self: super: {
 
  quaternion-operation = self.callPackage ./quaternion-operation {};
 
+ r2r-spl-7 = self.callPackage ./r2r-spl-7 {};
+
  radar-msgs = self.callPackage ./radar-msgs {};
 
  random-numbers = self.callPackage ./random-numbers {};
@@ -945,6 +969,14 @@ self: super: {
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
 
  rcdiscover = self.callPackage ./rcdiscover {};
+
+ rcgcd-spl-14 = self.callPackage ./rcgcd-spl-14 {};
+
+ rcgcd-spl-14-conversion = self.callPackage ./rcgcd-spl-14-conversion {};
+
+ rcgcrd-spl-4 = self.callPackage ./rcgcrd-spl-4 {};
+
+ rcgcrd-spl-4-conversion = self.callPackage ./rcgcrd-spl-4-conversion {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -1101,6 +1133,16 @@ self: super: {
  rmw-implementation = self.callPackage ./rmw-implementation {};
 
  rmw-implementation-cmake = self.callPackage ./rmw-implementation-cmake {};
+
+ robot-calibration = self.callPackage ./robot-calibration {};
+
+ robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
+
+ robot-controllers = self.callPackage ./robot-controllers {};
+
+ robot-controllers-interface = self.callPackage ./robot-controllers-interface {};
+
+ robot-controllers-msgs = self.callPackage ./robot-controllers-msgs {};
 
  robot-localization = self.callPackage ./robot-localization {};
 
@@ -1302,6 +1344,10 @@ self: super: {
 
  rqt-topic = self.callPackage ./rqt-topic {};
 
+ rt-manipulators-cpp = self.callPackage ./rt-manipulators-cpp {};
+
+ rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
+
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
 
  rttest = self.callPackage ./rttest {};
@@ -1328,7 +1374,11 @@ self: super: {
 
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
+ sdformat-test-files = self.callPackage ./sdformat-test-files {};
+
  sdl2-vendor = self.callPackage ./sdl2-vendor {};
+
+ self-test = self.callPackage ./self-test {};
 
  sensor-msgs = self.callPackage ./sensor-msgs {};
 
@@ -1358,6 +1408,8 @@ self: super: {
 
  snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
 
+ soccer-interfaces = self.callPackage ./soccer-interfaces {};
+
  soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
  soccer-object-msgs = self.callPackage ./soccer-object-msgs {};
@@ -1373,6 +1425,10 @@ self: super: {
  spacenav = self.callPackage ./spacenav {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ splsm-7 = self.callPackage ./splsm-7 {};
+
+ splsm-7-conversion = self.callPackage ./splsm-7-conversion {};
 
  sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
 
@@ -1492,6 +1548,8 @@ self: super: {
 
  tracetools-acceleration = self.callPackage ./tracetools-acceleration {};
 
+ tracetools-analysis = self.callPackage ./tracetools-analysis {};
+
  tracetools-image-pipeline = self.callPackage ./tracetools-image-pipeline {};
 
  tracetools-launch = self.callPackage ./tracetools-launch {};
@@ -1506,13 +1564,29 @@ self: super: {
 
  turtle-tf2-py = self.callPackage ./turtle-tf2-py {};
 
+ turtlebot3 = self.callPackage ./turtlebot3 {};
+
+ turtlebot3-bringup = self.callPackage ./turtlebot3-bringup {};
+
+ turtlebot3-cartographer = self.callPackage ./turtlebot3-cartographer {};
+
+ turtlebot3-description = self.callPackage ./turtlebot3-description {};
+
+ turtlebot3-example = self.callPackage ./turtlebot3-example {};
+
  turtlebot3-fake-node = self.callPackage ./turtlebot3-fake-node {};
 
  turtlebot3-gazebo = self.callPackage ./turtlebot3-gazebo {};
 
  turtlebot3-msgs = self.callPackage ./turtlebot3-msgs {};
 
+ turtlebot3-navigation2 = self.callPackage ./turtlebot3-navigation2 {};
+
+ turtlebot3-node = self.callPackage ./turtlebot3-node {};
+
  turtlebot3-simulations = self.callPackage ./turtlebot3-simulations {};
+
+ turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
  turtlesim = self.callPackage ./turtlesim {};
 
@@ -1544,11 +1618,25 @@ self: super: {
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
+ ur = self.callPackage ./ur {};
+
+ ur-bringup = self.callPackage ./ur-bringup {};
+
+ ur-calibration = self.callPackage ./ur-calibration {};
+
  ur-client-library = self.callPackage ./ur-client-library {};
+
+ ur-controllers = self.callPackage ./ur-controllers {};
+
+ ur-dashboard-msgs = self.callPackage ./ur-dashboard-msgs {};
 
  ur-description = self.callPackage ./ur-description {};
 
+ ur-moveit-config = self.callPackage ./ur-moveit-config {};
+
  ur-msgs = self.callPackage ./ur-msgs {};
+
+ ur-robot-driver = self.callPackage ./ur-robot-driver {};
 
  urdf = self.callPackage ./urdf {};
 
@@ -1627,6 +1715,8 @@ self: super: {
  yaml-cpp-vendor = self.callPackage ./yaml-cpp-vendor {};
 
  zbar-ros = self.callPackage ./zbar-ros {};
+
+ zenoh-bridge-dds = self.callPackage ./zenoh-bridge-dds {};
 
  zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
 

--- a/distros/humble/grasping-msgs/default.nix
+++ b/distros/humble/grasping-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, moveit-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs }:
+buildRosPackage {
+  pname = "ros-humble-grasping-msgs";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mikeferguson/grasping_msgs-ros2-gbp/archive/release/humble/grasping_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d1782b7c1cd993b36a2a6615c9b79db45608f80c017deabdc313cdfeb9d8da14";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs moveit-msgs rosidl-default-runtime sensor-msgs shape-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages for describing objects and how to grasp them.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "372cbcf1d8c0d3921548778043858da38de8967eaf81402ead95cc5a968ab264";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "9967838cc9fb2e9355fbf2f06c3d84b5a0884da725a6c78701d67dddf4c296d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gscam/default.nix
+++ b/distros/humble/gscam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, class-loader, cv-bridge, gst_all_1, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-gscam";
-  version = "2.0.1-r2";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gscam-release/archive/release/humble/gscam/2.0.1-2.tar.gz";
-    name = "2.0.1-2.tar.gz";
-    sha256 = "0d91a0f8240352258d1870c6ba8884bfa09a075f312672952fd9e41ff5c25ef3";
+    url = "https://github.com/ros2-gbp/gscam-release/archive/release/humble/gscam/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "98ee381e66ca35a2b2b3aa69299e1895641a8115a2c13a3e5a74f58167f7e810";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "db2c35d7f8fb122590fe04aea66852b61e0db92100f35e1912c839c12af74412";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "b0627f785056baa349508378657d4aeda1770eae2bdbd4936cb31dc109180641";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "7fd46ab2223b6eb3a39e46721436938abc07665701634c58a1d73e55fb1ece95";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "3998156b0cca994f2898a3186b3afc5c700e3be4490fe3dd63b14389a5565270";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "88256cae915ac29f3e0207968c41066716fcc42289f8603d7914958dfcc5e4d2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "1b541160c39235c5ae6e9b6342bbd1283def84623e5f3d97d4f2a73e297dc1ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "a77013bc66d6cacb29c1213b492441af1d20691bccd4132026882b309bc3a0df";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "5ed590175c6ddbe4bfc9d280898086330425e92a4141eabbd7836ec4d8c1d730";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/libmavconn/default.nix
+++ b/distros/humble/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-libmavconn";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "1d0c3ac972c444522a8f34433213281142459241ffdd08efbb64c154793502a6";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f3e2ee1bb2f20dbb3756386dfd4035ecc839f98ac2db1df7049c9a3cd3d7c0fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-extras/default.nix
+++ b/distros/humble/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-mavros-extras";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "81cbdf1712f8823c57c506b7d61387a2e412e06d12f22eb54a0d5e85498d878f";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "18e921badf521f08d1160d73258a23ba222e7e0fbd3ff45cc4f48bf5f242ce03";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-msgs/default.nix
+++ b/distros/humble/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros-msgs";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "d6ae8e437cbc0a0a3942757d900707abbf45d956509f93167fc766cd67daba62";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "caf60d83c1ca13f4e5055b5c4cf8a0d8db5b1d8e6ff47f37ce89bbb627ef8c33";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros/default.nix
+++ b/distros/humble/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "8bb43a13864bf2f17eb92f0273ccb77caf76cbca3c65f6ec93b6613eaac8f793";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e5d6df79214074723de321732afa7896b66c00d6d707f1709e0c480b1808714c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/message-filters/default.nix
+++ b/distros/humble/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-filters";
-  version = "4.3.1-r2";
+  version = "4.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.1-2.tar.gz";
-    name = "4.3.1-2.tar.gz";
-    sha256 = "90376526a4760d8d21f2d213adcf45f4fd8b901ccc53177f85dffbab4fcbd58c";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.2-1.tar.gz";
+    name = "4.3.2-1.tar.gz";
+    sha256 = "a741780b7aff3cab204e82c1fe6a13cd366ba6d6936b96c8f6ae6e921fdba3ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-fanuc-description/default.nix
+++ b/distros/humble/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-fanuc-description";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_description/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "3698f8f92f11baf94e2b0e05f9d51ca270d8f699712228e937a77814597ab1c2";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_description/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "00c4614194fe443fc78eb6968211e0bccba534c7b22a09edef23531dc4fa7eae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/humble/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-fanuc-moveit-config";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_moveit_config/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "99c417db0756fa3327c2bcd26d49df138784667c494ea77345d6b18e9f9e99fe";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_moveit_config/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "f97be0485282bc20f319e149ca91eae824090dd1581187eac0351983775f6585";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-panda-description/default.nix
+++ b/distros/humble/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-panda-description";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_description/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "337c928c6409019ba9c179bf018a07d4013a90c4e22ba014e6d969ee37d719ec";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_description/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "20abf19afb6f8721b1b691dd4aec8637716a80391094226cdf4485051676f764";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/humble/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-panda-moveit-config";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_moveit_config/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "6fe7c54f7d01522deac07117f89e7df98f42149ad10e5b14b2abaa083eba6f28";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_moveit_config/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "60ff512e969f1afcddb4a161ebcdffa4b0a224e80be4787e92a1fe14327e1935";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-pr2-description/default.nix
+++ b/distros/humble/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-pr2-description";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_pr2_description/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "3877c469bd09b7d7b6c879db2e64c78c0a02be9028e346c358d2fb22e5852a54";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_pr2_description/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "34fbaedbd5530abdeaf18b293b47c9708e2d92080c04f4123ee5ae8ae736ad7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources/default.nix
+++ b/distros/humble/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "b1f05ec0189cd302672b0b9c8ac5d1e262f8e911427bed04feedce75695dfe22";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "1a2888ac632779eec3e47d3f42f3bd82146e9b1e6a0191054feeb40b8764af77";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-msgs/default.nix
+++ b/distros/humble/mrpt-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/humble/mrpt_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "908ca6ac208252da5fcfcddd76aeb49726a787158aac7bbea90c0aac3d64908e";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/humble/mrpt_msgs/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "2212ce3dea3407855e05d7c4f1b405abe5a245850796abc01b926d8db4f084d3";
   };
 
-  buildType = "cmake";
+  buildType = "ament_cmake";
   buildInputs = [ ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cppcheck ament-cpplint ament-lint-auto ament-lint-cmake ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];

--- a/distros/humble/ntpd-driver/default.nix
+++ b/distros/humble/ntpd-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, poco, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-ntpd-driver";
-  version = "2.1.0-r1";
+  version = "2.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntpd_driver-release/archive/release/humble/ntpd_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b0a540240f8c5f9240cd057fa94e9839dd7e0bf0bc50d3e1a01db7d88779f066";
+    url = "https://github.com/ros2-gbp/ntpd_driver-release/archive/release/humble/ntpd_driver/2.1.0-2.tar.gz";
+    name = "2.1.0-2.tar.gz";
+    sha256 = "682fec236cc686248ffcfe7d5a3f074efa029fcf6859f7f5594e01b4d28fc51a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/orocos-kdl-vendor/default.nix
+++ b/distros/humble/orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, git, orocos-kdl }:
 buildRosPackage {
   pname = "ros-humble-orocos-kdl-vendor";
-  version = "0.2.2-r3";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/orocos_kdl_vendor/0.2.2-3.tar.gz";
-    name = "0.2.2-3.tar.gz";
-    sha256 = "31de19ed029028bdad7eb5c0db32485108e00ba9bdc32dbd06f931659309508b";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/orocos_kdl_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "16b43362fa4ac66f83e3e10f09b4fcfdb994152a8b7e0f0ccd5a10022c0d4696";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/performance-report/default.nix
+++ b/distros/humble/performance-report/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, chromium, performance-test, python3Packages, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-performance-report";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_report/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "dcb7eed87c7a7cc4506451c3aa1e6ee6cfd9baf0eecda56cccc772b1768fa38f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pyyaml pythonPackages.pytest ];
+  propagatedBuildInputs = [ chromium performance-test python3Packages.pandas python3Packages.selenium rclpy ];
+
+  meta = {
+    description = ''Apex.AI performance_test runner, plotter, and reporter'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/performance-test/default.nix
+++ b/distros/humble/performance-test/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-performance-test";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_test/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "86837cb1939cb826de597334ba5d7653deafbcf42a572ab28c7b45406d94ef1e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ osrf-testing-tools-cpp ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing rmw-implementation-cmake ];
+  propagatedBuildInputs = [ rclcpp rmw-implementation rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Tool to test performance of ROS2 and DDS data layers and communication.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.4.4-r1";
+  version = "3.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.4.4-1.tar.gz";
-    name = "3.4.4-1.tar.gz";
-    sha256 = "173036d0104edaaf0e70ddb86cb1dbabcb059874c603d39909b66607c8649b66";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.4.5-1.tar.gz";
+    name = "3.4.5-1.tar.gz";
+    sha256 = "1fc1975a2b35713e13a567fee71991ba735097a94a83c054193c4f2921e719f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-cov-ops/default.nix
+++ b/distros/humble/pose-cov-ops/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-pose-cov-ops";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "47629a776d64c1cf59d61570b18f1fc22fab5a94386f78e19bd4e92006b0fc5e";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "298e0ecc078c61cb172f85f2ef3e326e9803293ec0f7da266e7a8512dbf38504";
   };
 
-  buildType = "cmake";
+  buildType = "ament_cmake";
   buildInputs = [ ament-cmake-xmllint ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common gtest ];
   propagatedBuildInputs = [ geometry-msgs mrpt2 ];

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "47c7f357e5e2a8c453e7984b0d926cf598a0b37a29bb189cbbba26119606fd99";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "1115b85b403054cce853ea461cdf4721c1d150a3cffa6e25473f3092b9d1fe94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pybind11-vendor/default.nix
+++ b/distros/humble/pybind11-vendor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, pybind11 }:
 buildRosPackage {
   pname = "ros-humble-pybind11-vendor";
   version = "2.4.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ pythonPackages.pybind11 ];
+  propagatedBuildInputs = [ pybind11 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/python-orocos-kdl-vendor/default.nix
+++ b/distros/humble/python-orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, orocos-kdl-vendor, pybind11-vendor, python-cmake-module, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-python-orocos-kdl-vendor";
-  version = "0.2.2-r3";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/python_orocos_kdl_vendor/0.2.2-3.tar.gz";
-    name = "0.2.2-3.tar.gz";
-    sha256 = "8568fe986677ac102c94958763484aa46006521329a940aa2a74727da510ef5b";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/python_orocos_kdl_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "72815f58f8cb90a0e7d1c62a6a63a5f86a09bd51addf098d482f6f214becebde";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/r2r-spl-7/default.nix
+++ b/distros/humble/r2r-spl-7/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, splsm-7-conversion }:
+buildRosPackage {
+  pname = "ros-humble-r2r-spl-7";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/r2r_spl_7/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "f1a69085060ca09ac44c27177464c46ff36af826f5468ea55749f34bd9e34457";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ rclpy splsm-7-conversion ];
+
+  meta = {
+    description = ''Robot-To-Robot communication in RoboCup SPL using SPLSM V7'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rcgcd-spl-14-conversion/default.nix
+++ b/distros/humble/rcgcd-spl-14-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rcgcd-spl-14 }:
+buildRosPackage {
+  pname = "ros-humble-rcgcd-spl-14-conversion";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/humble/rcgcd_spl_14_conversion/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "02c1b7e40b784a16574d9a44ba39ae006f5999f6e72d3bfe2855effc42a12424";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct rcgcd-spl-14 ];
+
+  meta = {
+    description = ''Converts RoboCup SPL GameController Data V14 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rcgcd-spl-14/default.nix
+++ b/distros/humble/rcgcd-spl-14/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-rcgcd-spl-14";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/humble/rcgcd_spl_14/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a15dc993030f80c4b4d009d9506fb16bee35b40e39e2199204eb9cd253238d1f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup SPL GameController Data V14 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rcgcrd-spl-4-conversion/default.nix
+++ b/distros/humble/rcgcrd-spl-4-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rcgcrd-spl-4 }:
+buildRosPackage {
+  pname = "ros-humble-rcgcrd-spl-4-conversion";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/humble/rcgcrd_spl_4_conversion/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a6343f4ebbd8d3c5a6dc10d5b0864c79acf266d02adfb6d9baccd6792453b6a2";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct rcgcrd-spl-4 ];
+
+  meta = {
+    description = ''Converts RoboCup SPL GameController Return Data V4 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rcgcrd-spl-4/default.nix
+++ b/distros/humble/rcgcrd-spl-4/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-rcgcrd-spl-4";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gc_spl-release/archive/release/humble/rcgcrd_spl_4/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "7277ccaf67c282aa7347c38ed6b19d6e843e165a99833516789edd565c87eca4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup SPL GameController Return Data V4 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rcss3d-agent-basic/default.nix
+++ b/distros/humble/rcss3d-agent-basic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp-components, rcss3d-agent }:
 buildRosPackage {
   pname = "ros-humble-rcss3d-agent-basic";
-  version = "0.0.7-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/humble/rcss3d_agent_basic/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "2d65714464a0ac3bdc1088f415e7a463bfcc7d687c54464a63f64e61aea6bf2e";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/humble/rcss3d_agent_basic/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "ded0658fe1d76fc73085dbf2b55e56cf7383ca65d073c64cce65e82058821757";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcss3d-agent-msgs/default.nix
+++ b/distros/humble/rcss3d-agent-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rcss3d-agent-msgs";
-  version = "0.0.7-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/humble/rcss3d_agent_msgs/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "4869f307c1fb4abb37e1ffe35a365869efd8ba431d959eb7a6fcfc03c5f870e8";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/humble/rcss3d_agent_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "0c3b009d8c37479415cc2da4b9f4e5ad1a65436a97173c05be01db2ebff302f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcss3d-agent/default.nix
+++ b/distros/humble/rcss3d-agent/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcss3d-agent-msgs }:
 buildRosPackage {
   pname = "ros-humble-rcss3d-agent";
-  version = "0.0.7-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/humble/rcss3d_agent/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "5b1ac0a51fe624f20a516d992eb2f3d99ca3fa6290c96d74b6d6657abda36e5f";
+    url = "https://github.com/ros2-gbp/rcss3d_agent-release/archive/release/humble/rcss3d_agent/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d42fe79013b25837e8955923aed1079cfce2426c321df6ba011ed8e68c388045";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-calibration-msgs/default.nix
+++ b/distros/humble/robot-calibration-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-robot-calibration-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "416c8562484550974e108e3e7c3adcc48f50e2bbde1bf75a843d57ece74e927d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-generators rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for calibrating a robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/robot-calibration/default.nix
+++ b/distros/humble/robot-calibration/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, libyamlcpp, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-robot-calibration";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "61615283317eda03d7dd8cb7955576b5ff1904f58617c476c82610acfa70822d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost eigen ];
+  checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser libyamlcpp moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Calibrate a Robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/robot-controllers-interface/default.nix
+++ b/distros/humble/robot-controllers-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, pluginlib, rclcpp, rclcpp-action, robot-controllers-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-robot-controllers-interface";
+  version = "0.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_interface/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "539295fe2ee86178d68928a34ae807d098a4f8042f28a40b53d0d3e72e44b57c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cpplint ];
+  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-action robot-controllers-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic framework for robot controls.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/robot-controllers-msgs/default.nix
+++ b/distros/humble/robot-controllers-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-robot-controllers-msgs";
+  version = "0.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_msgs/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "f23761f861321bb3f6789c6b817b58182eb8fa0c0915339c374339f8e37b50a0";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-generators rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for use with robot_controllers framework.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/robot-controllers/default.nix
+++ b/distros/humble/robot-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-gtest, angles, control-msgs, geometry-msgs, kdl-parser, nav-msgs, orocos-kdl, pluginlib, rclcpp, rclcpp-action, robot-controllers-interface, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-humble-robot-controllers";
+  version = "0.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "a7889ac9763f3584fb5f992761432247ae72ede182c24083d59223e49a703e43";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cpplint ament-cmake-gtest ];
+  propagatedBuildInputs = [ angles control-msgs geometry-msgs kdl-parser nav-msgs orocos-kdl pluginlib rclcpp rclcpp-action robot-controllers-interface sensor-msgs std-msgs tf2-geometry-msgs tf2-ros trajectory-msgs urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Some basic robot controllers for use with robot_controllers_interface.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ros-image-to-qimage/default.nix
+++ b/distros/humble/ros-image-to-qimage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, qt5, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-image-to-qimage";
-  version = "0.0.2-r3";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_image_to_qimage-release/archive/release/humble/ros_image_to_qimage/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "658c3dd9a7319971d08e2be0b29741c3d799fc62f7a993468ea946dd85061c7f";
+    url = "https://github.com/ros2-gbp/ros_image_to_qimage-release/archive/release/humble/ros_image_to_qimage/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "298b7641924fd579da9ca0592643229beb33470fbd90480b8534a3c96df1cc95";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "a9dff8937f3fece3d79dcd64e6d1ad56efddf690dd664739d494e035774c65d1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "8b48952fb28390d9dd18a01b07445e4bf7964d6896eb438f15c01cf4fa04bc37";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "27a3d386df67ba51a7b925f72d5d8ae98921a95def75c88abd704b2c375b0c17";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "cd8b0f926e36823a7739828e128ea675ff595a7e5e1f3529eac8fea1f57dc294";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "cf414633aea7e946ed6cd052a770d0d953c616102524bbab6ce6d3e196ffb370";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "3df266cd5c34da5b05baf43a8498c7fb7df4f46a6b7d71f00faaa98271c33e8b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "eff612079aedbea08b581ed7d40734dffa12ed52aa43f83dd8ec44e73f8513c8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "1ff31c6221b72986086287985b8b8f02ac3b59ef8d0bdde3e6b0b0dea76dbd61";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "0aa626e6def2795cb60f8b02111bbd333f4929f449816c8296787af729a0a6b2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "2412876bb89624e74e4714386a3cec3af87226a69e4fd7c75c430a49609c75ad";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-image-overlay-layer/default.nix
+++ b/distros/humble/rqt-image-overlay-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, message-filters, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-rqt-image-overlay-layer";
-  version = "0.0.5-r2";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay_layer/0.0.5-2.tar.gz";
-    name = "0.0.5-2.tar.gz";
-    sha256 = "b8dc9346f0cb299558cfa9a8311b693133546b0bc5af24eb81bf32614405b2f9";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay_layer/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "00a8669b2da753054fe1b7080d8ed91376e8f5870dc28b648fe0ce06cf867bcd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-image-overlay/default.nix
+++ b/distros/humble/rqt-image-overlay/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs, theora-image-transport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, compressed-image-transport, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-image-overlay";
-  version = "0.0.5-r2";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay/0.0.5-2.tar.gz";
-    name = "0.0.5-2.tar.gz";
-    sha256 = "c54ff92c70daf979088dfea9a9aba1c0c4054241e53ed9557e05cb1c44d24217";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "f7d4cab6b629671a9a9040a526fd35c57dc326079754986af2fc227ced478f3d";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common std-msgs theora-image-transport ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common compressed-image-transport std-msgs ];
   propagatedBuildInputs = [ image-transport pluginlib qt5.qtbase rclcpp ros-image-to-qimage rqt-gui-cpp rqt-image-overlay-layer ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/rt-manipulators-cpp/default.nix
+++ b/distros/humble/rt-manipulators-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, libyamlcpp, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-humble-rt-manipulators-cpp";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/rt_manipulators_cpp-release/archive/release/humble/rt_manipulators_cpp/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "73bfa412d1d5371ad93e51e3bf60f69c564927c72083089eb304520db4bbb338";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module libyamlcpp yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RT Manipulators C++ Library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rt-manipulators-examples/default.nix
+++ b/distros/humble/rt-manipulators-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rt-manipulators-cpp }:
+buildRosPackage {
+  pname = "ros-humble-rt-manipulators-examples";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/rt_manipulators_cpp-release/archive/release/humble/rt_manipulators_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "20c93e6ae62c7089a508a37243b60017ff27c403f1dc1791499b81d6a2aaa3af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rt-manipulators-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Examples for RT Manipulators C++ Library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/sdformat-test-files/default.nix
+++ b/distros/humble/sdformat-test-files/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-humble-sdformat-test-files";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/sdformat_urdf-release/archive/release/humble/sdformat_test_files/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "864a5bcab04762e47305d3e33b7feb6437e8b79443aad0077fc0ee813350b559";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Example SDFormat XML files for testing tools using hthis format.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/self-test/default.nix
+++ b/distros/humble/self-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-self-test";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "8acb8d00b7710ecd2f1a5e0242c132953f85934edde4f7c41ca39774fbfda3dd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''self_test'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/septentrio-gnss-driver/default.nix
+++ b/distros/humble/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-septentrio-gnss-driver";
-  version = "1.2.1-r1";
+  version = "1.2.2-r5";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "03f75c4ed8a19977ed866245c885f9a70dc4c3f1bde04e567e1319b7931a5e12";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.2.2-5.tar.gz";
+    name = "1.2.2-5.tar.gz";
+    sha256 = "1b42e522477db30b574b2301f5bef310eacdd56a70cbd91261819fccee3c1934";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/simple-launch/default.nix
+++ b/distros/humble/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-simple-launch";
-  version = "1.3.1-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "6f206b0b2cc556f302be38eb11509f0a0b27288cecd72a21302146e2af01d7af";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "323335217360f26bea3981863b5848e0c0c1a953a5441bb2a2a3b8c6e2027c09";
   };
 
   buildType = "ament_python";

--- a/distros/humble/soccer-interfaces/default.nix
+++ b/distros/humble/soccer-interfaces/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, soccer-vision-2d-msgs, soccer-vision-3d-msgs, soccer-vision-attribute-msgs }:
+buildRosPackage {
+  pname = "ros-humble-soccer-interfaces";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/soccer_interfaces-release/archive/release/humble/soccer_interfaces/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "eebcf5e4c80c4f01480092b62b2d478737c77e8c8cc5403e55536dea91f35177";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ soccer-vision-2d-msgs soccer-vision-3d-msgs soccer-vision-attribute-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for soccer-related interfaces'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/soccer-vision-2d-msgs/default.nix
+++ b/distros/humble/soccer-vision-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, soccer-vision-attribute-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-soccer-vision-2d-msgs";
-  version = "0.0.1-r2";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/soccer_interfaces-release/archive/release/humble/soccer_vision_2d_msgs/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "07d07d73a46a91562c7e7f90a0e945900529b652db664270a192ec1d914ae5f0";
+    url = "https://github.com/ros2-gbp/soccer_interfaces-release/archive/release/humble/soccer_vision_2d_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "30318a8f571af873874353c0a07c0a4aca66073eb8043a18ed247c1b5bae30e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/soccer-vision-3d-msgs/default.nix
+++ b/distros/humble/soccer-vision-3d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, soccer-vision-attribute-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-soccer-vision-3d-msgs";
-  version = "0.0.1-r2";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/soccer_interfaces-release/archive/release/humble/soccer_vision_3d_msgs/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "a2e609533da31fd9c973d1084f59eb1fbadae93f1c76728648bbb99053a5df52";
+    url = "https://github.com/ros2-gbp/soccer_interfaces-release/archive/release/humble/soccer_vision_3d_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "2cee361ffc8624a6ff9836b411cba5520a00097b458e3e284c9661897dcc066f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/soccer-vision-attribute-msgs/default.nix
+++ b/distros/humble/soccer-vision-attribute-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-soccer-vision-attribute-msgs";
-  version = "0.0.1-r2";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/soccer_interfaces-release/archive/release/humble/soccer_vision_attribute_msgs/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "7125bbe67762fe27d5f08d27690b9514b9e443f1e55de040cc51129c52b8e5cc";
+    url = "https://github.com/ros2-gbp/soccer_interfaces-release/archive/release/humble/soccer_vision_attribute_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "dbf7fe11d29216fe3df9e25a18acd15628b9337d9ec62e80127dbd5ef1b0f30b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/splsm-7-conversion/default.nix
+++ b/distros/humble/splsm-7-conversion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, splsm-7 }:
+buildRosPackage {
+  pname = "ros-humble-splsm-7-conversion";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/splsm_7_conversion/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "b940f58b8609dd37df707d711db51b2728bf5251b43d5907a0b1b1906b54adc1";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.construct splsm-7 ];
+
+  meta = {
+    description = ''Converts Standard Platform League Standard Message V7 between ROS msg and UDP raw bytes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/splsm-7/default.nix
+++ b/distros/humble/splsm-7/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-splsm-7";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/splsm_7/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8bad0253685ffcfab8dceb6aaa17faffba711e9c5e8bd708060f3a309fbadb3b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RoboCup Standard Platform League Standard Message V7 ROS msg'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/tensorrt-cmake-module/default.nix
+++ b/distros/humble/tensorrt-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-tensorrt-cmake-module";
-  version = "0.0.2-r3";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/humble/tensorrt_cmake_module/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "e2a872466534fab60a991122816f3876aca8ab236d1280d5ddc1cc5840d9bb0d";
+    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/humble/tensorrt_cmake_module/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "88f160087413626acfae816787221f5e9f5afe5b11fb478808645c5892d7f838";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tracetools-analysis/default.nix
+++ b/distros/humble/tracetools-analysis/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, jupyter, python3Packages, pythonPackages, tracetools-read }:
+buildRosPackage {
+  pname = "ros-humble-tracetools-analysis";
+  version = "3.0.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tracetools_analysis-release/archive/release/humble/tracetools_analysis/3.0.0-4.tar.gz";
+    name = "3.0.0-4.tar.gz";
+    sha256 = "f2c261ab9e97233d32ab2c6654fca868fae3ff3a0afb3f3098834816023e4f45";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ jupyter python3Packages.pandas tracetools-read ];
+
+  meta = {
+    description = ''Tools for analysing trace data.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "2471c3a236120f8851ecf9050fcf7d482849215617646de10ce5f62b36f9db20";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "8b33f7304104a367b15a395e4b37c684795ebc17aa7d475233ab04666ad56c6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-bringup/default.nix
+++ b/distros/humble/turtlebot3-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, hls-lfcd-lds-driver, robot-state-publisher, rviz2, turtlebot3-description, turtlebot3-node }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3-bringup";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_bringup/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "a977ec054028a87f8e21ce5e44dae3fe7ffb4e23b78e181644317539075c9c06";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ hls-lfcd-lds-driver robot-state-publisher rviz2 turtlebot3-description turtlebot3-node ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for starting the TurtleBot3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlebot3-cartographer/default.nix
+++ b/distros/humble/turtlebot3-cartographer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cartographer-ros }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3-cartographer";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_cartographer/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "e4c91424a42e773b3f6bf41c56cb43bd4e975ca039cc7a72ae4ea64ab431ef35";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ cartographer-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for cartographer'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlebot3-description/default.nix
+++ b/distros/humble/turtlebot3-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, urdf }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3-description";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_description/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "28ac59116690e5f0c57bde8c74578c1727788dd995cfe207bd65ef93f4ae5db7";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''3D models of the TurtleBot3 for simulation and visualization'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlebot3-example/default.nix
+++ b/distros/humble/turtlebot3-example/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclpy, sensor-msgs, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3-example";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_example/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "22e2c299d1330b74a496a92129cd7821413b02d9fabeb8128680e5c16b753e34";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclpy sensor-msgs turtlebot3-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package provides four basic examples for TurtleBot3 (i.e., interactive marker, object detection, patrol and position control).'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlebot3-navigation2/default.nix
+++ b/distros/humble/turtlebot3-navigation2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3-navigation2";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_navigation2/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "d86c6480db51e1e321baac1d7438d157f1dcb3f8116a478e0a7f23f871c96726";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ nav2-bringup ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for navigation2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlebot3-node/default.nix
+++ b/distros/humble/turtlebot3-node/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, geometry-msgs, message-filters, nav-msgs, rclcpp, rcutils, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3-node";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_node/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "9269171788c34a5a8baa58bc9dc89845520d93da5a40274ef1eaffe263610bb3";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ dynamixel-sdk geometry-msgs message-filters nav-msgs rclcpp rcutils sensor-msgs std-msgs std-srvs tf2 tf2-ros turtlebot3-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TurtleBot3 driver node that include diff drive controller, odometry and tf node'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlebot3-teleop/default.nix
+++ b/distros/humble/turtlebot3-teleop/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3-teleop";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_teleop/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "13b92dbda7241dcaa188416f813bcb14676f8e8abc908d72903d2594a3cc2896";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs rclpy ];
+
+  meta = {
+    description = ''Teleoperation node using keyboard for TurtleBot3.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlebot3/default.nix
+++ b/distros/humble/turtlebot3/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-bringup, turtlebot3-cartographer, turtlebot3-description, turtlebot3-example, turtlebot3-navigation2, turtlebot3-node, turtlebot3-teleop }:
+buildRosPackage {
+  pname = "ros-humble-turtlebot3";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "6d86273def64bcfd3e07449a7662ca9a971abd37be209a327455da3bd0b3b1ec";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ turtlebot3-bringup turtlebot3-cartographer turtlebot3-description turtlebot3-example turtlebot3-navigation2 turtlebot3-node turtlebot3-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 packages for TurtleBot3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-humble-ur-bringup";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "89cde969371cd97f49c2c7f2c5205a1cfbbd87486af8ff835daae57b9d87bbdc";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-manager force-torque-sensor-broadcaster joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros position-controllers rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 ur-controllers ur-description urdf velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Launch file and run-time configurations, e.g. controllers.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
+buildRosPackage {
+  pname = "ros-humble-ur-calibration";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "362da25a0733de4698789b974017ce1530af903a436da4a1a2b15c2f4c261ba1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen libyamlcpp rclcpp ur-client-library ur-robot-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for extracting the factory calibration from a UR robot and change it such that it can be used by ur_description to gain a correct URDF'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ur-controllers";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "e1a7d71f0cc74f090b2240a590c59025f392655edd1c8e4d5c211cf89b4bb54d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ angles controller-interface joint-trajectory-controller lifecycle-msgs pluginlib rclcpp-lifecycle rcutils realtime-tools std-msgs std-srvs ur-dashboard-msgs ur-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides controllers that use the speed scaling interface of Universal Robots.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-ur-dashboard-msgs";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "3a67b8caa676a8cf655e382591b5ffb5397dabc779761f5f40f09d005ca19578";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages around the UR Dashboard server.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
+buildRosPackage {
+  pname = "ros-humble-ur-moveit-config";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "be79389a06449cc4fa5394097f27df4b29f489a6d918f5bdfa08595f833e8dc2";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ launch launch-ros moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-servo moveit-simple-controller-manager rviz2 ur-description urdf warehouse-ros-sqlite xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''An example package with MoveIt2 configurations for UR robots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-humble-ur-robot-driver";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "809dbc94fe918768e37223a25e68334fa6345aad876fefad0eb423b54826819e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ controller-manager controller-manager-msgs force-torque-sensor-broadcaster geometry-msgs hardware-interface joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros pluginlib position-controllers rclcpp rclcpp-lifecycle rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 std-msgs std-srvs tf2-geometry-msgs ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs urdf velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The new driver for Universal Robots UR3, UR5 and UR10 robots with CB3 controllers and the e-series.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
+buildRosPackage {
+  pname = "ros-humble-ur";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c74a81834783f3de0f56f36b7e91e3233085524a4ed61fe6473c3451869d0283";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ur-calibration ur-controllers ur-dashboard-msgs ur-moveit-config ur-robot-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for universal robots'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "ebc3e6610dad424374fd4514ad57c3ffc0e5bc188decfa10eede5ad585628a89";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "89d0d36f6bfcaf5704e8f5e07e6717a6c5e0ff01ede1db07c6d2e5f774a92f99";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zenoh-bridge-dds/default.nix
+++ b/distros/humble/zenoh-bridge-dds/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cargo, clang }:
+buildRosPackage {
+  pname = "ros-humble-zenoh-bridge-dds";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/zenoh_bridge_dds-release/archive/release/humble/zenoh_bridge_dds/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "59d609c97faf07682c563c837f9ae4bbf4f0219a9bbf81c17a919600a40e5abb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ cargo clang ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Bridge between ROS2/DDS and Eclipse zenoh (https://zenoh.io). It allows the integration of zenoh applications with ROS2,
+    or the tunneling of ROS2 communications between nodes via the zenoh protocol at Internet scale.'';
+    license = with lib.licenses; [ "EPL-2.0" asl20 ];
+  };
+}

--- a/distros/melodic/autoware-can-msgs/default.nix
+++ b/distros/melodic/autoware-can-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_can_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "073221a49f18b6ec6f8c9212fbb04e741c50df80a186cc35844a16d15d99fb41";
+    sha256 = "1e50f649b44dc8ad43ccada6bec907f06e81e1568b12ae5141f2e0ff3967f8e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-config-msgs/default.nix
+++ b/distros/melodic/autoware-config-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_config_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "8ddf21ec12618481606bec665161d5baf3000d258ad46e7970ebd38838680f96";
+    sha256 = "d60ba3433659548c626d654074c19395ac5ec153efc98ae862fdd521170a950a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-external-msgs/default.nix
+++ b/distros/melodic/autoware-external-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_external_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "5c63a69ac01afaf5e14e3bafd269dd84cc39da498ec765a90c3c87868a5a4f1a";
+    sha256 = "7c79c2c05eccebce61b3be3fd3c13d440c9014b5e1425d752732ff557e402543";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-lanelet2-msgs/default.nix
+++ b/distros/melodic/autoware-lanelet2-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_lanelet2_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "a7a1ac35c328f23be34a4c3a48dbd7fcf0398469fdef47e0e5e778e0fb5b81ac";
+    sha256 = "499647b4641b7b3894314e2b1855809983b2c25787db20187b41cdb0d2cd5c12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-map-msgs/default.nix
+++ b/distros/melodic/autoware-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "d5fe344b85d8e5b0fc01fc3375a8fb47ef62e04733457d503c142ad059e5f88d";
+    sha256 = "657e98a615e03cabd4a43531f59636f763b69c1ed17e083bdcba0cb54f756967";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-msgs/default.nix
+++ b/distros/melodic/autoware-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "44ecb84a0ea81721e4b7efac8c258bfabfeec1859e081770a6518f8b3bcbd460";
+    sha256 = "565ea9d118130516a2c35ef6a701b65b72ea89941c21349544dc57be3ebe782b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/autoware-system-msgs/default.nix
+++ b/distros/melodic/autoware-system-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/autoware_system_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "38acd44d460adf08104f65df50ca6b1f25ee7d1a09bb9f482700e74e862f2e20";
+    sha256 = "45baf85696feee43e02e8d82ddc2ee9e75199c6996b7635f68c78074be0b25f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/collada-parser/default.nix
+++ b/distros/melodic/collada-parser/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, collada-dom, rosconsole, urdf, urdf-parser-plugin, urdfdom-headers }:
+buildRosPackage {
+  pname = "ros-melodic-collada-parser";
+  version = "1.12.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/collada_urdf-release/archive/release/melodic/collada_parser/1.12.13-1.tar.gz";
+    name = "1.12.13-1.tar.gz";
+    sha256 = "bdcdbf33d3121ac98b74357a573fbb75dec755f579a341aa1ddeaa9bdcd625c9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ urdfdom-headers ];
+  propagatedBuildInputs = [ class-loader collada-dom rosconsole urdf urdf-parser-plugin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a C++ parser for the Collada robot
+    description format. The parser reads a Collada XML robot
+    description, and creates a C++ URDF model. Although it is possible
+    to directly use this parser when working with Collada robot
+    descriptions, the preferred user API is found in the urdf package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/collada-urdf/default.nix
+++ b/distros/melodic/collada-urdf/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, assimp, catkin, cmake-modules, collada-dom, collada-parser, eigen, geometric-shapes, resource-retriever, rosconsole, urdf, urdfdom, urdfdom-headers }:
+buildRosPackage {
+  pname = "ros-melodic-collada-urdf";
+  version = "1.12.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/collada_urdf-release/archive/release/melodic/collada_urdf/1.12.13-1.tar.gz";
+    name = "1.12.13-1.tar.gz";
+    sha256 = "f7d6164dbb2c9a92a9e9c80887c9b78b0cb9160d18273f8a4eba3c0d56eed363";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles cmake-modules eigen ];
+  propagatedBuildInputs = [ assimp collada-dom collada-parser geometric-shapes resource-retriever rosconsole urdf urdfdom urdfdom-headers ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a tool to convert Unified Robot Description Format (URDF) documents into COLLAborative Design Activity (COLLADA) documents.
+
+    Implements robot-specific COLLADA extensions as defined by
+    http://openrave.programmingvision.com/index.php/Started:COLLADA'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "3664e366f7ebd962056f104b284f8933eeee40c14a35371a30e6594c0e014959";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "47858bb6feda73d45f258f788360159c31fdcb1f4547a1324c9a1bc7e402acb1";
   };
 
   buildType = "cmake";

--- a/distros/melodic/er-public-msgs/default.nix
+++ b/distros/melodic/er-public-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-er-public-msgs";
-  version = "1.1.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/enabled-robotics/er_public_msgs-release/archive/release/melodic/er_public_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2972efbea34c8656d0bda3483c2df3365ad0d595d703f71e7a15433981cb7c7c";
+    url = "https://github.com/enabled-robotics/er_public_msgs-release/archive/release/melodic/er_public_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "99d548a04ceb0efb2eb1c6ee68d91041b90e466ff69d71b53e65ffa91b16f860";
   };
 
   buildType = "catkin";

--- a/distros/melodic/euscollada/default.nix
+++ b/distros/melodic/euscollada/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, libyamlcpp, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom }:
+buildRosPackage {
+  pname = "ros-melodic-euscollada";
+  version = "0.4.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/melodic/euscollada/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "66836a2b67d75a93f8b328355c0bef40fd8894e4640f144bd3751c7b36a5f6b6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules mk rosboost-cfg rosbuild ];
+  checkInputs = [ openhrp3 pr2-description roseus ];
+  propagatedBuildInputs = [ assimp-devel collada-dom collada-parser collada-urdf libyamlcpp qhull resource-retriever roscpp rospack rostest tf urdf urdfdom ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''euscollada'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -536,6 +536,10 @@ self: super: {
 
  codec-image-transport = self.callPackage ./codec-image-transport {};
 
+ collada-parser = self.callPackage ./collada-parser {};
+
+ collada-urdf = self.callPackage ./collada-urdf {};
+
  color-util = self.callPackage ./color-util {};
 
  combined-robot-hw = self.callPackage ./combined-robot-hw {};
@@ -959,6 +963,8 @@ self: super: {
  eus-qp = self.callPackage ./eus-qp {};
 
  eus-qpoases = self.callPackage ./eus-qpoases {};
+
+ euscollada = self.callPackage ./euscollada {};
 
  euslime = self.callPackage ./euslime {};
 
@@ -1706,6 +1712,8 @@ self: super: {
 
  jsk-pr2eus = self.callPackage ./jsk-pr2eus {};
 
+ jsk-python-orocos-kdl-python3 = self.callPackage ./jsk-python-orocos-kdl-python3 {};
+
  jsk-recognition = self.callPackage ./jsk-recognition {};
 
  jsk-recognition-msgs = self.callPackage ./jsk-recognition-msgs {};
@@ -1718,7 +1726,11 @@ self: super: {
 
  jsk-teleop-joy = self.callPackage ./jsk-teleop-joy {};
 
+ jsk-tf2-py-python3 = self.callPackage ./jsk-tf2-py-python3 {};
+
  jsk-tilt-laser = self.callPackage ./jsk-tilt-laser {};
+
+ jsk-topic-tools = self.callPackage ./jsk-topic-tools {};
 
  jsk-visualization = self.callPackage ./jsk-visualization {};
 
@@ -2314,13 +2326,11 @@ self: super: {
 
  mrpt1 = self.callPackage ./mrpt1 {};
 
- mrpt-bridge = self.callPackage ./mrpt-bridge {};
-
  mrpt-ekf-slam-2d = self.callPackage ./mrpt-ekf-slam-2d {};
 
  mrpt-ekf-slam-3d = self.callPackage ./mrpt-ekf-slam-3d {};
 
- mrpt-graphslam-2d = self.callPackage ./mrpt-graphslam-2d {};
+ mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};
 
  mrpt-icp-slam-2d = self.callPackage ./mrpt-icp-slam-2d {};
 
@@ -2332,6 +2342,8 @@ self: super: {
 
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
+ mrpt-msgs-bridge = self.callPackage ./mrpt-msgs-bridge {};
+
  mrpt-navigation = self.callPackage ./mrpt-navigation {};
 
  mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
@@ -2339,6 +2351,10 @@ self: super: {
  mrpt-rbpf-slam = self.callPackage ./mrpt-rbpf-slam {};
 
  mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
+
+ mrpt-sensorlib = self.callPackage ./mrpt-sensorlib {};
+
+ mrpt-sensors = self.callPackage ./mrpt-sensors {};
 
  mrpt-slam = self.callPackage ./mrpt-slam {};
 

--- a/distros/melodic/graceful-controller-ros/default.nix
+++ b/distros/melodic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller-ros";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "63b90862eb6f741b80a22886497e5ee11e9f53eb32ba15c492de22b823e2f91b";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "4c7ec4845974f1fd1125416c9af67d0197d19e552ab0a185a26b191123bb0ff5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/graceful-controller/default.nix
+++ b/distros/melodic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "cdcb7159de9367132010c9fa37e919445d4ff265a05b2a296871c1c5e6e07df0";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "44a363a6561d7b3c8a02c94964a19214f508eff1bcbfa07e5fa0bf71642696b9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hri-msgs/default.nix
+++ b/distros/melodic/hri-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hri-msgs";
-  version = "0.5.2-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/melodic/hri_msgs/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "cac21b2c2d95c7e9c5ec331d0d85367c5bcdaea90f25ec964b70657e7226da20";
+    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/melodic/hri_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "3384ce663a164b9d795faedc8135152f3826378f08ccf97348efbbd9612e1d37";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-python-orocos-kdl-python3/default.nix
+++ b/distros/melodic/jsk-python-orocos-kdl-python3/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, orocos-kdl, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-melodic-jsk-python-orocos-kdl-python3";
+  version = "1.4.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/orocos-kdl_python3-release/archive/release/melodic/jsk_python_orocos_kdl_python3/1.4.2-2.tar.gz";
+    name = "1.4.2-2.tar.gz";
+    sha256 = "519c3d3a7ce2739bfedf3b94d39b9b1351c38cfaa3aaddb1a865a23ca5f0b1fe";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ python3Packages.sip_4 ];
+  propagatedBuildInputs = [ catkin orocos-kdl python3 ];
+  nativeBuildInputs = [ catkin python3Packages.catkin-pkg ];
+
+  meta = {
+    description = ''This package contains the python bindings PyKDL for the Kinematics and Dynamics
+    Library (KDL), distributed by the Orocos Project.
+    This repository is for python3 compatibility in melodic environment.
+    Supported by ROS community.'';
+    license = with lib.licenses; [ "LGPL" ];
+  };
+}

--- a/distros/melodic/jsk-tf2-py-python3/default.nix
+++ b/distros/melodic/jsk-tf2-py-python3/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy, tf2 }:
+buildRosPackage {
+  pname = "ros-melodic-jsk-tf2-py-python3";
+  version = "0.6.9-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/geometry2_python3-release/archive/release/melodic/jsk_tf2_py_python3/0.6.9-2.tar.gz";
+    name = "0.6.9-2.tar.gz";
+    sha256 = "b9dcbe07c5e9e519cbb81170f910d4ccc865bee3d180db3862ab4a6fe6398cf6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.rospkg rospy tf2 ];
+  nativeBuildInputs = [ catkin python3Packages.catkin-pkg ];
+
+  meta = {
+    description = ''The tf2_py package for python3 compatibility in melodic environment. Supported by ROS community.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/jsk-topic-tools/default.nix
+++ b/distros/melodic/jsk-topic-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, pythonPackages, roscpp, roscpp-tutorials, roslaunch, roslint, rosnode, rostest, rostime, rostopic, sensor-msgs, sound-play, std-msgs, std-srvs, tf, topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, pythonPackages, roscpp, roscpp-tutorials, roslaunch, roslint, rosnode, rostest, rostime, rostopic, sensor-msgs, sound-play, std-msgs, std-srvs, tf, topic-tools, unixtools }:
 buildRosPackage {
   pname = "ros-melodic-jsk-topic-tools";
-  version = "2.2.11-r1";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/melodic/jsk_topic_tools/2.2.11-1.tar.gz";
-    name = "2.2.11-1.tar.gz";
-    sha256 = "3a62a5dec26eb3aa8de5043dcc0f5318e95f1f7886e8d547e0d39883542b169c";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/melodic/jsk_topic_tools/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "2f7cb216f61223ced93c39253049e49baa9fd4878decdd5d94c80a6ca5f09280";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation rostest ];
   checkInputs = [ roscpp-tutorials roslint ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet pythonPackages.numpy pythonPackages.opencv3 pythonPackages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet pythonPackages.numpy pythonPackages.opencv3 pythonPackages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools unixtools.ping ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/melodic/mrpt-ekf-slam-2d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-rawlog, mrpt1, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-ekf-slam-2d";
-  version = "0.1.10-r1";
+  version = "0.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_ekf_slam_2d/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "51decbfdfc3f8107bec91c24d0525839afadadb3c4252263e6e24eea49c76bb0";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_ekf_slam_2d/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "6d79212d84c0e2cdb8cdfcfd2f16b0a1686692598e8008f34dea7fb120cb7a61";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-rawlog mrpt1 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/melodic/mrpt-ekf-slam-3d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-bridge, mrpt-rawlog, mrpt1, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-ekf-slam-3d";
-  version = "0.1.10-r1";
+  version = "0.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_ekf_slam_3d/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "a2e86b343a30fa5f18bacf864fbdbc0623114a646802dd39fabab40f08ab3535";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_ekf_slam_3d/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "8415b192c8681e63926e8b73938931b29d762b8b32fae88139fd01fb5d13f7de";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure mrpt-bridge mrpt-rawlog mrpt1 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-generic-sensor/default.nix
+++ b/distros/melodic/mrpt-generic-sensor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-sensorlib, mrpt2, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-mrpt-generic-sensor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/melodic/mrpt_generic_sensor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "916c926cdda245d427cb9cf890177ca9d9c0db245b7aacd451c9e78777094d40";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-sensorlib mrpt2 roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for interfacing any sensor supported by mrpt-hwdrivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mrpt-icp-slam-2d/default.nix
+++ b/distros/melodic/mrpt-icp-slam-2d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-rawlog, mrpt1, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-icp-slam-2d";
-  version = "0.1.10-r1";
+  version = "0.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_icp_slam_2d/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "94d220bc8036d748aa9003080ad6a11dc8dd38b039efbd097549075c0146c971";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_icp_slam_2d/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "184bccb5b6188df6fe089f0312c22b7ba313e91bec80ef27d878942786d4cb1e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-rawlog mrpt1 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-local-obstacles/default.nix
+++ b/distros/melodic/mrpt-local-obstacles/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt2, roscpp, sensor-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt2, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-local-obstacles";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_local_obstacles/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "4a2da9e5d359a399bcc0a1f994efb8a16f9be09175fce08ffdc875c0a5522e26";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_local_obstacles/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "3b83801d32ab3cd2a9d4058928f76d41f1745c8a32649aef69b868eeadc3e1b0";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt2 roscpp sensor-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt2 roscpp sensor-msgs tf2 tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-localization/default.nix
+++ b/distros/melodic/mrpt-localization/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-localization";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_localization/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b58e4b2540affcda0127cf95910f82b86e98747186bcd0d9af350dc59966ca34";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_localization/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "b4aa12aa07af68af304861ea58caf7efd1062ba46fea2d37f69e6554dd00623e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-msgs mrpt2 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-map/default.nix
+++ b/distros/melodic/mrpt-map/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mrpt-bridge, mrpt2, nav-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, mrpt2, nav-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-map";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_map/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7af95b573fa3ab1972b6e4ca1b6246c1991a98eff45bb9ba1c4e1b3e46172725";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_map/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "24ef2e1113adfdd73ba8564c967eb127dc979be58553a0446113c1e1188f8692";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mrpt-bridge mrpt2 nav-msgs roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ mrpt2 nav-msgs roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-msgs-bridge/default.nix
+++ b/distros/melodic/mrpt-msgs-bridge/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, marker-msgs, mrpt-msgs, mrpt2, ros-environment, roscpp, tf2 }:
+buildRosPackage {
+  pname = "ros-melodic-mrpt-msgs-bridge";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_msgs_bridge/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "35fe4314b5efcd7172fcad4750d00030e53020644233c9743953f7cb09541f0c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment ];
+  propagatedBuildInputs = [ geometry-msgs marker-msgs mrpt-msgs mrpt2 roscpp tf2 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library to convert between custom mrpt_msgs messages and native MRPT classes'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mrpt-msgs/default.nix
+++ b/distros/melodic/mrpt-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "fc307fe3df5c94c3e163021ccabe4cc435c035e732f200b94ea8967aa72954ee";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/melodic/mrpt_msgs/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "71c42945e7dc24d7a6600f9d069f1657fa5b04ed5e1a7d23c7054e5dc742eb4c";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/mrpt-navigation/default.nix
+++ b/distros/melodic/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-local-obstacles, mrpt-localization, mrpt-map, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-navigation";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_navigation/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "59256dc71fcdaf3d4ea3070a6f811162441316c3bc83f87b501e028456c21d52";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_navigation/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "6d49ff754d1b5169fc887c9982d4619f39d863e48f320e33a1c639cef52cc24b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mrpt-rawlog/default.nix
+++ b/distros/melodic/mrpt-rawlog/default.nix
@@ -2,24 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-rawlog";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_rawlog/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d418ff87ddff3ead415f7c555c2c7ca2caf900f0059d3c2a9be23b3ffb5c1bf7";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_rawlog/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "8f78c6047035c49022fac2b1d7daa4ebab2a6e3294c25fd6b1e62f66f066abfe";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-bridge mrpt-msgs mrpt2 nav-msgs rosbag roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs rosbag roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''This package enables you to record a rawlog from a ROS drive robot.
-  At the moment the package is able to deal with odometry and 2d laser scans.'';
+    description = ''This package provides nodes to record and play MRPT rawlogs.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mrpt-rbpf-slam/default.nix
+++ b/distros/melodic/mrpt-rbpf-slam/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-rawlog, mrpt1, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-rbpf-slam";
-  version = "0.1.10-r1";
+  version = "0.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_rbpf_slam/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "4926983cae5f3691b438d230ed804f213b05adec5ff71abe23ba48b44ac5332c";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_rbpf_slam/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "de2e658b643fe38035439a83db18a58d36f8d4604e8d377a2e0c26cf65b2905e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-rawlog mrpt1 mvsim nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 mvsim nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''This package is used for gridmap SLAM. The interface is similar to gmapping (http://wiki.ros.org/gmapping) but the package supports different particle-filter algorithms, range-only SLAM, can work with several grid maps simultaneously and more.'';
+    description = ''This package is used for gridmap SLAM. The interface is similar to gmapping (https://wiki.ros.org/gmapping) but the package supports different particle-filter algorithms, range-only SLAM, can work with several grid maps simultaneously and more.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mrpt-reactivenav2d/default.nix
+++ b/distros/melodic/mrpt-reactivenav2d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-bridge, mrpt2, roscpp, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt2, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-reactivenav2d";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_reactivenav2d/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "679da45a84c04348062a832fc991de4c3ae33c955ebeae73dec5845a0df39eb4";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_reactivenav2d/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "b0934b30d0c7e715d832d3daabfa32de16ad59b6c21d61e8ba35bcbbd8219e27";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-bridge mrpt2 roscpp tf visualization-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt2 roscpp tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-sensorlib/default.nix
+++ b/distros/melodic/mrpt-sensorlib/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, mrpt-msgs, mrpt2, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mrpt-sensorlib";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/melodic/mrpt_sensorlib/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "a0e9b917797b73226f1b1880273bf7328b88616e9617db3c3882d6f707dc6cb5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime mrpt-msgs mrpt2 roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library for the base generic MRPT sensor node'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mrpt-sensors/default.nix
+++ b/distros/melodic/mrpt-sensors/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-generic-sensor, mrpt-sensorlib }:
+buildRosPackage {
+  pname = "ros-melodic-mrpt-sensors";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/melodic/mrpt_sensors/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "e85fc055d90365682b4d820a786ed4abb82e0e33550712670bb58de14c8ea252";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-generic-sensor mrpt-sensorlib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS nodes for various robotics sensors via mrpt-hwdrivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mrpt-slam/default.nix
+++ b/distros/melodic/mrpt-slam/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-slam";
-  version = "0.1.10-r1";
+  version = "0.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_slam/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "cd4cceb5206c92510212ad222c8d3084d4513fa2426331273b2ed9cf17b17625";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/melodic/mrpt_slam/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "095d88fd8e61c6fd259a94866a6c7945099a3617243cffb6148a44e1ea16a735";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mrpt-ekf-slam-2d mrpt-ekf-slam-3d mrpt-graphslam-2d mrpt-icp-slam-2d mrpt-rbpf-slam ];
+  propagatedBuildInputs = [ mrpt-ekf-slam-2d mrpt-ekf-slam-3d mrpt-icp-slam-2d mrpt-rbpf-slam ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt-tutorials/default.nix
+++ b/distros/melodic/mrpt-tutorials/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-mrpt-tutorials";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_tutorials/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "01d612ea5a187fb104a8d858af95bf27ba9dacdd49f0c6214889e089bd4e80aa";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/melodic/mrpt_tutorials/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d773ba2b3007224578954e4ec26e2d245727851cc4bd89063fbe59a288f0af31";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ teleop-twist-keyboard tf ];
+  propagatedBuildInputs = [ teleop-twist-keyboard tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/nerian-stereo/default.nix
+++ b/distros/melodic/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-nerian-stereo";
-  version = "3.9.1-r1";
+  version = "3.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.9.1-1.tar.gz";
-    name = "3.9.1-1.tar.gz";
-    sha256 = "abba9d9164a09220a25d121267acf7c0409d604e19d2e734d20dace5184ca303";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.10.0-1.tar.gz";
+    name = "3.10.0-1.tar.gz";
+    sha256 = "5fe38746fbafe7c2c9a0d02f81184f9e7706b729ab3b244e99e41cceea49b8ae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.4.3-r1";
+  version = "3.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.3-1.tar.gz";
-    name = "3.4.3-1.tar.gz";
-    sha256 = "e536e5798bca5add4a0ab13c06ba675e107eeae8c3587aab0b355379dcc46e30";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.5-1.tar.gz";
+    name = "3.4.5-1.tar.gz";
+    sha256 = "948274a0d011a24ce56055c64ea5a2b851e4026e6aae35793b28e0962f5469f2";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roslib ];
+  propagatedBuildInputs = [ binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/pose-cov-ops/default.nix
+++ b/distros/melodic/pose-cov-ops/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pose-cov-ops";
-  version = "0.3.2-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ac4c22782f5b83108c80988bd6077869e5c9f88a0aeaabb58dfc3b03e547f71e";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "c0527d339121a324ca1b64e5353d6bd6b24b02a75267ffefe485b8b966a7e125";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
   propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];

--- a/distros/melodic/pr2-controller-interface/default.nix
+++ b/distros/melodic/pr2-controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, pr2-mechanism-model, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-pr2-controller-interface";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_interface/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "5995e8f908240cb86b088e71a7c9a21526ba960e2917341fab816e3a28b19299";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_interface/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "cd8ca8d577d00d71e7dd1a4bd3b922988892b95e14e2c5e49a00e5f2326fad83";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-controller-manager/default.nix
+++ b/distros/melodic/pr2-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, pluginlib, pr2-controller-interface, pr2-description, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model, pr2-mechanism-msgs, realtime-tools, robot-state-publisher, roscpp, roslaunch, rosparam, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pr2-controller-manager";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_manager/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "f7f5a2b6fe73113e955a3dac37499052a0846510f01ab5d6dcc9829c8dea7663";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_controller_manager/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "9651055d1018467c24f5ae4bd31849371199779f3488968dfad85cf994bcd243";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-hardware-interface/default.nix
+++ b/distros/melodic/pr2-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-pr2-hardware-interface";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_hardware_interface/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "9ce45f51e932c93e2b463687e8b2a00756aa97f885b00636c9d2095f9b09b7d6";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_hardware_interface/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "0c5975d128782c1c16eb7423855e0c17f4b317eb8faa67868e126170fdcb8d27";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-mechanism-diagnostics/default.nix
+++ b/distros/melodic/pr2-mechanism-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-msgs, diagnostic-updater, pr2-mechanism-model, pr2-mechanism-msgs, roscpp, rospy, rostest, std-msgs, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-pr2-mechanism-diagnostics";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_diagnostics/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "233eefb27b334851a0fbc9e9d13215934b09f9ba90c7cc304a9188e24f41eea8";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_diagnostics/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "3badb0392210f96cb78d66bbc1b3e6fd5f1d4b07d162612225c02529d66ad395";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-mechanism-model/default.nix
+++ b/distros/melodic/pr2-mechanism-model/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, hardware-interface, kdl-parser, pluginlib, pr2-hardware-interface, roscpp, rostest, rosunit, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pr2-mechanism-model";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_model/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "f241977ea5b1ddc575ca11ead81f5a795c98c7a4258a36fe2c6d83edd1ae2fa9";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism_model/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "b84afbaecefda7be65c217c9af6c759906caf111538828d363877659854903d2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-mechanism/default.nix
+++ b/distros/melodic/pr2-mechanism/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-controller-interface, pr2-controller-manager, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model }:
 buildRosPackage {
   pname = "ros-melodic-pr2-mechanism";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "d9fc465f3077fe29eec22da9d34f1573c8639c010bf1707686b6fde3e233d7a0";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/melodic/pr2_mechanism/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "7b282ac39621bcdf976a9913c0d3308add9e15b15c72be8400308d4fe9951cdb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration-msgs/default.nix
+++ b/distros/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "c56502d5634b26aabfab1a700fa163704139938adfb617975183876517ca5c91";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "17994426e0050496894f53ef412f16f3f7d16fbdade040b0b8b82568d309c16c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration/default.nix
+++ b/distros/melodic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "bc802d9ee3d0dc1dc1737c925e8ac21aee07ff1cdc8a08b49c71b507d33c87e2";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "7fdd451c86b8c47d73377414efa7da84f2a0cb3d8126e59033d1dc38600ed295";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosapi/default.nix
+++ b/distros/melodic/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosapi";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "8dd2d89502c76eb8a847aad9f578066d61f410b80d56e373c009eca14593d480";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "b939e2ea599570df602a3994b0cd7e3555b2b307e147727433141211451a01b9";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   propagatedBuildInputs = [ message-runtime rosbridge-library rosgraph rosnode rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Provides service calls for getting ros meta-information, like list of

--- a/distros/melodic/rosbridge-library/default.nix
+++ b/distros/melodic/rosbridge-library/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, rosunit, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-library";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "bab43201a6930ad627b5d150e943ac8f2bee4872d854a2acc5372abff437a507";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "b7ae2c4e2b41d4252bb47d57064a9e0f4067609f723d75845b06fd7691845481";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest rosunit sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ geometry-msgs message-runtime pythonPackages.bson pythonPackages.future pythonPackages.pillow roscpp rosgraph rospy rosservice rostopic std-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''The core rosbridge package, responsible for interpreting JSON and performing

--- a/distros/melodic/rosbridge-msgs/default.nix
+++ b/distros/melodic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-msgs";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "8daceccd6f43239a3e76d0a360370be56146dcb8c37b4f554b99fc63ca8732ff";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "507e1ede4d358eff7204455099bc2ddc1cb813bc0f5a0b871c253388a59004e9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-server/default.nix
+++ b/distros/melodic/rosbridge-server/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-server";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "d699e369ab5377894f549cc369194340d97185b362a9e685f2ede6d4e9c9fcfc";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "f4930786659ffde8fa7b30bb69093d05be004b59117841f5dd0536471b5a22bc";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ pythonPackages.autobahn pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''A WebSocket interface to rosbridge.'';

--- a/distros/melodic/rosbridge-suite/default.nix
+++ b/distros/melodic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-suite";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "cc42c8d4a63e7fdf1ca54c691cdab84d6807fec6c86845d50d2dcc948c6c0833";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "5692c065bca1dae9c1986bb94afedad08112e8ea21b2c40966551098d46f9887";
   };
 
   buildType = "catkin";

--- a/distros/melodic/septentrio-gnss-driver/default.nix
+++ b/distros/melodic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-septentrio-gnss-driver";
-  version = "1.1.1-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "f1f2e70d210988a9ab33a3ee66081b69dbaf837e2749127a66921db14b60e23a";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "401978f3634233e0e68e0baf91c91a0ee000b27a1ba6bf5fbfdd6b6e29eb3bb0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tablet-socket-msgs/default.nix
+++ b/distros/melodic/tablet-socket-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/tablet_socket_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "c9de9912c721e5d0440d175016ffe402f207fd0f4347aaa2d85a4359d0f40327";
+    sha256 = "46866d3f0916a650ea03de6f93ad4f7488b1c2d79c48bd87112d8c6b04573e1d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/vector-map-msgs/default.nix
+++ b/distros/melodic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "121a81bc986a40e9e83e28737b74241bdf9332c0f95e1ea42c3deb03aeb4a8b7";
+    sha256 = "116c8842e3f610f9c6c59fe5db04d2f6cf998a11fb1f85bcb8748cfe247490ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/amcl/default.nix
+++ b/distros/noetic/amcl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, message-filters, nav-msgs, python3Packages, rosbag, roscpp, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, message-filters, nav-msgs, python3Packages, rosbag, roscpp, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-amcl";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/amcl/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "c3c1da52bed8f467982fc733c2658bbb9997215837ec2aa500121583cff587bd";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/amcl/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "176626de453a712746fd4d999d87fec0529884168f63587fba32bdc9a3a27abb";
   };
 
   buildType = "catkin";
   buildInputs = [ message-filters tf2-geometry-msgs ];
-  checkInputs = [ map-server python3Packages.pykdl rostest ];
+  checkInputs = [ map-server python3Packages.pykdl rostest tf2-py ];
   propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure geometry-msgs nav-msgs rosbag roscpp sensor-msgs std-srvs tf2 tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/autoware-can-msgs/default.nix
+++ b/distros/noetic/autoware-can-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_can_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "f7b4868e4fb6ce3d591b53a3f9e744e9a1a3194ccba26b63dc4540ad5491f0b3";
+    sha256 = "5748fa3830917c00b34adc2d5e3873b259807230d05cd8469ad99ae0a547e6c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-config-msgs/default.nix
+++ b/distros/noetic/autoware-config-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_config_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "eafaea3c8e37f57ddb46a1f4b9cb3152ba49dec22a3cf4b13e538c70c2947ccf";
+    sha256 = "6ed8afd9b570d46d1957fd3aa581d9cc0fc16ada8f3d826c5c488d60957b39a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-external-msgs/default.nix
+++ b/distros/noetic/autoware-external-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_external_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "9e46e8c0fb4b274a632a42d058fe1b33b556a809f602ec8a9567c468c719b2a6";
+    sha256 = "b9437beeb25e6a7ced4e934c7b4f959ddadd62ce1e29c27142f4b693137052be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-lanelet2-msgs/default.nix
+++ b/distros/noetic/autoware-lanelet2-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_lanelet2_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "fa2a058aa23ed50120b0e7ac33a75dfe637ea301578124929ab0126de9f61f43";
+    sha256 = "3c187aaea630f63cb1c0988407ffd065bd2fc5c393e4ca0d27acbad5f2bd8c75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-map-msgs/default.nix
+++ b/distros/noetic/autoware-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "dfea163b4bd892c5a7cbd519885e309449e6a0f21fe088bd91ce9836b0b68247";
+    sha256 = "766ca0323e7e168b4ff3bf6f748df6ebb1dcd55f9e2f76c05138492fa3a59af6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-msgs/default.nix
+++ b/distros/noetic/autoware-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "f445a6713e8764e34e58f34fc1f8ad56637b3699546b7912baba2cd05c7b31ee";
+    sha256 = "c5016d542bf88e545096e2fef89cb49ee05afe6dde62c3da59df33a11d02444f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-system-msgs/default.nix
+++ b/distros/noetic/autoware-system-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_system_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "7bc5e114a49f6224db2da7cba91ce2e05baf589858391e1366616066a8ded740";
+    sha256 = "04c9598cea451a0f0f7aea0480985b8f3d23c89c3bdc50f4596c51b9b5301a1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/base-local-planner/default.nix
+++ b/distros/noetic/base-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, eigen, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, rosconsole, roscpp, rospy, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs, voxel-grid }:
 buildRosPackage {
   pname = "ros-noetic-base-local-planner";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/base_local_planner/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "67075742009295b3faf50b1003c185472ce7ace920d74412b83dafd2c3bfbba5";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/base_local_planner/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "b3c85eea5390620d3a05541e22652a1458925d9adbbbcb5e5cea8edd9251e18e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/boost-plugin-loader/default.nix
+++ b/distros/noetic/boost-plugin-loader/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, gtest, ros-industrial-cmake-boilerplate }:
+buildRosPackage {
+  pname = "ros-noetic-boost-plugin-loader";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tesseract-robotics-release/boost_plugin_loader-release/archive/release/noetic/boost_plugin_loader/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "304122a4b9423b6512662cadb878f0ad355a5574b77b81715302f4349a59018c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Boost plugin loader implementation'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/carrot-planner/default.nix
+++ b/distros/noetic/carrot-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, eigen, nav-core, pluginlib, roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, eigen, nav-core, pluginlib, roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-carrot-planner";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/carrot_planner/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "193637bdfaa2a703f05a4d0e68ff02e5cf937d5860974315054792535e922809";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/carrot_planner/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "4b97d1b64c80686f5e27d0bc312f2cdc1cc158bc6cf25b15c4d8489fdb7b7f73";
   };
 
   buildType = "catkin";
   buildInputs = [ tf2-geometry-msgs ];
-  propagatedBuildInputs = [ base-local-planner costmap-2d eigen nav-core pluginlib roscpp tf2 tf2-ros ];
+  propagatedBuildInputs = [ angles base-local-planner costmap-2d eigen nav-core pluginlib roscpp tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/clear-costmap-recovery/default.nix
+++ b/distros/noetic/clear-costmap-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, eigen, nav-core, pluginlib, roscpp, rostest, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-clear-costmap-recovery";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/clear_costmap_recovery/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "19ba82e12b6d0282e13403cf382f42eaf9bbcfd5474740ff0094e85609676f06";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/clear_costmap_recovery/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "332dce9e91e3da8c242b94d812cb29f488403bdc5febab4ab4b52c8e6bcc6948";
   };
 
   buildType = "catkin";

--- a/distros/noetic/collada-parser/default.nix
+++ b/distros/noetic/collada-parser/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, collada-dom, rosconsole, urdf, urdf-parser-plugin, urdfdom-headers }:
+buildRosPackage {
+  pname = "ros-noetic-collada-parser";
+  version = "1.12.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/collada_urdf-release/archive/release/noetic/collada_parser/1.12.13-1.tar.gz";
+    name = "1.12.13-1.tar.gz";
+    sha256 = "a8f581653cdb7959042888e450bb0a814e1fe99cd3e1e9e608c35bddcce78712";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ urdfdom-headers ];
+  propagatedBuildInputs = [ class-loader collada-dom rosconsole urdf urdf-parser-plugin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a C++ parser for the Collada robot
+    description format. The parser reads a Collada XML robot
+    description, and creates a C++ URDF model. Although it is possible
+    to directly use this parser when working with Collada robot
+    descriptions, the preferred user API is found in the urdf package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/collada-urdf/default.nix
+++ b/distros/noetic/collada-urdf/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, assimp, catkin, cmake-modules, collada-dom, collada-parser, eigen, geometric-shapes, resource-retriever, rosconsole, urdf, urdfdom, urdfdom-headers }:
+buildRosPackage {
+  pname = "ros-noetic-collada-urdf";
+  version = "1.12.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/collada_urdf-release/archive/release/noetic/collada_urdf/1.12.13-1.tar.gz";
+    name = "1.12.13-1.tar.gz";
+    sha256 = "779ef6779c062cc025f262cc360e4a5ece09203a3bc30e4d754a22148dfdd265";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles cmake-modules eigen ];
+  propagatedBuildInputs = [ assimp collada-dom collada-parser geometric-shapes resource-retriever rosconsole urdf urdfdom urdfdom-headers ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a tool to convert Unified Robot Description Format (URDF) documents into COLLAborative Design Activity (COLLADA) documents.
+
+    Implements robot-specific COLLADA extensions as defined by
+    http://openrave.programmingvision.com/index.php/Started:COLLADA'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/costmap-2d/default.nix
+++ b/distros/noetic/costmap-2d/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, geometry-msgs, laser-geometry, map-msgs, map-server, message-filters, message-generation, message-runtime, nav-msgs, pluginlib, rosbag, rosconsole, roscpp, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs, voxel-grid }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen, geometry-msgs, laser-geometry, map-msgs, map-server, message-filters, message-generation, message-runtime, nav-msgs, pluginlib, rosbag, rosconsole, roscpp, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs, voxel-grid }:
 buildRosPackage {
   pname = "ros-noetic-costmap-2d";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/costmap_2d/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "41e3539a9e75d2ac7ed492e115128f999bf108a7ea29a7c60ac26426c7edd537";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/costmap_2d/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "9006e8366006566d6f5a859dbd972c4a572cd5723ed01cb125436d7da37e2d7a";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules message-generation tf2-geometry-msgs tf2-sensor-msgs ];
   checkInputs = [ map-server rosbag rostest rosunit ];
-  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs laser-geometry map-msgs message-filters message-runtime nav-msgs pluginlib rosconsole roscpp rostest sensor-msgs std-msgs tf2 tf2-ros visualization-msgs voxel-grid ];
+  propagatedBuildInputs = [ dynamic-reconfigure eigen geometry-msgs laser-geometry map-msgs message-filters message-runtime nav-msgs pluginlib rosconsole roscpp rostest sensor-msgs std-msgs tf2 tf2-ros visualization-msgs voxel-grid ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dwa-local-planner/default.nix
+++ b/distros/noetic/dwa-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, eigen, nav-core, nav-msgs, pluginlib, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-dwa-local-planner";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/dwa_local_planner/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "7cddc2ccdf4053cd6290ab5d912dad9352989db2ecd52d8a41ae7713b7fea0d6";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/dwa_local_planner/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "7a33aea335a10418c1df4816fbfc210c423151784bec50aad9c749d580b8d737";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "c56ab85eaf5e7c4a0895b548aeccc81c210cca1e9ccd5fca9e4c4179bce1f23d";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "20f26008a32add65e560c36ba04ca221c7d96025e9828f4d52a291b6dd86e1a2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/er-public-msgs/default.nix
+++ b/distros/noetic/er-public-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-er-public-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/enabled-robotics/er_public_msgs-release/archive/release/noetic/er_public_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "8b3a5ea6bd66d117c64698d536344509f4c399541dc22f7b55d967a407ad2c4a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Enabled Robotics public messages package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/euscollada/default.nix
+++ b/distros/noetic/euscollada/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, libyamlcpp, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom }:
+buildRosPackage {
+  pname = "ros-noetic-euscollada";
+  version = "0.4.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "6f2a764637787cb278ad506b5d7207109c6b3e5e87a498d71453cdf9c1b1cb7a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules mk rosboost-cfg rosbuild ];
+  checkInputs = [ openhrp3 pr2-description roseus ];
+  propagatedBuildInputs = [ assimp-devel collada-dom collada-parser collada-urdf libyamlcpp qhull resource-retriever roscpp rospack rostest tf urdf urdfdom ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''euscollada'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fake-localization/default.nix
+++ b/distros/noetic/fake-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, geometry-msgs, message-filters, nav-msgs, rosconsole, roscpp, rospy, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-fake-localization";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/fake_localization/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "5b385408855c4d724fd7f63b76bea87f4f792a1e87814c175bd305556e1db6fd";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/fake_localization/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "62fbd3a17ce0c0fa5dabc97dbbef09ae8f24315544d01a76910bb5a8f06b4ad4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-msgs/default.nix
+++ b/distros/noetic/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "c6643f8a3f6c772b1b6049af88567e15001fe53e75e37ce1b289dbe0a137daea";
+    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "1c6e26e9ae43492fa69865d5ccccdea346c5121a80bc6c017cddc2a49c50a951";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -126,6 +126,8 @@ self: super: {
 
  bondpy = self.callPackage ./bondpy {};
 
+ boost-plugin-loader = self.callPackage ./boost-plugin-loader {};
+
  boost-sml = self.callPackage ./boost-sml {};
 
  bosch-locator-bridge = self.callPackage ./bosch-locator-bridge {};
@@ -433,6 +435,10 @@ self: super: {
  code-coverage = self.callPackage ./code-coverage {};
 
  codec-image-transport = self.callPackage ./codec-image-transport {};
+
+ collada-parser = self.callPackage ./collada-parser {};
+
+ collada-urdf = self.callPackage ./collada-urdf {};
 
  color-util = self.callPackage ./color-util {};
 
@@ -774,6 +780,8 @@ self: super: {
 
  end-effector = self.callPackage ./end-effector {};
 
+ er-public-msgs = self.callPackage ./er-public-msgs {};
+
  ergodic-exploration = self.callPackage ./ergodic-exploration {};
 
  ethercat-grant = self.callPackage ./ethercat-grant {};
@@ -783,6 +791,8 @@ self: super: {
  ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
 
  eus-assimp = self.callPackage ./eus-assimp {};
+
+ euscollada = self.callPackage ./euscollada {};
 
  euslime = self.callPackage ./euslime {};
 
@@ -1063,6 +1073,8 @@ self: super: {
  gmcl = self.callPackage ./gmcl {};
 
  goal-passer = self.callPackage ./goal-passer {};
+
+ gpio-controller = self.callPackage ./gpio-controller {};
 
  gpp-interface = self.callPackage ./gpp-interface {};
 
@@ -1734,6 +1746,8 @@ self: super: {
 
  mikrotik-swos-tools = self.callPackage ./mikrotik-swos-tools {};
 
+ mimic-joint-controller = self.callPackage ./mimic-joint-controller {};
+
  mini-maxwell = self.callPackage ./mini-maxwell {};
 
  mir-actions = self.callPackage ./mir-actions {};
@@ -1872,7 +1886,7 @@ self: super: {
 
  mqtt-client = self.callPackage ./mqtt-client {};
 
- mrpt-bridge = self.callPackage ./mrpt-bridge {};
+ mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};
 
  mrpt-local-obstacles = self.callPackage ./mrpt-local-obstacles {};
 
@@ -1882,11 +1896,17 @@ self: super: {
 
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
+ mrpt-msgs-bridge = self.callPackage ./mrpt-msgs-bridge {};
+
  mrpt-navigation = self.callPackage ./mrpt-navigation {};
 
  mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
 
  mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
+
+ mrpt-sensorlib = self.callPackage ./mrpt-sensorlib {};
+
+ mrpt-sensors = self.callPackage ./mrpt-sensors {};
 
  mrpt-tutorials = self.callPackage ./mrpt-tutorials {};
 
@@ -3145,6 +3165,8 @@ self: super: {
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  tello-driver = self.callPackage ./tello-driver {};
+
+ tesseract-collision = self.callPackage ./tesseract-collision {};
 
  tesseract-common = self.callPackage ./tesseract-common {};
 

--- a/distros/noetic/global-planner/default.nix
+++ b/distros/noetic/global-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-core, nav-msgs, navfn, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-global-planner";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/global_planner/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "46208b4e5eea1e5f52c8aaf2ec09a684debb2d4b5600766ec2442caf85357a4e";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/global_planner/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "feb8a04bb141d5f90d4e2e0985845b15fcbbe9c66c122c85deeb07a1535f827e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gpio-controller/default.nix
+++ b/distros/noetic/gpio-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-gpio-controller";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/gpio_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "6e41a2493b047162393cf144c616cfcc5875fd3eb7f4369ded498abde3b23781";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The gpio_controller package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/graceful-controller-ros/default.nix
+++ b/distros/noetic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller-ros";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "f72edbfa7a0dd5a22e30194a5a040a51c424d25a36e882547b55f3967e6b8315";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "a45b8cccba427db5a9b267b01815424c13fc32861634149473941a8d7a1cc701";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller/default.nix
+++ b/distros/noetic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "f32d7af9a5f1d8acaef59eec3f9ed9f2221fa8ae43f318c3769961c69bfa54a9";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "9d021f2438fc3baf92eced76f0bdc7bfae43187403f9cf937b34b0ab398a49ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/grepros/default.nix
+++ b/distros/noetic/grepros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, python3Packages, rosbag, roslib, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-grepros";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/suurjaak/grepros-release/archive/release/noetic/grepros/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "481d6e759580e9469e789ed1d04fca46c2b6ea7578e7afedb3c0c008dd806a33";
+    url = "https://github.com/suurjaak/grepros-release/archive/release/noetic/grepros/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "6d40147184d6eaff7b1912ca40cfed946127325c81c5cb00769e0619b5abc04d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hri-msgs/default.nix
+++ b/distros/noetic/hri-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hri-msgs";
-  version = "0.5.2-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "f8a10c45b41a78bc11d2eec3ae1b11667eae0a8b6a5f26df56ad473ce133f752";
+    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "3cef50ee325c9408c0d6254a31653cc9131074cef9085863334b3f60eb7b649c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-control/default.nix
+++ b/distros/noetic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-husky-control";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "9966a4304e61c68b5d2056d5fb94460bd80ffcaa750f76985792f1387337db79";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "b28c657882d0d212dd5bf7ef2ea6c62a108d1d183efee115379a16f4e8af427e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-description/default.nix
+++ b/distros/noetic/husky-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flir-camera-description, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, fath-pivot-mount-description, flir-camera-description, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-husky-description";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "370ca36ae053b2c82658b56e94d96ed8d7cfbf620aab1a8fd151391ff766641d";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "56955e5ac78346b7457af21dc026a3a0062d97cd17cc4a115653374e1846d69d";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ flir-camera-description lms1xx realsense2-description urdf velodyne-description xacro ];
+  propagatedBuildInputs = [ fath-pivot-mount-description flir-camera-description lms1xx realsense2-description urdf velodyne-description xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/husky-desktop/default.nix
+++ b/distros/noetic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-noetic-husky-desktop";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "34ea1bf27ab789439da80491dffb9edb825c72cf91b10a1b3893f8240fd2a28a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "9a693e4e1b5d25ee4c9a3dfe7e47e3390ded21e0b11b8ed7b43d315256f0f36b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-gazebo/default.nix
+++ b/distros/noetic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-husky-gazebo";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "5f61a79cf313359e882853e9c36d3787d3ca5785e26d6f1ea2580a9c8da01032";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "5926be296e854845807759aa7d4bcf82d0dce50dbc5e6440ad76de4e6770c04c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-msgs/default.nix
+++ b/distros/noetic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-husky-msgs";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "0a28e9b15d0fc29732c086911837fd69c8e86fe4b6251f569756d7654f8b09a2";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "f9a8be02d8b0aa7ca89e320b12cb68a41c1b739b899dafe723567133c48c09ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-navigation/default.nix
+++ b/distros/noetic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-husky-navigation";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "e9b274a28c8f9dd20c145e2d0be3a4d12ad5625c89c35a461577be4776ec7969";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "f42177d10e0d70c81c4c4c043845bf3f96436acf1964f61ed15eaeade972d0e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-simulator/default.nix
+++ b/distros/noetic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-noetic-husky-simulator";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "96c15f21e9674dac759904c2d81d957d126c7def7e1edf95f27634b8ea901310";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "27a2b13ce85c3e67f7e5fc76bf00fe6bd018a305247fd0296be8aa98fd205acb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-viz/default.nix
+++ b/distros/noetic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-noetic-husky-viz";
-  version = "0.6.3-r1";
+  version = "0.6.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "8096e5f4f238880e988801f59af0491269696faa21d62669c7dce305601d2eb2";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "f9d79a8cd265776bb11268711852415e4cb0441a21340882ef7cb3cb33a07fd7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-server/default.nix
+++ b/distros/noetic/map-server/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, SDL, SDL_image, bullet, catkin, libyamlcpp, nav-msgs, roscpp, rospy, rostest, rosunit, tf2 }:
+{ lib, buildRosPackage, fetchurl, SDL, SDL_image, bullet, catkin, libyamlcpp, nav-msgs, roscpp, roslib, rospy, rostest, rosunit, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-map-server";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/map_server/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "273158150e0511c75e0e4896d68fc99eeb314c87c9d5923d441a47a450340f8d";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/map_server/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "2aba872bfa613a6f0b91cfe7005e168c82919e3d38c6c6330f8bab2c2b028b82";
   };
 
   buildType = "catkin";
-  checkInputs = [ rospy rostest rosunit ];
+  checkInputs = [ roslib rospy rostest rosunit ];
   propagatedBuildInputs = [ SDL SDL_image bullet libyamlcpp nav-msgs roscpp tf2 ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/mimic-joint-controller/default.nix
+++ b/distros/noetic/mimic-joint-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-mimic-joint-controller";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/mimic_joint_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "b3eedf1cfefd8d05f5a2a9ab7c40c9c87fc6a2208da6f3cb46c71322e306e170";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface hardware-interface pluginlib roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mimic_joint_controller package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/move-base/default.nix
+++ b/distros/noetic/move-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, base-local-planner, catkin, clear-costmap-recovery, cmake-modules, costmap-2d, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-core, nav-msgs, navfn, pluginlib, roscpp, rospy, rotate-recovery, std-srvs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-move-base";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/move_base/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "da7d138060b080425bd0dde2569aa1c4dbfc03c41137e655da956c1145e968e5";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/move_base/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "9d46fc421767d28c64b66649fb743fb371d371d54f4678aa4309dca75c8dd453";
   };
 
   buildType = "catkin";

--- a/distros/noetic/move-slow-and-clear/default.nix
+++ b/distros/noetic/move-slow-and-clear/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, geometry-msgs, nav-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-move-slow-and-clear";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/move_slow_and_clear/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "0b838414f4c7d8a9bf703ad2839bc84f683c3f30f94e9ad1b103714ee8c39013";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/move_slow_and_clear/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "40d597dddc79fa8f15830ade5bbee6f1f72cb748bde6795eb987a1073cbb353c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-generic-sensor/default.nix
+++ b/distros/noetic/mrpt-generic-sensor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-sensorlib, mrpt2, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-generic-sensor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_generic_sensor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "99619824bb7ebfde60c350946ed3ec9693c59691963aa845afbe57af433dab24";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-sensorlib mrpt2 roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for interfacing any sensor supported by mrpt-hwdrivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-local-obstacles/default.nix
+++ b/distros/noetic/mrpt-local-obstacles/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt2, roscpp, sensor-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt2, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-local-obstacles";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c5c40f46c0e038cbff0acfbe206d2b43d43a3ee2606acf02ca3d6c5489e72c92";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "9503be42ae3e96ae3b2a56ed3bedf01d1df1d039ca3fd9ccfae8f3793fbef07c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt2 roscpp sensor-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt2 roscpp sensor-msgs tf2 tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-localization/default.nix
+++ b/distros/noetic/mrpt-localization/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-localization";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "4f2bbe76c3d9c30e1134e0673d65f2875eabdc5313139df5d2fd37c23018c5d3";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "a914b6aed98ee95d00e2f4633742f9583f33411870a700be25f6eccfbc6e48e7";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-bridge mrpt-msgs mrpt2 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-map/default.nix
+++ b/distros/noetic/mrpt-map/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mrpt-bridge, mrpt2, nav-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, mrpt2, nav-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-map";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e4e657ac8765764b6f8efd661d66102e91391a15cb3655d87b01981799e5e7c0";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "9fcc7b62c1c398b76086ffebfff86a10bce18cfe9dda5df3703a0f5fe6266fd2";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mrpt-bridge mrpt2 nav-msgs roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ mrpt2 nav-msgs roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-msgs-bridge/default.nix
+++ b/distros/noetic/mrpt-msgs-bridge/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, marker-msgs, mrpt-msgs, mrpt2, ros-environment, roscpp, tf2 }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-msgs-bridge";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_msgs_bridge/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f6c355b4d13d3b99100526b9d29a85e7be079b0c09b8620c5da2911844a77b05";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment ];
+  propagatedBuildInputs = [ geometry-msgs marker-msgs mrpt-msgs mrpt2 roscpp tf2 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library to convert between custom mrpt_msgs messages and native MRPT classes'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-msgs/default.nix
+++ b/distros/noetic/mrpt-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "57974058d5f4a98b8c9bfc7866bde56095a3d186b5e2edc20bdf1d50bbc6bbae";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "28ed29f25f7680e838c0d3066e6e3a3ed0c673e1efa590eba163e380299a125b";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/noetic/mrpt-navigation/default.nix
+++ b/distros/noetic/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-local-obstacles, mrpt-localization, mrpt-map, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-navigation";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "576a3f8930809254bec26794f2a5b53957fb644973dbe1d0adfed70c3ac6d143";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "dcdb033ee157f532cb51e3c945b9c8e23a7964a9f411495944dcf279c94d0ae9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-rawlog/default.nix
+++ b/distros/noetic/mrpt-rawlog/default.nix
@@ -2,24 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rawlog";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d7fb9297a5262abbf3b4134468e1d7dc3b295e9dceb65cb229218c71b7e2aba3";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "69e6a8aa77ffc0db373e8878ebba3b32a118ea4df86efbe7918340e954b21afe";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-bridge mrpt-msgs mrpt2 nav-msgs rosbag roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs rosbag roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''This package enables you to record a rawlog from a ROS drive robot.
-  At the moment the package is able to deal with odometry and 2d laser scans.'';
+    description = ''This package provides nodes to record and play MRPT rawlogs.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/mrpt-reactivenav2d/default.nix
+++ b/distros/noetic/mrpt-reactivenav2d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-bridge, mrpt2, roscpp, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt2, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-reactivenav2d";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "cf9a3bfeb2dd0cea18fc6285c63299860a3773b393b5ee3a808e69d0dfe8ba78";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "234c6fae02512b5a0dfe33fc3e89ec70284294ea12d0388590e206a32d584e19";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-bridge mrpt2 roscpp tf visualization-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt2 roscpp tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-sensorlib/default.nix
+++ b/distros/noetic/mrpt-sensorlib/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, mrpt-msgs, mrpt2, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-sensorlib";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensorlib/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "c70391dffc776e5b5cdac8106d8829aaa22d1b62c3a73c60027e348f3e828d7a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime mrpt-msgs mrpt2 roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library for the base generic MRPT sensor node'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-sensors/default.nix
+++ b/distros/noetic/mrpt-sensors/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-generic-sensor, mrpt-sensorlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-sensors";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensors/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "0af2934a0866238496c073ca88e5a5e9735730bfffab2b75e5dbfdbd2c286bef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-generic-sensor mrpt-sensorlib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS nodes for various robotics sensors via mrpt-hwdrivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-tutorials/default.nix
+++ b/distros/noetic/mrpt-tutorials/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-tutorials";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ce65c0e46bbcad164c62f87d9441a5a242a1d733296acc750deaf56053468818";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "b6a8337039fdf84f0c3d01e4e65c26fc7f8feaab900e75511dbc15c70a652b21";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ teleop-twist-keyboard tf ];
+  propagatedBuildInputs = [ teleop-twist-keyboard tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/nav-core/default.nix
+++ b/distros/noetic/nav-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-nav-core";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/nav_core/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "f735e3cace9b61e0810a288235ddfe9c98c999a1aa854c365b08076057c9b1a0";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/nav_core/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "319e2bcb324f9229899c41944ca013d64c1f0d4adaff84a3c53aa7651816fadd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/navfn/default.nix
+++ b/distros/noetic/navfn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, netpbm, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-navfn";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/navfn/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "fbba051fa9405f7f45f1a3d0f2b6b1872b56ddff4b3dfcbd283d51e2eded1176";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/navfn/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "fcc0b0ec8831039cf46378d4bbace12deada0099b5e158904a2055bdeebf7b9b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/navigation/default.nix
+++ b/distros/noetic/navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, carrot-planner, catkin, clear-costmap-recovery, costmap-2d, dwa-local-planner, fake-localization, global-planner, map-server, move-base, move-base-msgs, move-slow-and-clear, nav-core, navfn, rotate-recovery, voxel-grid }:
 buildRosPackage {
   pname = "ros-noetic-navigation";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/navigation/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "4115399b1b834cc194d48d0cd27645cb0378f0f977b58364a56a3289ac63f855";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/navigation/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "f9ad7c4bf14a54f994acb35405495d488d3b38001e46c29c1674898d81d368d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nerian-stereo/default.nix
+++ b/distros/noetic/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-nerian-stereo";
-  version = "3.9.1-r1";
+  version = "3.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/noetic/nerian_stereo/3.9.1-1.tar.gz";
-    name = "3.9.1-1.tar.gz";
-    sha256 = "945a07fb5c85e0c49c8197a74a3d11971469e263ff82ee3d1f765161e1dd9f52";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/noetic/nerian_stereo/3.10.0-1.tar.gz";
+    name = "3.10.0-1.tar.gz";
+    sha256 = "f5772a719bfa7ac6aaad47c7f2af549a1b572c32f7ee09d803b490d589d68e77";
   };
 
   buildType = "catkin";

--- a/distros/noetic/opw-kinematics/default.nix
+++ b/distros/noetic/opw-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
 buildRosPackage {
   pname = "ros-noetic-opw-kinematics";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "562983049818dbdb37ad49078e881bc6b68c61151a2507cc5bb7728b55f9160d";
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "35e451e0bfdafa08c2c3aa83707151fa50b268218acc0fb200b162390d061eea";
   };
 
   buildType = "cmake";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.4.3-r1";
+  version = "3.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.3-1.tar.gz";
-    name = "3.4.3-1.tar.gz";
-    sha256 = "6ab175c195eb7bf73cdc1bf2761e92f225d28568bc70b20eaca3f7c3541e88d1";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.5-1.tar.gz";
+    name = "3.4.5-1.tar.gz";
+    sha256 = "963ee8025d8304980ba6265d9ce86264e0130a120860f7d5ebaff4aa6ae859f4";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roslib ];
+  propagatedBuildInputs = [ binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-pose-cov-ops";
-  version = "0.3.2-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "a39bd4d3350f24be404f95c4e4e524b4dfa68cc05aa67f6bf0152d1286daa921";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "8c9cb108156d3ba5c46ef86f43d42991d395256c10b0cd06fcf04a7d42b777eb";
   };
 
-  buildType = "cmake";
+  buildType = "catkin";
   buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
   propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];

--- a/distros/noetic/pr2-controller-interface/default.nix
+++ b/distros/noetic/pr2-controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, pr2-mechanism-model, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-pr2-controller-interface";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_interface/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "342a638061f38dae1fafd79fdfb455d8e72bf18baf33f8da65e8c2921b90aadf";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_interface/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "df620b6b8c062ebddcc12df1b44e4f8f68ccde059936d8ac3c7a3be9f9edce67";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-controller-manager/default.nix
+++ b/distros/noetic/pr2-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, pluginlib, pr2-controller-interface, pr2-description, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model, pr2-mechanism-msgs, realtime-tools, robot-state-publisher, roscpp, roslaunch, rosparam, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pr2-controller-manager";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_manager/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "72589694697a9398ef49985c274570dabe03428f2595844565e4903ca2be9315";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_controller_manager/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "7ee04c0a574c04e73efba92a61e9d62cc44916ea119873ba1de723f49dd4f791";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-hardware-interface/default.nix
+++ b/distros/noetic/pr2-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-pr2-hardware-interface";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_hardware_interface/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "73009b090f3fb86f9d2a2b888711cca808fcfa69b2d867feb3c46005b43cd3d2";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_hardware_interface/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "49586d13272ba7514ab047b8f34173b27271b3bb675e3d1fa52787ce3b66d4cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-mechanism-diagnostics/default.nix
+++ b/distros/noetic/pr2-mechanism-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-msgs, diagnostic-updater, pr2-mechanism-model, pr2-mechanism-msgs, roscpp, rospy, rostest, std-msgs, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-pr2-mechanism-diagnostics";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_diagnostics/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "de4e8793e5c1bd642890966d940651c6c80d5245106228ee6a8917041b5d682c";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_diagnostics/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "8ba0687a92fb5bf9db20ddf18f6a9fb7c0d14bbf6c5772e7237e1b1079facaa0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-mechanism-model/default.nix
+++ b/distros/noetic/pr2-mechanism-model/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, hardware-interface, kdl-parser, pluginlib, pr2-hardware-interface, roscpp, rostest, rosunit, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pr2-mechanism-model";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_model/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "d0666b26576067e36060036a57987b3488edde73c3c9b04ed95d8e5bc0d667f4";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism_model/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "96f55706f4dd71093d8d87651c7856c80319051eec1fd3434b249c9547d410d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-mechanism/default.nix
+++ b/distros/noetic/pr2-mechanism/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-controller-interface, pr2-controller-manager, pr2-hardware-interface, pr2-mechanism-diagnostics, pr2-mechanism-model }:
 buildRosPackage {
   pname = "ros-noetic-pr2-mechanism";
-  version = "1.8.20-r1";
+  version = "1.8.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism/1.8.20-1.tar.gz";
-    name = "1.8.20-1.tar.gz";
-    sha256 = "baa3422215d31a8e1f7dd865ec5976aee4b61df00e8038c9ce064f518e10ad4c";
+    url = "https://github.com/pr2-gbp/pr2_mechanism-release/archive/release/noetic/pr2_mechanism/1.8.21-1.tar.gz";
+    name = "1.8.21-1.tar.gz";
+    sha256 = "4a14ba5e7beae789f61d22b7cb244b8871bfa539af91831f1b7a965fa1b6febc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-calibration-controllers/default.nix
+++ b/distros/noetic/rm-calibration-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, effort-controllers, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-calibration-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "3b66b04c5521583c0d8698b69578ae5ab520ab6216d11fdf1b635dce840197b1";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "fd88731b495674968c92a0b97e9af484f2c00b715fe1b19f92bd613ce813bd85";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-chassis-controllers/default.nix
+++ b/distros/noetic/rm-chassis-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, nav-msgs, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-chassis-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "a68edec6acb1bc0073560a8ee0e63ae205000ba6015214c98f050ec8191ae00b";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "51104a57ca6d339eeb3fba735592430ce710dab5f326a0c1b67128cb05ea68c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, imu-complementary-filter, imu-filter-madgwick, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "6d8ef6bb2d532672d6bd4736b0eb67f7166a33b4cb92f90e135cf23edbb66bbd";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "acd6500480193a21f7f726a694c2d8fbb77634c9b219a07e3448984b0512637d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, rm-dbus, rm-description, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "d87e8ee13e677baab8320bf6e3f340ee2b22abc085b0def23a126e204eec0d09";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "32b4894122ec106292b595ec710c372a95b96c509eaf2915de63e49a7a7dd543";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-controllers/default.nix
+++ b/distros/noetic/rm-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rm-calibration-controllers, rm-chassis-controllers, rm-gimbal-controllers, rm-orientation-controller, rm-shooter-controllers, robot-state-controller, tof-sensor-controller }:
+{ lib, buildRosPackage, fetchurl, catkin, gpio-controller, mimic-joint-controller, rm-calibration-controllers, rm-chassis-controllers, rm-gimbal-controllers, rm-orientation-controller, rm-shooter-controllers, robot-state-controller, tof-sensor-controller }:
 buildRosPackage {
   pname = "ros-noetic-rm-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "88c6a49a51cba27838ef00d2a5f5623fc4a3efcfd7473eb6cb34bec0d8edf04b";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "88b28ad85a307d3e429e5fda647ff71fd7df08abdc7c91fb65559db822629e68";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rm-calibration-controllers rm-chassis-controllers rm-gimbal-controllers rm-orientation-controller rm-shooter-controllers robot-state-controller tof-sensor-controller ];
+  propagatedBuildInputs = [ gpio-controller mimic-joint-controller rm-calibration-controllers rm-chassis-controllers rm-gimbal-controllers rm-orientation-controller rm-shooter-controllers robot-state-controller tof-sensor-controller ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "403fb7f9e910b555337cfbeae1e4217202db0e7aa17e4d5c2e9890841979381c";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "3970f914fefb1865e1ba6805dc546e104106366fb818c438820c6ac75cb2f96d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "649fa3b863a9fab84ac7275ecab74ec165325a1a53c9614cf271f41c037e4a0b";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "fadc636dbb602f42d78a0ef14b86d3eaebf1b375dedd3ffc98896fb2071e8ec0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gimbal-controllers/default.nix
+++ b/distros/noetic/rm-gimbal-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-eigen, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-gimbal-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "7f9539163424ec2c1e8819e7d81ec0fa606b415554a4e9f514f9d7bddce9ba83";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "bafa8c534faf6970c510e9e2256f402cbaf8a7e9815e1a22b4b0b26e768de408";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "536a4b3b4514401c93cb1bf2671d769d3971e61dea6cf2ce129f2313c7854633";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "6db581b3793c26a2add3cbbb9b291716fd403667249b658e1ed4a785503bbb7d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.10-r2";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.10-2.tar.gz";
-    name = "0.1.10-2.tar.gz";
-    sha256 = "92c5a64870baa96396bfe47fb2b536ed83d4e4b5504f6faa90928d9564659643";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "84d51eba57e6ba8fc9cf7ba6488def3ccbc1e5b82f2227440f8495ca749dead4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-orientation-controller/default.nix
+++ b/distros/noetic/rm-orientation-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-orientation-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_orientation_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "c33e18f1b6bc67e127e0d35f5485da9d9a61d8b7899d5b45856ad32d16da06cc";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_orientation_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "c5bdefd94013ce7d7c5d8c90f7af5b47d61a842961e6ed0bf080007906c059c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-shooter-controllers/default.nix
+++ b/distros/noetic/rm-shooter-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-shooter-controllers";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "5bbfaee47610ef6066a73d13de234d363fceca38c75571fd096f3a3d1aab8305";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "d540be1f264d25d78c0af5ad5144ccdb046f340ba2acc22804efdee4afa3e903";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-calibration-msgs/default.nix
+++ b/distros/noetic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-calibration-msgs";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "b4c71fc3494c5b5107f13be141a132595b12c323d7fa86f0f2239e6399115f68";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "89f31ebc8290f8e3470d855fc22436836547759b533c1b33e1d83e9a1fe1a078";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-calibration/default.nix
+++ b/distros/noetic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-calibration";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "c80bb52777ce861d3b2a273cd7f27a955d71ca824effe8d372b16ffb6b738357";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "77a5afa9c62334f5a17c54ebb122194b870ae88c6e188e99c18c279a30580cf2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-state-controller/default.nix
+++ b/distros/noetic/robot-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, kdl-parser, pluginlib, realtime-tools, rm-common, roscpp, roslint, tf2-kdl, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "d4871215d719822b637e070802843bab2c10e0fcb5e2c854fb86096c1ca52b31";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "0bc69ea2aeb3ed0b870613fe331adb3647150469405d53e1088774833d4c7015";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.2.15-r1";
+  version = "0.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.15-1.tar.gz";
-    name = "0.2.15-1.tar.gz";
-    sha256 = "70de58258726026ac0ce20e0365b01950e80fc15d607605701a7075e628eab6f";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.16-1.tar.gz";
+    name = "0.2.16-1.tar.gz";
+    sha256 = "207b6d1ee9c8f6cf12c189ea22497b21be84a7ab8d7507e0810ec3c9f9ab10f7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rosapi/default.nix
+++ b/distros/noetic/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosapi";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosapi/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "7f6c99d9bf84c75f396ddc7ce31bcea6d9ef5a3f92f1819c10a010cd9b260f62";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosapi/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "7eed9ef3333837df51f12c4ee571b3329030b437b9341d81ade34b7fb1840cf0";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   propagatedBuildInputs = [ message-runtime rosbridge-library rosgraph rosnode rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''Provides service calls for getting ros meta-information, like list of

--- a/distros/noetic/rosbridge-library/default.nix
+++ b/distros/noetic/rosbridge-library/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, python3Packages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, python3Packages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, rosunit, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-library";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_library/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "7dd8d20143d1f25edd3a4712168e4784a94ff65c4ee24e2601d1810675f886c0";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_library/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "5402e1a9596229104dc4cf6973439ba860a6e09bb1a65d3aaadc01bed14534ee";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest rosunit sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ geometry-msgs message-runtime python3Packages.bson python3Packages.pillow roscpp rosgraph rospy rosservice rostopic std-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''The core rosbridge package, responsible for interpreting JSON and performing

--- a/distros/noetic/rosbridge-msgs/default.nix
+++ b/distros/noetic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-msgs";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_msgs/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "1e9f6b9cf45ea986f00fe0a40b8864125f91481011ad6b987d3984f8cabdfa2b";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_msgs/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "def6afc928622244bb2572c7c3ffdfb25c910c54c02a37377e96225dd74f5a74";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbridge-server/default.nix
+++ b/distros/noetic/rosbridge-server/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-server";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_server/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "33e04c5be92316b620a92933d1ad6b171a9b9fe859d3c4a2ef521535625ae26d";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_server/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "f8b64e0a923e542d0b801dea40772778701bf5db532640506341a6f9d5cfa054";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ python3Packages.autobahn python3Packages.tornado python3Packages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''A WebSocket interface to rosbridge.'';

--- a/distros/noetic/rosbridge-suite/default.nix
+++ b/distros/noetic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-suite";
-  version = "0.11.13-r1";
+  version = "0.11.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_suite/0.11.13-1.tar.gz";
-    name = "0.11.13-1.tar.gz";
-    sha256 = "fc10627e5ccda12582d057a6dc6e319fcf42d7090454777b4fddbe14f7cd155e";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_suite/0.11.14-1.tar.gz";
+    name = "0.11.14-1.tar.gz";
+    sha256 = "401e1fb55db4bdd458647d1c39ebf4ddcafe4f974edccbafd28d1bcdf42db4eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rotate-recovery/default.nix
+++ b/distros/noetic/rotate-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, cmake-modules, costmap-2d, eigen, geometry-msgs, nav-core, pluginlib, roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rotate-recovery";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/rotate_recovery/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "924651b6fd60db56e151f68a907da6506e9d295081b2daae6f44ac55f7212d0d";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/rotate_recovery/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "87a081850938a83f23315d8a610537e35a6d45aa0278ca5d502e3b11bc3dba41";
   };
 
   buildType = "catkin";

--- a/distros/noetic/septentrio-gnss-driver/default.nix
+++ b/distros/noetic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-septentrio-gnss-driver";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d94097675afc971808cecc27c6ea9fea074bdcb3c8512eca4a7ec505f589cf23";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "02496e96957e578886bd8e064f601d6a4aaf6b1296ab3656b016b332f446ef8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tablet-socket-msgs/default.nix
+++ b/distros/noetic/tablet-socket-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/tablet_socket_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "6bf111b0e4f1332a69414b38dbed9f61247e048b4018e882997ad99a93fd90f8";
+    sha256 = "65f6bd52a23f56ee5ff3e096b3d56feb572123ab4e9961e3616df395ba59e949";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tesseract-collision/default.nix
+++ b/distros/noetic/tesseract-collision/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, libyamlcpp, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-collision";
+  version = "0.8.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "e3d10f41b5117bfb77242fe3cdb7896c226b80e6390a8e2c389e61b2dae5d6f8";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gbenchmark gtest tesseract-scene-graph ];
+  propagatedBuildInputs = [ boost bullet console-bridge eigen fcl libyamlcpp llvmPackages.openmp tesseract-common tesseract-geometry tesseract-support ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_collision package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tf2-server/default.nix
+++ b/distros/noetic/tf2-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, message-generation, message-runtime, nodelet, python3Packages, roscpp, rospy, rostest, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-server";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/tf2_server-release/archive/release/noetic/tf2_server/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "7b473444ace213203c6d276cdb7ef2f37794da2187901cdfdbb6d68b59746f8a";
+    url = "https://github.com/peci1/tf2_server-release/archive/release/noetic/tf2_server/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "0ec115bae4a412ef6d2ffb78be3ac3eaf93d84afba296b398c3253447f5c120d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tof-sensor-controller/default.nix
+++ b/distros/noetic/tof-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-tof-sensor-controller";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/tof_sensor_controller/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "9915f2cc49f0b8b47642f2ff1278478467f846bc0bc110439f032992a6f1453b";
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/tof_sensor_controller/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "f661879fbed2c87d9d3a8320b8179bb0f164cfc6f5c05f041d56d3f69a171cbf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vector-map-msgs/default.nix
+++ b/distros/noetic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "4132fc88a828774dc43bac8d108aed130622159af96ab717a8a0c8464929a65f";
+    sha256 = "870df6369942aa12d4c13eca898c481571bb2464d0333c56258e2f2498c8eded";
   };
 
   buildType = "catkin";

--- a/distros/noetic/voxel-grid/default.nix
+++ b/distros/noetic/voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-voxel-grid";
-  version = "1.17.1-r1";
+  version = "1.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/voxel_grid/1.17.1-1.tar.gz";
-    name = "1.17.1-1.tar.gz";
-    sha256 = "cc821d076c94cd6250a2a632d0575747e87c5cdc3f2f042d13bc3512da95b831";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/noetic/voxel_grid/1.17.2-1.tar.gz";
+    name = "1.17.2-1.tar.gz";
+    sha256 = "e7c58b56a3b31f78d302aaeeaeba39d9e03a505f053d550b9e3253c8d344aff9";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit 6b09de5c1acde28f358a052bcbf9eb7cb481cdce.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *ament-download 0.0.5-r1*
* *boost-geometry-util 0.0.1-r1*
* *bosch-locator-bridge 2.0.6-r1 --> 2.0.7-r1*
* *crane-plus 1.0.0-r5*
* *crane-plus-control 1.0.0-r5*
* *crane-plus-description 1.0.0-r5*
* *crane-plus-examples 1.0.0-r5*
* *crane-plus-gazebo 1.0.0-r5*
* *crane-plus-ignition 1.0.0-r5*
* *crane-plus-moveit-config 1.0.0-r5*
* *depthai 2.15.4-r1 --> 2.15.5-r1*
* *eigenpy 2.7.4-r1 --> 2.7.5-r1*
* *fluent-rviz 0.0.3-r3*
* *foxglove-msgs 1.2.1-r1 --> 1.2.2-r1*
* *gc-spl-2022 0.0.1-r1*
* *grepros 0.4.6-r1 --> 0.4.7-r1*
* *gscam 2.0.1-r1 --> 2.0.2-r1*
* *maliput 1.0.3-r1 --> 1.0.4-r1*
* *maliput-dragway 0.1.1-r1*
* *maliput-drake 0.1.1-r1*
* *maliput-integration 0.1.0-r1*
* *maliput-malidrive 0.1.1-r1*
* *maliput-multilane 0.1.0-r1*
* *maliput-object 0.1.1-r1*
* *maliput-object-py 0.1.1-r1*
* *maliput-py 0.1.1-r1*
* *mrpt-msgs 0.4.2-r1 --> 0.4.4-r1*
* *nerian-stereo 1.0.3-r1 --> 1.1.0-r1*
* *plotjuggler 3.4.4-r1 --> 3.4.5-r1*
* *pose-cov-ops 0.3.5-r1 --> 0.3.6-r1*
* *r2r-spl-7 0.0.1-r1*
* *rcgcd-spl-14 0.0.1-r1*
* *rcgcd-spl-14-conversion 0.0.1-r1*
* *rcgcrd-spl-4 0.0.1-r1*
* *rcgcrd-spl-4-conversion 0.0.1-r1*
* *rt-manipulators-cpp 1.0.0-r1*
* *rt-manipulators-examples 1.0.0-r1*
* *septentrio-gnss-driver 1.2.1-r1 --> 1.2.2-r2*
* *splsm-7 0.0.1-r1*
* *splsm-7-conversion 0.0.1-r1*
* *tracetools-analysis 1.0.3-r1*
* *ur-bringup 2.0.0-r1*
* *ur-controllers 2.0.0-r1*
* *ur-dashboard-msgs 2.0.0-r1*
* *ur-description 2.0.0-r1*
* *ur-moveit-config 2.0.0-r1*
* *ur-robot-driver 2.0.0-r1*

Galactic Changes:
-----------------
* *boost-geometry-util 0.0.1-r1*
* *control-toolbox 2.0.2-r1 --> 2.1.0-r1*
* *costmap-queue 1.0.11-r1 --> 1.0.12-r1*
* *depthai 2.15.4-r2 --> 2.15.5-r1*
* *dwb-core 1.0.11-r1 --> 1.0.12-r1*
* *dwb-critics 1.0.11-r1 --> 1.0.12-r1*
* *dwb-msgs 1.0.11-r1 --> 1.0.12-r1*
* *dwb-plugins 1.0.11-r1 --> 1.0.12-r1*
* *examples-tf2-py 0.17.3-r1 --> 0.17.4-r1*
* *fluent-rviz 0.0.2-r1 --> 0.0.3-r1*
* *foxglove-msgs 1.2.1-r1 --> 1.2.2-r1*
* *gc-spl-2022 1.0.0-r1*
* *geometry2 0.17.3-r1 --> 0.17.4-r1*
* *gscam 2.0.1-r1 --> 2.0.2-r1*
* *mrpt-msgs 0.4.3-r1 --> 0.4.4-r1*
* *nav-2d-msgs 1.0.11-r1 --> 1.0.12-r1*
* *nav-2d-utils 1.0.11-r1 --> 1.0.12-r1*
* *nav2-amcl 1.0.11-r1 --> 1.0.12-r1*
* *nav2-behavior-tree 1.0.11-r1 --> 1.0.12-r1*
* *nav2-bringup 1.0.11-r1 --> 1.0.12-r1*
* *nav2-bt-navigator 1.0.11-r1 --> 1.0.12-r1*
* *nav2-common 1.0.11-r1 --> 1.0.12-r1*
* *nav2-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-core 1.0.11-r1 --> 1.0.12-r1*
* *nav2-costmap-2d 1.0.11-r1 --> 1.0.12-r1*
* *nav2-dwb-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-gazebo-spawner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-lifecycle-manager 1.0.11-r1 --> 1.0.12-r1*
* *nav2-map-server 1.0.11-r1 --> 1.0.12-r1*
* *nav2-msgs 1.0.11-r1 --> 1.0.12-r1*
* *nav2-navfn-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-recoveries 1.0.11-r1 --> 1.0.12-r1*
* *nav2-regulated-pure-pursuit-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-rotation-shim-controller 1.0.11-r1 --> 1.0.12-r1*
* *nav2-rviz-plugins 1.0.11-r1 --> 1.0.12-r1*
* *nav2-simple-commander 1.0.11-r1 --> 1.0.12-r1*
* *nav2-smac-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-system-tests 1.0.11-r1 --> 1.0.12-r1*
* *nav2-theta-star-planner 1.0.11-r1 --> 1.0.12-r1*
* *nav2-util 1.0.11-r1 --> 1.0.12-r1*
* *nav2-voxel-grid 1.0.11-r1 --> 1.0.12-r1*
* *nav2-waypoint-follower 1.0.11-r1 --> 1.0.12-r1*
* *navigation2 1.0.11-r1 --> 1.0.12-r1*
* *plotjuggler 3.4.4-r1 --> 3.4.5-r1*
* *pose-cov-ops 0.3.5-r1 --> 0.3.6-r1*
* *r2r-spl-7 1.0.0-r1*
* *rcgcd-spl-14 1.0.0-r1*
* *rcgcd-spl-14-conversion 1.0.0-r1*
* *rcgcrd-spl-4 1.0.0-r1*
* *rcgcrd-spl-4-conversion 1.0.0-r1*
* *rclpy 1.9.1-r1 --> 1.9.2-r1*
* *rcss3d-agent 0.0.7-r1 --> 0.1.1-r1*
* *rcss3d-agent-basic 0.0.7-r1 --> 0.1.1-r1*
* *rcss3d-agent-msgs 0.0.7-r1 --> 0.1.1-r1*
* *rcutils 4.0.2-r2 --> 4.0.3-r1*
* *ros-image-to-qimage 0.0.2-r1 --> 0.1.0-r1*
* *ros2action 0.13.3-r1 --> 0.13.4-r1*
* *ros2cli 0.13.3-r1 --> 0.13.4-r1*
* *ros2cli-test-interfaces 0.13.3-r1 --> 0.13.4-r1*
* *ros2component 0.13.3-r1 --> 0.13.4-r1*
* *ros2interface 0.13.3-r1 --> 0.13.4-r1*
* *ros2lifecycle 0.13.3-r1 --> 0.13.4-r1*
* *ros2lifecycle-test-fixtures 0.13.3-r1 --> 0.13.4-r1*
* *ros2multicast 0.13.3-r1 --> 0.13.4-r1*
* *ros2node 0.13.3-r1 --> 0.13.4-r1*
* *ros2param 0.13.3-r1 --> 0.13.4-r1*
* *ros2pkg 0.13.3-r1 --> 0.13.4-r1*
* *ros2run 0.13.3-r1 --> 0.13.4-r1*
* *ros2service 0.13.3-r1 --> 0.13.4-r1*
* *ros2topic 0.13.3-r1 --> 0.13.4-r1*
* *rqt-image-overlay 0.0.5-r1 --> 0.0.6-r1*
* *rqt-image-overlay-layer 0.0.5-r1 --> 0.0.6-r1*
* *rt-manipulators-cpp 1.0.0-r1*
* *rt-manipulators-examples 1.0.0-r1*
* *septentrio-gnss-driver 1.2.1-r1 --> 1.2.2-r3*
* *splsm-7 1.0.0-r1*
* *splsm-7-conversion 1.0.0-r1*
* *tensorrt-cmake-module 0.0.2-r1 --> 0.0.3-r1*
* *tf2 0.17.3-r1 --> 0.17.4-r1*
* *tf2-bullet 0.17.3-r1 --> 0.17.4-r1*
* *tf2-eigen 0.17.3-r1 --> 0.17.4-r1*
* *tf2-eigen-kdl 0.17.3-r1 --> 0.17.4-r1*
* *tf2-geometry-msgs 0.17.3-r1 --> 0.17.4-r1*
* *tf2-kdl 0.17.3-r1 --> 0.17.4-r1*
* *tf2-msgs 0.17.3-r1 --> 0.17.4-r1*
* *tf2-py 0.17.3-r1 --> 0.17.4-r1*
* *tf2-ros 0.17.3-r1 --> 0.17.4-r1*
* *tf2-ros-py 0.17.3-r1 --> 0.17.4-r1*
* *tf2-sensor-msgs 0.17.3-r1 --> 0.17.4-r1*
* *tf2-tools 0.17.3-r1 --> 0.17.4-r1*
* *tracetools-analysis 2.0.3-r4*
* *turtlebot4-base 0.1.2-r1*
* *zmqpp-vendor 0.0.1-r2 --> 0.0.2-r1*

Humble Changes:
---------------
* *ament-download 0.0.5-r1*
* *aws-robomaker-small-warehouse-world 1.0.5-r1*
* *boost-geometry-util 0.0.1-r1*
* *cartographer 2.0.9002-r2*
* *cartographer-ros 2.0.9000-r2*
* *cartographer-rviz 2.0.9000-r2*
* *control-toolbox 2.0.2-r3 --> 2.1.0-r1*
* *controller-interface 2.9.0-r1 --> 2.10.0-r1*
* *controller-manager 2.9.0-r1 --> 2.10.0-r1*
* *controller-manager-msgs 2.9.0-r1 --> 2.10.0-r1*
* *diagnostic-aggregator 2.1.3-r3 --> 3.0.0-r1*
* *diagnostic-updater 2.1.3-r3 --> 3.0.0-r1*
* *diff-drive-controller 2.5.0-r1 --> 2.6.0-r1*
* *effort-controllers 2.5.0-r1 --> 2.6.0-r1*
* *fastrtps 2.6.0-r3 --> 2.6.1-r1*
* *fluent-rviz 0.0.3-r2*
* *fogros2-examples 0.1.4-r1 --> 0.1.6-r3*
* *force-torque-sensor-broadcaster 2.5.0-r1 --> 2.6.0-r1*
* *forward-command-controller 2.5.0-r1 --> 2.6.0-r1*
* *foxglove-msgs 1.2.1-r1 --> 1.2.2-r1*
* *gazebo-dev 3.6.0-r1 --> 3.7.0-r1*
* *gazebo-msgs 3.6.0-r1 --> 3.7.0-r1*
* *gazebo-plugins 3.6.0-r1 --> 3.7.0-r1*
* *gazebo-ros 3.6.0-r1 --> 3.7.0-r1*
* *gazebo-ros-pkgs 3.6.0-r1 --> 3.7.0-r1*
* *gc-spl-2022 2.0.0-r1*
* *grasping-msgs 0.4.0-r1*
* *gripper-controllers 2.5.0-r1 --> 2.6.0-r1*
* *gscam 2.0.1-r2 --> 2.0.2-r1*
* *hardware-interface 2.9.0-r1 --> 2.10.0-r1*
* *imu-sensor-broadcaster 2.5.0-r1 --> 2.6.0-r1*
* *joint-state-broadcaster 2.5.0-r1 --> 2.6.0-r1*
* *joint-trajectory-controller 2.5.0-r1 --> 2.6.0-r1*
* *libmavconn 2.1.0-r3 --> 2.2.0-r1*
* *mavros 2.1.0-r3 --> 2.2.0-r1*
* *mavros-extras 2.1.0-r3 --> 2.2.0-r1*
* *mavros-msgs 2.1.0-r3 --> 2.2.0-r1*
* *message-filters 4.3.1-r2 --> 4.3.2-r1*
* *moveit-resources 2.0.4-r1 --> 2.0.5-r1*
* *moveit-resources-fanuc-description 2.0.4-r1 --> 2.0.5-r1*
* *moveit-resources-fanuc-moveit-config 2.0.4-r1 --> 2.0.5-r1*
* *moveit-resources-panda-description 2.0.4-r1 --> 2.0.5-r1*
* *moveit-resources-panda-moveit-config 2.0.4-r1 --> 2.0.5-r1*
* *moveit-resources-pr2-description 2.0.4-r1 --> 2.0.5-r1*
* *mrpt-msgs 0.4.3-r1 --> 0.4.4-r1*
* *ntpd-driver 2.1.0-r1 --> 2.1.0-r2*
* *orocos-kdl-vendor 0.2.2-r3 --> 0.2.3-r1*
* *performance-report 1.1.0-r1*
* *performance-test 1.1.0-r1*
* *plotjuggler 3.4.4-r1 --> 3.4.5-r1*
* *pose-cov-ops 0.3.4-r1 --> 0.3.6-r1*
* *position-controllers 2.5.0-r1 --> 2.6.0-r1*
* *python-orocos-kdl-vendor 0.2.2-r3 --> 0.2.3-r1*
* *r2r-spl-7 2.0.0-r1*
* *rcgcd-spl-14 2.0.0-r1*
* *rcgcd-spl-14-conversion 2.0.0-r1*
* *rcgcrd-spl-4 2.0.0-r1*
* *rcgcrd-spl-4-conversion 2.0.0-r1*
* *rcss3d-agent 0.0.7-r1 --> 0.2.1-r1*
* *rcss3d-agent-basic 0.0.7-r1 --> 0.2.1-r1*
* *rcss3d-agent-msgs 0.0.7-r1 --> 0.2.1-r1*
* *robot-calibration 0.8.0-r1*
* *robot-calibration-msgs 0.8.0-r1*
* *robot-controllers 0.9.2-r1*
* *robot-controllers-interface 0.9.2-r1*
* *robot-controllers-msgs 0.9.2-r1*
* *ros-image-to-qimage 0.0.2-r3 --> 0.2.0-r1*
* *ros2-control 2.9.0-r1 --> 2.10.0-r1*
* *ros2-control-test-assets 2.9.0-r1 --> 2.10.0-r1*
* *ros2-controllers 2.5.0-r1 --> 2.6.0-r1*
* *ros2-controllers-test-nodes 2.5.0-r1 --> 2.6.0-r1*
* *ros2controlcli 2.9.0-r1 --> 2.10.0-r1*
* *rqt-image-overlay 0.0.5-r2 --> 0.1.0-r1*
* *rqt-image-overlay-layer 0.0.5-r2 --> 0.1.0-r1*
* *rt-manipulators-cpp 1.0.0-r1*
* *rt-manipulators-examples 1.0.0-r1*
* *sdformat-test-files 1.0.1-r1*
* *self-test 3.0.0-r1*
* *septentrio-gnss-driver 1.2.1-r1 --> 1.2.2-r5*
* *simple-launch 1.3.1-r1 --> 1.4.1-r1*
* *soccer-interfaces 0.1.0-r1*
* *soccer-vision-2d-msgs 0.0.1-r2 --> 0.1.0-r1*
* *soccer-vision-3d-msgs 0.0.1-r2 --> 0.1.0-r1*
* *soccer-vision-attribute-msgs 0.0.1-r2 --> 0.1.0-r1*
* *splsm-7 2.0.0-r1*
* *splsm-7-conversion 2.0.0-r1*
* *tensorrt-cmake-module 0.0.2-r3 --> 0.0.3-r1*
* *tracetools-analysis 3.0.0-r4*
* *transmission-interface 2.9.0-r1 --> 2.10.0-r1*
* *turtlebot3 2.1.5-r1*
* *turtlebot3-bringup 2.1.5-r1*
* *turtlebot3-cartographer 2.1.5-r1*
* *turtlebot3-description 2.1.5-r1*
* *turtlebot3-example 2.1.5-r1*
* *turtlebot3-navigation2 2.1.5-r1*
* *turtlebot3-node 2.1.5-r1*
* *turtlebot3-teleop 2.1.5-r1*
* *ur 2.2.1-r1*
* *ur-bringup 2.2.1-r1*
* *ur-calibration 2.2.1-r1*
* *ur-controllers 2.2.1-r1*
* *ur-dashboard-msgs 2.2.1-r1*
* *ur-moveit-config 2.2.1-r1*
* *ur-robot-driver 2.2.1-r1*
* *velocity-controllers 2.5.0-r1 --> 2.6.0-r1*
* *zenoh-bridge-dds 0.5.0-r3*

Melodic Changes:
----------------
* *collada-parser 1.12.13-r1*
* *collada-urdf 1.12.13-r1*
* *eigenpy 2.7.4-r1 --> 2.7.5-r1*
* *er-public-msgs 1.1.0-r1 --> 1.4.0-r1*
* *euscollada 0.4.4-r1*
* *graceful-controller 0.4.2-r1 --> 0.4.3-r1*
* *graceful-controller-ros 0.4.2-r1 --> 0.4.3-r1*
* *hri-msgs 0.5.2-r1 --> 0.7.0-r1*
* *jsk-python-orocos-kdl-python3 1.4.2-r2*
* *jsk-tf2-py-python3 0.6.9-r2*
* *jsk-topic-tools 2.2.11-r1 --> 2.2.12-r1*
* *mrpt-ekf-slam-2d 0.1.10-r1 --> 0.1.12-r1*
* *mrpt-ekf-slam-3d 0.1.10-r1 --> 0.1.12-r1*
* *mrpt-generic-sensor 0.0.2-r1*
* *mrpt-icp-slam-2d 0.1.10-r1 --> 0.1.12-r1*
* *mrpt-local-obstacles 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-localization 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-map 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-msgs 0.4.0-r1 --> 0.4.4-r1*
* *mrpt-msgs-bridge 1.0.3-r1*
* *mrpt-navigation 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-rawlog 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-rbpf-slam 0.1.10-r1 --> 0.1.12-r1*
* *mrpt-reactivenav2d 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-sensorlib 0.0.2-r1*
* *mrpt-sensors 0.0.2-r1*
* *mrpt-slam 0.1.10-r1 --> 0.1.12-r1*
* *mrpt-tutorials 1.0.0-r1 --> 1.0.3-r1*
* *nerian-stereo 3.9.1-r1 --> 3.10.0-r1*
* *plotjuggler 3.4.3-r1 --> 3.4.5-r1*
* *pose-cov-ops 0.3.2-r1 --> 0.3.7-r1*
* *pr2-controller-interface 1.8.20-r1 --> 1.8.21-r1*
* *pr2-controller-manager 1.8.20-r1 --> 1.8.21-r1*
* *pr2-hardware-interface 1.8.20-r1 --> 1.8.21-r1*
* *pr2-mechanism 1.8.20-r1 --> 1.8.21-r1*
* *pr2-mechanism-diagnostics 1.8.20-r1 --> 1.8.21-r1*
* *pr2-mechanism-model 1.8.20-r1 --> 1.8.21-r1*
* *robot-calibration 0.7.0-r1 --> 0.7.1-r1*
* *robot-calibration-msgs 0.7.0-r1 --> 0.7.1-r1*
* *rosapi 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-library 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-msgs 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-server 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-suite 0.11.13-r1 --> 0.11.14-r1*
* *septentrio-gnss-driver 1.1.1-r1 --> 1.1.2-r2*

Noetic Changes:
---------------
* *amcl 1.17.1-r1 --> 1.17.2-r1*
* *base-local-planner 1.17.1-r1 --> 1.17.2-r1*
* *boost-plugin-loader 0.2.0-r1*
* *carrot-planner 1.17.1-r1 --> 1.17.2-r1*
* *clear-costmap-recovery 1.17.1-r1 --> 1.17.2-r1*
* *collada-parser 1.12.13-r1*
* *collada-urdf 1.12.13-r1*
* *costmap-2d 1.17.1-r1 --> 1.17.2-r1*
* *dwa-local-planner 1.17.1-r1 --> 1.17.2-r1*
* *eigenpy 2.7.4-r1 --> 2.7.5-r1*
* *er-public-msgs 1.4.0-r1*
* *euscollada 0.4.4-r1*
* *fake-localization 1.17.1-r1 --> 1.17.2-r1*
* *foxglove-msgs 1.2.1-r1 --> 1.2.2-r1*
* *global-planner 1.17.1-r1 --> 1.17.2-r1*
* *gpio-controller 0.1.5-r1*
* *graceful-controller 0.4.2-r1 --> 0.4.3-r1*
* *graceful-controller-ros 0.4.2-r1 --> 0.4.3-r1*
* *grepros 0.4.6-r1 --> 0.4.7-r1*
* *hri-msgs 0.5.2-r1 --> 0.7.0-r1*
* *husky-control 0.6.3-r1 --> 0.6.4-r2*
* *husky-description 0.6.3-r1 --> 0.6.4-r2*
* *husky-desktop 0.6.3-r1 --> 0.6.4-r2*
* *husky-gazebo 0.6.3-r1 --> 0.6.4-r2*
* *husky-msgs 0.6.3-r1 --> 0.6.4-r2*
* *husky-navigation 0.6.3-r1 --> 0.6.4-r2*
* *husky-simulator 0.6.3-r1 --> 0.6.4-r2*
* *husky-viz 0.6.3-r1 --> 0.6.4-r2*
* *map-server 1.17.1-r1 --> 1.17.2-r1*
* *mimic-joint-controller 0.1.5-r1*
* *move-base 1.17.1-r1 --> 1.17.2-r1*
* *move-slow-and-clear 1.17.1-r1 --> 1.17.2-r1*
* *mrpt-generic-sensor 0.0.2-r1*
* *mrpt-local-obstacles 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-localization 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-map 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-msgs 0.4.0-r1 --> 0.4.4-r1*
* *mrpt-msgs-bridge 1.0.3-r1*
* *mrpt-navigation 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-rawlog 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-reactivenav2d 1.0.0-r1 --> 1.0.3-r1*
* *mrpt-sensorlib 0.0.2-r1*
* *mrpt-sensors 0.0.2-r1*
* *mrpt-tutorials 1.0.0-r1 --> 1.0.3-r1*
* *nav-core 1.17.1-r1 --> 1.17.2-r1*
* *navfn 1.17.1-r1 --> 1.17.2-r1*
* *navigation 1.17.1-r1 --> 1.17.2-r1*
* *nerian-stereo 3.9.1-r1 --> 3.10.0-r1*
* *opw-kinematics 0.4.5-r1 --> 0.4.6-r1*
* *plotjuggler 3.4.3-r1 --> 3.4.5-r1*
* *pose-cov-ops 0.3.2-r1 --> 0.3.7-r1*
* *pr2-controller-interface 1.8.20-r1 --> 1.8.21-r1*
* *pr2-controller-manager 1.8.20-r1 --> 1.8.21-r1*
* *pr2-hardware-interface 1.8.20-r1 --> 1.8.21-r1*
* *pr2-mechanism 1.8.20-r1 --> 1.8.21-r1*
* *pr2-mechanism-diagnostics 1.8.20-r1 --> 1.8.21-r1*
* *pr2-mechanism-model 1.8.20-r1 --> 1.8.21-r1*
* *rm-calibration-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-chassis-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-common 0.1.10-r2 --> 0.1.13-r1*
* *rm-control 0.1.10-r2 --> 0.1.13-r1*
* *rm-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-dbus 0.1.10-r2 --> 0.1.13-r1*
* *rm-gazebo 0.1.10-r2 --> 0.1.13-r1*
* *rm-gimbal-controllers 0.1.4-r1 --> 0.1.5-r1*
* *rm-hw 0.1.10-r2 --> 0.1.13-r1*
* *rm-msgs 0.1.10-r2 --> 0.1.13-r1*
* *rm-orientation-controller 0.1.4-r1 --> 0.1.5-r1*
* *rm-shooter-controllers 0.1.4-r1 --> 0.1.5-r1*
* *robot-calibration 0.7.0-r1 --> 0.7.1-r1*
* *robot-calibration-msgs 0.7.0-r1 --> 0.7.1-r1*
* *robot-state-controller 0.1.4-r1 --> 0.1.5-r1*
* *ros-industrial-cmake-boilerplate 0.2.15-r1 --> 0.2.16-r1*
* *rosapi 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-library 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-msgs 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-server 0.11.13-r1 --> 0.11.14-r1*
* *rosbridge-suite 0.11.13-r1 --> 0.11.14-r1*
* *rotate-recovery 1.17.1-r1 --> 1.17.2-r1*
* *septentrio-gnss-driver 1.1.1-r1 --> 1.1.2-r1*
* *tesseract-collision 0.8.6-r1*
* *tf2-server 1.1.1-r1 --> 1.1.2-r1*
* *tof-sensor-controller 0.1.4-r1 --> 0.1.5-r1*
* *voxel-grid 1.17.1-r1 --> 1.17.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bokeh-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-pytest-timeout
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

