### PR TITLE
rosdistro sync, Fri Jul  8 13:26:44 2022

### DIFF
--- a/distros/foxy/maliput-dragway/default.nix
+++ b/distros/foxy/maliput-dragway/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, pybind11, python3 }:
 buildRosPackage {
   pname = "ros-foxy-maliput-dragway";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "748dd0110dc11469dc428ebc8d18e9262ee8f3b528be3b9f945bcdd8bb0c6d21";
+    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "cd69db9752c89e4be9eaea375ea99960bcdd28b3c4a5541d239f14aebd9c840b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-malidrive/default.nix
+++ b/distros/foxy/maliput-malidrive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, fmt, maliput, maliput-drake, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-maliput-malidrive";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f643c9761b5333d6cc0856263e49ef2931b4820f5b141f800639a2d800276971";
+    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "e37a774e2665aa4364f3cd6c3bb3f1a941c517ce2e3457e163b935edac5741cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
 buildRosPackage {
   pname = "ros-foxy-maliput-multilane";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "527698d08a50d9a49c0d3382e62f2854ebb5e02dee52873dfd3668f25c16e55f";
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "bbb58467ea2752e8ddea5494fdc03fef593e0327761740cbc9971bce1d5081f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -652,6 +652,8 @@ self: super: {
 
  lifecycle-msgs = self.callPackage ./lifecycle-msgs {};
 
+ log-view = self.callPackage ./log-view {};
+
  logging-demo = self.callPackage ./logging-demo {};
 
  lua-vendor = self.callPackage ./lua-vendor {};
@@ -867,6 +869,8 @@ self: super: {
  navigation2 = self.callPackage ./navigation2 {};
 
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
+
+ nerian-stereo = self.callPackage ./nerian-stereo {};
 
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
@@ -1763,6 +1767,8 @@ self: super: {
  tvm-vendor = self.callPackage ./tvm-vendor {};
 
  twist-mux = self.callPackage ./twist-mux {};
+
+ twist-stamper = self.callPackage ./twist-stamper {};
 
  ublox = self.callPackage ./ublox {};
 

--- a/distros/galactic/log-view/default.nix
+++ b/distros/galactic/log-view/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip }:
+buildRosPackage {
+  pname = "ros-galactic-log-view";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/hatchbed/log_view-release/archive/release/galactic/log_view/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "40d3d506de9c09ad9b2add8be4049691de7e944305d0227bad1a22eef7f5f2a0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The log_view package provides a ncurses based terminal GUI for
+    viewing and filtering published ROS log messages.
+
+    This is an alternative to rqt_console and swri_console that doesn't depend
+    on qt and can be run directly in a terminal.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/magic-enum/default.nix
+++ b/distros/galactic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-galactic-magic-enum";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/galactic/magic_enum/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "b7a5b2ddba201a6238ddbeada09f5eb887711aff17b87f7418f1cb2202aa0eec";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/galactic/magic_enum/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "41c5912bf40f134d2beddb3138d243ed76be21f27875bb777f78a1ab04bcb7c4";
   };
 
   buildType = "cmake";

--- a/distros/galactic/nerian-stereo/default.nix
+++ b/distros/galactic/nerian-stereo/default.nix
@@ -4,13 +4,13 @@
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
-  pname = "ros-foxy-nerian-stereo";
+  pname = "ros-galactic-nerian-stereo";
   version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.1.1-1.tar.gz";
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/galactic/nerian_stereo/1.1.1-1.tar.gz";
     name = "1.1.1-1.tar.gz";
-    sha256 = "33f56cf27bfb2363f02ad66a3ef9ad6ad162fb055a4916f9435e3f59dd58ed10";
+    sha256 = "05cda22e7fa5597a900ab06c0e893cc6b7cc85ea237896ebba554d029bbc1fed";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/twist-stamper/default.nix
+++ b/distros/galactic/twist-stamper/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-twist-stamper";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/joshnewans/twist_stamper-release/archive/release/galactic/twist_stamper/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "97147c9dee8f70d3de5a198f96be3f521aa101ff2edf690a9712a5764ab609c4";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs rclpy std-msgs ];
+
+  meta = {
+    description = ''ROS2 package for converting between Twist and TwistStamped messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/bag2-to-image/default.nix
+++ b/distros/humble/bag2-to-image/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, opencv, rclcpp, rclcpp-components, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-bag2-to-image";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bag2_to_image-release/archive/release/humble/bag2_to_image/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "49394a857b402145a03cf4e1e9fc0a2e6edccc9857d0485acf337a0c057fbcca";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ opencv rclcpp rclcpp-components rosbag2-cpp rosbag2-storage sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The bag2_to_image package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "da02ea88c85592d1fd49d2413f9e5559f2f1a63708c8a37289c03f9774b78702";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "28fc379923f018acfb7cf348a983ddea2d10d48e5fdf4d298c9b7bc05b020e38";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "e89206b5b735ad6dbb5fdccc9b9e0f20a14ba23e4157e8e108b3bb1168b75988";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "c7ecb99e26fe5daae7d4b5463b55abab0995943bd45fff1a0ef3863143bb9305";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "0e497ae8cbcf367e9518113551a0b6146ac3aa3503e79701356f40ba177218a2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "7c7f36713024231d4ec848d39613b27313ee675559a62d23a07e0049c8d03a9e";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock realtime-tools ];
   propagatedBuildInputs = [ ament-index-cpp controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils ros2-control-test-assets ros2param ros2run ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "8d3ad011895aa982b63e3b6d538cabe8cec2b6234f8cf5f129e20f18d24fb93d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "f474847ee27f655a572e3a561534fe53976d4b45940de0bcefa39d7e48e41f10";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "4b5d59637695d9ac321935e91a72ee9fa5a0eb1dbb23792c7ab92d9fa1741413";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "86162f273ac360f6af883333c3937c9d8d680494a4be1f331fd4c4c1587d24ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0a66cfd0d15adce846a70ad75760d6f8c2a9dfa48d7d566dd2e44db019cc15d4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "a0a861981bc2fffa67a2bc9f4502bf17ffddb51164dd65d1b3579481bbcbb9c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "bc71e32986238aa890af5292b3277a218de36bfff01dfa0d5572bec88de6ea83";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "1b1905d1f2513750671929b1ce4fbf47b524dcd9021e43e2cd9e768bfa4f9208";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -168,6 +168,8 @@ self: super: {
 
  backward-ros = self.callPackage ./backward-ros {};
 
+ bag2-to-image = self.callPackage ./bag2-to-image {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  bno055 = self.callPackage ./bno055 {};
@@ -801,6 +803,8 @@ self: super: {
  navigation2 = self.callPackage ./navigation2 {};
 
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
+
+ nerian-stereo = self.callPackage ./nerian-stereo {};
 
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "9967838cc9fb2e9355fbf2f06c3d84b5a0884da725a6c78701d67dddf4c296d3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "7edf0de6d0591dc4adc30a795a7a5d6f9effbdd2d3ab37e7f66ca5ddff3828e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "b0627f785056baa349508378657d4aeda1770eae2bdbd4936cb31dc109180641";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "7c0c2de57871be8f38024ab4d20c404d21db5d6ab16fef2bba5c321a75df2dac";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''ROS2 ros_control hardware interface'';
+    description = ''ros2_control hardware interface'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "3998156b0cca994f2898a3186b3afc5c700e3be4490fe3dd63b14389a5565270";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "875fdc084b151e44d593f6940d524c3d8c4249770cb957aab55e1dd75810681d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1b541160c39235c5ae6e9b6342bbd1283def84623e5f3d97d4f2a73e297dc1ea";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "995ccc31896db45a09a6905dcee3bd890392d62b329d01d70188ae218e08fee6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "5ed590175c6ddbe4bfc9d280898086330425e92a4141eabbd7836ec4d8c1d730";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "9dbd7e4aed1eccf00953a7dbcfe1ed8b6efee6b56dfb892ef2b721198f01ba60";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mavlink";
-  version = "2022.2.2-r3";
+  version = "2022.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.2.2-3.tar.gz";
-    name = "2022.2.2-3.tar.gz";
-    sha256 = "854a80be0a0e7612d2bd5543a7fa9cc96179c1e509e679dff556636565f715a7";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.6.27-1.tar.gz";
+    name = "2022.6.27-1.tar.gz";
+    sha256 = "6c2d7e176a4e4f0cddf67d5c385a8b3f2ec2d5b7bb64bab84b1672b55bc36970";
   };
 
   buildType = "cmake";

--- a/distros/humble/nerian-stereo/default.nix
+++ b/distros/humble/nerian-stereo/default.nix
@@ -4,13 +4,13 @@
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
-  pname = "ros-foxy-nerian-stereo";
+  pname = "ros-humble-nerian-stereo";
   version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.1.1-1.tar.gz";
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/humble/nerian_stereo/1.1.1-1.tar.gz";
     name = "1.1.1-1.tar.gz";
-    sha256 = "33f56cf27bfb2363f02ad66a3ef9ad6ad162fb055a4916f9435e3f59dd58ed10";
+    sha256 = "52fe766f6f1a4802a71645820e77e2e536840498ebb64acf2086af3a94de2e2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1115b85b403054cce853ea461cdf4721c1d150a3cffa6e25473f3092b9d1fe94";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "32f069297ab666e150a8a0e444f3784986c0a78303de6fdea6a83d265ee1c006";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8b48952fb28390d9dd18a01b07445e4bf7964d6896eb438f15c01cf4fa04bc37";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "4df04edfba5a96d2d4bca31c3d730d8490477fbad8c2e21950cd0d67f66c0223";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "cd8b0f926e36823a7739828e128ea675ff595a7e5e1f3529eac8fea1f57dc294";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "1f8be7a9e5940c7003d42f804dc23e62ff5345ab087ba3c62076ffd3409a1a47";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "3df266cd5c34da5b05baf43a8498c7fb7df4f46a6b7d71f00faaa98271c33e8b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "7e0e8c3279bc1828e5beeb0f7dc1e535c9724ab4f02059d1b6bb52d4303708aa";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1ff31c6221b72986086287985b8b8f02ac3b59ef8d0bdde3e6b0b0dea76dbd61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "13541040dee87194a251889bf40ea7c5cbca0b6d9d88b447ff4b4cf84f7f3380";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "2412876bb89624e74e4714386a3cec3af87226a69e4fd7c75c430a49609c75ad";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "da2651c598e38d5fd00bdb45f1fd298a30133ca5db9d708b4180b14cf13f9c0d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, pluginlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8b33f7304104a367b15a395e4b37c684795ebc17aa7d475233ab04666ad56c6e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "5b9a2fe90e4bf0e88331194dbf184896a2ca6514150b0611cef63c3e45a04db1";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ hardware-interface pluginlib ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "89d0d36f6bfcaf5704e8f5e07e6717a6c5e0ff01ede1db07c6d2e5f774a92f99";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "6517296dc6626c1a21f7d2f2feacfd60de7e523af9de51b076d2aeddd85490e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "7770553df791212fe6f509e6e8516463585f9b428e02b7d54084785a704961a8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "9abbec16cc4b07195ef1446258656b08111f0d4cda8f5b7463cc23c97b8ff9e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "93497feb0d2d8acc5e9e0133e91d198c13176c61ab43b981aa294e4dcba4505e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "bdcd61aac304ca86cb8476e0dc07a5a3fde4aa9c46d2e62a09d083b2cfa942d4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "b4c8d4d44de65616f62256198e7e0b0c83a603fb1adf980b78402d43eab82b29";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "05c7805d49ca6a4940f5522fa848527599050575a704456fd950603289547709";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "122b043304b5867f6664ed14cb1e26a6aab43780e318ea4096f6f5e0814728d6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "6e78e951f307b0ca231972802c92b6ceae07a00b6d38dec4ef60394c53d705db";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "724526fda1e17c41b91fa4b54edf6dbbc254042e96b95c4ca2b534fdda6262ba";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "f3554aa15757b69650059ab09fa555ee778b2f57a77f4809307638ecb211a607";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "1ff537ae41f70249a409ee6e19fdc7d913e6789d6913e3d87910453ccdf7cf9f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "d993896baf3da8326d92570379da297621a2cf9dc3fe404d46c50051bb22f614";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "43f3b346311dcee72b3ce20a76dd42fb2dfdcb869c19e42cf9cb7481801e6fd2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "e18c96dbab4141032fbb50465b3051a56d84270ab95791b03b439adb38dd7208";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9df9a503805cd397f061712eeeed67a12f45d47f0713b1248c88525977147994";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "04f32d7a342061fdf0ece200ecdd0ad71c82a022303db67b76b157e8f8d35110";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "ae02e9074ca4e6942a12474adeccb2eeb4c2d7ae5b5e4ddac8288ebc84695447";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "e9f609ee1509474ef29bfa71997ab368a325e8ecd9481d70f1a7277602964ee0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9fa36cd87066348cf327f78343dd378ac008a31a7f1d067d0193b32a7dd38709";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "00a8d9e58460713648cec3c39c1756c84c3c33f7658011e0525dbec8b9e3922e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "3dd560bf569f7dcfe1d2c7098e339932e3f9f092ee74c52f7f0a20f35887affa";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "59901b4d4831e1fdaf85918825267683ae37303929b468d857c1301ead9c81e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1886,7 +1886,15 @@ self: super: {
 
  mqtt-client = self.callPackage ./mqtt-client {};
 
+ mrpt-ekf-slam-2d = self.callPackage ./mrpt-ekf-slam-2d {};
+
+ mrpt-ekf-slam-3d = self.callPackage ./mrpt-ekf-slam-3d {};
+
  mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};
+
+ mrpt-graphslam-2d = self.callPackage ./mrpt-graphslam-2d {};
+
+ mrpt-icp-slam-2d = self.callPackage ./mrpt-icp-slam-2d {};
 
  mrpt-local-obstacles = self.callPackage ./mrpt-local-obstacles {};
 
@@ -1902,11 +1910,15 @@ self: super: {
 
  mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
 
+ mrpt-rbpf-slam = self.callPackage ./mrpt-rbpf-slam {};
+
  mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
 
  mrpt-sensorlib = self.callPackage ./mrpt-sensorlib {};
 
  mrpt-sensors = self.callPackage ./mrpt-sensors {};
+
+ mrpt-slam = self.callPackage ./mrpt-slam {};
 
  mrpt-tutorials = self.callPackage ./mrpt-tutorials {};
 

--- a/distros/noetic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-ekf-slam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "21ec278234298b03fe9d066a7cdd93c86b0ceea137239887774091287def6e2c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is a wrapper for the implementation of EKF-based SLAM with range-bearing sensors, odometry, and a 2D (+heading) robot pose, and 2D landmarks.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-3d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-ekf-slam-3d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "efd46ed9041241ca4160234c4db70bd95488f0564c4ed8c1a8806e45deef4aef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is a wrapper for the implementation of EKF-based SLAM with range-bearing sensors, odometry, a full 6D robot pose, and 3D landmarks.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-graphslam-2d/default.nix
+++ b/distros/noetic/mrpt-graphslam-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-graphslam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "004a9f7e9a6ebbdb9db83b1c2b45e1389754fedd5ded644b08d217261268bf9e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fkie-multimaster-msgs geometry-msgs mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs roscpp rospy sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implement graphSLAM using the mrpt-graphslam library, in an online fashion
+  	by directly reading measurements off ROS Topics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-icp-slam-2d/default.nix
+++ b/distros/noetic/mrpt-icp-slam-2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-icp-slam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "8027b57f93610518e7580e15912181a3b0d7b9329f750f268ff14a34d09780a8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''mrpt_icp_slam_2d contains a wrapper on MRPT's 2D ICP-SLAM algorithms.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-rbpf-slam/default.nix
+++ b/distros/noetic/mrpt-rbpf-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-rbpf-slam";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "29d9e82f748f18580fd8b628c708f68461ba338ab1bbf0214ae4f35f617a9470";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 mvsim nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is used for gridmap SLAM. The interface is similar to gmapping (https://wiki.ros.org/gmapping) but the package supports different particle-filter algorithms, range-only SLAM, can work with several grid maps simultaneously and more.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-slam/default.nix
+++ b/distros/noetic/mrpt-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-slam";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "732c625387478084e7d28ad83657ca7af8d807bdcf523cbdeaa1f4d173c26a3d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-ekf-slam-2d mrpt-ekf-slam-3d mrpt-graphslam-2d mrpt-icp-slam-2d mrpt-rbpf-slam ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''mrpt_slam'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit bb7b9e3723d3148f5ba8db85f9e10c4475efdaff.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *maliput-dragway 0.1.1-r1 --> 0.1.2-r1*
* *maliput-malidrive 0.1.1-r1 --> 0.1.2-r1*
* *maliput-multilane 0.1.0-r1 --> 0.1.1-r1*
* *nerian-stereo 1.1.0-r1 --> 1.1.1-r1*

Galactic Changes:
-----------------
* *log-view 0.2.0-r1*
* *magic-enum 0.7.3-r1 --> 0.8.0-r1*
* *nerian-stereo 1.1.1-r1*
* *twist-stamper 0.0.2-r1*

Humble Changes:
---------------
* *bag2-to-image 0.1.0-r1*
* *controller-interface 2.10.0-r1 --> 2.11.0-r1*
* *controller-manager 2.10.0-r1 --> 2.11.0-r1*
* *controller-manager-msgs 2.10.0-r1 --> 2.11.0-r1*
* *diff-drive-controller 2.6.0-r1 --> 2.7.0-r1*
* *effort-controllers 2.6.0-r1 --> 2.7.0-r1*
* *force-torque-sensor-broadcaster 2.6.0-r1 --> 2.7.0-r1*
* *forward-command-controller 2.6.0-r1 --> 2.7.0-r1*
* *gripper-controllers 2.6.0-r1 --> 2.7.0-r1*
* *hardware-interface 2.10.0-r1 --> 2.11.0-r1*
* *imu-sensor-broadcaster 2.6.0-r1 --> 2.7.0-r1*
* *joint-state-broadcaster 2.6.0-r1 --> 2.7.0-r1*
* *joint-trajectory-controller 2.6.0-r1 --> 2.7.0-r1*
* *mavlink 2022.2.2-r3 --> 2022.6.27-r1*
* *nerian-stereo 1.1.1-r1*
* *position-controllers 2.6.0-r1 --> 2.7.0-r1*
* *ros2-control 2.10.0-r1 --> 2.11.0-r1*
* *ros2-control-test-assets 2.10.0-r1 --> 2.11.0-r1*
* *ros2-controllers 2.6.0-r1 --> 2.7.0-r1*
* *ros2-controllers-test-nodes 2.6.0-r1 --> 2.7.0-r1*
* *ros2controlcli 2.10.0-r1 --> 2.11.0-r1*
* *transmission-interface 2.10.0-r1 --> 2.11.0-r1*
* *velocity-controllers 2.6.0-r1 --> 2.7.0-r1*

Melodic Changes:
----------------
* *costmap-cspace 0.11.4-r1 --> 0.11.5-r1*
* *joystick-interrupt 0.11.4-r1 --> 0.11.5-r1*
* *map-organizer 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation-common 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation-launch 0.11.4-r1 --> 0.11.5-r1*
* *obj-to-pointcloud 0.11.4-r1 --> 0.11.5-r1*
* *planner-cspace 0.11.4-r1 --> 0.11.5-r1*
* *safety-limiter 0.11.4-r1 --> 0.11.5-r1*
* *track-odometry 0.11.4-r1 --> 0.11.5-r1*
* *trajectory-tracker 0.11.4-r1 --> 0.11.5-r1*

Noetic Changes:
---------------
* *mrpt-ekf-slam-2d 0.1.11-r1*
* *mrpt-ekf-slam-3d 0.1.11-r1*
* *mrpt-graphslam-2d 0.1.11-r1*
* *mrpt-icp-slam-2d 0.1.11-r1*
* *mrpt-rbpf-slam 0.1.11-r1*
* *mrpt-slam 0.1.11-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bokeh-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-pytest-timeout
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

