### PR TITLE
rosdistro sync, Fri Jul 15 14:57:46 2022

### DIFF
--- a/distros/foxy/angles/default.nix
+++ b/distros/foxy/angles/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-angles";
-  version = "1.12.3-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/foxy/angles/1.12.3-1.tar.gz";
-    name = "1.12.3-1.tar.gz";
-    sha256 = "2ece091460ffc83df530336e95aaf361e1d760d236a3a0a04e3df2768d8ab94d";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/foxy/angles/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "a4f16d3854d340b4008e2cd556fe411cdf39c00764902264d2d6fa5dabe28e69";
   };
 
   buildType = "ament_cmake";
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 
   meta = {
     description = ''This package provides a set of simple math utilities to work

--- a/distros/foxy/camera-calibration-parsers/default.nix
+++ b/distros/foxy/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-camera-calibration-parsers";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_calibration_parsers/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "095e7dca0a824d48a168961e4fe157d55cef0e2a7b7a126252b713ed7e8f28f0";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_calibration_parsers/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "bd0f502363620e2bddef611dcde02e001208564be1c949f1a7feb0ddf622c2d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/camera-info-manager/default.nix
+++ b/distros/foxy/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-camera-info-manager";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_info_manager/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "ee222b6a1cca8221b859426c6d5d0254ee5bbb5fbc6669f979896c6cc24e9388";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_info_manager/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "f6ece97f5bf6e68f691cab308da708e380c8852dd452cdb5ce2fd2a22738567b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/depthai/default.nix
+++ b/distros/foxy/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-depthai";
-  version = "2.15.5-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.15.5-1.tar.gz";
-    name = "2.15.5-1.tar.gz";
-    sha256 = "687fd898f762a61c98888ca56f81ff4b4dd6cdfceb6b893aca8a01ad50b50845";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "f74a89ee0823cc61ebdddeb7c4253ab80297cf33d7b7822dd9770f0a95b87c17";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.5-r1";
+  version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "9b96e2ca134cbf95c31400f5ae7862e5e79b36a6133630079083734a461aa2c2";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.6-1.tar.gz";
+    name = "2.7.6-1.tar.gz";
+    sha256 = "6b7939517b821f33e478ce8a45566021c040c3936cce929742b27c53903a4054";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -792,6 +792,8 @@ self: super: {
 
  maliput-drake = self.callPackage ./maliput-drake {};
 
+ maliput-full = self.callPackage ./maliput-full {};
+
  maliput-integration = self.callPackage ./maliput-integration {};
 
  maliput-malidrive = self.callPackage ./maliput-malidrive {};
@@ -1211,6 +1213,8 @@ self: super: {
  raptor-pdu-msgs = self.callPackage ./raptor-pdu-msgs {};
 
  raspimouse = self.callPackage ./raspimouse {};
+
+ raspimouse-description = self.callPackage ./raspimouse-description {};
 
  raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
 
@@ -1973,6 +1977,8 @@ self: super: {
  vision-opencv = self.callPackage ./vision-opencv {};
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
+
+ vrpn = self.callPackage ./vrpn {};
 
  vrxperience-bridge = self.callPackage ./vrxperience-bridge {};
 

--- a/distros/foxy/image-common/default.nix
+++ b/distros/foxy/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-foxy-image-common";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_common/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "fc943f0730fe6f9a54fa8ab742b7ccd990e18b1763bb248217226e8acb2f7bdb";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_common/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "869d51bb9e5a490d6f22ea6355ea4db8a96e29c3a8caedbf4183222759963d38";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/image-transport/default.nix
+++ b/distros/foxy/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-image-transport";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_transport/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a83e667892dca1cc6a4fa8ad66e5e20f7a41e844365cdafc627736e266e31cb0";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_transport/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "64ad0f4165a117b50536b0545615472a3dc38938110222f11d992530e90c0454";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-complementary-filter/default.nix
+++ b/distros/foxy/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-imu-complementary-filter";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_complementary_filter/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "917d1cf764c96a1e68ba19046cd5a5ba656520fcee654492c40bc650c2bf0b4c";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_complementary_filter/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "59f4c53358e5bed435241d6b96098bfdc6f9e7eb7b7d417e8dcd3d977502aceb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-filter-madgwick/default.nix
+++ b/distros/foxy/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-filter-madgwick";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_filter_madgwick/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "eecc54e87078d1837f95a001934cb1d895e5e82fe430628dc8ed51aefb4bb779";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_filter_madgwick/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ecd44aacd384ec18eb9da3f7ae576fc1632331a279bcacb61cb69172534ed363";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-tools/default.nix
+++ b/distros/foxy/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-foxy-imu-tools";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_tools/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "f36db5f5d7dcc16202cbad8e30ba863e813c5301a4017c9d7bbb8cc0fdc96251";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "711d04a76ab71d447824b520da25b6a02255348abe179a71720ac27fd77654e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-dragway/default.nix
+++ b/distros/foxy/maliput-dragway/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, pybind11, python3 }:
 buildRosPackage {
   pname = "ros-foxy-maliput-dragway";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "748dd0110dc11469dc428ebc8d18e9262ee8f3b528be3b9f945bcdd8bb0c6d21";
+    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "cd69db9752c89e4be9eaea375ea99960bcdd28b3c4a5541d239f14aebd9c840b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-full/default.nix
+++ b/distros/foxy/maliput-full/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, maliput, maliput-dragway, maliput-drake, maliput-integration, maliput-malidrive, maliput-multilane, maliput-object, maliput-object-py, maliput-py }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-full";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_infrastructure-release/archive/release/foxy/maliput_full/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "3d6e191e7efa5169c258c109d0f67b3d2859d36d7e4bc65407d2271f95363016";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ maliput maliput-dragway maliput-drake maliput-integration maliput-malidrive maliput-multilane maliput-object maliput-object-py maliput-py ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta package that concentrates all maliput-related packages'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/maliput-malidrive/default.nix
+++ b/distros/foxy/maliput-malidrive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, fmt, maliput, maliput-drake, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-maliput-malidrive";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f643c9761b5333d6cc0856263e49ef2931b4820f5b141f800639a2d800276971";
+    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "e37a774e2665aa4364f3cd6c3bb3f1a941c517ce2e3457e163b935edac5741cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
 buildRosPackage {
   pname = "ros-foxy-maliput-multilane";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "527698d08a50d9a49c0d3382e62f2854ebb5e02dee52873dfd3668f25c16e55f";
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "bbb58467ea2752e8ddea5494fdc03fef593e0327761740cbc9971bce1d5081f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nerian-stereo/default.nix
+++ b/distros/foxy/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nerian-stereo";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "16ae46284080599ab25f9ab506f11696fefefe00f6bf598dde4a82a134a9318d";
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "33f56cf27bfb2363f02ad66a3ef9ad6ad162fb055a4916f9435e3f59dd58ed10";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/performance-test/default.nix
+++ b/distros/foxy/performance-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-performance-test";
-  version = "1.0.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/foxy/performance_test/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9035cf4ff43fa584da5ed5cc28853032b3d143eb7bd75606d94cad0c159b250b";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/foxy/performance_test/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "525cfade4a96984b86c41f451b3f15cf7617c346952e1a48139c437fd94513f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "9c260ad1a41cd500a74c037b76e1604f5accda21d4dddc9067db2243caebfe77";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "5d4be39f01bc0c2c6970d9ab928c31c4247c82db04378b4d5bc8d21d33e49af8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raspimouse-description/default.nix
+++ b/distros/foxy/raspimouse-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-raspimouse-description";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/foxy/raspimouse_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4c14a50a79d663917064832aebf8d44ff60ad26c0d52faaebe53153977566c81";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The raspimouse_description package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/rviz-imu-plugin/default.nix
+++ b/distros/foxy/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, message-filters, pluginlib, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-rviz-imu-plugin";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/rviz_imu_plugin/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "6bdb2b29fe1c2f100789638f542752b6c41c51a038a7b05929e4a92490968027";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/rviz_imu_plugin/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5e0221c97bee7ffbbd24a6c0f77e16b1c7055341cef45af6293fad9b9d650ebf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/vrpn/default.nix
+++ b/distros/foxy/vrpn/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
+buildRosPackage {
+  pname = "ros-foxy-vrpn";
+  version = "7.35.0-r8";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/vrpn-release/archive/release/foxy/vrpn/7.35.0-8.tar.gz";
+    name = "7.35.0-8.tar.gz";
+    sha256 = "4d663529646e6697043507eff26ff773a71e01663373dc5c976a5b857bcfd7b1";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The VRPN is a library and set of servers that interfaces with virtual-reality systems, such as VICON, OptiTrack, and others.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/angles/default.nix
+++ b/distros/galactic/angles/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-angles";
-  version = "1.12.4-r2";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/galactic/angles/1.12.4-2.tar.gz";
-    name = "1.12.4-2.tar.gz";
-    sha256 = "374d88ee725f7a532408549f8933795ec1d360095395410b1c8f72a6c307a17b";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/galactic/angles/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "3c77795be096e8bbeb34b3ae79528a2764cf5db6177361ab208e3321f223b866";
   };
 
   buildType = "ament_cmake";
-  nativeBuildInputs = [ ament-cmake python3Packages.setuptools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 
   meta = {
     description = ''This package provides a set of simple math utilities to work

--- a/distros/galactic/camera-calibration-parsers/default.nix
+++ b/distros/galactic/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-camera-calibration-parsers";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_calibration_parsers/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "6a3dd247c289a58239c0f5f379d5433cb480f118cd61859901d9e9be3bbb4747";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_calibration_parsers/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "62001acece6e528bd548dc91a801201ea85abb1f28b47440355b6e4c98112c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/camera-info-manager/default.nix
+++ b/distros/galactic/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-camera-info-manager";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_info_manager/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "ecef86201cb6ce31ac6650d46104673d030940187f54eb42f7c5bf41278d2a7c";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_info_manager/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "2462a605ffd15667c92532ee1d3e6c70ac85a71dd8e552d9f14af637d1870004";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai/default.nix
+++ b/distros/galactic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-depthai";
-  version = "2.15.5-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.15.5-1.tar.gz";
-    name = "2.15.5-1.tar.gz";
-    sha256 = "4986156602eab268b763908b1c26d67e4404f43476a61a026ddd6c6b95b901fe";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "4115e30bead9e68dd945ad2444fdcd2ad48ee7b0fa688e920f838f3ec46c456a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -652,6 +652,8 @@ self: super: {
 
  lifecycle-msgs = self.callPackage ./lifecycle-msgs {};
 
+ log-view = self.callPackage ./log-view {};
+
  logging-demo = self.callPackage ./logging-demo {};
 
  lua-vendor = self.callPackage ./lua-vendor {};
@@ -867,6 +869,8 @@ self: super: {
  navigation2 = self.callPackage ./navigation2 {};
 
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
+
+ nerian-stereo = self.callPackage ./nerian-stereo {};
 
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
@@ -1763,6 +1767,8 @@ self: super: {
  tvm-vendor = self.callPackage ./tvm-vendor {};
 
  twist-mux = self.callPackage ./twist-mux {};
+
+ twist-stamper = self.callPackage ./twist-stamper {};
 
  ublox = self.callPackage ./ublox {};
 

--- a/distros/galactic/image-common/default.nix
+++ b/distros/galactic/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-galactic-image-common";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_common/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "ae20aae3bf832989304e36066c7b6eb0c32086972fdc954b9483e8517dcddd73";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_common/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "47330b6d8403c509ec0b882b339b6e0387923897229d91e152a941bff9bbe436";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/image-transport/default.nix
+++ b/distros/galactic/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-image-transport";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "d91cad7553e537d5a94395a4cf1ac807ff599d021f268ac14ac9b44e324a35c7";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_transport/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "57d015f1158eb157ccc9d118409531273d134485ff0ebc0dc7a32ca37a62b542";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-complementary-filter/default.nix
+++ b/distros/galactic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-imu-complementary-filter";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_complementary_filter/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "b89699b5b628132a105294c7b1249bd306f57d354c2e62c05cfb3abc82ce5d4e";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_complementary_filter/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a9805b2dcd9e9e5866d320a51216b2746b56aa8cabd0cfc0d5745ab785ae40b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-filter-madgwick/default.nix
+++ b/distros/galactic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-imu-filter-madgwick";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_filter_madgwick/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "c794017fd4504666bd09c906a557cbe8116da75390e5ae57839468429fc064a1";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_filter_madgwick/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "1796b29e38544e9bf04be52df9f52e01bb2e661f37c8a65c942cf9173869457a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-tools/default.nix
+++ b/distros/galactic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-galactic-imu-tools";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_tools/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "c63023f9943ff06b0af316fa12ef1e7014393297fbf4197386eeb027a340f078";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "0c716be4760a0b7c4c72422e4e573c20bc13461f8fb7cf1a7189b9a2dcfb2ba5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/log-view/default.nix
+++ b/distros/galactic/log-view/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip }:
+buildRosPackage {
+  pname = "ros-galactic-log-view";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/hatchbed/log_view-release/archive/release/galactic/log_view/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "781f8752d3cb932e45943a800019cfdf176d0439e2090bc20a2be58ae81e49dc";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The log_view package provides a ncurses based terminal GUI for
+    viewing and filtering published ROS log messages.
+
+    This is an alternative to rqt_console and swri_console that doesn't depend
+    on qt and can be run directly in a terminal.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/magic-enum/default.nix
+++ b/distros/galactic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-galactic-magic-enum";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/galactic/magic_enum/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "b7a5b2ddba201a6238ddbeada09f5eb887711aff17b87f7418f1cb2202aa0eec";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/galactic/magic_enum/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "41c5912bf40f134d2beddb3138d243ed76be21f27875bb777f78a1ab04bcb7c4";
   };
 
   buildType = "cmake";

--- a/distros/galactic/nerian-stereo/default.nix
+++ b/distros/galactic/nerian-stereo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-nerian-stereo";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/galactic/nerian_stereo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "05cda22e7fa5597a900ab06c0e893cc6b7cc85ea237896ebba554d029bbc1fed";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake cv-bridge rosidl-default-generators rosidl-default-runtime sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Driver node for ROS 2 for Scarlet, SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/performance-test/default.nix
+++ b/distros/galactic/performance-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-performance-test";
-  version = "1.0.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/galactic/performance_test/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8c787535f563bb788d647b5519c9a15cdacaac88b1ef87652762314dc0c413bd";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/galactic/performance_test/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "9e8b988f5349aa1b8a340cd3f240ff2758d040a58da673e33f06af79541cc798";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "f81e9ee36e799cba846e96439f43e1b60af3d85325b57b03b5d6c1b42a474992";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "7ec0eac90188417ec8414d3f9fec2ba17c3cb92170e62b690e562f28e2ca7102";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-imu-plugin/default.nix
+++ b/distros/galactic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, message-filters, pluginlib, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-rviz-imu-plugin";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/rviz_imu_plugin/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "701b199d1b6ecdb5aeb78cc8912fcdb513d3ef1071a5a56e6f717b5a057cad19";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/rviz_imu_plugin/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c18b74be79f4e84ceb530f16ca650a01e60a0cc34838f926afce956056b1f89f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-description/default.nix
+++ b/distros/galactic/turtlebot4-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-description, robot-state-publisher, urdf }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-description";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "6f9fb98d371d784f3ff06385bf82dd1b2c69f64aa974658ead54a1f6ad0df63f";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_description/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "99b2667a429039ffd5c6624b4fc0f51595e898508fd6e5085706640941a469a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-msgs/default.nix
+++ b/distros/galactic/turtlebot4-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "1c3b89649c5251aab468fc6bcc71b6914cf1290f91b7e1644b938ef93cbfdfd8";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "e73f3c3470a535dfd614e85824e38c740fc8bf7c4862aec073f4ed6bebe2ad69";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-navigation/default.nix
+++ b/distros/galactic/turtlebot4-navigation/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav2-bringup, slam-toolbox }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, nav2-bringup, nav2-simple-commander, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-navigation";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_navigation/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "173e72b8c0b910c817c14632186ebaa04658b5d15981ae2f8819f6a28c5328dc";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_navigation/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "48e91cd72555d9c49e59596d75757861cc99bef05a2be183a1c32a0303236334";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav2-bringup slam-toolbox ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav2-bringup nav2-simple-commander slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''Turtlebot4 Navigation'';

--- a/distros/galactic/turtlebot4-node/default.nix
+++ b/distros/galactic/turtlebot4-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-node";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_node/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "cf5dff74cf226318ca2f7dfa60d081212d2a3479c70b1903e80d59d0c3b06bef";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_node/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "292334aba2cd09be5ebea47d25627b49f151c749dfcd315dc43f23ff8e699064";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/twist-stamper/default.nix
+++ b/distros/galactic/twist-stamper/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-twist-stamper";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/joshnewans/twist_stamper-release/archive/release/galactic/twist_stamper/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "97147c9dee8f70d3de5a198f96be3f521aa101ff2edf690a9712a5764ab609c4";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs rclpy std-msgs ];
+
+  meta = {
+    description = ''ROS2 package for converting between Twist and TwistStamped messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/velodyne-driver/default.nix
+++ b/distros/galactic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-driver";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "63b305d7113d4ec7f977da66faba82f3427cfa4453da6993709bbb50a43402de";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "4742dabcbde7a4736da17493bf638bb49d4155d67f777bed371e82e5df98dda8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-laserscan/default.nix
+++ b/distros/galactic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-laserscan";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "409d3a53c5b4a6c7164b3f85d7e9a4635119751820fd22c7c46b8730b3ee1794";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "879837e0ef4588822d03f9229afcf2ab8b88017cf89b7a6a663f57c4c575b36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-msgs/default.nix
+++ b/distros/galactic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-msgs";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5557887b891ea9c9b3ac06a8aae9129c7c78badbba97b18a145055c1c72fc4fb";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "68de3c5fd4cb13ea6b6cff164a2044635eefc02984bedd5ed464d301de4d1840";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-pointcloud/default.nix
+++ b/distros/galactic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-pointcloud";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "14336818e211d7231a126ab5e45762cd4170f4f9472f1af3e505d67e8c6e2796";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "edd5447b505a0f786f0a98bf33fbbf8b9d58af488aa0241d3ebaa50a9dd4f0cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne/default.nix
+++ b/distros/galactic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-galactic-velodyne";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "838f82656dfefc285648931d87839ae27b2dfcf13ad7c7d81803012b1ff3b6c7";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "333e193dc90c1dd1846ade0e0f656bd9f5918f596b443b0dc885306b497fd875";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bag2-to-image/default.nix
+++ b/distros/humble/bag2-to-image/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, opencv, rclcpp, rclcpp-components, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-bag2-to-image";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bag2_to_image-release/archive/release/humble/bag2_to_image/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "49394a857b402145a03cf4e1e9fc0a2e6edccc9857d0485acf337a0c057fbcca";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ opencv rclcpp rclcpp-components rosbag2-cpp rosbag2-storage sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The bag2_to_image package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "da02ea88c85592d1fd49d2413f9e5559f2f1a63708c8a37289c03f9774b78702";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "eb9f4b18f85ecc73dd7c7f4d0a111bea03ddd0db1d2a4f6691e0bf85ff8be54e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "e89206b5b735ad6dbb5fdccc9b9e0f20a14ba23e4157e8e108b3bb1168b75988";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "1aa76228bdd8bd5756a2eaef5652ce295de7d1d0b022070d85aa6215739b705e";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "0e497ae8cbcf367e9518113551a0b6146ac3aa3503e79701356f40ba177218a2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "1c103626cab226004f3c80b99752a55a7d69312138b419abc62112d35b0b7ed4";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock realtime-tools ];
   propagatedBuildInputs = [ ament-index-cpp controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils ros2-control-test-assets ros2param ros2run ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "8d3ad011895aa982b63e3b6d538cabe8cec2b6234f8cf5f129e20f18d24fb93d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "e1da8c7d44bbfbaae2ce41e9cdb8d31c4c85951dd493b2883165ba35d14702f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "4b5d59637695d9ac321935e91a72ee9fa5a0eb1dbb23792c7ab92d9fa1741413";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "02ef7dcb1090be8f23430dd5d258a653d8c1178c4ed9b6dcd332aa8633cd3b1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0a66cfd0d15adce846a70ad75760d6f8c2a9dfa48d7d566dd2e44db019cc15d4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "9d285d3ec8b9bbebabb0101f941891dd91b87596db2537749e7a4c095f2dcbfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "bc71e32986238aa890af5292b3277a218de36bfff01dfa0d5572bec88de6ea83";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "402212b2f7ac5c0a789c7e1d5e517e89b1e5a8e3b535b22fd42e021e752c59e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -168,6 +168,8 @@ self: super: {
 
  backward-ros = self.callPackage ./backward-ros {};
 
+ bag2-to-image = self.callPackage ./bag2-to-image {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  bno055 = self.callPackage ./bno055 {};
@@ -492,6 +494,8 @@ self: super: {
 
  io-context = self.callPackage ./io-context {};
 
+ joint-limits = self.callPackage ./joint-limits {};
+
  joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
@@ -802,6 +806,8 @@ self: super: {
 
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
 
+ nerian-stereo = self.callPackage ./nerian-stereo {};
+
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
@@ -863,8 +869,6 @@ self: super: {
  perception = self.callPackage ./perception {};
 
  perception-pcl = self.callPackage ./perception-pcl {};
-
- performance-report = self.callPackage ./performance-report {};
 
  performance-test = self.callPackage ./performance-test {};
 
@@ -1662,9 +1666,19 @@ self: super: {
 
  velocity-controllers = self.callPackage ./velocity-controllers {};
 
+ velodyne = self.callPackage ./velodyne {};
+
  velodyne-description = self.callPackage ./velodyne-description {};
 
+ velodyne-driver = self.callPackage ./velodyne-driver {};
+
  velodyne-gazebo-plugins = self.callPackage ./velodyne-gazebo-plugins {};
+
+ velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
+
+ velodyne-msgs = self.callPackage ./velodyne-msgs {};
+
+ velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
  velodyne-simulator = self.callPackage ./velodyne-simulator {};
 

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "9967838cc9fb2e9355fbf2f06c3d84b5a0884da725a6c78701d67dddf4c296d3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "f55707446b243efd781e07da2257babe82360dd18ee95f42c3eb05d343304884";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "b0627f785056baa349508378657d4aeda1770eae2bdbd4936cb31dc109180641";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "5a6aea12bb6246794d04745f3fa733c51d53cc84f97ed42782c638a1dee29ac3";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''ROS2 ros_control hardware interface'';
+    description = ''ros2_control hardware interface'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "3998156b0cca994f2898a3186b3afc5c700e3be4490fe3dd63b14389a5565270";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "d54e465e65b80c32790853df2ccf3989388ae3d1f5983b221353cd54d17797e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-humble-joint-limits";
+  version = "2.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "0442245a960d277054ebfe540f2fc51d66bda201d4846f09492106234aada6e7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces for handling of joint limits for controllers or hardware.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1b541160c39235c5ae6e9b6342bbd1283def84623e5f3d97d4f2a73e297dc1ea";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "32aa2925be62bff92fa97b5a202ed285275ce281269e8adaeb9df9d3fb61eaa0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "5ed590175c6ddbe4bfc9d280898086330425e92a4141eabbd7836ec4d8c1d730";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "1e739f7534bd5726e905883a65a0f086483b3bd1cacee5aecf0419f41ddd04f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mavlink";
-  version = "2022.2.2-r3";
+  version = "2022.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.2.2-3.tar.gz";
-    name = "2022.2.2-3.tar.gz";
-    sha256 = "854a80be0a0e7612d2bd5543a7fa9cc96179c1e509e679dff556636565f715a7";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.6.27-1.tar.gz";
+    name = "2022.6.27-1.tar.gz";
+    sha256 = "6c2d7e176a4e4f0cddf67d5c385a8b3f2ec2d5b7bb64bab84b1672b55bc36970";
   };
 
   buildType = "cmake";

--- a/distros/humble/nerian-stereo/default.nix
+++ b/distros/humble/nerian-stereo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-nerian-stereo";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/humble/nerian_stereo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "52fe766f6f1a4802a71645820e77e2e536840498ebb64acf2086af3a94de2e2f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake cv-bridge rosidl-default-generators rosidl-default-runtime sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Driver node for ROS 2 for Scarlet, SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/performance-test/default.nix
+++ b/distros/humble/performance-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-performance-test";
-  version = "1.1.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_test/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "86837cb1939cb826de597334ba5d7653deafbcf42a572ab28c7b45406d94ef1e";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_test/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "c2c82361579b9a02dea39bc4d3b589c0ed055bacf12b701e291e4629d96f7585";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1115b85b403054cce853ea461cdf4721c1d150a3cffa6e25473f3092b9d1fe94";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "40f41c4512255f3d348c56cfce7a41208b8ff91f5c8072e71dae4d0b48a55187";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8b48952fb28390d9dd18a01b07445e4bf7964d6896eb438f15c01cf4fa04bc37";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "384211164a16ad708be18296538b458b3a378781b861109ece84c74f6616622a";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "cd8b0f926e36823a7739828e128ea675ff595a7e5e1f3529eac8fea1f57dc294";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "a817cc0157eccff03e59e58eef0efbc8e8ea3c8419dc543080e4308354072ae2";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface ros2-control-test-assets ros2controlcli transmission-interface ];
+  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface joint-limits ros2-control-test-assets ros2controlcli transmission-interface ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "3df266cd5c34da5b05baf43a8498c7fb7df4f46a6b7d71f00faaa98271c33e8b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "28f94c91d1bbc6fda155b51e58ee56f163608bc29e030cafdb9ee3d746e5e96a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1ff31c6221b72986086287985b8b8f02ac3b59ef8d0bdde3e6b0b0dea76dbd61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "24b7ab6f7c662a39e5511919a388841d5fef777062a70d35633c83faa73a3e9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "2412876bb89624e74e4714386a3cec3af87226a69e4fd7c75c430a49609c75ad";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "9e7d6cc88e961f505e961904fd9212962bd1f8c1a3578cdf880c8d05fbd418ee";
   };
 
   buildType = "ament_python";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, pluginlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8b33f7304104a367b15a395e4b37c684795ebc17aa7d475233ab04666ad56c6e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "402299d4a1347b8b98428551701dc3d1c279ecde1ae89c37e10e3195407505e0";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ hardware-interface pluginlib ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.6.0-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "89d0d36f6bfcaf5704e8f5e07e6717a6c5e0ff01ede1db07c6d2e5f774a92f99";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "7b9ad4612c7f6b6e054b335428c2c689d07d517bb3ff18a6bf7d0f35ee2b3795";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velodyne-driver/default.nix
+++ b/distros/humble/velodyne-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-driver";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "6644989f62b15fe9466eaccbf4732c0ca066bc256e1d1e746a614e071adee5ec";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater libpcap rclcpp rclcpp-components tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS device driver for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne-laserscan/default.nix
+++ b/distros/humble/velodyne-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-laserscan";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_laserscan/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "9aea61bf55a6472f5a4a00eef32030d629693578687b9142d75295461d261823";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Extract a single ring of a Velodyne PointCloud2 and publish it as a LaserScan message'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne-msgs/default.nix
+++ b/distros/humble/velodyne-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-msgs";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "9d8ca6f3b6140078f6a83def16ba1a147d9812097e6bf0743c255b868323eb9e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS message definitions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne-pointcloud/default.nix
+++ b/distros/humble/velodyne-pointcloud/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-pointcloud";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_pointcloud/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2a84eaaf7b0435550cc89b4e8624f63477a071ee82bd375b8d8b345e565280f7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Point cloud conversions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne/default.nix
+++ b/distros/humble/velodyne/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-humble-velodyne";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e30613ff99d96ec03c47047920fda2473a0b73e8ebcb805a005584b09fa30956";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-driver velodyne-laserscan velodyne-msgs velodyne-pointcloud ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Basic ROS support for the Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/camera-calibration/default.nix
+++ b/distros/melodic/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, message-filters, rospy, rostest, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-camera-calibration";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "184268a2b78b1373289cf8c047e3f2069911dff625cfeb36ae34a19dc241ba5f";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "f383771fde50848fb35e7dacc89351e9ac856f5b50c7c15d02d5b69dec321e04";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "7770553df791212fe6f509e6e8516463585f9b428e02b7d54084785a704961a8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "9abbec16cc4b07195ef1446258656b08111f0d4cda8f5b7463cc23c97b8ff9e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/depth-image-proc/default.nix
+++ b/distros/melodic/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cv-bridge, eigen-conversions, image-geometry, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-depth-image-proc";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "dd1e8a0b66ed4ad80d8f4eb4cbeaa315ba8f1c6d3d5d096edf9b55153bd9f90a";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "1a96a4b0043043f126f78236f49b335d69c163137c2a2b4af38db5e157e82289";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.5-r1";
+  version = "2.7.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "47858bb6feda73d45f258f788360159c31fdcb1f4547a1324c9a1bc7e402acb1";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.6-3.tar.gz";
+    name = "2.7.6-3.tar.gz";
+    sha256 = "710f25eb0a89b65f87f525563aa7dd3b7bfa500a93367f88c337aa90bf9da0e2";
   };
 
   buildType = "cmake";

--- a/distros/melodic/image-pipeline/default.nix
+++ b/distros/melodic/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration, catkin, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-image-pipeline";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "5101a0cae0545e8384888172b1b7a4bd870a221d7c741e128a1bc89186ef4c76";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "4a7d7906fa86fb64308ab843b43e48fabe79bfaaa085e662a95dfbd4517c1991";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-proc/default.nix
+++ b/distros/melodic/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-transport, nodelet, nodelet-topic-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-proc";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "146972719c251c70dd8702ef84d65da3a188f8b30090e95ca70455cc8282d9a3";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "e93866f644228cb471e156021c77dd987a92015937ca917048616898b1d6f778";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-publisher/default.nix
+++ b/distros/melodic/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-publisher";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "3117e0d51d6395341b07f4292606dee9bd69ebbfeb0327504e249e4ad5a61228";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "843271015b7a665270a06c1eaa430e1364462bbcc180be8e1fd04c9332532b69";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-rotate/default.nix
+++ b/distros/melodic/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, nodelet, roscpp, rostest, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-image-rotate";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "5c0bacf9c4f2a6761d532cb05d28d6fc877c2ec6b10471bbf1e59eede33449b1";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "a8e9c585ede1f4c11f7bb189064ec13f2b01321b1bf1725a335b1f7d051d0994";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-view/default.nix
+++ b/distros/melodic/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, gtk2, image-transport, message-filters, message-generation, nodelet, rosconsole, roscpp, rostest, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-view";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "4642943d875d6450ed805d977595e993d7d6bf83fe487b018e1e1300e2edfa7a";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "29776f65d7776982f87630615460afec9ae3666212b1ce2384b91c954cce154c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "93497feb0d2d8acc5e9e0133e91d198c13176c61ab43b981aa294e4dcba4505e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "bdcd61aac304ca86cb8476e0dc07a5a3fde4aa9c46d2e62a09d083b2cfa942d4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "b4c8d4d44de65616f62256198e7e0b0c83a603fb1adf980b78402d43eab82b29";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "05c7805d49ca6a4940f5522fa848527599050575a704456fd950603289547709";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "122b043304b5867f6664ed14cb1e26a6aab43780e318ea4096f6f5e0814728d6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "6e78e951f307b0ca231972802c92b6ceae07a00b6d38dec4ef60394c53d705db";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "724526fda1e17c41b91fa4b54edf6dbbc254042e96b95c4ca2b534fdda6262ba";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "f3554aa15757b69650059ab09fa555ee778b2f57a77f4809307638ecb211a607";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "1ff537ae41f70249a409ee6e19fdc7d913e6789d6913e3d87910453ccdf7cf9f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "d993896baf3da8326d92570379da297621a2cf9dc3fe404d46c50051bb22f614";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "43f3b346311dcee72b3ce20a76dd42fb2dfdcb869c19e42cf9cb7481801e6fd2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "e18c96dbab4141032fbb50465b3051a56d84270ab95791b03b439adb38dd7208";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9df9a503805cd397f061712eeeed67a12f45d47f0713b1248c88525977147994";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "04f32d7a342061fdf0ece200ecdd0ad71c82a022303db67b76b157e8f8d35110";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "948274a0d011a24ce56055c64ea5a2b851e4026e6aae35793b28e0962f5469f2";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "b0436fcfbf375334b35ac5e009a2cd3cb10f586c25f8bc9032391cca8b918899";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "ae02e9074ca4e6942a12474adeccb2eeb4c2d7ae5b5e4ddac8288ebc84695447";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "e9f609ee1509474ef29bfa71997ab368a325e8ecd9481d70f1a7277602964ee0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/stereo-image-proc/default.nix
+++ b/distros/melodic/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-stereo-image-proc";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "d5db016ee55d4ece1413ee83fe1d02315c43e0e97c4a320ece9310b061c45c1d";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "0eb1ce0600f114d0ba5e2e145c05c4cc0b76c8fcd92186100851b0ddaf56c0e3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9fa36cd87066348cf327f78343dd378ac008a31a7f1d067d0193b32a7dd38709";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "00a8d9e58460713648cec3c39c1756c84c3c33f7658011e0525dbec8b9e3922e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "3dd560bf569f7dcfe1d2c7098e339932e3f9f092ee74c52f7f0a20f35887affa";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "59901b4d4831e1fdaf85918825267683ae37303929b468d857c1301ead9c81e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aruco-opencv/default.nix
+++ b/distros/noetic/aruco-opencv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-opencv";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "11d15b4f656ba5b83f80f7c629e0aefba94fa7a32f5142abdc9496d2ed860f02";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs image-transport message-runtime nodelet roscpp std-msgs tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ArUco marker detection using aruco module from OpenCV libraries.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/audio-video-recorder/default.nix
+++ b/distros/noetic/audio-video-recorder/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, message-filters, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-audio-video-recorder";
+  version = "2.2.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/audio_video_recorder/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "e5d81483f8363b44f037d1bb399a315c5aab9a60e23a2c9815670c1ff1c67c43";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ audio-common-msgs gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer message-filters roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package for recording image and audio synchronously'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/camera-aravis/default.nix
+++ b/distros/noetic/camera-aravis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aravis, camera-info-manager, catkin, dynamic-reconfigure, glib, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-camera-aravis";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "a186ad55b2a74110cf821cd72c0fa3de1b8798b8880569d155a3c82637ae9b21";
+    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "966628c385a6c1b7c4c2429bcd0ae2fea2c63f8800420b1b8edc59b66fe13b2f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9ef0852470d1eb2afd6597aff3a4d923b1c3614339c518d8b7e56f474ea51088";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "7ad5b54a4ce232a509ec32ac95365f7f74663679473e2b5c3a3b75f5ccf69945";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.15.5-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.15.5-1.tar.gz";
-    name = "2.15.5-1.tar.gz";
-    sha256 = "637f309313ca3addf67d79e67bb46e6888181c6a5948430f4658e9e42c8d3b91";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "0a8689e29b8f036540f2b10fdd45c840d119cbac80c99cc29d71677ef90700f7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-tf-publisher/default.nix
+++ b/distros/noetic/dynamic-tf-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-tf-publisher";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/dynamic_tf_publisher/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "641d4138a4c105415c5199235e6b783357adbf11831e9ab0e60ec3a368bcefc5";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/dynamic_tf_publisher/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "d86fbdd0d5b80c942ab48aa045fb81528da2cc0d5814c25545ea708230d36b52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.5-r1";
+  version = "2.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "20f26008a32add65e560c36ba04ca221c7d96025e9828f4d52a291b6dd86e1a2";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.6-1.tar.gz";
+    name = "2.7.6-1.tar.gz";
+    sha256 = "761531cbc8c4e59e2c5cbd0cc3e5c6f18cdd079d052a246382f84e093aedb58e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-noetic-eus-assimp";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "f166cf1a93f42fc5f713ab98b2048206a69fefd26cebafeb45b9da845cd8317e";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "0fb75b49127281e801e04d76051da15d7a8c2eac4fbf4505d63b09a99850d865";
   };
 
   buildType = "catkin";

--- a/distros/noetic/euscollada/default.nix
+++ b/distros/noetic/euscollada/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, libyamlcpp, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-euscollada";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "6f2a764637787cb278ad506b5d7207109c6b3e5e87a498d71453cdf9c1b1cb7a";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "b5fa910e58ddba38c42ae3063d931e0d4c4793693522cb946e431708ac502dbb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, python3Packages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-noetic-eusurdf";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "45ce43d84f15082ea736caa61f9bc71503b97b54e5c7c6f6b479eeb7f9bf4131";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "ddc05b743572e8dc8e9ac5ed0b1898030cd1603dcab5483db037d8074f728532";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-master-discovery/default.nix
+++ b/distros/noetic/fkie-master-discovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avahi, catkin, fkie-multimaster-msgs, rosgraph, roslib, rospy, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-fkie-master-discovery";
-  version = "1.2.7-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_discovery/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "203483ec58feb471f5a9561b0cd1dd8d3baf7f3d123a8a026455bef1053e9991";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_discovery/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "ef1f4057d587946bc39846a292e6e279eda7c254edf33a6cf6d0947271db8932";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-master-sync/default.nix
+++ b/distros/noetic/fkie-master-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-multimaster-msgs, rosgraph, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fkie-master-sync";
-  version = "1.2.7-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_sync/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "aa23531aee7d5e6d922d20f985399670edb3982d07746e731edb87ae10ead213";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_sync/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "4cd2b623572d81bae982c363c762e59b9eb27795656fba031bfe5a00df7a8119";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-multimaster-msgs/default.nix
+++ b/distros/noetic/fkie-multimaster-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fkie-multimaster-msgs";
-  version = "1.2.7-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster_msgs/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "dc900162eb805de7db2f86c7e61e069ae6c814577a17a591dce54e422574c5fe";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster_msgs/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "883c434cf285df3ecdd19c9358b9e77eaf05fb82f255c447ff2be7bb035e8ee5";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation python3Packages.grpcio-tools ];
+  buildInputs = [ message-generation ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/fkie-multimaster/default.nix
+++ b/distros/noetic/fkie-multimaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-master-sync, fkie-multimaster-msgs, fkie-node-manager, fkie-node-manager-daemon }:
 buildRosPackage {
   pname = "ros-noetic-fkie-multimaster";
-  version = "1.2.7-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "40bde8a434e6a4f82a0bae231bd7c2308db56856ebf8900fad43b4bfdf138780";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "f51c29dfdf8e8b809b49df9c9e95cdefc66cf999142dfd241672b9f1cccb1a56";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-node-manager-daemon/default.nix
+++ b/distros/noetic/fkie-node-manager-daemon/default.nix
@@ -5,18 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, fkie-master-discovery, fkie-multimaster-msgs, python3Packages, roslaunch, rospy, rostest, screen }:
 buildRosPackage {
   pname = "ros-noetic-fkie-node-manager-daemon";
-  version = "1.2.7-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager_daemon/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "3fa68a0bf213d497d7b682978a9be23f70068066cf05c397eaa1b940994d63fc";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager_daemon/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "5048b20fa316d70db15dc49267fc557cde70dbb91b712f99737f5115be97ef04";
   };
 
   buildType = "catkin";
-  buildInputs = [ python3Packages.catkin-pkg ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs fkie-master-discovery fkie-multimaster-msgs python3Packages.grpcio python3Packages.psutil python3Packages.rospkg python3Packages.ruamel_yaml roslaunch rospy screen ];
+  propagatedBuildInputs = [ diagnostic-msgs fkie-master-discovery fkie-multimaster-msgs python3Packages.grpcio python3Packages.grpcio-tools python3Packages.psutil python3Packages.rospkg python3Packages.ruamel_yaml roslaunch rospy screen ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/fkie-node-manager/default.nix
+++ b/distros/noetic/fkie-node-manager/default.nix
@@ -5,16 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, dynamic-reconfigure, fkie-master-discovery, fkie-master-sync, fkie-multimaster-msgs, fkie-node-manager-daemon, python-qt-binding, python3Packages, rosgraph, roslaunch, roslib, rosmsg, rospy, rosservice, rqt-gui, rqt-reconfigure, screen, xterm }:
 buildRosPackage {
   pname = "ros-noetic-fkie-node-manager";
-  version = "1.2.7-r1";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "cc1bfb1eb02d1e7e28feb6902e61121f928b01a74f0b9204299386bd45318b73";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "b0bbcec7e9087a14a19c45255242d39662ed77f2b08bb6e40f385c25f2e2f017";
   };
 
   buildType = "catkin";
-  buildInputs = [ python3Packages.catkin-pkg ];
   propagatedBuildInputs = [ diagnostic-msgs dynamic-reconfigure fkie-master-discovery fkie-master-sync fkie-multimaster-msgs fkie-node-manager-daemon python-qt-binding python3Packages.docutils python3Packages.paramiko python3Packages.pycryptodomex python3Packages.pyqt5_with_qtwebkit python3Packages.ruamel_yaml rosgraph roslaunch roslib rosmsg rospy rosservice rqt-gui rqt-reconfigure screen xterm ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -56,6 +56,8 @@ self: super: {
 
  aruco-msgs = self.callPackage ./aruco-msgs {};
 
+ aruco-opencv = self.callPackage ./aruco-opencv {};
+
  aruco-ros = self.callPackage ./aruco-ros {};
 
  assimp-devel = self.callPackage ./assimp-devel {};
@@ -79,6 +81,8 @@ self: super: {
  audio-play = self.callPackage ./audio-play {};
 
  audio-to-spectrogram = self.callPackage ./audio-to-spectrogram {};
+
+ audio-video-recorder = self.callPackage ./audio-video-recorder {};
 
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
@@ -1206,6 +1210,8 @@ self: super: {
 
  hri-msgs = self.callPackage ./hri-msgs {};
 
+ hri-rviz = self.callPackage ./hri-rviz {};
+
  human-description = self.callPackage ./human-description {};
 
  husky-control = self.callPackage ./husky-control {};
@@ -1886,7 +1892,15 @@ self: super: {
 
  mqtt-client = self.callPackage ./mqtt-client {};
 
+ mrpt-ekf-slam-2d = self.callPackage ./mrpt-ekf-slam-2d {};
+
+ mrpt-ekf-slam-3d = self.callPackage ./mrpt-ekf-slam-3d {};
+
  mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};
+
+ mrpt-graphslam-2d = self.callPackage ./mrpt-graphslam-2d {};
+
+ mrpt-icp-slam-2d = self.callPackage ./mrpt-icp-slam-2d {};
 
  mrpt-local-obstacles = self.callPackage ./mrpt-local-obstacles {};
 
@@ -1902,11 +1916,15 @@ self: super: {
 
  mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
 
+ mrpt-rbpf-slam = self.callPackage ./mrpt-rbpf-slam {};
+
  mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
 
  mrpt-sensorlib = self.callPackage ./mrpt-sensorlib {};
 
  mrpt-sensors = self.callPackage ./mrpt-sensors {};
+
+ mrpt-slam = self.callPackage ./mrpt-slam {};
 
  mrpt-tutorials = self.callPackage ./mrpt-tutorials {};
 

--- a/distros/noetic/hri-rviz/default.nix
+++ b/distros/noetic/hri-rviz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, hri, hri-msgs, qt5, roscpp, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-hri-rviz";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "cd6d26e6326015a4f93aed18262afbefd5f25c4dbae23ad3b2d1c4dd2659f9b0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge hri hri-msgs qt5.qtbase roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains several rviz plugins to visualize HRI-related topics (like face/body region of interests, 3D skeletons...)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/image-view2/default.nix
+++ b/distros/noetic/image-view2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-geometry, image-transport, image-view, message-filters, message-generation, message-runtime, pcl-ros, python3Packages, roscpp, rostest, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-image-view2";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/image_view2/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "07e18eb3ce6a3761e5d3a2a6ded61460d1e41b08001bc442bd8a1c3c5e0b4dc2";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/image_view2/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "342ebba57f329112be80d432c5f1eca5aeb7b00d44c4e5171e021a74feb52209";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "ad8e3063c16bed7e06a5a61a70e3dbce6d5d683656c8908d2cc6f00562aee11d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "7b81c43f1de55224f6134c810a1840a3bacfe8487f376590d920aa371640f633";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-common/default.nix
+++ b/distros/noetic/jsk-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-tf-publisher, image-view2, jsk-network-tools, jsk-tilt-laser, jsk-tools, jsk-topic-tools, multi-map-server, virtual-force-publisher }:
+{ lib, buildRosPackage, fetchurl, audio-video-recorder, catkin, dynamic-tf-publisher, image-view2, jsk-network-tools, jsk-tilt-laser, jsk-tools, jsk-topic-tools, multi-map-server, virtual-force-publisher }:
 buildRosPackage {
   pname = "ros-noetic-jsk-common";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_common/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "9ee5054f39d5142c74fa731f7d481591fd93a3bd0b95efe1302ed6c8d63d9653";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_common/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "aba0111078224438e6e2135b0553eb2307494052ad39d89f77dc95eab1408945";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-tf-publisher image-view2 jsk-network-tools jsk-tilt-laser jsk-tools jsk-topic-tools multi-map-server virtual-force-publisher ];
+  propagatedBuildInputs = [ audio-video-recorder dynamic-tf-publisher image-view2 jsk-network-tools jsk-tilt-laser jsk-tools jsk-topic-tools multi-map-server virtual-force-publisher ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-noetic-jsk-model-tools";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "a98c65b7bd5eae30a78d619e77f7c5ea47c1910f4d2b9ddd524b7888783a9108";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "01078b70b2d69d83a5a531d05c4f546d557a8281c6376a3e090aa274df68173b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-network-tools/default.nix
+++ b/distros/noetic/jsk-network-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, rospy, rostest, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-network-tools";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_network_tools/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "f3976c28ca7989552adb68edacaf2a1e8817ea05341eecc772acf10d45c4a4fc";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_network_tools/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "21b402ed5de2bcf9052d49b0c4cb1e5607eeb7320474179995e5d04cfb8d508f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-tilt-laser/default.nix
+++ b/distros/noetic/jsk-tilt-laser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, laser-assembler, laser-filters, robot-state-publisher, sensor-msgs, tf, tf-conversions, urg-node }:
 buildRosPackage {
   pname = "ros-noetic-jsk-tilt-laser";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_tilt_laser/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "32b4a5b174f2864b9b7279990b19fe86b7b5f623c00042bddef623618ffab997";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_tilt_laser/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "a7f28528f48b54cabeaa344687640f515aa524f5f1c8c9e213137193848797a1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-topic-tools/default.nix
+++ b/distros/noetic/jsk-topic-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, python3Packages, roscpp, roscpp-tutorials, roslaunch, roslint, rosnode, rostest, rostime, rostopic, sensor-msgs, sound-play, std-msgs, std-srvs, tf, topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, python3Packages, roscpp, roscpp-tutorials, roslaunch, roslint, rosnode, rostest, rostime, rostopic, sensor-msgs, sound-play, std-msgs, std-srvs, tf, topic-tools, unixtools }:
 buildRosPackage {
   pname = "ros-noetic-jsk-topic-tools";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_topic_tools/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "a58c0a7e52161b09eb76b6eb9a0b52b12fa7f91ec4dcd5e5c32391bf16c94263";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_topic_tools/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "4dd91f7b7c8c736cba993b8866f47166a4b6c7de7e28f888053e052b71f5dfc7";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation rostest ];
   checkInputs = [ roscpp-tutorials roslint ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet python3Packages.numpy python3Packages.opencv3 python3Packages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet python3Packages.numpy python3Packages.opencv3 python3Packages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools unixtools.ping ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/magic-enum/default.nix
+++ b/distros/noetic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-magic-enum";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e202abeeafa9e4ed596c9e5d44a6627d95d9886e606e604cccbc57ff1b68bdcb";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "6799e1c3715bcdf6a48ef778e8c8565604cbb9d9498f375282c01b8dde2ad051";
   };
 
   buildType = "cmake";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "66e823da2743503cf4f541769282d8517cf9a646fe49394990f89aa9568429d1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "ac34769724e0d1ec5c0ded8c81724a6fae0ff3d21ccfba16b44945d5bdb6020f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-ekf-slam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "21ec278234298b03fe9d066a7cdd93c86b0ceea137239887774091287def6e2c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is a wrapper for the implementation of EKF-based SLAM with range-bearing sensors, odometry, and a 2D (+heading) robot pose, and 2D landmarks.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-3d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-ekf-slam-3d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "efd46ed9041241ca4160234c4db70bd95488f0564c4ed8c1a8806e45deef4aef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is a wrapper for the implementation of EKF-based SLAM with range-bearing sensors, odometry, a full 6D robot pose, and 3D landmarks.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-graphslam-2d/default.nix
+++ b/distros/noetic/mrpt-graphslam-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-graphslam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "004a9f7e9a6ebbdb9db83b1c2b45e1389754fedd5ded644b08d217261268bf9e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fkie-multimaster-msgs geometry-msgs mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs roscpp rospy sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implement graphSLAM using the mrpt-graphslam library, in an online fashion
+  	by directly reading measurements off ROS Topics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-icp-slam-2d/default.nix
+++ b/distros/noetic/mrpt-icp-slam-2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-icp-slam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "8027b57f93610518e7580e15912181a3b0d7b9329f750f268ff14a34d09780a8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''mrpt_icp_slam_2d contains a wrapper on MRPT's 2D ICP-SLAM algorithms.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-rbpf-slam/default.nix
+++ b/distros/noetic/mrpt-rbpf-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-rbpf-slam";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "29d9e82f748f18580fd8b628c708f68461ba338ab1bbf0214ae4f35f617a9470";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 mvsim nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is used for gridmap SLAM. The interface is similar to gmapping (https://wiki.ros.org/gmapping) but the package supports different particle-filter algorithms, range-only SLAM, can work with several grid maps simultaneously and more.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-slam/default.nix
+++ b/distros/noetic/mrpt-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-slam";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "732c625387478084e7d28ad83657ca7af8d807bdcf523cbdeaa1f4d173c26a3d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-ekf-slam-2d mrpt-ekf-slam-3d mrpt-graphslam-2d mrpt-icp-slam-2d mrpt-rbpf-slam ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''mrpt_slam'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/multi-map-server/default.nix
+++ b/distros/noetic/multi-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL_image, catkin, jsk-tools, libyamlcpp, map-server, nav-msgs, python3Packages, pythonPackages, rosconsole, roscpp, rosmake, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-multi-map-server";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/multi_map_server/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "e29c65c0ecd6a1199c1f247b056d171b575c49225866c48f504a2c06b6735d1c";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/multi_map_server/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "2c5ce65b15604abc1c9786f7a777931762d636f6d8198a7db495c89fa7843f3a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "99867366412b3cdda7ada38987083c0cefdd91bdeaf605cb003bae9c117f2070";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "ca06332049220af0960821effb8e59725669af89ba49f8b9b55620e43aeea414";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "3f995c56c91db2d26dc40561a4206d69766d1f428a61ebc43d6705774f7de2f4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "61278c476757448c958569658a636073e8c2669867097f6722674cb71d9f8f8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "77430da5ef95b43cde1a9f83ca860c72576ffe9d77df3d6ceea34abf1c2a23a6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "2ffeb11460dd5ab5988811851632078b3563058aa437ce8f85aa76e1dbef592f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "0e7d51261ef5d100ee63b16415f9846cc79992839bd516570e1928b0e0a966e8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "d2342eefad5f0e2319f36df650df43203a0c45b2da455475b02a9a0ef99c7af1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/opw-kinematics/default.nix
+++ b/distros/noetic/opw-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
 buildRosPackage {
   pname = "ros-noetic-opw-kinematics";
-  version = "0.4.6-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "35e451e0bfdafa08c2c3aa83707151fa50b268218acc0fb200b162390d061eea";
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "076f8b32d2e15749226cf1e5f41fc999b7345b2beec597905692a8515dfcf2f6";
   };
 
   buildType = "cmake";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "bee09c8e3ed4f307b8eb24a4325f7c9cc6ade5edcc9216596dd1f1ec6ab2ae4d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "ba12098a426ff865e79fffc064d712741e4cda03e27455ae28684f9352d221f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "963ee8025d8304980ba6265d9ce86264e0130a120860f7d5ebaff4aa6ae859f4";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "353b5412b138cab459ec9039fe6a2e501393fb03a62f4e64f0430ec7a8fa9a28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.2.16-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.16-1.tar.gz";
-    name = "0.2.16-1.tar.gz";
-    sha256 = "207b6d1ee9c8f6cf12c189ea22497b21be84a7ab8d7507e0810ec3c9f9ab10f7";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2fc8b5eb51d4318c8d6be0d08269ef39b3355f63e44d0a616e58fef8ba6d01a2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "37453b18c8d6af04dc7ce2ea33d4c59610de57ea052d5b4dea53d125f01b783e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "8df56db62d304965869d5ff0a177fbeb37fddc2c8c59438c547b937378ba63b0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tesseract-collision/default.nix
+++ b/distros/noetic/tesseract-collision/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, libyamlcpp, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-collision";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "e3d10f41b5117bfb77242fe3cdb7896c226b80e6390a8e2c389e61b2dae5d6f8";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "9fddb20b329c9944b75f6d3c39fa26b76a5d2b9a9b50db2481939e6c6825fbaf";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, libyamlcpp, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "5c4ece28129365022c802643d8003476e3bdee5c0ce36a45ab150864c7ec3f25";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "c1ae68273e615d8674706e93918beeae6a1c0abb629106ab61dc11587f1c03cc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-environment/default.nix
+++ b/distros/noetic/tesseract-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-kinematics, tesseract-scene-graph, tesseract-srdf, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-environment";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "c9992fd05f8487eea55117b6fa881edbf55b608b4ed62abe98b61e8841297177";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "7723880ce1089b1c2c4542ef76bd37c551c2a2b183207b4f04e11638a8c17318";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "b478751f162246eef72f690590fef994a3805bbaf2ee7c9eed6dbb7ad652b083";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "223a60f3a2198a25a9fb670630f9e9a7920ee8af9d017971b95fd28cc6a5f3aa";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, liblapack, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "34bd6f187f97406224e16611c69db6d04978c167a2faf024539d6b982416478f";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "c26800e1071d9d6d252e4ee6b0e8e92e6e2d0b36251a48ae4ed9295d3d0489e4";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate ];
-  checkInputs = [ gtest tesseract-support tesseract-urdf ];
+  checkInputs = [ gtest liblapack tesseract-support tesseract-urdf ];
   propagatedBuildInputs = [ console-bridge eigen libyamlcpp opw-kinematics orocos-kdl tesseract-common tesseract-scene-graph tesseract-state-solver ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "2fc3a129727bafdbd2b6f4813c4d98268881440d73816434a3b8a43dfc4a5135";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "f0c423827f53a6e1c223d89bb8dcb005b93be789d4eb4bf8123e69033cb0d047";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "78887ebdad2465941e5abe95945548f28f92c648405af0b8d7c56de9df7da057";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "461c36be5fe17d4098ecba44b624919145d05152cf5a052b03b693c70aa8086a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-state-solver/default.nix
+++ b/distros/noetic/tesseract-state-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-state-solver";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "276a04d82d2fbd90a0bd4d837a0bf8146a16e2189abeaef32c815c554c625b60";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "ba8d1721abe0cdd5bdf212ed11afa95112179791d993d0a130f64289e8d23cdf";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, ros-industrial-cmake-boilerplate, tesseract-common }:
+{ lib, buildRosPackage, fetchurl, cmake, gtest, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "bf93f39eecfde80a2434bd4eeef21a305cc1deed3e4cfcacdc636436c2b1ab92";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "f8d6b95012b572b247346d6299462853e1e4609398a7ee27802690d3f07dd85c";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate tesseract-common ];
+  checkInputs = [ gtest ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "150e54042c1be7c974cd53c1bdba2518bc7780ca398ca2d66470328c8940b18d";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "5935cf6018f53546ff2f63a95c13cf3f26461a89a2a843dac021ee56cfaa8a38";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "ccae1dd8faef9902d4bf96c31ea88c5093f3c12c900b5436622c58355b04f43b";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "1f51efa4b56399d1f0f707757148cde5d84081b11cc44957195b904d7a3ca7e3";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ console-bridge eigen tesseract-collision tesseract-common tesseract-environment tesseract-scene-graph tesseract-state-solver ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "d86bace24916802bdecf648563de5e5485500109b5e968dc09e89317e05759a3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "2a6702b4d3a2e536e8e21f4ea19a23e22b13d13529210616d608773b0cfd58c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.11.4-r1";
+  version = "0.11.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "379f24eec4ea136dab01e975a27ef3f15aa0025478944eb0da2e1721140678e5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.5-1.tar.gz";
+    name = "0.11.5-1.tar.gz";
+    sha256 = "05197952bbcb16e121edfb312c2c449dbd74345cc8470aa7f51a055dbd2e10ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-driver/default.nix
+++ b/distros/noetic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libpcap, nodelet, roscpp, roslaunch, roslint, rostest, tf, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-driver";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "d0ac953f3a48c3e13e60a94fb9ed768ea22699004bc7c62a638785dc37f1ffea";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "e409444fad24c80117381fc5f0445b0ab30b0a32c13ccbff331e666f15ed1fa6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-laserscan/default.nix
+++ b/distros/noetic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nodelet, roscpp, roslaunch, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-laserscan";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "bbe1d9264cf193a2b2610fa19280c3a7a57f0de6c3d4c1a037ba713127e63438";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "341bf6a4773deb0266a8afb12db34c069c9d03e2ebc34fdd269c367d2064a35c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-msgs/default.nix
+++ b/distros/noetic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-msgs";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "fb3b32e45e68234f8e01121aeee2e8d33966379c3a5ce4c2365e3751ee284e2f";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "508ef5d08d4d2168dae0e7adf55eeae4f6090c01c05280d0bf1d9f2f31a1ee0f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pcl/default.nix
+++ b/distros/noetic/velodyne-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-ros, roslint }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pcl";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "08d0a84826d952dc1b0ae6cec5909fcb70a291dcd96f817cf54a34e24024751e";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "d4dae03da906b8fa5814d3c20b469e637a6046d89d5130567474c1f4e9dadbe8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pointcloud/default.nix
+++ b/distros/noetic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-updater, dynamic-reconfigure, eigen, libyamlcpp, nodelet, roscpp, roslaunch, roslib, roslint, rostest, rosunit, sensor-msgs, tf2-ros, velodyne-driver, velodyne-laserscan, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pointcloud";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "49cf0b37a42143d5cbbc93086d4a478372201ef6b758891a06807abba7e16c29";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "b8425f2244f94b610459ede15bdb228eb842e4cd84a6ae10aed6dd67962b6de7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne/default.nix
+++ b/distros/noetic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-noetic-velodyne";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "20968c2bc112c14694268e3b421517184a68bec969904cb167c7c14ab11b415a";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "3bee8e89bc6438c14fa690e18dd43db01a78ab2a5e445252700579f220b3cefc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/virtual-force-publisher/default.nix
+++ b/distros/noetic/virtual-force-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, kdl-parser, sensor-msgs, tf-conversions, urdf }:
 buildRosPackage {
   pname = "ros-noetic-virtual-force-publisher";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/virtual_force_publisher/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "2525226fd6c507c40f78ca2fcb145b28fd8f83c0090e4afea891408d3d3aa396";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/virtual_force_publisher/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "5dacad62f81a05fffab95f19dd5ebf306902d484eae537467c45ec348267ce64";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit bb7b9e3723d3148f5ba8db85f9e10c4475efdaff.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *angles 1.12.3-r1 --> 1.12.6-r1*
* *camera-calibration-parsers 2.3.0-r1 --> 2.4.0-r1*
* *camera-info-manager 2.3.0-r1 --> 2.4.0-r1*
* *depthai 2.15.5-r1 --> 2.17.0-r1*
* *eigenpy 2.7.5-r1 --> 2.7.6-r1*
* *image-common 2.3.0-r1 --> 2.4.0-r1*
* *image-transport 2.3.0-r1 --> 2.4.0-r1*
* *imu-complementary-filter 2.0.2-r1 --> 2.0.3-r1*
* *imu-filter-madgwick 2.0.2-r1 --> 2.0.3-r1*
* *imu-tools 2.0.2-r1 --> 2.0.3-r1*
* *maliput-dragway 0.1.1-r1 --> 0.1.2-r1*
* *maliput-full 0.1.0-r2*
* *maliput-malidrive 0.1.1-r1 --> 0.1.2-r1*
* *maliput-multilane 0.1.0-r1 --> 0.1.1-r1*
* *nerian-stereo 1.1.0-r1 --> 1.1.1-r1*
* *performance-test 1.0.0-r1 --> 1.2.1-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *raspimouse-description 1.0.0-r1*
* *rviz-imu-plugin 2.0.2-r1 --> 2.0.3-r1*
* *vrpn 7.35.0-r8*

Galactic Changes:
-----------------
* *angles 1.12.4-r2 --> 1.14.0-r1*
* *camera-calibration-parsers 2.3.1-r1 --> 2.5.0-r1*
* *camera-info-manager 2.3.1-r1 --> 2.5.0-r1*
* *depthai 2.15.5-r1 --> 2.17.0-r1*
* *image-common 2.3.1-r1 --> 2.5.0-r1*
* *image-transport 2.3.1-r1 --> 2.5.0-r1*
* *imu-complementary-filter 2.0.2-r1 --> 2.0.3-r1*
* *imu-filter-madgwick 2.0.2-r1 --> 2.0.3-r1*
* *imu-tools 2.0.2-r1 --> 2.0.3-r1*
* *log-view 0.2.1-r1*
* *magic-enum 0.7.3-r1 --> 0.8.0-r1*
* *nerian-stereo 1.1.1-r1*
* *performance-test 1.0.0-r1 --> 1.2.1-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *rviz-imu-plugin 2.0.2-r1 --> 2.0.3-r1*
* *turtlebot4-description 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-msgs 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-navigation 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-node 0.1.0-r1 --> 0.1.1-r1*
* *twist-stamper 0.0.2-r1*
* *velodyne 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-driver 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-laserscan 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-msgs 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-pointcloud 2.2.0-r1 --> 2.3.0-r1*

Humble Changes:
---------------
* *bag2-to-image 0.1.0-r1*
* *controller-interface 2.10.0-r1 --> 2.12.1-r1*
* *controller-manager 2.10.0-r1 --> 2.12.1-r1*
* *controller-manager-msgs 2.10.0-r1 --> 2.12.1-r1*
* *diff-drive-controller 2.6.0-r1 --> 2.8.0-r1*
* *effort-controllers 2.6.0-r1 --> 2.8.0-r1*
* *force-torque-sensor-broadcaster 2.6.0-r1 --> 2.8.0-r1*
* *forward-command-controller 2.6.0-r1 --> 2.8.0-r1*
* *gripper-controllers 2.6.0-r1 --> 2.8.0-r1*
* *hardware-interface 2.10.0-r1 --> 2.12.1-r1*
* *imu-sensor-broadcaster 2.6.0-r1 --> 2.8.0-r1*
* *joint-limits 2.12.1-r1*
* *joint-state-broadcaster 2.6.0-r1 --> 2.8.0-r1*
* *joint-trajectory-controller 2.6.0-r1 --> 2.8.0-r1*
* *mavlink 2022.2.2-r3 --> 2022.6.27-r1*
* *nerian-stereo 1.1.1-r1*
* *performance-test 1.1.0-r1 --> 1.2.1-r1*
* *position-controllers 2.6.0-r1 --> 2.8.0-r1*
* *ros2-control 2.10.0-r1 --> 2.12.1-r1*
* *ros2-control-test-assets 2.10.0-r1 --> 2.12.1-r1*
* *ros2-controllers 2.6.0-r1 --> 2.8.0-r1*
* *ros2-controllers-test-nodes 2.6.0-r1 --> 2.8.0-r1*
* *ros2controlcli 2.10.0-r1 --> 2.12.1-r1*
* *transmission-interface 2.10.0-r1 --> 2.12.1-r1*
* *velocity-controllers 2.6.0-r1 --> 2.8.0-r1*
* *velodyne 2.3.0-r1*
* *velodyne-driver 2.3.0-r1*
* *velodyne-laserscan 2.3.0-r1*
* *velodyne-msgs 2.3.0-r1*
* *velodyne-pointcloud 2.3.0-r1*

Melodic Changes:
----------------
* *camera-calibration 1.15.0-r1 --> 1.15.2-r1*
* *costmap-cspace 0.11.4-r1 --> 0.11.5-r1*
* *depth-image-proc 1.15.0-r1 --> 1.15.2-r1*
* *eigenpy 2.7.5-r1 --> 2.7.6-r3*
* *image-pipeline 1.15.0-r1 --> 1.15.2-r1*
* *image-proc 1.15.0-r1 --> 1.15.2-r1*
* *image-publisher 1.15.0-r1 --> 1.15.2-r1*
* *image-rotate 1.15.0-r1 --> 1.15.2-r1*
* *image-view 1.15.0-r1 --> 1.15.2-r1*
* *joystick-interrupt 0.11.4-r1 --> 0.11.5-r1*
* *map-organizer 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation-common 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation-launch 0.11.4-r1 --> 0.11.5-r1*
* *obj-to-pointcloud 0.11.4-r1 --> 0.11.5-r1*
* *planner-cspace 0.11.4-r1 --> 0.11.5-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *safety-limiter 0.11.4-r1 --> 0.11.5-r1*
* *stereo-image-proc 1.15.0-r1 --> 1.15.2-r1*
* *track-odometry 0.11.4-r1 --> 0.11.5-r1*
* *trajectory-tracker 0.11.4-r1 --> 0.11.5-r1*

Noetic Changes:
---------------
* *aruco-opencv 0.1.0-r1*
* *audio-video-recorder 2.2.12-r1*
* *camera-aravis 4.0.2-r1 --> 4.0.3-r1*
* *costmap-cspace 0.11.4-r1 --> 0.11.5-r1*
* *depthai 2.15.5-r1 --> 2.17.0-r1*
* *dynamic-tf-publisher 2.2.11-r2 --> 2.2.12-r1*
* *eigenpy 2.7.5-r1 --> 2.7.6-r1*
* *eus-assimp 0.4.4-r1 --> 0.4.4-r2*
* *euscollada 0.4.4-r1 --> 0.4.4-r2*
* *eusurdf 0.4.4-r1 --> 0.4.4-r2*
* *fkie-master-discovery 1.2.7-r1 --> 1.3.0-r2*
* *fkie-master-sync 1.2.7-r1 --> 1.3.0-r2*
* *fkie-multimaster 1.2.7-r1 --> 1.3.0-r2*
* *fkie-multimaster-msgs 1.2.7-r1 --> 1.3.0-r2*
* *fkie-node-manager 1.2.7-r1 --> 1.3.0-r2*
* *fkie-node-manager-daemon 1.2.7-r1 --> 1.3.0-r2*
* *hri-rviz 0.3.1-r1*
* *image-view2 2.2.11-r2 --> 2.2.12-r1*
* *joystick-interrupt 0.11.4-r1 --> 0.11.5-r1*
* *jsk-common 2.2.11-r2 --> 2.2.12-r1*
* *jsk-model-tools 0.4.4-r1 --> 0.4.4-r2*
* *jsk-network-tools 2.2.11-r2 --> 2.2.12-r1*
* *jsk-tilt-laser 2.2.11-r2 --> 2.2.12-r1*
* *jsk-topic-tools 2.2.11-r2 --> 2.2.12-r1*
* *magic-enum 0.7.3-r1 --> 0.8.0-r1*
* *map-organizer 0.11.4-r1 --> 0.11.5-r1*
* *mrpt-ekf-slam-2d 0.1.11-r1*
* *mrpt-ekf-slam-3d 0.1.11-r1*
* *mrpt-graphslam-2d 0.1.11-r1*
* *mrpt-icp-slam-2d 0.1.11-r1*
* *mrpt-rbpf-slam 0.1.11-r1*
* *mrpt-slam 0.1.11-r1*
* *multi-map-server 2.2.11-r2 --> 2.2.12-r1*
* *neonavigation 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation-common 0.11.4-r1 --> 0.11.5-r1*
* *neonavigation-launch 0.11.4-r1 --> 0.11.5-r1*
* *obj-to-pointcloud 0.11.4-r1 --> 0.11.5-r1*
* *opw-kinematics 0.4.6-r1 --> 0.5.0-r1*
* *planner-cspace 0.11.4-r1 --> 0.11.5-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *ros-industrial-cmake-boilerplate 0.2.16-r1 --> 0.3.0-r1*
* *safety-limiter 0.11.4-r1 --> 0.11.5-r1*
* *tesseract-collision 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-common 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-environment 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-geometry 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-kinematics 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-scene-graph 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-srdf 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-state-solver 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-support 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-urdf 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-visualization 0.8.6-r1 --> 0.10.0-r1*
* *track-odometry 0.11.4-r1 --> 0.11.5-r1*
* *trajectory-tracker 0.11.4-r1 --> 0.11.5-r1*
* *velodyne 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-driver 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-laserscan 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-msgs 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-pcl 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-pointcloud 1.6.1-r1 --> 1.7.0-r1*
* *virtual-force-publisher 2.2.11-r2 --> 2.2.12-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-pytest-timeout
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

