### PR TITLE
rosdistro sync, Fri Jul 22 14:48:09 2022

### DIFF
--- a/distros/foxy/angles/default.nix
+++ b/distros/foxy/angles/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-angles";
-  version = "1.12.3-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/foxy/angles/1.12.3-1.tar.gz";
-    name = "1.12.3-1.tar.gz";
-    sha256 = "2ece091460ffc83df530336e95aaf361e1d760d236a3a0a04e3df2768d8ab94d";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/foxy/angles/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "a4f16d3854d340b4008e2cd556fe411cdf39c00764902264d2d6fa5dabe28e69";
   };
 
   buildType = "ament_cmake";
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 
   meta = {
     description = ''This package provides a set of simple math utilities to work

--- a/distros/foxy/camera-calibration-parsers/default.nix
+++ b/distros/foxy/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-camera-calibration-parsers";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_calibration_parsers/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "095e7dca0a824d48a168961e4fe157d55cef0e2a7b7a126252b713ed7e8f28f0";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_calibration_parsers/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "bd0f502363620e2bddef611dcde02e001208564be1c949f1a7feb0ddf622c2d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/camera-info-manager/default.nix
+++ b/distros/foxy/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-camera-info-manager";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_info_manager/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "ee222b6a1cca8221b859426c6d5d0254ee5bbb5fbc6669f979896c6cc24e9388";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/camera_info_manager/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "f6ece97f5bf6e68f691cab308da708e380c8852dd452cdb5ce2fd2a22738567b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/depthai/default.nix
+++ b/distros/foxy/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-depthai";
-  version = "2.15.5-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.15.5-1.tar.gz";
-    name = "2.15.5-1.tar.gz";
-    sha256 = "687fd898f762a61c98888ca56f81ff4b4dd6cdfceb6b893aca8a01ad50b50845";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "f74a89ee0823cc61ebdddeb7c4253ab80297cf33d7b7822dd9770f0a95b87c17";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.5-r1";
+  version = "2.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "9b96e2ca134cbf95c31400f5ae7862e5e79b36a6133630079083734a461aa2c2";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.7-1.tar.gz";
+    name = "2.7.7-1.tar.gz";
+    sha256 = "be06d935b2e1b088e110f17a8e623f8d6fbfe37ada3b5763600961dc2e61332f";
   };
 
   buildType = "cmake";

--- a/distros/foxy/foxglove-msgs/default.nix
+++ b/distros/foxy/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-foxglove-msgs";
-  version = "1.2.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/foxy/foxglove_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "21ed8c1eb314f12467a00e273f506b2ec7b2f75689b610495b4b31f8f3421b34";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/foxy/foxglove_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "980dce53340baccb914898dc092b6a3e597f727c36ba3d02da5611e2300ec093";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -792,6 +792,8 @@ self: super: {
 
  maliput-drake = self.callPackage ./maliput-drake {};
 
+ maliput-full = self.callPackage ./maliput-full {};
+
  maliput-integration = self.callPackage ./maliput-integration {};
 
  maliput-malidrive = self.callPackage ./maliput-malidrive {};
@@ -1211,6 +1213,8 @@ self: super: {
  raptor-pdu-msgs = self.callPackage ./raptor-pdu-msgs {};
 
  raspimouse = self.callPackage ./raspimouse {};
+
+ raspimouse-description = self.callPackage ./raspimouse-description {};
 
  raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
 
@@ -1973,6 +1977,8 @@ self: super: {
  vision-opencv = self.callPackage ./vision-opencv {};
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
+
+ vrpn = self.callPackage ./vrpn {};
 
  vrxperience-bridge = self.callPackage ./vrxperience-bridge {};
 

--- a/distros/foxy/image-common/default.nix
+++ b/distros/foxy/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-foxy-image-common";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_common/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "fc943f0730fe6f9a54fa8ab742b7ccd990e18b1763bb248217226e8acb2f7bdb";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_common/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "869d51bb9e5a490d6f22ea6355ea4db8a96e29c3a8caedbf4183222759963d38";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/image-transport/default.nix
+++ b/distros/foxy/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-image-transport";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_transport/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a83e667892dca1cc6a4fa8ad66e5e20f7a41e844365cdafc627736e266e31cb0";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/foxy/image_transport/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "64ad0f4165a117b50536b0545615472a3dc38938110222f11d992530e90c0454";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-complementary-filter/default.nix
+++ b/distros/foxy/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-imu-complementary-filter";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_complementary_filter/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "917d1cf764c96a1e68ba19046cd5a5ba656520fcee654492c40bc650c2bf0b4c";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_complementary_filter/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "59f4c53358e5bed435241d6b96098bfdc6f9e7eb7b7d417e8dcd3d977502aceb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-filter-madgwick/default.nix
+++ b/distros/foxy/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-filter-madgwick";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_filter_madgwick/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "eecc54e87078d1837f95a001934cb1d895e5e82fe430628dc8ed51aefb4bb779";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_filter_madgwick/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ecd44aacd384ec18eb9da3f7ae576fc1632331a279bcacb61cb69172534ed363";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-tools/default.nix
+++ b/distros/foxy/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-foxy-imu-tools";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_tools/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "f36db5f5d7dcc16202cbad8e30ba863e813c5301a4017c9d7bbb8cc0fdc96251";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/imu_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "711d04a76ab71d447824b520da25b6a02255348abe179a71720ac27fd77654e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-dragway/default.nix
+++ b/distros/foxy/maliput-dragway/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, pybind11, python3 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, python3, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-maliput-dragway";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "748dd0110dc11469dc428ebc8d18e9262ee8f3b528be3b9f945bcdd8bb0c6d21";
+    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "cd69db9752c89e4be9eaea375ea99960bcdd28b3c4a5541d239f14aebd9c840b";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ maliput maliput-py pybind11 python3 ];
+  propagatedBuildInputs = [ maliput maliput-py python3 pythonPackages.pybind11 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/maliput-full/default.nix
+++ b/distros/foxy/maliput-full/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, maliput, maliput-dragway, maliput-drake, maliput-integration, maliput-malidrive, maliput-multilane, maliput-object, maliput-object-py, maliput-py }:
+buildRosPackage {
+  pname = "ros-foxy-maliput-full";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/maliput_infrastructure-release/archive/release/foxy/maliput_full/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "3d6e191e7efa5169c258c109d0f67b3d2859d36d7e4bc65407d2271f95363016";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ maliput maliput-dragway maliput-drake maliput-integration maliput-malidrive maliput-multilane maliput-object maliput-object-py maliput-py ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta package that concentrates all maliput-related packages'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/maliput-malidrive/default.nix
+++ b/distros/foxy/maliput-malidrive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, fmt, maliput, maliput-drake, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-maliput-malidrive";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f643c9761b5333d6cc0856263e49ef2931b4820f5b141f800639a2d800276971";
+    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "e37a774e2665aa4364f3cd6c3bb3f1a941c517ce2e3457e163b935edac5741cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
 buildRosPackage {
   pname = "ros-foxy-maliput-multilane";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "527698d08a50d9a49c0d3382e62f2854ebb5e02dee52873dfd3668f25c16e55f";
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "bbb58467ea2752e8ddea5494fdc03fef593e0327761740cbc9971bce1d5081f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-object-py/default.nix
+++ b/distros/foxy/maliput-object-py/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput-object, pybind11, python3 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput-object, python3, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-maliput-object-py";
   version = "0.1.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ python3 ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-pytest ];
-  propagatedBuildInputs = [ maliput-object pybind11 ];
+  propagatedBuildInputs = [ maliput-object pythonPackages.pybind11 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/maliput-py/default.nix
+++ b/distros/foxy/maliput-py/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput, pybind11, python3 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput, python3, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-maliput-py";
   version = "0.1.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ python3 ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-pytest ];
-  propagatedBuildInputs = [ maliput pybind11 ];
+  propagatedBuildInputs = [ maliput pythonPackages.pybind11 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/nerian-stereo/default.nix
+++ b/distros/foxy/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nerian-stereo";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "16ae46284080599ab25f9ab506f11696fefefe00f6bf598dde4a82a134a9318d";
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "33f56cf27bfb2363f02ad66a3ef9ad6ad162fb055a4916f9435e3f59dd58ed10";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/performance-test/default.nix
+++ b/distros/foxy/performance-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-performance-test";
-  version = "1.0.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/foxy/performance_test/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9035cf4ff43fa584da5ed5cc28853032b3d143eb7bd75606d94cad0c159b250b";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/foxy/performance_test/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "525cfade4a96984b86c41f451b3f15cf7617c346952e1a48139c437fd94513f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "9c260ad1a41cd500a74c037b76e1604f5accda21d4dddc9067db2243caebfe77";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "5d4be39f01bc0c2c6970d9ab928c31c4247c82db04378b4d5bc8d21d33e49af8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raspimouse-description/default.nix
+++ b/distros/foxy/raspimouse-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-raspimouse-description";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/foxy/raspimouse_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4c14a50a79d663917064832aebf8d44ff60ad26c0d52faaebe53153977566c81";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The raspimouse_description package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/rqt-console/default.nix
+++ b/distros/foxy/rqt-console/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, python-qt-binding, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-console";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/foxy/rqt_console/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "f5a82fc3756f1e06c789139378fa3de968ca02f29d54bd46bac747bd4a3b13fa";
+    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/foxy/rqt_console/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "e30be415ef6ffa55d20c4da0230ac456b9677cdb9dbc79a46a7fc34e983a22f0";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ ament-index-python python-qt-binding rcl-interfaces rclpy rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_console provides a GUI plugin for displaying and filtering ROS messages.'';

--- a/distros/foxy/rviz-imu-plugin/default.nix
+++ b/distros/foxy/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, message-filters, pluginlib, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-rviz-imu-plugin";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/rviz_imu_plugin/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "6bdb2b29fe1c2f100789638f542752b6c41c51a038a7b05929e4a92490968027";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/foxy/rviz_imu_plugin/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5e0221c97bee7ffbbd24a6c0f77e16b1c7055341cef45af6293fad9b9d650ebf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/vrpn/default.nix
+++ b/distros/foxy/vrpn/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
+buildRosPackage {
+  pname = "ros-foxy-vrpn";
+  version = "7.35.0-r8";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/vrpn-release/archive/release/foxy/vrpn/7.35.0-8.tar.gz";
+    name = "7.35.0-8.tar.gz";
+    sha256 = "4d663529646e6697043507eff26ff773a71e01663373dc5c976a5b857bcfd7b1";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The VRPN is a library and set of servers that interfaces with virtual-reality systems, such as VICON, OptiTrack, and others.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/angles/default.nix
+++ b/distros/galactic/angles/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-angles";
-  version = "1.12.4-r2";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/galactic/angles/1.12.4-2.tar.gz";
-    name = "1.12.4-2.tar.gz";
-    sha256 = "374d88ee725f7a532408549f8933795ec1d360095395410b1c8f72a6c307a17b";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/galactic/angles/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "3c77795be096e8bbeb34b3ae79528a2764cf5db6177361ab208e3321f223b866";
   };
 
   buildType = "ament_cmake";
-  nativeBuildInputs = [ ament-cmake python3Packages.setuptools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 
   meta = {
     description = ''This package provides a set of simple math utilities to work

--- a/distros/galactic/camera-calibration-parsers/default.nix
+++ b/distros/galactic/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-camera-calibration-parsers";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_calibration_parsers/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "6a3dd247c289a58239c0f5f379d5433cb480f118cd61859901d9e9be3bbb4747";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_calibration_parsers/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "62001acece6e528bd548dc91a801201ea85abb1f28b47440355b6e4c98112c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/camera-info-manager/default.nix
+++ b/distros/galactic/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-camera-info-manager";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_info_manager/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "ecef86201cb6ce31ac6650d46104673d030940187f54eb42f7c5bf41278d2a7c";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/camera_info_manager/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "2462a605ffd15667c92532ee1d3e6c70ac85a71dd8e552d9f14af637d1870004";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai/default.nix
+++ b/distros/galactic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-depthai";
-  version = "2.15.5-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.15.5-1.tar.gz";
-    name = "2.15.5-1.tar.gz";
-    sha256 = "4986156602eab268b763908b1c26d67e4404f43476a61a026ddd6c6b95b901fe";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "4115e30bead9e68dd945ad2444fdcd2ad48ee7b0fa688e920f838f3ec46c456a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/eigenpy/default.nix
+++ b/distros/galactic/eigenpy/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-galactic-eigenpy";
+  version = "2.7.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.7-1.tar.gz";
+    name = "2.7.7-1.tar.gz";
+    sha256 = "9357d8db0a07420fe4e0fd471f2fafb46dcae3ca26b3e84e41bb6c5dc9072098";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost eigen python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Bindings between Numpy and Eigen using Boost.Python'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/foxglove-msgs/default.nix
+++ b/distros/galactic/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-foxglove-msgs";
-  version = "1.2.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/galactic/foxglove_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "e8e81d56cd17a73f6a2ab55780aa20aa5e466832bf2b5b0bcfd3f884ff7f0c31";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/galactic/foxglove_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "2d795a63b180eef0c0ee8952972668b3fedbed8593d7374179577b0eb5f9a4eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -370,6 +370,8 @@ self: super: {
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
 
+ eigenpy = self.callPackage ./eigenpy {};
+
  example-interfaces = self.callPackage ./example-interfaces {};
 
  examples-rclcpp-cbg-executor = self.callPackage ./examples-rclcpp-cbg-executor {};
@@ -652,6 +654,8 @@ self: super: {
 
  lifecycle-msgs = self.callPackage ./lifecycle-msgs {};
 
+ log-view = self.callPackage ./log-view {};
+
  logging-demo = self.callPackage ./logging-demo {};
 
  lua-vendor = self.callPackage ./lua-vendor {};
@@ -867,6 +871,8 @@ self: super: {
  navigation2 = self.callPackage ./navigation2 {};
 
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
+
+ nerian-stereo = self.callPackage ./nerian-stereo {};
 
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
@@ -1763,6 +1769,8 @@ self: super: {
  tvm-vendor = self.callPackage ./tvm-vendor {};
 
  twist-mux = self.callPackage ./twist-mux {};
+
+ twist-stamper = self.callPackage ./twist-stamper {};
 
  ublox = self.callPackage ./ublox {};
 

--- a/distros/galactic/image-common/default.nix
+++ b/distros/galactic/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-galactic-image-common";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_common/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "ae20aae3bf832989304e36066c7b6eb0c32086972fdc954b9483e8517dcddd73";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_common/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "47330b6d8403c509ec0b882b339b6e0387923897229d91e152a941bff9bbe436";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/image-transport/default.nix
+++ b/distros/galactic/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-image-transport";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_transport/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "d91cad7553e537d5a94395a4cf1ac807ff599d021f268ac14ac9b44e324a35c7";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/galactic/image_transport/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "57d015f1158eb157ccc9d118409531273d134485ff0ebc0dc7a32ca37a62b542";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-complementary-filter/default.nix
+++ b/distros/galactic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-imu-complementary-filter";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_complementary_filter/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "b89699b5b628132a105294c7b1249bd306f57d354c2e62c05cfb3abc82ce5d4e";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_complementary_filter/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a9805b2dcd9e9e5866d320a51216b2746b56aa8cabd0cfc0d5745ab785ae40b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-filter-madgwick/default.nix
+++ b/distros/galactic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-imu-filter-madgwick";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_filter_madgwick/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "c794017fd4504666bd09c906a557cbe8116da75390e5ae57839468429fc064a1";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_filter_madgwick/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "1796b29e38544e9bf04be52df9f52e01bb2e661f37c8a65c942cf9173869457a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/imu-tools/default.nix
+++ b/distros/galactic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-galactic-imu-tools";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_tools/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "c63023f9943ff06b0af316fa12ef1e7014393297fbf4197386eeb027a340f078";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/imu_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "0c716be4760a0b7c4c72422e4e573c20bc13461f8fb7cf1a7189b9a2dcfb2ba5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/log-view/default.nix
+++ b/distros/galactic/log-view/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip }:
+buildRosPackage {
+  pname = "ros-galactic-log-view";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/hatchbed/log_view-release/archive/release/galactic/log_view/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "781f8752d3cb932e45943a800019cfdf176d0439e2090bc20a2be58ae81e49dc";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The log_view package provides a ncurses based terminal GUI for
+    viewing and filtering published ROS log messages.
+
+    This is an alternative to rqt_console and swri_console that doesn't depend
+    on qt and can be run directly in a terminal.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/magic-enum/default.nix
+++ b/distros/galactic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-galactic-magic-enum";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/galactic/magic_enum/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "b7a5b2ddba201a6238ddbeada09f5eb887711aff17b87f7418f1cb2202aa0eec";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/galactic/magic_enum/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "41c5912bf40f134d2beddb3138d243ed76be21f27875bb777f78a1ab04bcb7c4";
   };
 
   buildType = "cmake";

--- a/distros/galactic/nao-lola/default.nix
+++ b/distros/galactic/nao-lola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nao-lola";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ijnek/nao_lola-release/archive/release/galactic/nao_lola/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "e6fa466bf82175af43aad3397b46c25977b6e414525c046f07d87fcd159be3fd";
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/galactic/nao_lola/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "7698764e64152cd55248ed644c71d2f0cb174303033cbf1a6a762ba7edb3375a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nerian-stereo/default.nix
+++ b/distros/galactic/nerian-stereo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-nerian-stereo";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/galactic/nerian_stereo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "05cda22e7fa5597a900ab06c0e893cc6b7cc85ea237896ebba554d029bbc1fed";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake cv-bridge rosidl-default-generators rosidl-default-runtime sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Driver node for ROS 2 for Scarlet, SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/performance-test/default.nix
+++ b/distros/galactic/performance-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-performance-test";
-  version = "1.0.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/galactic/performance_test/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8c787535f563bb788d647b5519c9a15cdacaac88b1ef87652762314dc0c413bd";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/galactic/performance_test/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "9e8b988f5349aa1b8a340cd3f240ff2758d040a58da673e33f06af79541cc798";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "f81e9ee36e799cba846e96439f43e1b60af3d85325b57b03b5d6c1b42a474992";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "7ec0eac90188417ec8414d3f9fec2ba17c3cb92170e62b690e562f28e2ca7102";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros-image-to-qimage/default.nix
+++ b/distros/galactic/ros-image-to-qimage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, qt5, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros-image-to-qimage";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_image_to_qimage-release/archive/release/galactic/ros_image_to_qimage/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "53f38fc3a197011cbe0978745d73f38f5943fbeb86d253530dbd11696ec8c8f4";
+    url = "https://github.com/ros2-gbp/ros_image_to_qimage-release/archive/release/galactic/ros_image_to_qimage/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "3fb3c0549f954b1438de980fa1edd4eab93c3dbb966b0b5bdde4a750550ba940";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rviz-imu-plugin/default.nix
+++ b/distros/galactic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, message-filters, pluginlib, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-rviz-imu-plugin";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/rviz_imu_plugin/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "701b199d1b6ecdb5aeb78cc8912fcdb513d3ef1071a5a56e6f717b5a057cad19";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/galactic/rviz_imu_plugin/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c18b74be79f4e84ceb530f16ca650a01e60a0cc34838f926afce956056b1f89f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-description/default.nix
+++ b/distros/galactic/turtlebot4-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-description, robot-state-publisher, urdf }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-description";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "6f9fb98d371d784f3ff06385bf82dd1b2c69f64aa974658ead54a1f6ad0df63f";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_description/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "99b2667a429039ffd5c6624b4fc0f51595e898508fd6e5085706640941a469a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-msgs/default.nix
+++ b/distros/galactic/turtlebot4-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "1c3b89649c5251aab468fc6bcc71b6914cf1290f91b7e1644b938ef93cbfdfd8";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "e73f3c3470a535dfd614e85824e38c740fc8bf7c4862aec073f4ed6bebe2ad69";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot4-navigation/default.nix
+++ b/distros/galactic/turtlebot4-navigation/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav2-bringup, slam-toolbox }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, nav2-bringup, nav2-simple-commander, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-navigation";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_navigation/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "173e72b8c0b910c817c14632186ebaa04658b5d15981ae2f8819f6a28c5328dc";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_navigation/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "48e91cd72555d9c49e59596d75757861cc99bef05a2be183a1c32a0303236334";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav2-bringup slam-toolbox ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav2-bringup nav2-simple-commander slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''Turtlebot4 Navigation'';

--- a/distros/galactic/turtlebot4-node/default.nix
+++ b/distros/galactic/turtlebot4-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot4-node";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_node/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "cf5dff74cf226318ca2f7dfa60d081212d2a3479c70b1903e80d59d0c3b06bef";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/galactic/turtlebot4_node/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "292334aba2cd09be5ebea47d25627b49f151c749dfcd315dc43f23ff8e699064";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/twist-stamper/default.nix
+++ b/distros/galactic/twist-stamper/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-twist-stamper";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/joshnewans/twist_stamper-release/archive/release/galactic/twist_stamper/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "97147c9dee8f70d3de5a198f96be3f521aa101ff2edf690a9712a5764ab609c4";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs rclpy std-msgs ];
+
+  meta = {
+    description = ''ROS2 package for converting between Twist and TwistStamped messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/velodyne-driver/default.nix
+++ b/distros/galactic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-driver";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "63b305d7113d4ec7f977da66faba82f3427cfa4453da6993709bbb50a43402de";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "4742dabcbde7a4736da17493bf638bb49d4155d67f777bed371e82e5df98dda8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-laserscan/default.nix
+++ b/distros/galactic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-laserscan";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "409d3a53c5b4a6c7164b3f85d7e9a4635119751820fd22c7c46b8730b3ee1794";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_laserscan/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "879837e0ef4588822d03f9229afcf2ab8b88017cf89b7a6a663f57c4c575b36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-msgs/default.nix
+++ b/distros/galactic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-msgs";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5557887b891ea9c9b3ac06a8aae9129c7c78badbba97b18a145055c1c72fc4fb";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "68de3c5fd4cb13ea6b6cff164a2044635eefc02984bedd5ed464d301de4d1840";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne-pointcloud/default.nix
+++ b/distros/galactic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-galactic-velodyne-pointcloud";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "14336818e211d7231a126ab5e45762cd4170f4f9472f1af3e505d67e8c6e2796";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne_pointcloud/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "edd5447b505a0f786f0a98bf33fbbf8b9d58af488aa0241d3ebaa50a9dd4f0cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/velodyne/default.nix
+++ b/distros/galactic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-galactic-velodyne";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "838f82656dfefc285648931d87839ae27b2dfcf13ad7c7d81803012b1ff3b6c7";
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/galactic/velodyne/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "333e193dc90c1dd1846ade0e0f656bd9f5918f596b443b0dc885306b497fd875";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/affordance-primitives/default.nix
+++ b/distros/humble/affordance-primitives/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-clang-format, ament-clang-tidy, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-cmake-lint-cmake, ament-lint-auto, geometry-msgs, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-humble-affordance-primitives";
+  version = "0.1.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/affordance_primitives-release/archive/release/humble/affordance_primitives/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "eb25ae49b78c3cb702387927258cb4d68a4b1548b403209645a1e7495f5986fa";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-clang-format ament-clang-tidy ament-cmake-copyright ament-cmake-gtest ament-cmake-lint-cmake ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs tf2-eigen ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Library for affordance motion primitives.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/angles/default.nix
+++ b/distros/humble/angles/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-angles";
-  version = "1.13.0-r3";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/angles-release/archive/release/humble/angles/1.13.0-3.tar.gz";
-    name = "1.13.0-3.tar.gz";
-    sha256 = "02c2047e640dfd8c64cc9df09d782564134db279c0396e0d5c177c728e36a9d3";
+    url = "https://github.com/ros2-gbp/angles-release/archive/release/humble/angles/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "fb21b4e5062cfbf56918f2ee479ed07d925f2108075f656261078df0eef3c606";
   };
 
   buildType = "ament_cmake";
   propagatedBuildInputs = [ ament-cmake ];
-  nativeBuildInputs = [ ament-cmake python3Packages.setuptools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python3Packages.setuptools ];
 
   meta = {
     description = ''This package provides a set of simple math utilities to work

--- a/distros/humble/bag2-to-image/default.nix
+++ b/distros/humble/bag2-to-image/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, opencv, rclcpp, rclcpp-components, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-bag2-to-image";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bag2_to_image-release/archive/release/humble/bag2_to_image/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "49394a857b402145a03cf4e1e9fc0a2e6edccc9857d0485acf337a0c057fbcca";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ opencv rclcpp rclcpp-components rosbag2-cpp rosbag2-storage sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The bag2_to_image package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "da02ea88c85592d1fd49d2413f9e5559f2f1a63708c8a37289c03f9774b78702";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "eb9f4b18f85ecc73dd7c7f4d0a111bea03ddd0db1d2a4f6691e0bf85ff8be54e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "e89206b5b735ad6dbb5fdccc9b9e0f20a14ba23e4157e8e108b3bb1168b75988";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "1aa76228bdd8bd5756a2eaef5652ce295de7d1d0b022070d85aa6215739b705e";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "0e497ae8cbcf367e9518113551a0b6146ac3aa3503e79701356f40ba177218a2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "1c103626cab226004f3c80b99752a55a7d69312138b419abc62112d35b0b7ed4";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock realtime-tools ];
   propagatedBuildInputs = [ ament-index-cpp controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils ros2-control-test-assets ros2param ros2run ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.15.5-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.15.5-1.tar.gz";
-    name = "2.15.5-1.tar.gz";
-    sha256 = "a0c6f736bd36fe918188731afdebe0b3c3dd614addeb06bc972e53fec3a3df6f";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "df4e22d13b98f50d9927c490793166e32269ad8b3a25d7a242738cb256c2890b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "8d3ad011895aa982b63e3b6d538cabe8cec2b6234f8cf5f129e20f18d24fb93d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "4276efb171ee3f2dd789e832dc81c6ab6af788df9c1a0c17cbdbf56572c28e6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "4b5d59637695d9ac321935e91a72ee9fa5a0eb1dbb23792c7ab92d9fa1741413";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "ce8a2a72232602f4da553e9fda8fce2abda3fba89fd5d1966b8d979bdb55a7e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-eigenpy";
+  version = "2.7.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.7.7-1.tar.gz";
+    name = "2.7.7-1.tar.gz";
+    sha256 = "06634b9f4d5f5be07ced394692443ddd5cfa5e4952ace4a1f99988e9d9859b39";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost eigen python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Bindings between Numpy and Eigen using Boost.Python'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/fogros2-examples/default.nix
+++ b/distros/humble/fogros2-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, fogros2, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-fogros2-examples";
-  version = "0.1.6-r3";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fogros2-release/archive/release/humble/fogros2_examples/0.1.6-3.tar.gz";
-    name = "0.1.6-3.tar.gz";
-    sha256 = "b85aecd15e3e9df1eb973162f632b32313bdac7ea88daed79daf9e438111055a";
+    url = "https://github.com/ros2-gbp/fogros2-release/archive/release/humble/fogros2_examples/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "de71035ee00fb2c2b280815d8b277cbb1d61a09be05d638ff8eba42243c7ac21";
   };
 
   buildType = "ament_python";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0a66cfd0d15adce846a70ad75760d6f8c2a9dfa48d7d566dd2e44db019cc15d4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "468ca1f95c1c59c4c61aa6218c22021deaadfa533be6a870c0531ffa24591e2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "bc71e32986238aa890af5292b3277a218de36bfff01dfa0d5572bec88de6ea83";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "7a178d7da11106c3d02c55ee6fa22ddc9b70eaab09d446c888e7dbc87a662f64";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-msgs/default.nix
+++ b/distros/humble/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-foxglove-msgs";
-  version = "1.2.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/humble/foxglove_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "3d4874e7d7aefac1ea20ce159024052e8b0dd7f9788c5d649d9e29dc29e82cf4";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/humble/foxglove_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "e412a4992d62f5fb999e5e61b210fde3961e06787201c4e7fff5b0eef161908a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -20,6 +20,8 @@ self: super: {
 
  adaptive-component = self.callPackage ./adaptive-component {};
 
+ affordance-primitives = self.callPackage ./affordance-primitives {};
+
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
  ament-clang-format = self.callPackage ./ament-clang-format {};
@@ -168,6 +170,8 @@ self: super: {
 
  backward-ros = self.callPackage ./backward-ros {};
 
+ bag2-to-image = self.callPackage ./bag2-to-image {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  bno055 = self.callPackage ./bno055 {};
@@ -309,6 +313,8 @@ self: super: {
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
+
+ eigenpy = self.callPackage ./eigenpy {};
 
  example-interfaces = self.callPackage ./example-interfaces {};
 
@@ -492,6 +498,8 @@ self: super: {
 
  io-context = self.callPackage ./io-context {};
 
+ joint-limits = self.callPackage ./joint-limits {};
+
  joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
@@ -617,6 +625,10 @@ self: super: {
  marti-status-msgs = self.callPackage ./marti-status-msgs {};
 
  marti-visualization-msgs = self.callPackage ./marti-visualization-msgs {};
+
+ marvelmind-ros2 = self.callPackage ./marvelmind-ros2 {};
+
+ marvelmind-ros2-msgs = self.callPackage ./marvelmind-ros2-msgs {};
 
  mavlink = self.callPackage ./mavlink {};
 
@@ -802,6 +814,8 @@ self: super: {
 
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
 
+ nerian-stereo = self.callPackage ./nerian-stereo {};
+
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
@@ -864,8 +878,6 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
- performance-report = self.callPackage ./performance-report {};
-
  performance-test = self.callPackage ./performance-test {};
 
  performance-test-fixture = self.callPackage ./performance-test-fixture {};
@@ -903,6 +915,32 @@ self: super: {
  pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
 
  pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
+
+ plansys2-bringup = self.callPackage ./plansys2-bringup {};
+
+ plansys2-bt-actions = self.callPackage ./plansys2-bt-actions {};
+
+ plansys2-core = self.callPackage ./plansys2-core {};
+
+ plansys2-domain-expert = self.callPackage ./plansys2-domain-expert {};
+
+ plansys2-executor = self.callPackage ./plansys2-executor {};
+
+ plansys2-lifecycle-manager = self.callPackage ./plansys2-lifecycle-manager {};
+
+ plansys2-msgs = self.callPackage ./plansys2-msgs {};
+
+ plansys2-pddl-parser = self.callPackage ./plansys2-pddl-parser {};
+
+ plansys2-planner = self.callPackage ./plansys2-planner {};
+
+ plansys2-popf-plan-solver = self.callPackage ./plansys2-popf-plan-solver {};
+
+ plansys2-problem-expert = self.callPackage ./plansys2-problem-expert {};
+
+ plansys2-terminal = self.callPackage ./plansys2-terminal {};
+
+ plansys2-tools = self.callPackage ./plansys2-tools {};
 
  plotjuggler = self.callPackage ./plotjuggler {};
 
@@ -1392,6 +1430,12 @@ self: super: {
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
 
+ sick-safetyscanners2 = self.callPackage ./sick-safetyscanners2 {};
+
+ sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};
+
+ sick-safetyscanners-base = self.callPackage ./sick-safetyscanners-base {};
+
  simple-launch = self.callPackage ./simple-launch {};
 
  simulation = self.callPackage ./simulation {};
@@ -1662,9 +1706,19 @@ self: super: {
 
  velocity-controllers = self.callPackage ./velocity-controllers {};
 
+ velodyne = self.callPackage ./velodyne {};
+
  velodyne-description = self.callPackage ./velodyne-description {};
 
+ velodyne-driver = self.callPackage ./velodyne-driver {};
+
  velodyne-gazebo-plugins = self.callPackage ./velodyne-gazebo-plugins {};
+
+ velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
+
+ velodyne-msgs = self.callPackage ./velodyne-msgs {};
+
+ velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
  velodyne-simulator = self.callPackage ./velodyne-simulator {};
 

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "9967838cc9fb2e9355fbf2f06c3d84b5a0884da725a6c78701d67dddf4c296d3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "b36f8d2f30bf656f1dc9c7e41515a2b7f356446cbf6b4c81dc70aa8b4e7d0464";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "b0627f785056baa349508378657d4aeda1770eae2bdbd4936cb31dc109180641";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "5a6aea12bb6246794d04745f3fa733c51d53cc84f97ed42782c638a1dee29ac3";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''ROS2 ros_control hardware interface'';
+    description = ''ros2_control hardware interface'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/imu-complementary-filter/default.nix
+++ b/distros/humble/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-imu-complementary-filter";
-  version = "2.1.1-r1";
+  version = "2.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/imu_complementary_filter/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "8b0b4b0f0990ee561c51d0e15fd36dc1a4e99a1bc616b4c58049eb3c402b459a";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/imu_complementary_filter/2.1.1-2.tar.gz";
+    name = "2.1.1-2.tar.gz";
+    sha256 = "970465a940e67f46148fe7a5a95f0c4b2c54316ac3a1f254c14c1e3f6717e60d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-filter-madgwick/default.nix
+++ b/distros/humble/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-filter-madgwick";
-  version = "2.1.1-r1";
+  version = "2.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/imu_filter_madgwick/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "d0728ac0a2c455f20357dfcaba127485688604f1667c39bca11351be7e521a0b";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/imu_filter_madgwick/2.1.1-2.tar.gz";
+    name = "2.1.1-2.tar.gz";
+    sha256 = "4f61fe56b2166f3e4cd757d841fa751c747f9009a26417108257197b6f95bb1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "3998156b0cca994f2898a3186b3afc5c700e3be4490fe3dd63b14389a5565270";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "3eebc2229b47e992730b15cf22c9d52e4e90b9ad69c133480906436b7717b7cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-tools/default.nix
+++ b/distros/humble/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-humble-imu-tools";
-  version = "2.1.1-r1";
+  version = "2.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/imu_tools/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "3e56de1fd79a2f0f70a836f75c70f2645e87d409e3213d3b0ed5d26140291d1e";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/imu_tools/2.1.1-2.tar.gz";
+    name = "2.1.1-2.tar.gz";
+    sha256 = "266855f40acda24f17a3a8ba8ab43a47f486670c115d8504e654787437ecb394";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-humble-joint-limits";
+  version = "2.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "0442245a960d277054ebfe540f2fc51d66bda201d4846f09492106234aada6e7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces for handling of joint limits for controllers or hardware.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1b541160c39235c5ae6e9b6342bbd1283def84623e5f3d97d4f2a73e297dc1ea";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "c6eef3c5b8160f8461cc2470ef8acf48f26e007c57de787c6662fb6ec30eeb39";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "5ed590175c6ddbe4bfc9d280898086330425e92a4141eabbd7836ec4d8c1d730";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "f94c3bc85c19aa51980e27348926fa4e930a73872dea21a320a68037a3c376f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marvelmind-ros2-msgs/default.nix
+++ b/distros/humble/marvelmind-ros2-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-marvelmind-ros2-msgs";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarvelmindRobotics/marvelmind_ros2_msgs_release/archive/release/humble/marvelmind_ros2_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "0c0fd3f728b00a79ecc089b18f80b5bbd5d4ceb4bc3d96827121d15f70665517";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Marvelmind message package for ROS2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/marvelmind-ros2/default.nix
+++ b/distros/humble/marvelmind-ros2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, marvelmind-ros2-msgs, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-marvelmind-ros2";
+  version = "1.0.2-r3";
+
+  src = fetchurl {
+    url = "https://github.com/MarvelmindRobotics/marvelmind_ros2_release_repo/archive/release/humble/marvelmind_ros2/1.0.2-3.tar.gz";
+    name = "1.0.2-3.tar.gz";
+    sha256 = "8a1b92d9ba2b5277fdffb56943594f20f2b5391b2692522e67def8ac2153be9b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs launch-xml marvelmind-ros2-msgs rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Marvelmind ROS2 package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mavlink";
-  version = "2022.2.2-r3";
+  version = "2022.6.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.2.2-3.tar.gz";
-    name = "2022.2.2-3.tar.gz";
-    sha256 = "854a80be0a0e7612d2bd5543a7fa9cc96179c1e509e679dff556636565f715a7";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.6.27-1.tar.gz";
+    name = "2022.6.27-1.tar.gz";
+    sha256 = "6c2d7e176a4e4f0cddf67d5c385a8b3f2ec2d5b7bb64bab84b1672b55bc36970";
   };
 
   buildType = "cmake";

--- a/distros/humble/moveit-resources-fanuc-description/default.nix
+++ b/distros/humble/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-fanuc-description";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_description/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "00c4614194fe443fc78eb6968211e0bccba534c7b22a09edef23531dc4fa7eae";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_description/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "8a4cb78d5e11e83c10aab085cb4d29bd40661c4acd002ccf370b8f6ec4a4051a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/humble/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-fanuc-moveit-config";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_moveit_config/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "f97be0485282bc20f319e149ca91eae824090dd1581187eac0351983775f6585";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_fanuc_moveit_config/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "90c0fa7a63c84f2058a11ada4a09396ede328d13143c1668197e0fd341e28e4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-panda-description/default.nix
+++ b/distros/humble/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-panda-description";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_description/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "20abf19afb6f8721b1b691dd4aec8637716a80391094226cdf4485051676f764";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_description/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "861423d0c6b90275e98ccb51cfadaed56abe997b42942cc1c636307ea8a52034";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/humble/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-panda-moveit-config";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_moveit_config/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "60ff512e969f1afcddb4a161ebcdffa4b0a224e80be4787e92a1fe14327e1935";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_panda_moveit_config/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "099ee845ec5a0e783ad0d6d47ddb08fd29bbfd580c6f44707d7c5b7d673b33a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-pr2-description/default.nix
+++ b/distros/humble/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-pr2-description";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_pr2_description/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "34fbaedbd5530abdeaf18b293b47c9708e2d92080c04f4123ee5ae8ae736ad7d";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources_pr2_description/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "6aceda0debfdfaff5560094dbcd7f8fbcb54dc7541f94a3459f58157d02164f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources/default.nix
+++ b/distros/humble/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "1a2888ac632779eec3e47d3f42f3bd82146e9b1e6a0191054feeb40b8764af77";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/humble/moveit_resources/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "aa1965f41cef5f77bef6064e569d41cfb266e29e016acacfe8521c7f8b468019";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nao-lola/default.nix
+++ b/distros/humble/nao-lola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nao-lola";
-  version = "0.0.4-r4";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/humble/nao_lola/0.0.4-4.tar.gz";
-    name = "0.0.4-4.tar.gz";
-    sha256 = "2c7a7eae17c9036b9e8723916d7eba364fbe7665b1af015155cc2e03747f449e";
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/humble/nao_lola/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "efe25b61711696e649f69f3012a7c047646c8d6f95c03dfdc3b333093a7b5aa9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nerian-stereo/default.nix
+++ b/distros/humble/nerian-stereo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-nerian-stereo";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/humble/nerian_stereo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "52fe766f6f1a4802a71645820e77e2e536840498ebb64acf2086af3a94de2e2f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake cv-bridge rosidl-default-generators rosidl-default-runtime sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Driver node for ROS 2 for Scarlet, SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/performance-test/default.nix
+++ b/distros/humble/performance-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-performance-test";
-  version = "1.1.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_test/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "86837cb1939cb826de597334ba5d7653deafbcf42a572ab28c7b45406d94ef1e";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/humble/performance_test/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "c2c82361579b9a02dea39bc4d3b589c0ed055bacf12b701e291e4629d96f7585";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/plansys2-bringup/default.nix
+++ b/distros/humble/plansys2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-bringup";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_bringup/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "32170ab857b2071dad4dcd809df81f2ebd5235ddf4effa4d7cdfc6cce56ed6e1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common launch launch-testing ];
+  propagatedBuildInputs = [ launch-ros plansys2-domain-expert plansys2-executor plansys2-lifecycle-manager plansys2-planner plansys2-problem-expert rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Bringup scripts and configurations for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-bt-actions/default.nix
+++ b/distros/humble/plansys2-bt-actions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-bt-actions";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_bt_actions/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "fe1fb5738032954183cfff057cfa7b666fcd82d743d5132e5cf311e6bfbbbb69";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs plansys2-msgs test-msgs ];
+  propagatedBuildInputs = [ action-msgs behaviortree-cpp-v3 cppzmq plansys2-executor rclcpp rclcpp-action rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Problem Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-core/default.nix
+++ b/distros/humble/plansys2-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-core";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_core/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "fbe5b993e5bc29baae502543f7a9c3771bf458ba2522b3c4856725959f07b34c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-pddl-parser pluginlib rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based core  for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-domain-expert/default.nix
+++ b/distros/humble/plansys2-domain-expert/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-domain-expert";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_domain_expert/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "22283f3daa19eabb6b4010c9c78ca187f5330582d954aa946481397bdd1fd6a1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-core plansys2-msgs plansys2-pddl-parser plansys2-popf-plan-solver rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Domain Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-executor/default.nix
+++ b/distros/humble/plansys2-executor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-executor";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_executor/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "3a3c0f072210f99de58c42f50f7ff118975de45994e7bbd041efec13030a687f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 cppzmq lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Executor module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-lifecycle-manager/default.nix
+++ b/distros/humble/plansys2-lifecycle-manager/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-lifecycle-manager";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_lifecycle_manager/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "21a0300aa3e4d1384c94de6e648f41da578c86e2cc4208ed5d37b583f82299a4";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ lifecycle-msgs rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A controller/manager for the lifecycle nodes of the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-msgs/default.nix
+++ b/distros/humble/plansys2-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-msgs";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_msgs/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "ef76e8857f55adc6c0a9ddd2b4fc2be364c6bd0cba7b425463db530460618a64";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rclcpp rosidl-default-generators std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages and service files for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-pddl-parser/default.nix
+++ b/distros/humble/plansys2-pddl-parser/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-pddl-parser";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_pddl_parser/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "1267fa667dae732ae36a8ffbae96a94fad768143a2f650f049dc34ae601dde32";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains a library for parsing PDDL domains and problems.
+  
+    This package derives from the work of Anders Jonsson, contained in https://github.com/wisdompoet/universal-pddl-parser.git
+    with many modifications by Francisco Martin:
+      * ROS2 packaging
+      * Source code structure refactor
+      * CMakeLists.txt for cmake compilation
+      * Reading from String instead of files
+      * Licensing'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-planner/default.nix
+++ b/distros/humble/plansys2-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-planner";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_planner/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "9679a922f17c3822e00f0f82937ae263eb3a6592447f85cf3be2386331e381c0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-popf-plan-solver plansys2-problem-expert pluginlib rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based Planner module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-popf-plan-solver/default.nix
+++ b/distros/humble/plansys2-popf-plan-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-popf-plan-solver";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_popf_plan_solver/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "f78c8cf57f4f6b58bba9fe65189ec71c484a368d0740c163750501f480999fc0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp plansys2-core pluginlib popf rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based Planner module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-problem-expert/default.nix
+++ b/distros/humble/plansys2-problem-expert/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, qt5, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-problem-expert";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_problem_expert/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "10a58835eb024f566955955712d8d1a8cf8e538ec6f74a1800d92d3f7ba6bda5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser qt5.qtbase rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Problem Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-terminal/default.nix
+++ b/distros/humble/plansys2-terminal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-terminal";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_terminal/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "14c15bb200de3fce3c8c70862c9792243b03562fe48fb74bcd8172f40f2f32b5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common lifecycle-msgs ];
+  propagatedBuildInputs = [ plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle readline ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A terminal tool for monitor and manage the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plansys2-tools/default.nix
+++ b/distros/humble/plansys2-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, qt5, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
+buildRosPackage {
+  pname = "ros-humble-plansys2-tools";
+  version = "2.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/humble/plansys2_tools/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "88d195db8b6e90a1c6f39abe91829f3ea8a731f73ff8a0d0f48fb8c8b7b6fc87";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ qt5.qtbase ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-problem-expert qt-gui-cpp rclcpp rclcpp-lifecycle rqt-gui rqt-gui-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A set of tools for monitoring ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/plotjuggler-ros/default.nix
+++ b/distros/humble/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler-ros";
-  version = "1.5.1-r3";
+  version = "1.7.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/humble/plotjuggler_ros/1.5.1-3.tar.gz";
-    name = "1.5.1-3.tar.gz";
-    sha256 = "12e2d2ff4df721386ed1417ffad4a2028c697cd22f125c99d59a55b8ed805ca9";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/humble/plotjuggler_ros/1.7.1-3.tar.gz";
+    name = "1.7.1-3.tar.gz";
+    sha256 = "a0859904ec7094be45e1b05568231b31d13507d8493d1bd8d6c69ef2529cda63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "1fc1975a2b35713e13a567fee71991ba735097a94a83c054193c4f2921e719f3";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "00dbc8be0f111b5945f2bca06562d5e560045a7d8cb4550c4daa6dc7f91c3410";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1115b85b403054cce853ea461cdf4721c1d150a3cffa6e25473f3092b9d1fe94";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "1e005325743b01929aa36a465652a6a9ba04410fcd2323a07deb891de1f46582";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pybind11-vendor/default.nix
+++ b/distros/humble/pybind11-vendor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, pybind11 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-pybind11-vendor";
   version = "2.4.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ pybind11 ];
+  propagatedBuildInputs = [ pythonPackages.pybind11 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rclc-examples/default.nix
+++ b/distros/humble/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclc-examples";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc_examples/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "9e7bf396b8306a9dc0354280e6181b0a50119b4d3c38cc5eb0ed95c520dad3ce";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc_examples/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "0251aef75cf428670e80610e95f664154e947e058e50672a6aba93ea667d381b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclc-lifecycle/default.nix
+++ b/distros/humble/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclc-lifecycle";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc_lifecycle/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "4ee89d1d8e2e7fb12432c2bcf1e2b44958561ed0229f463fe5c13be31b40978c";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc_lifecycle/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "8da35c6cbf78abc94580f3b4424d5dc70774d2af6b0559670db08cc9549008d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclc-parameter/default.nix
+++ b/distros/humble/rclc-parameter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclc-parameter";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc_parameter/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "59378a31bc294f3a96e57a84b3d7f8332eb3e5fde7f7dd0d390e2b7af9e1f7bf";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc_parameter/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "fec60d842c9539ad58782da003118668a093d1ccd5fb08d4537bf468a05aa1f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclc/default.nix
+++ b/distros/humble/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcl-action, rclcpp, rclcpp-action, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclc";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "9f1db553aa26ec7b554469179333916659766b69f5ceee4509e00813b25ef230";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/humble/rclc/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "7440f465d2b9d7dbea651dc3885b852728aea8f38e33ff36852493683a84730c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-image-to-qimage/default.nix
+++ b/distros/humble/ros-image-to-qimage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, qt5, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-image-to-qimage";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_image_to_qimage-release/archive/release/humble/ros_image_to_qimage/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "298b7641924fd579da9ca0592643229beb33470fbd90480b8534a3c96df1cc95";
+    url = "https://github.com/ros2-gbp/ros_image_to_qimage-release/archive/release/humble/ros_image_to_qimage/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "871e132e8af334e312f8594c0b7484f7e239baf7f404b671206e03b44102a245";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8b48952fb28390d9dd18a01b07445e4bf7964d6896eb438f15c01cf4fa04bc37";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "384211164a16ad708be18296538b458b3a378781b861109ece84c74f6616622a";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "cd8b0f926e36823a7739828e128ea675ff595a7e5e1f3529eac8fea1f57dc294";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "a817cc0157eccff03e59e58eef0efbc8e8ea3c8419dc543080e4308354072ae2";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface ros2-control-test-assets ros2controlcli transmission-interface ];
+  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface joint-limits ros2-control-test-assets ros2controlcli transmission-interface ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "3df266cd5c34da5b05baf43a8498c7fb7df4f46a6b7d71f00faaa98271c33e8b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "bc1fb4974bb45607d3b44081a069e859cbceff1de325f2d02a01ac898c8c6972";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1ff31c6221b72986086287985b8b8f02ac3b59ef8d0bdde3e6b0b0dea76dbd61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "c1426d25c42f2324f82b1d5fd5b5507c2c082d011a386f52641840cb5500f6f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "2412876bb89624e74e4714386a3cec3af87226a69e4fd7c75c430a49609c75ad";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "9e7d6cc88e961f505e961904fd9212962bd1f8c1a3578cdf880c8d05fbd418ee";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rviz-imu-plugin/default.nix
+++ b/distros/humble/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, message-filters, pluginlib, qt5, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rviz-imu-plugin";
-  version = "2.1.1-r1";
+  version = "2.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/rviz_imu_plugin/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ed2e7e14e30b972a86d50f9acab890bf5c8811755e3d1d78f84732a1b59cbee0";
+    url = "https://github.com/ros2-gbp/imu_tools-release/archive/release/humble/rviz_imu_plugin/2.1.1-2.tar.gz";
+    name = "2.1.1-2.tar.gz";
+    sha256 = "80464e8983cb36774125bccdad20c54b2bf71780a4742bb7b22390430f1fe896";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-tools/default.nix
+++ b/distros/humble/rviz-visual-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-tools";
-  version = "4.1.2-r3";
+  version = "4.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/humble/rviz_visual_tools/4.1.2-3.tar.gz";
-    name = "4.1.2-3.tar.gz";
-    sha256 = "865ffedba33fcb27fcb61a17d94a20b2d493f8ce000790a40d9c5d9fca7bad8a";
+    url = "https://github.com/ros2-gbp/rviz_visual_tools-release/archive/release/humble/rviz_visual_tools/4.1.3-1.tar.gz";
+    name = "4.1.3-1.tar.gz";
+    sha256 = "49e3607f5fd4c62155d1b9522c53a1eb2103359ec19ee0ed41840fb44b0dd51b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sick-safetyscanners-base/default.nix
+++ b/distros/humble/sick-safetyscanners-base/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake }:
+buildRosPackage {
+  pname = "ros-humble-sick-safetyscanners-base";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/humble/sick_safetyscanners_base/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "76d51b27367cd21ae26243c1708211816868ed939079158785594fae3fe35486";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Provides an Interface to read the sensor output of a SICK
+  Safety Scanner'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/humble/sick-safetyscanners2-interfaces/default.nix
+++ b/distros/humble/sick-safetyscanners2-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-sick-safetyscanners2-interfaces";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners2_interfaces-release/archive/release/humble/sick_safetyscanners2_interfaces/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "1fb6b3dd93f0e5dd909963e75c254915785554b6b0cdd8f2f54e9801ad373fcb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces for the sick_safetyscanners ros2 driver'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/humble/sick-safetyscanners2/default.nix
+++ b/distros/humble/sick-safetyscanners2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
+buildRosPackage {
+  pname = "ros-humble-sick-safetyscanners2";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/humble/sick_safetyscanners2/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "067552406896f93c603177816048db9d818e84bd2d81880e2ba42b1ddbdfb40c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle sensor-msgs sick-safetyscanners-base sick-safetyscanners2-interfaces ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 Driver for the SICK safetyscanners'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, pluginlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.10.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8b33f7304104a367b15a395e4b37c684795ebc17aa7d475233ab04666ad56c6e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "402299d4a1347b8b98428551701dc3d1c279ecde1ae89c37e10e3195407505e0";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ hardware-interface pluginlib ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "89cde969371cd97f49c2c7f2c5205a1cfbbd87486af8ff835daae57b9d87bbdc";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "ddc448885d87663bf53c367f97951eb6ade9a73e2ac709fa131671de5a4c1e37";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "362da25a0733de4698789b974017ce1530af903a436da4a1a2b15c2f4c261ba1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "dc0c2a21ff540948f3cc4fa0212e2740d35c1f5b057bc94e1aed7398621578b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "e1a7d71f0cc74f090b2240a590c59025f392655edd1c8e4d5c211cf89b4bb54d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "03efe222a5b41a9c2162c86ee5fb45cf1fd5c6b73f65722d20664e7f190249b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "3a67b8caa676a8cf655e382591b5ffb5397dabc779761f5f40f09d005ca19578";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "604202b502a65fde044743abb56a87294e59f8f91f0d8180e76c44e9a0e5738a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "be79389a06449cc4fa5394097f27df4b29f489a6d918f5bdfa08595f833e8dc2";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "110665b9a12576963fdfbd51e99717e945353e078a02285aca596c91f5dbf625";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-robot-driver";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "809dbc94fe918768e37223a25e68334fa6345aad876fefad0eb423b54826819e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "58dd4062c0b70f1f4f6c9a815947b5334794837d5f81536a1b0ff06dbd317199";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "c74a81834783f3de0f56f36b7e91e3233085524a4ed61fe6473c3451869d0283";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "adb00447e2ca801b3a9dfceb6928929502efaebecc7a96f81d97b7ee6d0784e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.6.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "89d0d36f6bfcaf5704e8f5e07e6717a6c5e0ff01ede1db07c6d2e5f774a92f99";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "df3560c715554bc59a71363499293a4a33a864ea6fad2fc80db0d5780a8663d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velodyne-driver/default.nix
+++ b/distros/humble/velodyne-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-driver";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_driver/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "6644989f62b15fe9466eaccbf4732c0ca066bc256e1d1e746a614e071adee5ec";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater libpcap rclcpp rclcpp-components tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS device driver for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne-laserscan/default.nix
+++ b/distros/humble/velodyne-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-laserscan";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_laserscan/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "9aea61bf55a6472f5a4a00eef32030d629693578687b9142d75295461d261823";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Extract a single ring of a Velodyne PointCloud2 and publish it as a LaserScan message'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne-msgs/default.nix
+++ b/distros/humble/velodyne-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-msgs";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "9d8ca6f3b6140078f6a83def16ba1a147d9812097e6bf0743c255b868323eb9e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS message definitions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne-pointcloud/default.nix
+++ b/distros/humble/velodyne-pointcloud/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-humble-velodyne-pointcloud";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne_pointcloud/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2a84eaaf7b0435550cc89b4e8624f63477a071ee82bd375b8d8b345e565280f7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Point cloud conversions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velodyne/default.nix
+++ b/distros/humble/velodyne/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-humble-velodyne";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/velodyne-release/archive/release/humble/velodyne/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e30613ff99d96ec03c47047920fda2473a0b73e8ebcb805a005584b09fa30956";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-driver velodyne-laserscan velodyne-msgs velodyne-pointcloud ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Basic ROS support for the Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/camera-calibration/default.nix
+++ b/distros/melodic/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, message-filters, rospy, rostest, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-camera-calibration";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "184268a2b78b1373289cf8c047e3f2069911dff625cfeb36ae34a19dc241ba5f";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "f383771fde50848fb35e7dacc89351e9ac856f5b50c7c15d02d5b69dec321e04";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "7770553df791212fe6f509e6e8516463585f9b428e02b7d54084785a704961a8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "d59e3de47f5f91cffc04b496c2118019068e785c2898db983adc534fbfe29a0e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/depth-image-proc/default.nix
+++ b/distros/melodic/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cv-bridge, eigen-conversions, image-geometry, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-depth-image-proc";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "dd1e8a0b66ed4ad80d8f4eb4cbeaa315ba8f1c6d3d5d096edf9b55153bd9f90a";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "1a96a4b0043043f126f78236f49b335d69c163137c2a2b4af38db5e157e82289";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.5-r1";
+  version = "2.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "47858bb6feda73d45f258f788360159c31fdcb1f4547a1324c9a1bc7e402acb1";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.7-1.tar.gz";
+    name = "2.7.7-1.tar.gz";
+    sha256 = "527591d8fc3c0c759a54e72db95fab3ce9d10e53701ee72ff086819d53c760cb";
   };
 
   buildType = "cmake";

--- a/distros/melodic/foxglove-msgs/default.nix
+++ b/distros/melodic/foxglove-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-foxglove-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/melodic/foxglove_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "35a8abe8b7f56b02eedbccb37c5b9c264c34c0d628f4b2084c543d0357a7271d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''foxglove_msgs provides visualization messages that are supported by Foxglove Studio.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1146,6 +1146,8 @@ self: super: {
 
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
+ foxglove-msgs = self.callPackage ./foxglove-msgs {};
+
  frame-editor = self.callPackage ./frame-editor {};
 
  franka-control = self.callPackage ./franka-control {};
@@ -3051,6 +3053,8 @@ self: super: {
  qb-device-description = self.callPackage ./qb-device-description {};
 
  qb-device-driver = self.callPackage ./qb-device-driver {};
+
+ qb-device-gazebo = self.callPackage ./qb-device-gazebo {};
 
  qb-device-hardware-interface = self.callPackage ./qb-device-hardware-interface {};
 

--- a/distros/melodic/hri-msgs/default.nix
+++ b/distros/melodic/hri-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hri-msgs";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/melodic/hri_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "3384ce663a164b9d795faedc8135152f3826378f08ccf97348efbbd9612e1d37";
+    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/melodic/hri_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "38e6797d23d882d009dba699e06459a65efe381cebba9f18d619a92f1a8f26ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-pipeline/default.nix
+++ b/distros/melodic/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration, catkin, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-image-pipeline";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "5101a0cae0545e8384888172b1b7a4bd870a221d7c741e128a1bc89186ef4c76";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "4a7d7906fa86fb64308ab843b43e48fabe79bfaaa085e662a95dfbd4517c1991";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-proc/default.nix
+++ b/distros/melodic/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-transport, nodelet, nodelet-topic-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-proc";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "146972719c251c70dd8702ef84d65da3a188f8b30090e95ca70455cc8282d9a3";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "e93866f644228cb471e156021c77dd987a92015937ca917048616898b1d6f778";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-publisher/default.nix
+++ b/distros/melodic/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-publisher";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "3117e0d51d6395341b07f4292606dee9bd69ebbfeb0327504e249e4ad5a61228";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "843271015b7a665270a06c1eaa430e1364462bbcc180be8e1fd04c9332532b69";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-rotate/default.nix
+++ b/distros/melodic/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, nodelet, roscpp, rostest, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-image-rotate";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "5c0bacf9c4f2a6761d532cb05d28d6fc877c2ec6b10471bbf1e59eede33449b1";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "a8e9c585ede1f4c11f7bb189064ec13f2b01321b1bf1725a335b1f7d051d0994";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-view/default.nix
+++ b/distros/melodic/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, gtk2, image-transport, message-filters, message-generation, nodelet, rosconsole, roscpp, rostest, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-view";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "4642943d875d6450ed805d977595e993d7d6bf83fe487b018e1e1300e2edfa7a";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "29776f65d7776982f87630615460afec9ae3666212b1ce2384b91c954cce154c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "93497feb0d2d8acc5e9e0133e91d198c13176c61ab43b981aa294e4dcba4505e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "82c3ffe715f43c374082ff221c3929e0dc2bd62b1339ba86c6780318af557d2d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "b4c8d4d44de65616f62256198e7e0b0c83a603fb1adf980b78402d43eab82b29";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "f332f7aec5dfcb61a9a378f5b62ce58b44da29fb963143fb61eb3e71742e9eb5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "122b043304b5867f6664ed14cb1e26a6aab43780e318ea4096f6f5e0814728d6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "ad5eaaa8bdf00484fb0a2491467c2ff09cb08ca84a6d4bfa850a59e7f0192cd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "724526fda1e17c41b91fa4b54edf6dbbc254042e96b95c4ca2b534fdda6262ba";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "2d0e70c41b1166d74eac8be05284d09630ecab2242be326d217ed88e7ed80a6c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "1ff537ae41f70249a409ee6e19fdc7d913e6789d6913e3d87910453ccdf7cf9f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "b8f186e8f7d1793373b898ce204884a1f2148f5e308f20da7e6f7328d8bee186";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "43f3b346311dcee72b3ce20a76dd42fb2dfdcb869c19e42cf9cb7481801e6fd2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "1392cf82e43d5b8ba62485eb503210d947aad768f6fc32561148b248fccfb17a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9df9a503805cd397f061712eeeed67a12f45d47f0713b1248c88525977147994";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "21f1e16e0703dcd1478c899655a9d44d9648c7dbc3f77c1bd51103b416888719";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "948274a0d011a24ce56055c64ea5a2b851e4026e6aae35793b28e0962f5469f2";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "b0436fcfbf375334b35ac5e009a2cd3cb10f586c25f8bc9032391cca8b918899";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-bringup/default.nix
+++ b/distros/melodic/qb-device-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-bringup";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "443a0556f062e710b5f7d7dc73d706cf568d89df0fd7ad5166709f879da7949b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "81662c352d3fa32e5921ad7b369256dcfa2e75f7e65178a5ea611cd1fb8a9a2f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-control/default.nix
+++ b/distros/melodic/qb-device-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, combined-robot-hw, control-msgs, controller-manager, qb-device-hardware-interface, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-control";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "aa15f86f450ad62174010eae97ce5ba325a52e62a638a01ae3b7a100ec406a6b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "b6c02de60209d47bf9c36a7fb666156c7288a40521a4411a0b2894524ee60379";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-description/default.nix
+++ b/distros/melodic/qb-device-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-description";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "68b1656670c1a86828fc13dd7ad3943209f3b95df25079c632717d2a3a326aea";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "e97366b8ad45040b9b0df0cfd4d90f1ad1ca5b11155ab8a175436fd2ba8177ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-driver/default.nix
+++ b/distros/melodic/qb-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-srvs, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-driver";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "5b3ec2c7b2ecf6aa8e1b99156423cb9f88208eb8d02024c2b30b8c6b1570e5d4";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "88165e642422e39a656dc437b119ad761d025fe87bc5b231b8e7aa8a4e58d929";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-gazebo/default.nix
+++ b/distros/melodic/qb-device-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-qb-device-gazebo";
+  version = "3.0.4-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_gazebo/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "02b73c3b0ed2d31485b622f5bcaa2db7633752da7e366d2ffb1c47aab67a9388";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros-control roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the Gazebo ROS control custom dependencies for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/melodic/qb-device-hardware-interface/default.nix
+++ b/distros/melodic/qb-device-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-hardware-interface";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "16e0d28b4e8b145ae272049cdf232830fd7e6ffc50145bcb04a1570fa1e0f791";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "122419019922e26fc861a51e23d1f004c6ef72d62972cb5724f815e3897c3581";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-msgs/default.nix
+++ b/distros/melodic/qb-device-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-msgs";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "0a101007de0e30caec152ebe1d7f6bd676382b6b9df4e8353acb6a061bb57ab6";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "a63d3ea20ccf397ab3436495b3ef35a09e3fc0cd22b8593b2c54ba7c9581b063";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-srvs/default.nix
+++ b/distros/melodic/qb-device-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-device-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-srvs";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "3368262c75e15bb0fe756a1a54ae5dbef310d58c351c97e62766135641c68cab";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "af9ceb93a063468004e50ed38ee47368ea55e4b76fbb1b04f204c146b6971474";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-utils/default.nix
+++ b/distros/melodic/qb-device-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-utils";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "b7ece361d35ee477a65ab530192408ac5a4fb3f8813c52a48a911989568fd0cf";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "319d5dcb10146d13330e008e62df8314219d57778ecb29a6af8ebb5e60eec0cf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device/default.nix
+++ b/distros/melodic/qb-device/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-gazebo, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs, qb-device-utils }:
 buildRosPackage {
   pname = "ros-melodic-qb-device";
-  version = "2.0.1";
+  version = "3.0.4-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "732baae03ff35decece845d122f21d7b7b86d2c31f726cfce269be208c306724";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/3.0.4-3.tar.gz";
+    name = "3.0.4-3.tar.gz";
+    sha256 = "536c46cf7cfffb792c66af7ef6730bba94ae10487c9ff72ddf7f6fa77d143bc9";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-hardware-interface qb-device-msgs qb-device-srvs ];
+  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-gazebo qb-device-hardware-interface qb-device-msgs qb-device-srvs qb-device-utils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "ae02e9074ca4e6942a12474adeccb2eeb4c2d7ae5b5e4ddac8288ebc84695447";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "a79a9d1fb06f38309765346cab87c3278a27623c74b6914134f92d95731a6886";
   };
 
   buildType = "catkin";

--- a/distros/melodic/stereo-image-proc/default.nix
+++ b/distros/melodic/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-stereo-image-proc";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "d5db016ee55d4ece1413ee83fe1d02315c43e0e97c4a320ece9310b061c45c1d";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "0eb1ce0600f114d0ba5e2e145c05c4cc0b76c8fcd92186100851b0ddaf56c0e3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9fa36cd87066348cf327f78343dd378ac008a31a7f1d067d0193b32a7dd38709";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "2989ba04194669a597c7e1e4117b2241696e3d3d02dfa2cde72bf3aae1398ed7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "3dd560bf569f7dcfe1d2c7098e339932e3f9f092ee74c52f7f0a20f35887affa";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "d8618ac352b517ab035fa6ce716fec1671d2b7c2bfcb95f6e7cd7da2be1d0ae5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aruco-opencv/default.nix
+++ b/distros/noetic/aruco-opencv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-opencv";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "11d15b4f656ba5b83f80f7c629e0aefba94fa7a32f5142abdc9496d2ed860f02";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs image-transport message-runtime nodelet roscpp std-msgs tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ArUco marker detection using aruco module from OpenCV libraries.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/audio-video-recorder/default.nix
+++ b/distros/noetic/audio-video-recorder/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, message-filters, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-audio-video-recorder";
+  version = "2.2.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/audio_video_recorder/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "e5d81483f8363b44f037d1bb399a315c5aab9a60e23a2c9815670c1ff1c67c43";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ audio-common-msgs gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly gst_all_1.gstreamer message-filters roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package for recording image and audio synchronously'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/camera-aravis/default.nix
+++ b/distros/noetic/camera-aravis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aravis, camera-info-manager, catkin, dynamic-reconfigure, glib, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-camera-aravis";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "a186ad55b2a74110cf821cd72c0fa3de1b8798b8880569d155a3c82637ae9b21";
+    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "966628c385a6c1b7c4c2429bcd0ae2fea2c63f8800420b1b8edc59b66fe13b2f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "9ef0852470d1eb2afd6597aff3a4d923b1c3614339c518d8b7e56f474ea51088";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "0a4f0fef84c681b2433f00d4a615ef584ea86c0cf565170f8b49851dc0491365";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.15.5-r1";
+  version = "2.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.15.5-1.tar.gz";
-    name = "2.15.5-1.tar.gz";
-    sha256 = "637f309313ca3addf67d79e67bb46e6888181c6a5948430f4658e9e42c8d3b91";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.17.0-1.tar.gz";
+    name = "2.17.0-1.tar.gz";
+    sha256 = "0a8689e29b8f036540f2b10fdd45c840d119cbac80c99cc29d71677ef90700f7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-tf-publisher/default.nix
+++ b/distros/noetic/dynamic-tf-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-tf-publisher";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/dynamic_tf_publisher/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "641d4138a4c105415c5199235e6b783357adbf11831e9ab0e60ec3a368bcefc5";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/dynamic_tf_publisher/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "d86fbdd0d5b80c942ab48aa045fb81528da2cc0d5814c25545ea708230d36b52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.5-r1";
+  version = "2.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "20f26008a32add65e560c36ba04ca221c7d96025e9828f4d52a291b6dd86e1a2";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.7-1.tar.gz";
+    name = "2.7.7-1.tar.gz";
+    sha256 = "171f78bdac72ab9e7da8dfad5638669d7ceae4cfcd4e7a8db5e59b84b014f5c8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ess-imu-ros1-uart-driver/default.nix
+++ b/distros/noetic/ess-imu-ros1-uart-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ess-imu-ros1-uart-driver";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release/archive/release/noetic/ess_imu_ros1_uart_driver/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "a9f2be612ea0357d970ab88231b35436add0c5fd95467a6c1449922fab7a12b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Epson IMU Driver using UART interface for ROS package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-noetic-eus-assimp";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "f166cf1a93f42fc5f713ab98b2048206a69fefd26cebafeb45b9da845cd8317e";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "0fb75b49127281e801e04d76051da15d7a8c2eac4fbf4505d63b09a99850d865";
   };
 
   buildType = "catkin";

--- a/distros/noetic/euscollada/default.nix
+++ b/distros/noetic/euscollada/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, libyamlcpp, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-euscollada";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "6f2a764637787cb278ad506b5d7207109c6b3e5e87a498d71453cdf9c1b1cb7a";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "b5fa910e58ddba38c42ae3063d931e0d4c4793693522cb946e431708ac502dbb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, python3Packages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-noetic-eusurdf";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "45ce43d84f15082ea736caa61f9bc71503b97b54e5c7c6f6b479eeb7f9bf4131";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "ddc05b743572e8dc8e9ac5ed0b1898030cd1603dcab5483db037d8074f728532";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-master-discovery/default.nix
+++ b/distros/noetic/fkie-master-discovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avahi, catkin, fkie-multimaster-msgs, rosgraph, roslib, rospy, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-fkie-master-discovery";
-  version = "1.2.7-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_discovery/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "203483ec58feb471f5a9561b0cd1dd8d3baf7f3d123a8a026455bef1053e9991";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_discovery/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "de46fc8e8fd45b41af42317ce3c5e2f483b5c774549edd31036e4c21904a2866";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-master-sync/default.nix
+++ b/distros/noetic/fkie-master-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-multimaster-msgs, rosgraph, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fkie-master-sync";
-  version = "1.2.7-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_sync/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "aa23531aee7d5e6d922d20f985399670edb3982d07746e731edb87ae10ead213";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_sync/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "0986d615fc344af3fa7fbf4107ee5c1809f647c82754cae34cdcea4e53d07933";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-multimaster-msgs/default.nix
+++ b/distros/noetic/fkie-multimaster-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fkie-multimaster-msgs";
-  version = "1.2.7-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster_msgs/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "dc900162eb805de7db2f86c7e61e069ae6c814577a17a591dce54e422574c5fe";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster_msgs/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "42d517ebab9e0e36d0fd5da525f49f462053676fff9eac504ed63ed6e271c96f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-multimaster/default.nix
+++ b/distros/noetic/fkie-multimaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-master-sync, fkie-multimaster-msgs, fkie-node-manager, fkie-node-manager-daemon }:
 buildRosPackage {
   pname = "ros-noetic-fkie-multimaster";
-  version = "1.2.7-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "40bde8a434e6a4f82a0bae231bd7c2308db56856ebf8900fad43b4bfdf138780";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "e006e70c321461c9a806c2af8cd06f130e51a418abc670d4883a26043fc7a123";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-node-manager-daemon/default.nix
+++ b/distros/noetic/fkie-node-manager-daemon/default.nix
@@ -5,18 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, fkie-master-discovery, fkie-multimaster-msgs, python3Packages, roslaunch, rospy, rostest, screen }:
 buildRosPackage {
   pname = "ros-noetic-fkie-node-manager-daemon";
-  version = "1.2.7-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager_daemon/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "3fa68a0bf213d497d7b682978a9be23f70068066cf05c397eaa1b940994d63fc";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager_daemon/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "972ea9be6f5dc6cb600a7dc3e157b5b9b16c20160e1c1aaf38c1373597347aae";
   };
 
   buildType = "catkin";
-  buildInputs = [ python3Packages.catkin-pkg ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs fkie-master-discovery fkie-multimaster-msgs python3Packages.grpcio python3Packages.psutil python3Packages.rospkg python3Packages.ruamel_yaml roslaunch rospy screen ];
+  propagatedBuildInputs = [ diagnostic-msgs fkie-master-discovery fkie-multimaster-msgs python3Packages.grpcio python3Packages.grpcio-tools python3Packages.psutil python3Packages.rospkg python3Packages.ruamel_yaml roslaunch rospy screen ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/fkie-node-manager/default.nix
+++ b/distros/noetic/fkie-node-manager/default.nix
@@ -5,16 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, dynamic-reconfigure, fkie-master-discovery, fkie-master-sync, fkie-multimaster-msgs, fkie-node-manager-daemon, python-qt-binding, python3Packages, rosgraph, roslaunch, roslib, rosmsg, rospy, rosservice, rqt-gui, rqt-reconfigure, screen, xterm }:
 buildRosPackage {
   pname = "ros-noetic-fkie-node-manager";
-  version = "1.2.7-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "cc1bfb1eb02d1e7e28feb6902e61121f928b01a74f0b9204299386bd45318b73";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "dafb2a70cdbcc712e03a69a5b94c28cc686bac6f3f28536c1f139fd718449a00";
   };
 
   buildType = "catkin";
-  buildInputs = [ python3Packages.catkin-pkg ];
   propagatedBuildInputs = [ diagnostic-msgs dynamic-reconfigure fkie-master-discovery fkie-master-sync fkie-multimaster-msgs fkie-node-manager-daemon python-qt-binding python3Packages.docutils python3Packages.paramiko python3Packages.pycryptodomex python3Packages.pyqt5_with_qtwebkit python3Packages.ruamel_yaml rosgraph roslaunch roslib rosmsg rospy rosservice rqt-gui rqt-reconfigure screen xterm ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/foxglove-msgs/default.nix
+++ b/distros/noetic/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-msgs";
-  version = "1.2.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "1c6e26e9ae43492fa69865d5ccccdea346c5121a80bc6c017cddc2a49c50a951";
+    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d9ad610609da0ebecb8b5d7b216bc9c7e6fa20c0c24a2e8e843d0cf7dca7cb87";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -56,6 +56,8 @@ self: super: {
 
  aruco-msgs = self.callPackage ./aruco-msgs {};
 
+ aruco-opencv = self.callPackage ./aruco-opencv {};
+
  aruco-ros = self.callPackage ./aruco-ros {};
 
  assimp-devel = self.callPackage ./assimp-devel {};
@@ -79,6 +81,8 @@ self: super: {
  audio-play = self.callPackage ./audio-play {};
 
  audio-to-spectrogram = self.callPackage ./audio-to-spectrogram {};
+
+ audio-video-recorder = self.callPackage ./audio-video-recorder {};
 
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
@@ -784,6 +788,8 @@ self: super: {
 
  ergodic-exploration = self.callPackage ./ergodic-exploration {};
 
+ ess-imu-ros1-uart-driver = self.callPackage ./ess-imu-ros1-uart-driver {};
+
  ethercat-grant = self.callPackage ./ethercat-grant {};
 
  ethercat-hardware = self.callPackage ./ethercat-hardware {};
@@ -1206,6 +1212,8 @@ self: super: {
 
  hri-msgs = self.callPackage ./hri-msgs {};
 
+ hri-rviz = self.callPackage ./hri-rviz {};
+
  human-description = self.callPackage ./human-description {};
 
  husky-control = self.callPackage ./husky-control {};
@@ -1616,6 +1624,8 @@ self: super: {
 
  lpg-planner = self.callPackage ./lpg-planner {};
 
+ lsc-ros-driver = self.callPackage ./lsc-ros-driver {};
+
  lusb = self.callPackage ./lusb {};
 
  magic-enum = self.callPackage ./magic-enum {};
@@ -1886,7 +1896,15 @@ self: super: {
 
  mqtt-client = self.callPackage ./mqtt-client {};
 
+ mrpt-ekf-slam-2d = self.callPackage ./mrpt-ekf-slam-2d {};
+
+ mrpt-ekf-slam-3d = self.callPackage ./mrpt-ekf-slam-3d {};
+
  mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};
+
+ mrpt-graphslam-2d = self.callPackage ./mrpt-graphslam-2d {};
+
+ mrpt-icp-slam-2d = self.callPackage ./mrpt-icp-slam-2d {};
 
  mrpt-local-obstacles = self.callPackage ./mrpt-local-obstacles {};
 
@@ -1902,11 +1920,15 @@ self: super: {
 
  mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
 
+ mrpt-rbpf-slam = self.callPackage ./mrpt-rbpf-slam {};
+
  mrpt-reactivenav2d = self.callPackage ./mrpt-reactivenav2d {};
 
  mrpt-sensorlib = self.callPackage ./mrpt-sensorlib {};
 
  mrpt-sensors = self.callPackage ./mrpt-sensors {};
+
+ mrpt-slam = self.callPackage ./mrpt-slam {};
 
  mrpt-tutorials = self.callPackage ./mrpt-tutorials {};
 
@@ -2394,6 +2416,8 @@ self: super: {
 
  pybind11-catkin = self.callPackage ./pybind11-catkin {};
 
+ pyhri = self.callPackage ./pyhri {};
+
  pyquaternion = self.callPackage ./pyquaternion {};
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
@@ -2408,17 +2432,45 @@ self: super: {
 
  qb-chain-msgs = self.callPackage ./qb-chain-msgs {};
 
+ qb-device = self.callPackage ./qb-device {};
+
+ qb-device-bringup = self.callPackage ./qb-device-bringup {};
+
+ qb-device-control = self.callPackage ./qb-device-control {};
+
+ qb-device-description = self.callPackage ./qb-device-description {};
+
+ qb-device-driver = self.callPackage ./qb-device-driver {};
+
+ qb-device-gazebo = self.callPackage ./qb-device-gazebo {};
+
+ qb-device-hardware-interface = self.callPackage ./qb-device-hardware-interface {};
+
+ qb-device-msgs = self.callPackage ./qb-device-msgs {};
+
+ qb-device-srvs = self.callPackage ./qb-device-srvs {};
+
+ qb-device-utils = self.callPackage ./qb-device-utils {};
+
  qb-hand = self.callPackage ./qb-hand {};
 
  qb-hand-control = self.callPackage ./qb-hand-control {};
 
  qb-hand-description = self.callPackage ./qb-hand-description {};
 
+ qb-hand-gazebo = self.callPackage ./qb-hand-gazebo {};
+
+ qb-hand-hardware-interface = self.callPackage ./qb-hand-hardware-interface {};
+
  qb-move = self.callPackage ./qb-move {};
 
  qb-move-control = self.callPackage ./qb-move-control {};
 
  qb-move-description = self.callPackage ./qb-move-description {};
+
+ qb-move-gazebo = self.callPackage ./qb-move-gazebo {};
+
+ qb-move-hardware-interface = self.callPackage ./qb-move-hardware-interface {};
 
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
 

--- a/distros/noetic/hri-msgs/default.nix
+++ b/distros/noetic/hri-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hri-msgs";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "3cef50ee325c9408c0d6254a31653cc9131074cef9085863334b3f60eb7b649c";
+    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "012eff5f101838a4d45b5a899479e36cca55f2a971e10d9c16b9ffbb0ddcb026";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hri-rviz/default.nix
+++ b/distros/noetic/hri-rviz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, hri, hri-msgs, qt5, roscpp, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-hri-rviz";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "cd6d26e6326015a4f93aed18262afbefd5f25c4dbae23ad3b2d1c4dd2659f9b0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge hri hri-msgs qt5.qtbase roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains several rviz plugins to visualize HRI-related topics (like face/body region of interests, 3D skeletons...)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/image-view2/default.nix
+++ b/distros/noetic/image-view2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-geometry, image-transport, image-view, message-filters, message-generation, message-runtime, pcl-ros, python3Packages, roscpp, rostest, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-image-view2";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/image_view2/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "07e18eb3ce6a3761e5d3a2a6ded61460d1e41b08001bc442bd8a1c3c5e0b4dc2";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/image_view2/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "342ebba57f329112be80d432c5f1eca5aeb7b00d44c4e5171e021a74feb52209";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "ad8e3063c16bed7e06a5a61a70e3dbce6d5d683656c8908d2cc6f00562aee11d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "5d583fa7d7e99eb64f3f48fd31579a5dfba9b5b9581bb382f5a5d7726f867d54";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-common/default.nix
+++ b/distros/noetic/jsk-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-tf-publisher, image-view2, jsk-network-tools, jsk-tilt-laser, jsk-tools, jsk-topic-tools, multi-map-server, virtual-force-publisher }:
+{ lib, buildRosPackage, fetchurl, audio-video-recorder, catkin, dynamic-tf-publisher, image-view2, jsk-network-tools, jsk-tilt-laser, jsk-tools, jsk-topic-tools, multi-map-server, virtual-force-publisher }:
 buildRosPackage {
   pname = "ros-noetic-jsk-common";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_common/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "9ee5054f39d5142c74fa731f7d481591fd93a3bd0b95efe1302ed6c8d63d9653";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_common/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "aba0111078224438e6e2135b0553eb2307494052ad39d89f77dc95eab1408945";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamic-tf-publisher image-view2 jsk-network-tools jsk-tilt-laser jsk-tools jsk-topic-tools multi-map-server virtual-force-publisher ];
+  propagatedBuildInputs = [ audio-video-recorder dynamic-tf-publisher image-view2 jsk-network-tools jsk-tilt-laser jsk-tools jsk-topic-tools multi-map-server virtual-force-publisher ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-noetic-jsk-model-tools";
-  version = "0.4.4-r1";
+  version = "0.4.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "a98c65b7bd5eae30a78d619e77f7c5ea47c1910f4d2b9ddd524b7888783a9108";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-2.tar.gz";
+    name = "0.4.4-2.tar.gz";
+    sha256 = "01078b70b2d69d83a5a531d05c4f546d557a8281c6376a3e090aa274df68173b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-network-tools/default.nix
+++ b/distros/noetic/jsk-network-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, rospy, rostest, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-network-tools";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_network_tools/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "f3976c28ca7989552adb68edacaf2a1e8817ea05341eecc772acf10d45c4a4fc";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_network_tools/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "21b402ed5de2bcf9052d49b0c4cb1e5607eeb7320474179995e5d04cfb8d508f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-tilt-laser/default.nix
+++ b/distros/noetic/jsk-tilt-laser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, laser-assembler, laser-filters, robot-state-publisher, sensor-msgs, tf, tf-conversions, urg-node }:
 buildRosPackage {
   pname = "ros-noetic-jsk-tilt-laser";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_tilt_laser/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "32b4a5b174f2864b9b7279990b19fe86b7b5f623c00042bddef623618ffab997";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_tilt_laser/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "a7f28528f48b54cabeaa344687640f515aa524f5f1c8c9e213137193848797a1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-topic-tools/default.nix
+++ b/distros/noetic/jsk-topic-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, python3Packages, roscpp, roscpp-tutorials, roslaunch, roslint, rosnode, rostest, rostime, rostopic, sensor-msgs, sound-play, std-msgs, std-srvs, tf, topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, python3Packages, roscpp, roscpp-tutorials, roslaunch, roslint, rosnode, rostest, rostime, rostopic, sensor-msgs, sound-play, std-msgs, std-srvs, tf, topic-tools, unixtools }:
 buildRosPackage {
   pname = "ros-noetic-jsk-topic-tools";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_topic_tools/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "a58c0a7e52161b09eb76b6eb9a0b52b12fa7f91ec4dcd5e5c32391bf16c94263";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_topic_tools/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "4dd91f7b7c8c736cba993b8866f47166a4b6c7de7e28f888053e052b71f5dfc7";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation rostest ];
   checkInputs = [ roscpp-tutorials roslint ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet python3Packages.numpy python3Packages.opencv3 python3Packages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet python3Packages.numpy python3Packages.opencv3 python3Packages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools unixtools.ping ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/lsc-ros-driver/default.nix
+++ b/distros/noetic/lsc-ros-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, self-test, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-lsc-ros-driver";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release/archive/release/noetic/lsc_ros_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "27f3f20c333d932eeeb3113e5e1e8fffe71bc6eb4afd607075a49711c6774076";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ diagnostic-updater self-test ];
+  propagatedBuildInputs = [ roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS driver package for LSC-C Series'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/magic-enum/default.nix
+++ b/distros/noetic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-magic-enum";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e202abeeafa9e4ed596c9e5d44a6627d95d9886e606e604cccbc57ff1b68bdcb";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "6799e1c3715bcdf6a48ef778e8c8565604cbb9d9498f375282c01b8dde2ad051";
   };
 
   buildType = "cmake";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "66e823da2743503cf4f541769282d8517cf9a646fe49394990f89aa9568429d1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "530dc00bed79a129f769b3fbc9601d735a6e8d9e7e43e6a366eedcfc586e60cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-ekf-slam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "21ec278234298b03fe9d066a7cdd93c86b0ceea137239887774091287def6e2c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is a wrapper for the implementation of EKF-based SLAM with range-bearing sensors, odometry, and a 2D (+heading) robot pose, and 2D landmarks.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-3d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-ekf-slam-3d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "efd46ed9041241ca4160234c4db70bd95488f0564c4ed8c1a8806e45deef4aef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is a wrapper for the implementation of EKF-based SLAM with range-bearing sensors, odometry, a full 6D robot pose, and 3D landmarks.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-graphslam-2d/default.nix
+++ b/distros/noetic/mrpt-graphslam-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-graphslam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "004a9f7e9a6ebbdb9db83b1c2b45e1389754fedd5ded644b08d217261268bf9e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fkie-multimaster-msgs geometry-msgs mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs roscpp rospy sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implement graphSLAM using the mrpt-graphslam library, in an online fashion
+  	by directly reading measurements off ROS Topics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-icp-slam-2d/default.nix
+++ b/distros/noetic/mrpt-icp-slam-2d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-icp-slam-2d";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "8027b57f93610518e7580e15912181a3b0d7b9329f750f268ff14a34d09780a8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''mrpt_icp_slam_2d contains a wrapper on MRPT's 2D ICP-SLAM algorithms.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-rbpf-slam/default.nix
+++ b/distros/noetic/mrpt-rbpf-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-rbpf-slam";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "29d9e82f748f18580fd8b628c708f68461ba338ab1bbf0214ae4f35f617a9470";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 mvsim nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is used for gridmap SLAM. The interface is similar to gmapping (https://wiki.ros.org/gmapping) but the package supports different particle-filter algorithms, range-only SLAM, can work with several grid maps simultaneously and more.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-slam/default.nix
+++ b/distros/noetic/mrpt-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-slam";
+  version = "0.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "732c625387478084e7d28ad83657ca7af8d807bdcf523cbdeaa1f4d173c26a3d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mrpt-ekf-slam-2d mrpt-ekf-slam-3d mrpt-graphslam-2d mrpt-icp-slam-2d mrpt-rbpf-slam ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''mrpt_slam'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/multi-map-server/default.nix
+++ b/distros/noetic/multi-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL_image, catkin, jsk-tools, libyamlcpp, map-server, nav-msgs, python3Packages, pythonPackages, rosconsole, roscpp, rosmake, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-multi-map-server";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/multi_map_server/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "e29c65c0ecd6a1199c1f247b056d171b575c49225866c48f504a2c06b6735d1c";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/multi_map_server/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "2c5ce65b15604abc1c9786f7a777931762d636f6d8198a7db495c89fa7843f3a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "99867366412b3cdda7ada38987083c0cefdd91bdeaf605cb003bae9c117f2070";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "af726ba868b2a9460acc4adb100f470adc48458a27b7c7a73056f6c6f19d81fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "3f995c56c91db2d26dc40561a4206d69766d1f428a61ebc43d6705774f7de2f4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "5decc58e1f516ee9e83e9043a5472501af2fe83b5468322fa591106c9e35fa97";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "77430da5ef95b43cde1a9f83ca860c72576ffe9d77df3d6ceea34abf1c2a23a6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "44968d444c3ac9e8314e6b7324add87acb34125152623d64dc95b27bce5eefa9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "0e7d51261ef5d100ee63b16415f9846cc79992839bd516570e1928b0e0a966e8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "a3f7925e5107021f59670fc22db60a7121628626949a920e9101dac77f06a0e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/opw-kinematics/default.nix
+++ b/distros/noetic/opw-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
 buildRosPackage {
   pname = "ros-noetic-opw-kinematics";
-  version = "0.4.6-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "35e451e0bfdafa08c2c3aa83707151fa50b268218acc0fb200b162390d061eea";
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "076f8b32d2e15749226cf1e5f41fc999b7345b2beec597905692a8515dfcf2f6";
   };
 
   buildType = "cmake";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "bee09c8e3ed4f307b8eb24a4325f7c9cc6ade5edcc9216596dd1f1ec6ab2ae4d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "ed72b5a43aea58fdeb080a51947dd7626b2a7b01f5275d87267e2298c0a5b918";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.4.5-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.4.5-1.tar.gz";
-    name = "3.4.5-1.tar.gz";
-    sha256 = "963ee8025d8304980ba6265d9ce86264e0130a120860f7d5ebaff4aa6ae859f4";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "353b5412b138cab459ec9039fe6a2e501393fb03a62f4e64f0430ec7a8fa9a28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pyhri/default.nix
+++ b/distros/noetic/pyhri/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, hri-msgs, rospy, sensor-msgs, std-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-pyhri";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/pyhri-release/archive/release/noetic/pyhri/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "6093ed779125728e862a74b56bf815e493edec47f8d8a79e90a7cbb6a35b6db7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge geometry-msgs hri-msgs rospy sensor-msgs std-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A Python wrapper library around the ROS4HRI ROS topics'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/qb-device-bringup/default.nix
+++ b/distros/noetic/qb-device-bringup/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-bringup";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_bringup/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "c7b025dccb947e1e87b222bec3801cc629f13e0cafdee21b3ea6308f12b66452";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a device-independent bringup utilities for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-control/default.nix
+++ b/distros/noetic/qb-device-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, combined-robot-hw, control-msgs, controller-manager, qb-device-hardware-interface, qb-device-utils, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-control";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_control/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "db1480fc86a8b672458722985bc6ddcc88d562978b0d9a24e45a85fa64c830dd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib combined-robot-hw control-msgs controller-manager qb-device-hardware-interface qb-device-utils roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a device-independent control library for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-description/default.nix
+++ b/distros/noetic/qb-device-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-description";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_description/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "34b74fe037976491c8508e88e9a9c02dacd8b4b10a48684181f9da8504da8414";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a device-independent description utilities for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-driver/default.nix
+++ b/distros/noetic/qb-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qb-device-srvs, qb-device-utils, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-driver";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_driver/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "41e7f2059c6e63c28ff45d24bc0c14ef505ec2d13ab15db4e5016f59f97b5589";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qb-device-srvs qb-device-utils roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a device-independent API wrapper for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-gazebo/default.nix
+++ b/distros/noetic/qb-device-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-gazebo";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_gazebo/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "b73b101337d4d7159ce6a7698643636210c02f1f7657ed2e5b390c622df6edb9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros-control roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the Gazebo ROS control custom dependencies for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-hardware-interface/default.nix
+++ b/distros/noetic/qb-device-hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-hardware-interface";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_hardware_interface/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "e0ec7545af3ee737acd780356691359f428febc2884d9cd4ffd04a9a3f740b38";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ hardware-interface joint-limits-interface qb-device-msgs qb-device-srvs roscpp transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a device-independent hardware interface for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-msgs/default.nix
+++ b/distros/noetic/qb-device-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-msgs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "717e04af776a6e48e1b262cfdeae20ef138c7b3ee475f3040bfe2fb6931b488c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the device-independent custom ROS messages for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-srvs/default.nix
+++ b/distros/noetic/qb-device-srvs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-device-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-srvs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_srvs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "8f2882e27eb15b82e19f1f63a19b572f1d32fefc4efb834af7529561b5241dd4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime qb-device-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the device-independent custom ROS services for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device-utils/default.nix
+++ b/distros/noetic/qb-device-utils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device-utils";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_utils/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "c63437817b78213f7fb62da84b7d55f6b968aadd93474307eedb6d37f3d6839b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a device-independent utility functions for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-device/default.nix
+++ b/distros/noetic/qb-device/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-gazebo, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs, qb-device-utils }:
+buildRosPackage {
+  pname = "ros-noetic-qb-device";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "176dc010e29639854f3cd135923ad5c3e27d333dd5c2c97e6628ac6f02b917c1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-gazebo qb-device-hardware-interface qb-device-msgs qb-device-srvs qb-device-utils ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a device-independent ROS interface for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-hand-gazebo/default.nix
+++ b/distros/noetic/qb-hand-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, qb-device-gazebo, qb-device-hardware-interface, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-hand-gazebo";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_gazebo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "6e69fdce6ab6853d3917f5596134abb3f042edc9bc3b540d86a6e331dfdfda77";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros-control qb-device-gazebo qb-device-hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the Gazebo ROS control plugins for qbrobotics® SoftHand device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-hand-hardware-interface/default.nix
+++ b/distros/noetic/qb-hand-hardware-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, qb-device-hardware-interface, roscpp, transmission-interface }:
+buildRosPackage {
+  pname = "ros-noetic-qb-hand-hardware-interface";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_hardware_interface/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "4801069a804c768c9a84453b6b5bb6e66113c465451f796aa5a53d251f5ea750";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox hardware-interface qb-device-hardware-interface roscpp transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the hardware interface for qbrobotics® qbhand device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-move-gazebo/default.nix
+++ b/distros/noetic/qb-move-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, qb-device-gazebo, qb-device-hardware-interface, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-move-gazebo";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_gazebo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "45d54aa657ed48fff70b90970ff8bd6fc84b4bd928a1f52dd422dc13bbfb498f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros-control qb-device-gazebo qb-device-hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the Gazebo ROS control plugins for qbrobotics® qbmove device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-move-hardware-interface/default.nix
+++ b/distros/noetic/qb-move-hardware-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, interactive-markers, qb-device-hardware-interface, roscpp, tf2, tf2-geometry-msgs, transmission-interface }:
+buildRosPackage {
+  pname = "ros-noetic-qb-move-hardware-interface";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_hardware_interface/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "1882f57bb9cde42e67e10bd809e50e5bfb53c285429dbce6092c7296458e2849";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox hardware-interface interactive-markers qb-device-hardware-interface roscpp tf2 tf2-geometry-msgs transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the hardware interface for qbrobotics® qbmove device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.2.16-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.16-1.tar.gz";
-    name = "0.2.16-1.tar.gz";
-    sha256 = "207b6d1ee9c8f6cf12c189ea22497b21be84a7ab8d7507e0810ec3c9f9ab10f7";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2fc8b5eb51d4318c8d6be0d08269ef39b3355f63e44d0a616e58fef8ba6d01a2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "37453b18c8d6af04dc7ce2ea33d4c59610de57ea052d5b4dea53d125f01b783e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "26a7b28ef387881b03caa3e234776e1815d6c9bbd816d0418a271887604cef61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tesseract-collision/default.nix
+++ b/distros/noetic/tesseract-collision/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, libyamlcpp, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-collision";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "e3d10f41b5117bfb77242fe3cdb7896c226b80e6390a8e2c389e61b2dae5d6f8";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "9fddb20b329c9944b75f6d3c39fa26b76a5d2b9a9b50db2481939e6c6825fbaf";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, libyamlcpp, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "5c4ece28129365022c802643d8003476e3bdee5c0ce36a45ab150864c7ec3f25";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "c1ae68273e615d8674706e93918beeae6a1c0abb629106ab61dc11587f1c03cc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-environment/default.nix
+++ b/distros/noetic/tesseract-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-kinematics, tesseract-scene-graph, tesseract-srdf, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-environment";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "c9992fd05f8487eea55117b6fa881edbf55b608b4ed62abe98b61e8841297177";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "7723880ce1089b1c2c4542ef76bd37c551c2a2b183207b4f04e11638a8c17318";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "b478751f162246eef72f690590fef994a3805bbaf2ee7c9eed6dbb7ad652b083";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "223a60f3a2198a25a9fb670630f9e9a7920ee8af9d017971b95fd28cc6a5f3aa";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, liblapack, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "34bd6f187f97406224e16611c69db6d04978c167a2faf024539d6b982416478f";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "c26800e1071d9d6d252e4ee6b0e8e92e6e2d0b36251a48ae4ed9295d3d0489e4";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate ];
-  checkInputs = [ gtest tesseract-support tesseract-urdf ];
+  checkInputs = [ gtest liblapack tesseract-support tesseract-urdf ];
   propagatedBuildInputs = [ console-bridge eigen libyamlcpp opw-kinematics orocos-kdl tesseract-common tesseract-scene-graph tesseract-state-solver ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "2fc3a129727bafdbd2b6f4813c4d98268881440d73816434a3b8a43dfc4a5135";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "f0c423827f53a6e1c223d89bb8dcb005b93be789d4eb4bf8123e69033cb0d047";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "78887ebdad2465941e5abe95945548f28f92c648405af0b8d7c56de9df7da057";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "461c36be5fe17d4098ecba44b624919145d05152cf5a052b03b693c70aa8086a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-state-solver/default.nix
+++ b/distros/noetic/tesseract-state-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-state-solver";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "276a04d82d2fbd90a0bd4d837a0bf8146a16e2189abeaef32c815c554c625b60";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "ba8d1721abe0cdd5bdf212ed11afa95112179791d993d0a130f64289e8d23cdf";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, ros-industrial-cmake-boilerplate, tesseract-common }:
+{ lib, buildRosPackage, fetchurl, cmake, gtest, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "bf93f39eecfde80a2434bd4eeef21a305cc1deed3e4cfcacdc636436c2b1ab92";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "f8d6b95012b572b247346d6299462853e1e4609398a7ee27802690d3f07dd85c";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate tesseract-common ];
+  checkInputs = [ gtest ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "150e54042c1be7c974cd53c1bdba2518bc7780ca398ca2d66470328c8940b18d";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "5935cf6018f53546ff2f63a95c13cf3f26461a89a2a843dac021ee56cfaa8a38";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.8.6-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "ccae1dd8faef9902d4bf96c31ea88c5093f3c12c900b5436622c58355b04f43b";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "1f51efa4b56399d1f0f707757148cde5d84081b11cc44957195b904d7a3ca7e3";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ console-bridge eigen tesseract-collision tesseract-common tesseract-environment tesseract-scene-graph tesseract-state-solver ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "d86bace24916802bdecf648563de5e5485500109b5e968dc09e89317e05759a3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "2a9d4b0f9f22fa88171edf02d591671ee0eb9b96b3abeff6a1e7f65ed73ea3f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.11.4-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.4-1.tar.gz";
-    name = "0.11.4-1.tar.gz";
-    sha256 = "379f24eec4ea136dab01e975a27ef3f15aa0025478944eb0da2e1721140678e5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "03d870a4ac8be7401832978edd34e6755664443521c996c1fa72dc288ab951d5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-driver/default.nix
+++ b/distros/noetic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libpcap, nodelet, roscpp, roslaunch, roslint, rostest, tf, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-driver";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "d0ac953f3a48c3e13e60a94fb9ed768ea22699004bc7c62a638785dc37f1ffea";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "e409444fad24c80117381fc5f0445b0ab30b0a32c13ccbff331e666f15ed1fa6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-laserscan/default.nix
+++ b/distros/noetic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nodelet, roscpp, roslaunch, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-laserscan";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "bbe1d9264cf193a2b2610fa19280c3a7a57f0de6c3d4c1a037ba713127e63438";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "341bf6a4773deb0266a8afb12db34c069c9d03e2ebc34fdd269c367d2064a35c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-msgs/default.nix
+++ b/distros/noetic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-msgs";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "fb3b32e45e68234f8e01121aeee2e8d33966379c3a5ce4c2365e3751ee284e2f";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "508ef5d08d4d2168dae0e7adf55eeae4f6090c01c05280d0bf1d9f2f31a1ee0f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pcl/default.nix
+++ b/distros/noetic/velodyne-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-ros, roslint }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pcl";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "08d0a84826d952dc1b0ae6cec5909fcb70a291dcd96f817cf54a34e24024751e";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "d4dae03da906b8fa5814d3c20b469e637a6046d89d5130567474c1f4e9dadbe8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pointcloud/default.nix
+++ b/distros/noetic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-updater, dynamic-reconfigure, eigen, libyamlcpp, nodelet, roscpp, roslaunch, roslib, roslint, rostest, rosunit, sensor-msgs, tf2-ros, velodyne-driver, velodyne-laserscan, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pointcloud";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "49cf0b37a42143d5cbbc93086d4a478372201ef6b758891a06807abba7e16c29";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "b8425f2244f94b610459ede15bdb228eb842e4cd84a6ae10aed6dd67962b6de7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne/default.nix
+++ b/distros/noetic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-noetic-velodyne";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "20968c2bc112c14694268e3b421517184a68bec969904cb167c7c14ab11b415a";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "3bee8e89bc6438c14fa690e18dd43db01a78ab2a5e445252700579f220b3cefc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/virtual-force-publisher/default.nix
+++ b/distros/noetic/virtual-force-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, kdl-parser, sensor-msgs, tf-conversions, urdf }:
 buildRosPackage {
   pname = "ros-noetic-virtual-force-publisher";
-  version = "2.2.11-r2";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/virtual_force_publisher/2.2.11-2.tar.gz";
-    name = "2.2.11-2.tar.gz";
-    sha256 = "2525226fd6c507c40f78ca2fcb145b28fd8f83c0090e4afea891408d3d3aa396";
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/virtual_force_publisher/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "5dacad62f81a05fffab95f19dd5ebf306902d484eae537467c45ec348267ce64";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit 055101b832671356779d2257cec5eea89fc8ac75.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *angles 1.12.3-r1 --> 1.12.6-r1*
* *camera-calibration-parsers 2.3.0-r1 --> 2.4.0-r1*
* *camera-info-manager 2.3.0-r1 --> 2.4.0-r1*
* *depthai 2.15.5-r1 --> 2.17.0-r1*
* *eigenpy 2.7.5-r1 --> 2.7.7-r1*
* *foxglove-msgs 1.2.2-r1 --> 2.0.0-r1*
* *image-common 2.3.0-r1 --> 2.4.0-r1*
* *image-transport 2.3.0-r1 --> 2.4.0-r1*
* *imu-complementary-filter 2.0.2-r1 --> 2.0.3-r1*
* *imu-filter-madgwick 2.0.2-r1 --> 2.0.3-r1*
* *imu-tools 2.0.2-r1 --> 2.0.3-r1*
* *maliput-dragway 0.1.1-r1 --> 0.1.2-r1*
* *maliput-full 0.1.0-r2*
* *maliput-malidrive 0.1.1-r1 --> 0.1.2-r1*
* *maliput-multilane 0.1.0-r1 --> 0.1.1-r1*
* *nerian-stereo 1.1.0-r1 --> 1.1.1-r1*
* *performance-test 1.0.0-r1 --> 1.2.1-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *raspimouse-description 1.0.0-r1*
* *rqt-console 1.1.1-r1 --> 1.1.2-r1*
* *rviz-imu-plugin 2.0.2-r1 --> 2.0.3-r1*
* *vrpn 7.35.0-r8*

Galactic Changes:
-----------------
* *angles 1.12.4-r2 --> 1.14.0-r1*
* *camera-calibration-parsers 2.3.1-r1 --> 2.5.0-r1*
* *camera-info-manager 2.3.1-r1 --> 2.5.0-r1*
* *depthai 2.15.5-r1 --> 2.17.0-r1*
* *eigenpy 2.7.7-r1*
* *foxglove-msgs 1.2.2-r1 --> 2.0.0-r1*
* *image-common 2.3.1-r1 --> 2.5.0-r1*
* *image-transport 2.3.1-r1 --> 2.5.0-r1*
* *imu-complementary-filter 2.0.2-r1 --> 2.0.3-r1*
* *imu-filter-madgwick 2.0.2-r1 --> 2.0.3-r1*
* *imu-tools 2.0.2-r1 --> 2.0.3-r1*
* *log-view 0.2.1-r1*
* *magic-enum 0.7.3-r1 --> 0.8.0-r1*
* *nao-lola 0.0.4-r1 --> 0.0.5-r1*
* *nerian-stereo 1.1.1-r1*
* *performance-test 1.0.0-r1 --> 1.2.1-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *ros-image-to-qimage 0.1.0-r1 --> 0.1.1-r1*
* *rviz-imu-plugin 2.0.2-r1 --> 2.0.3-r1*
* *turtlebot4-description 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-msgs 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-navigation 0.1.0-r1 --> 0.1.1-r1*
* *turtlebot4-node 0.1.0-r1 --> 0.1.1-r1*
* *twist-stamper 0.0.2-r1*
* *velodyne 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-driver 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-laserscan 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-msgs 2.2.0-r1 --> 2.3.0-r1*
* *velodyne-pointcloud 2.2.0-r1 --> 2.3.0-r1*

Humble Changes:
---------------
* *affordance-primitives 0.1.0-r3*
* *angles 1.13.0-r3 --> 1.15.0-r1*
* *bag2-to-image 0.1.0-r1*
* *controller-interface 2.10.0-r1 --> 2.12.1-r1*
* *controller-manager 2.10.0-r1 --> 2.12.1-r1*
* *controller-manager-msgs 2.10.0-r1 --> 2.12.1-r1*
* *depthai 2.15.5-r1 --> 2.17.0-r1*
* *diff-drive-controller 2.6.0-r1 --> 2.9.0-r1*
* *effort-controllers 2.6.0-r1 --> 2.9.0-r1*
* *eigenpy 2.7.7-r1*
* *fogros2-examples 0.1.6-r3 --> 0.1.7-r1*
* *force-torque-sensor-broadcaster 2.6.0-r1 --> 2.9.0-r1*
* *forward-command-controller 2.6.0-r1 --> 2.9.0-r1*
* *foxglove-msgs 1.2.2-r1 --> 2.0.0-r1*
* *gripper-controllers 2.6.0-r1 --> 2.9.0-r1*
* *hardware-interface 2.10.0-r1 --> 2.12.1-r1*
* *imu-complementary-filter 2.1.1-r1 --> 2.1.1-r2*
* *imu-filter-madgwick 2.1.1-r1 --> 2.1.1-r2*
* *imu-sensor-broadcaster 2.6.0-r1 --> 2.9.0-r1*
* *imu-tools 2.1.1-r1 --> 2.1.1-r2*
* *joint-limits 2.12.1-r1*
* *joint-state-broadcaster 2.6.0-r1 --> 2.9.0-r1*
* *joint-trajectory-controller 2.6.0-r1 --> 2.9.0-r1*
* *marvelmind-ros2 1.0.2-r3*
* *marvelmind-ros2-msgs 1.0.2-r1*
* *mavlink 2022.2.2-r3 --> 2022.6.27-r1*
* *moveit-resources 2.0.5-r1 --> 2.0.6-r1*
* *moveit-resources-fanuc-description 2.0.5-r1 --> 2.0.6-r1*
* *moveit-resources-fanuc-moveit-config 2.0.5-r1 --> 2.0.6-r1*
* *moveit-resources-panda-description 2.0.5-r1 --> 2.0.6-r1*
* *moveit-resources-panda-moveit-config 2.0.5-r1 --> 2.0.6-r1*
* *moveit-resources-pr2-description 2.0.5-r1 --> 2.0.6-r1*
* *nao-lola 0.0.4-r4 --> 0.1.0-r1*
* *nerian-stereo 1.1.1-r1*
* *performance-test 1.1.0-r1 --> 1.2.1-r1*
* *plansys2-bringup 2.0.9-r1*
* *plansys2-bt-actions 2.0.9-r1*
* *plansys2-core 2.0.9-r1*
* *plansys2-domain-expert 2.0.9-r1*
* *plansys2-executor 2.0.9-r1*
* *plansys2-lifecycle-manager 2.0.9-r1*
* *plansys2-msgs 2.0.9-r1*
* *plansys2-pddl-parser 2.0.9-r1*
* *plansys2-planner 2.0.9-r1*
* *plansys2-popf-plan-solver 2.0.9-r1*
* *plansys2-problem-expert 2.0.9-r1*
* *plansys2-terminal 2.0.9-r1*
* *plansys2-tools 2.0.9-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *plotjuggler-ros 1.5.1-r3 --> 1.7.1-r3*
* *position-controllers 2.6.0-r1 --> 2.9.0-r1*
* *rclc 4.0.0-r1 --> 4.0.1-r1*
* *rclc-examples 4.0.0-r1 --> 4.0.1-r1*
* *rclc-lifecycle 4.0.0-r1 --> 4.0.1-r1*
* *rclc-parameter 4.0.0-r1 --> 4.0.1-r1*
* *ros-image-to-qimage 0.2.0-r1 --> 0.2.1-r1*
* *ros2-control 2.10.0-r1 --> 2.12.1-r1*
* *ros2-control-test-assets 2.10.0-r1 --> 2.12.1-r1*
* *ros2-controllers 2.6.0-r1 --> 2.9.0-r1*
* *ros2-controllers-test-nodes 2.6.0-r1 --> 2.9.0-r1*
* *ros2controlcli 2.10.0-r1 --> 2.12.1-r1*
* *rviz-imu-plugin 2.1.1-r1 --> 2.1.1-r2*
* *rviz-visual-tools 4.1.2-r3 --> 4.1.3-r1*
* *sick-safetyscanners-base 1.0.2-r1*
* *sick-safetyscanners2 1.0.3-r1*
* *sick-safetyscanners2-interfaces 1.0.0-r2*
* *transmission-interface 2.10.0-r1 --> 2.12.1-r1*
* *ur 2.2.1-r1 --> 2.2.2-r1*
* *ur-bringup 2.2.1-r1 --> 2.2.2-r1*
* *ur-calibration 2.2.1-r1 --> 2.2.2-r1*
* *ur-controllers 2.2.1-r1 --> 2.2.2-r1*
* *ur-dashboard-msgs 2.2.1-r1 --> 2.2.2-r1*
* *ur-moveit-config 2.2.1-r1 --> 2.2.2-r1*
* *ur-robot-driver 2.2.1-r1 --> 2.2.2-r1*
* *velocity-controllers 2.6.0-r1 --> 2.9.0-r1*
* *velodyne 2.3.0-r1*
* *velodyne-driver 2.3.0-r1*
* *velodyne-laserscan 2.3.0-r1*
* *velodyne-msgs 2.3.0-r1*
* *velodyne-pointcloud 2.3.0-r1*

Melodic Changes:
----------------
* *camera-calibration 1.15.0-r1 --> 1.15.2-r1*
* *costmap-cspace 0.11.4-r1 --> 0.11.6-r1*
* *depth-image-proc 1.15.0-r1 --> 1.15.2-r1*
* *eigenpy 2.7.5-r1 --> 2.7.7-r1*
* *foxglove-msgs 2.0.0-r1*
* *hri-msgs 0.7.0-r1 --> 0.7.1-r1*
* *image-pipeline 1.15.0-r1 --> 1.15.2-r1*
* *image-proc 1.15.0-r1 --> 1.15.2-r1*
* *image-publisher 1.15.0-r1 --> 1.15.2-r1*
* *image-rotate 1.15.0-r1 --> 1.15.2-r1*
* *image-view 1.15.0-r1 --> 1.15.2-r1*
* *joystick-interrupt 0.11.4-r1 --> 0.11.6-r1*
* *map-organizer 0.11.4-r1 --> 0.11.6-r1*
* *neonavigation 0.11.4-r1 --> 0.11.6-r1*
* *neonavigation-common 0.11.4-r1 --> 0.11.6-r1*
* *neonavigation-launch 0.11.4-r1 --> 0.11.6-r1*
* *obj-to-pointcloud 0.11.4-r1 --> 0.11.6-r1*
* *planner-cspace 0.11.4-r1 --> 0.11.6-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *qb-device 2.0.1 --> 3.0.4-r3*
* *qb-device-bringup 2.0.1 --> 3.0.4-r3*
* *qb-device-control 2.0.1 --> 3.0.4-r3*
* *qb-device-description 2.0.1 --> 3.0.4-r3*
* *qb-device-driver 2.0.1 --> 3.0.4-r3*
* *qb-device-gazebo 3.0.4-r3*
* *qb-device-hardware-interface 2.0.1 --> 3.0.4-r3*
* *qb-device-msgs 2.0.1 --> 3.0.4-r3*
* *qb-device-srvs 2.0.1 --> 3.0.4-r3*
* *qb-device-utils 2.0.1 --> 3.0.4-r3*
* *safety-limiter 0.11.4-r1 --> 0.11.6-r1*
* *stereo-image-proc 1.15.0-r1 --> 1.15.2-r1*
* *track-odometry 0.11.4-r1 --> 0.11.6-r1*
* *trajectory-tracker 0.11.4-r1 --> 0.11.6-r1*

Noetic Changes:
---------------
* *aruco-opencv 0.1.0-r1*
* *audio-video-recorder 2.2.12-r1*
* *camera-aravis 4.0.2-r1 --> 4.0.3-r1*
* *costmap-cspace 0.11.4-r1 --> 0.11.6-r1*
* *depthai 2.15.5-r1 --> 2.17.0-r1*
* *dynamic-tf-publisher 2.2.11-r2 --> 2.2.12-r1*
* *eigenpy 2.7.5-r1 --> 2.7.7-r1*
* *ess-imu-ros1-uart-driver 1.3.1-r1*
* *eus-assimp 0.4.4-r1 --> 0.4.4-r2*
* *euscollada 0.4.4-r1 --> 0.4.4-r2*
* *eusurdf 0.4.4-r1 --> 0.4.4-r2*
* *fkie-master-discovery 1.2.7-r1 --> 1.3.2-r2*
* *fkie-master-sync 1.2.7-r1 --> 1.3.2-r2*
* *fkie-multimaster 1.2.7-r1 --> 1.3.2-r2*
* *fkie-multimaster-msgs 1.2.7-r1 --> 1.3.2-r2*
* *fkie-node-manager 1.2.7-r1 --> 1.3.2-r2*
* *fkie-node-manager-daemon 1.2.7-r1 --> 1.3.2-r2*
* *foxglove-msgs 1.2.2-r1 --> 2.0.0-r1*
* *hri-msgs 0.7.0-r1 --> 0.7.1-r1*
* *hri-rviz 0.3.1-r1*
* *image-view2 2.2.11-r2 --> 2.2.12-r1*
* *joystick-interrupt 0.11.4-r1 --> 0.11.6-r1*
* *jsk-common 2.2.11-r2 --> 2.2.12-r1*
* *jsk-model-tools 0.4.4-r1 --> 0.4.4-r2*
* *jsk-network-tools 2.2.11-r2 --> 2.2.12-r1*
* *jsk-tilt-laser 2.2.11-r2 --> 2.2.12-r1*
* *jsk-topic-tools 2.2.11-r2 --> 2.2.12-r1*
* *lsc-ros-driver 1.0.1-r1*
* *magic-enum 0.7.3-r1 --> 0.8.0-r1*
* *map-organizer 0.11.4-r1 --> 0.11.6-r1*
* *mrpt-ekf-slam-2d 0.1.11-r1*
* *mrpt-ekf-slam-3d 0.1.11-r1*
* *mrpt-graphslam-2d 0.1.11-r1*
* *mrpt-icp-slam-2d 0.1.11-r1*
* *mrpt-rbpf-slam 0.1.11-r1*
* *mrpt-slam 0.1.11-r1*
* *multi-map-server 2.2.11-r2 --> 2.2.12-r1*
* *neonavigation 0.11.4-r1 --> 0.11.6-r1*
* *neonavigation-common 0.11.4-r1 --> 0.11.6-r1*
* *neonavigation-launch 0.11.4-r1 --> 0.11.6-r1*
* *obj-to-pointcloud 0.11.4-r1 --> 0.11.6-r1*
* *opw-kinematics 0.4.6-r1 --> 0.5.0-r1*
* *planner-cspace 0.11.4-r1 --> 0.11.6-r1*
* *plotjuggler 3.4.5-r1 --> 3.5.0-r1*
* *pyhri 0.1.2-r1*
* *qb-device 3.0.4-r1*
* *qb-device-bringup 3.0.4-r1*
* *qb-device-control 3.0.4-r1*
* *qb-device-description 3.0.4-r1*
* *qb-device-driver 3.0.4-r1*
* *qb-device-gazebo 3.0.4-r1*
* *qb-device-hardware-interface 3.0.4-r1*
* *qb-device-msgs 3.0.4-r1*
* *qb-device-srvs 3.0.4-r1*
* *qb-device-utils 3.0.4-r1*
* *qb-hand-gazebo 2.2.2-r1*
* *qb-hand-hardware-interface 2.2.2-r1*
* *qb-move-gazebo 2.2.2-r1*
* *qb-move-hardware-interface 2.2.2-r1*
* *ros-industrial-cmake-boilerplate 0.2.16-r1 --> 0.3.0-r1*
* *safety-limiter 0.11.4-r1 --> 0.11.6-r1*
* *tesseract-collision 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-common 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-environment 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-geometry 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-kinematics 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-scene-graph 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-srdf 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-state-solver 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-support 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-urdf 0.8.6-r1 --> 0.10.0-r1*
* *tesseract-visualization 0.8.6-r1 --> 0.10.0-r1*
* *track-odometry 0.11.4-r1 --> 0.11.6-r1*
* *trajectory-tracker 0.11.4-r1 --> 0.11.6-r1*
* *velodyne 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-driver 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-laserscan 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-msgs 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-pcl 1.6.1-r1 --> 1.7.0-r1*
* *velodyne-pointcloud 1.6.1-r1 --> 1.7.0-r1*
* *virtual-force-publisher 2.2.11-r2 --> 2.2.12-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-pytest-timeout
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-websocket
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

