### PR TITLE
rosdistro sync, Fri Jul 29 14:00:58 2022

### DIFF
--- a/distros/foxy/action-tutorials-cpp/default.nix
+++ b/distros/foxy/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-foxy-action-tutorials-cpp";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/action_tutorials_cpp/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "816ab33375f8cc567cfb192bff96c4847eac39e290c69cf94384c67ccd4f3aca";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/action_tutorials_cpp/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "ece75ba361659c1f67b03a5066848efbc3e512aa17bc368bd1698b0b0d6c463f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/action-tutorials-interfaces/default.nix
+++ b/distros/foxy/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-action-tutorials-interfaces";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/action_tutorials_interfaces/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "509d00f49c0f504acf6082a000e021e59be05833281fb5855b6a3202fb3c3e9d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/action_tutorials_interfaces/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "2b1f8ba25a5b36b97825e1f701d2018bafb59e1d5377a550498fc8afb6696e41";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/action-tutorials-py/default.nix
+++ b/distros/foxy/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-lint-auto, ament-lint-common, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-action-tutorials-py";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/action_tutorials_py/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "afd80319550d71052ac8543e26dabe243d548a6543cd916f71da38eb6e652ea8";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/action_tutorials_py/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "b093ae3e3e88cfc08ad4d25476c9a29f37923bc6e4cceaabb43ccf46d3a7eba1";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-clang-format/default.nix
+++ b/distros/foxy/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-clang-format";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_clang_format/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "1defe50123b3cd1c1cda34f0491d44eea9bd25b09c8577bda3e5937115693651";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_clang_format/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "308eb252a60b39bcaadfe46035492c1ba8a06d86b58763625c30d4c3654040d8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-clang-tidy/default.nix
+++ b/distros/foxy/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-clang-tidy";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_clang_tidy/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "b61d717e3b88ef0fa85719dd1bf4ae52ee38548f7392a809347b782ef1377973";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_clang_tidy/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "8752cd7f34f1a8a9984f96669ff1382f85603e54d99415a271c3bd6202fa40eb";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-cmake-auto/default.nix
+++ b/distros/foxy/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-auto";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_auto/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "37945c309dad2ba313941722bbe01f2bed2516a796157dc4207f576ec5df2109";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_auto/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "2cd32be1d4b6e1ac63c2b6ca4114165d82dbc2cba9c04296e92919c2d4e0acba";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-clang-format/default.nix
+++ b/distros/foxy/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-clang-format";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_clang_format/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "163a7cd5ef4d2bb22463c95be490e88124ca7676c7cd620057d949af4ecea952";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_clang_format/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "258cb55a65b3bb6dd38695836e32a126a6d3c4556f4cd2ea1bacd94e9a493c64";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-clang-tidy/default.nix
+++ b/distros/foxy/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-clang-tidy";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_clang_tidy/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "d54dfde9a51eafc30460d556e75b013d6adbf89d1edb85bcf88c061e6539740a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_clang_tidy/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "54a27d55f677cc1e618510d2565eb6879670ad6369b409262be4b594f02ecbc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-copyright/default.nix
+++ b/distros/foxy/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-copyright";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_copyright/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "efb76c5814799e60604146636141238d69a87c2121e3ca775ce5d042e698fdcb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_copyright/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "be736f76073e12b9f5c9b958db28874a78fb3c7afc982d495c6918640236aa2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-core/default.nix
+++ b/distros/foxy/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-core";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_core/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "6ed5349e45a60badb1fbd224db3014b4e2783a7f524d7c78a0c331b16a36d2e2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_core/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "f5eb84aa16fd709b8e69c098e130d41d4231f7e8c2a22e63e9286cd6af8b16e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-cppcheck/default.nix
+++ b/distros/foxy/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-cppcheck";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_cppcheck/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "54e4f8de656428220630621cea6207e7db655784800f400040b8d468bb415921";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_cppcheck/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "c374f88631647cb7f38f98296bd7f69554c17310132934204a87454997b96ec3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-cpplint/default.nix
+++ b/distros/foxy/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-cpplint";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_cpplint/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "3031e2dc39176c85790efe287d63641dd75427ca62e8607676b642c72b36568e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_cpplint/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "a1e0378d2ddf4b6e8ba885161d071a79788f6b8c897bf6f1ac4b52c4a4cff045";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-definitions/default.nix
+++ b/distros/foxy/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-definitions";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_definitions/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "570791560b1ae35567b741689140e71e7a995d093421d2351c7e052c7033c55a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_definitions/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "391ea12d6443c40e14dcf6a25b34ed5542ad18ad8f896cc020faf0c534d40527";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-dependencies/default.nix
+++ b/distros/foxy/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-dependencies";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_dependencies/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "4b360d1e67fe4bf1a9bae38a43e71e85649c2ab15e579aa1ca87a474bcac5c20";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_dependencies/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "2fb2cd1cef9d4c2ac0ee36afea050a92974c11747775e8930ea112afeed68b67";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-include-directories/default.nix
+++ b/distros/foxy/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-include-directories";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_include_directories/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "c6f619c543c0521520f869a70f519a1ae6ff1fb5a1745347dc8e7e8432161a28";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_include_directories/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "33ace199325839f201cd5fe2b76e41e380d70930dd20e03ccd6bce4cf5fa4900";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-interfaces/default.nix
+++ b/distros/foxy/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-interfaces";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_interfaces/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "fb16cd40c247c9fa6cb60ab0dfd81fcdc6f5b3b6af81cb68ef31b123cb829d1b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_interfaces/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "0575b49e9d2ff075b1d421c105d6b2f6e1177510d7d8912129069aa469331c92";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-libraries/default.nix
+++ b/distros/foxy/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-libraries";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_libraries/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "0432bd3d6098f77c2e16e894700b00851e19948202808b4ccfad794cf67b4080";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_libraries/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "86738c847b492da5a90fdf5f19feecfb8f5e0f1a474871f5eee3b564c277f122";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-link-flags/default.nix
+++ b/distros/foxy/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-link-flags";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_link_flags/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "45aebc1193ea14668a8f6c03c1b7a8d44684b4a86d936f29499224b088a5ed6f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_link_flags/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "d0605740f4e0484097cff7f47f34b85cfefcc34c73753e0c6f661ad51ac9848c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-targets/default.nix
+++ b/distros/foxy/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-targets";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_targets/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "3795562d0eeb91c0eb3f59b43271eda4638611f34996573d96c9ac4852969ed7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_targets/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "86f7ef9b3f767574b432922b784f682dbd1ac11ea38cf3c5271c65a6c489452d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-flake8/default.nix
+++ b/distros/foxy/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-flake8";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_flake8/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "b85a5e4270744d15cc930d0adbda4c5b257d08d1399a520c5af1494dd2ead19e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_flake8/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "812850e933a4ac40b9f75dd3443f4ab56b68b002a7278f4606ce0a5fbd25648e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-gmock/default.nix
+++ b/distros/foxy/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-gmock";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gmock/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "3fafecf9716d5609a5b8bb95b28aa04e9f4cd160992604e6795536e55db37f34";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gmock/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "ad15e5567937da9268bbc395a6e282d5cda9572cb25a6e80ff6490ad695994f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-google-benchmark/default.nix
+++ b/distros/foxy/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-google-benchmark";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_google_benchmark/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "0a9fade740234a93a9549fccfe61613b287399673bba12671e9dcaf763d97524";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_google_benchmark/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "cd143598f57bcf2187bd44805af4429ed088c310b41211e345332f908fbace6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-gtest/default.nix
+++ b/distros/foxy/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-gtest";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gtest/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "0c39644d0755a4cb52787e8ba587aacae6d26d3e16af2ea2defdd055418751e5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gtest/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "b0db6d2e8f8a285f4b708beed8a2e9feedf63d3832a5116c12f6c6d24b644ba8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-include-directories/default.nix
+++ b/distros/foxy/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-include-directories";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_include_directories/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "cf95b1ccc8341e476dc266c0854ba3411dde433c0a50d00a7277e044d837a765";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_include_directories/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "7538b89f0a3bb5606a3cf316f31a5a3f156c9b0b389ebbeb39d8de378688f9bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-libraries/default.nix
+++ b/distros/foxy/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-libraries";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_libraries/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "e235cada5f26f96f140e080e9fd7d2c7dd056dbcc6f6c1cf9d1ae7e7d60d8001";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_libraries/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "76591081f263a7ead8d3359282f0dccf8d4e12af3a2834f2c7bb630a35bd576c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-lint-cmake/default.nix
+++ b/distros/foxy/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-lint-cmake";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_lint_cmake/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "b1e4e3c21482db2d95ccec638c94e491b4b854267e149029df23f80d848064a3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_lint_cmake/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "178f3389b715cdb5c4df353df3351d642e0ada38548592e17a3f572a98ae586c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-mypy/default.nix
+++ b/distros/foxy/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-mypy";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_mypy/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "1bc59cd47a18ea789fc869cf93b5f1cfb7d9e59081fcf737b1d904fa71141d74";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_mypy/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "047b53e267cd1d27f0fb32076fe57c5f59aa390c53a3e1aa37dc93905310de43";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-nose/default.nix
+++ b/distros/foxy/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-nose";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_nose/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "cbd00e249326951b0279fdec0ea15fc88cd5d08d404cae1c08983ac104900f7e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_nose/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "a5205968dde895f15cc44ca96c942220d42a2158eb2d430d603cef511bb4d031";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-pclint/default.nix
+++ b/distros/foxy/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-pclint";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pclint/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "bf63b68e37c67c12c160d9a6a8ec3807ebb310130da6b59966aa3e2c15650021";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pclint/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "150e254986adf3f691cc17d244d501d43723afab0128353b15bd4c0e2e0919fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-pep257/default.nix
+++ b/distros/foxy/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-pep257";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pep257/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "a4ab81fc474bd1c743af9fca4ba8fae28fa004f7af7288fd0c80a78266d85b39";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pep257/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "718800dfdc2ad8b3dfccd06c56bab33842caeaa65bdc50f347dc1ae355fd4bd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-pycodestyle/default.nix
+++ b/distros/foxy/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-pycodestyle";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pycodestyle/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "af5dbb5b3afaefcc532c405195975f3a46fc37f0b1996b5f8a26edf4bf7c378e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pycodestyle/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "3b912b09480c98f23a0ae4ea0834154213bfa5cc95e36f8df30a34c2488bb8a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-pyflakes/default.nix
+++ b/distros/foxy/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-pyflakes";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pyflakes/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "afad4c7a66716b332a6fb6dda5b4d5b13aede4959a674e1a4e2341ae6200b34c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_pyflakes/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "7422496ad319346a347756b1e3696c510a30ee48349096be15854d44922c7900";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-pytest/default.nix
+++ b/distros/foxy/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-pytest";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_pytest/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "6c2f1bc5048c4e08f7e46f08ac29ae86fd509a72030bf19b806185e84671f1e9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_pytest/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "103f7a88bf8dd8c512d3f170f26296b1c8c28ebc87d3bd7c64c3f60e9190c301";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-python/default.nix
+++ b/distros/foxy/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-python";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_python/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "5e32c4aaf7caf333b86e0d0cfe0fc137ce8e3a30c9a20828b1af9777c4c664f5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_python/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "6713040b141740131fc51203199e9d01aa3f2fc80778d0a9ddac7ac8af1ec772";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-target-dependencies/default.nix
+++ b/distros/foxy/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-target-dependencies";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_target_dependencies/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "9e4c049584955fa7e53f78e733e72b174d2919cc04a70e404d5a5999b293e23c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_target_dependencies/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "51f8516c0d4e88d535fa21a398cbd1f84c07f6633c4856686941d72dfc6d2412";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-test/default.nix
+++ b/distros/foxy/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-test";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_test/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "fe907d5b83d1d5214c498ea4f1c81cc535a793ba626fe4fc960b833f466d9d48";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_test/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "662b122754c40355ab418cb01c4256cb3d74951a4673c9dc78aae89a78bd288f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-uncrustify/default.nix
+++ b/distros/foxy/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-uncrustify";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_uncrustify/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "af2daa7d2c9df220245ec812f877c085c6a2795215cb3343fd5ea316aadfe052";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_uncrustify/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "f8e063e4d39c515259ecc2eb258f433143ab029c01c69290ee56f75f52ed3dd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-version/default.nix
+++ b/distros/foxy/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-version";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_version/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "b7b9e73d0ec88a5107d3ae72399bed115ef4af80ea5ef80966c4ebc58cff5e84";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_version/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "edbb6a5a0593612dd5df59e8bec07017351b592dd4477ea88a68fa74b7a33ea0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-xmllint/default.nix
+++ b/distros/foxy/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-xmllint";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_xmllint/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "3d7f4f7dbccb102c1063677075a69a2878595943ad9e143bb414b68ffd192400";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cmake_xmllint/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "d034066dd4b8db8129626257c817aed220e55fc93f67d206f112f48e4f9b1740";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake/default.nix
+++ b/distros/foxy/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "eb11d2cbebecb297f104c616329d1f62cde6d83ebe2ce6ab449829f38d868404";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "89b49ff5a1896c7752e8398e929703fcf4e9210e84e62251e46c06aa964995ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-copyright/default.nix
+++ b/distros/foxy/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-copyright";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_copyright/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "a1139d3f168c849c204a2ecf6ef0a2de96b5958e80845c0776fa001c310c80f9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_copyright/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "ef6f59b55470967d4cd72bbbfb74aa807f9414ecab08aa9c6ea81c96fcb99988";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-cppcheck/default.nix
+++ b/distros/foxy/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-foxy-ament-cppcheck";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cppcheck/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "ebe4dd748dfe04ed5c5848dd077fe04120a9e50223cdfe2ecaa3ddfe6e2925e8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cppcheck/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "6b1d0ba00aa5a8d1992ba3c9b4a80aaa9b1073d69510bd6d9cb7d18fafff5f57";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-cpplint/default.nix
+++ b/distros/foxy/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cpplint";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cpplint/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "a513755eab527da31817bc87eee5bdfb83e9d442903d6b44b12731833cb63887";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_cpplint/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "aba0bf64ed047084b1bac202d6816724171fd0406caa79c29a043375fe18d90f";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-flake8/default.nix
+++ b/distros/foxy/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-flake8";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_flake8/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "e13aa279b173d6f73811e4916ad40b2fc76b3ead3ba7065e85a074e83cd27846";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_flake8/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "42aa8919b7e8740f0c9108769042e47b0a2c84f377d86b64f27f2eeeb0204725";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-lint-auto/default.nix
+++ b/distros/foxy/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-foxy-ament-lint-auto";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint_auto/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "006a98b75f022f08c3fd7178dcfc5bafab6b99ac8d93acd3ae23cf18ac761434";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint_auto/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "0690f0cc33d831b61202e7e90818f382da20f47fc4cf75985659f2cfab85021c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-lint-cmake/default.nix
+++ b/distros/foxy/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-lint-cmake";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint_cmake/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "086e2d74ec45522c7bc6d82b222118cda0df7f70dbb31a6d899fd761471fb259";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint_cmake/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "e18a2b08e3a26970b95b2cbc207ee2f394d76f51f43240f1f9f58baf71919804";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-lint-common/default.nix
+++ b/distros/foxy/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-foxy-ament-lint-common";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint_common/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "16088f42aa98c9134fa14e8e0c91b52cefff7dfcbd7f9ef4beb0460c73eb9876";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint_common/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "f3dc9f7eb651724f145365af45500c820fc3a5009f2105edd58bc96c87d6c973";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-lint/default.nix
+++ b/distros/foxy/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-foxy-ament-lint";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "3e23ac3262d07507d9be01e81e3b0364c1f18e554952585832c58280bc65edc5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_lint/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "9aee5e2700aae351fed70c81df96070afaa1fe5eb3509b018e1b58f5064ae884";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-mypy/default.nix
+++ b/distros/foxy/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-mypy";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_mypy/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "5cf760fcbb7456532d18283a5f23bca960d33735dacee1a8f0666c0bf085633d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_mypy/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "5cb77b532a22bef923c5b6ff2e12313970669837fe803be54dc517eb2711a59c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-pclint/default.nix
+++ b/distros/foxy/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-pclint";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pclint/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "e76d16ecd5be3086fa5c5bac61405e3e84f3dda012d68c1c28bf7656c1ac4a14";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pclint/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "2a1e0a247f7967924b513ee9fa60a42e7ddabecd34d8b9cb2b71c7db9d10ab46";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-pep257/default.nix
+++ b/distros/foxy/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-pep257";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pep257/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "8337985799849dad47fbd93e2fa91b06642578d008289ca6e2d11f3113105e40";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pep257/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "eed3c2e08af94e7f6ec7c48b79849463c21b684116686901d49dc152a72804e3";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-pycodestyle/default.nix
+++ b/distros/foxy/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-pycodestyle";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pycodestyle/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "e3e01f876f82d48b4dd4f3effaa2c454d4b567bb287cd5d59e733a2735f9b15c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pycodestyle/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "8a2865bbc9e4eae39bc94672f5dba534235c67d705dec948ea1d544098cf4a2e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-pyflakes/default.nix
+++ b/distros/foxy/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-pyflakes";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pyflakes/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "066b1bac7e17ddf86bac5726a83039c569c3129c81ba554c73a5c642b1eeaf90";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_pyflakes/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "cb8f9f88408d8677f76b4d27d8b74972b385fe407d299a69086ddb52818b7475";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-uncrustify/default.nix
+++ b/distros/foxy/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-foxy-ament-uncrustify";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_uncrustify/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "0eae1895d2089d72b06e14052efcb5d4e65a822ca55691388ad0f52ee2695112";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_uncrustify/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "d04a19bba75e222b756b90f8ec97332ff5765ce97d881a9b8ec38a1dbaa0c7bd";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ament-xmllint/default.nix
+++ b/distros/foxy/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-xmllint";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_xmllint/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "e8671e3c2df237c2828a575dfc1c103e86b36c2193458a502baced4dcf75006f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/foxy/ament_xmllint/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "4a0e356141c75852cdf0471d87afda115074b544b1245cd51fe3dfde544833ac";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/class-loader/default.nix
+++ b/distros/foxy/class-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, rcpputils }:
 buildRosPackage {
   pname = "ros-foxy-class-loader";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/foxy/class_loader/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "c75955459e9ad5f60755571d3a8018dfe27ef9204544d7346c1d04fe1a71f1d4";
+    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/foxy/class_loader/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "4f79f4f883be95b2580b184def1ef5779a2d60135849b139e3ee678e3f0ef60e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/composition/default.nix
+++ b/distros/foxy/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-composition";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/composition/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "120513c48efdbab0b7eb4b1ac018740f5a57d8c84cb2e1a45eb3f971cb87641e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/composition/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "df5d41e3c4b82aa0f9b6d18566cbed1664bfc0cee2972aa9778885f8b94c674a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/demo-nodes-cpp-native/default.nix
+++ b/distros/foxy/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-demo-nodes-cpp-native";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/demo_nodes_cpp_native/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "9e082ddaa648aaa990973210b016667d2b3ec0f7352e49bb4bccb3fc6f42e6bd";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/demo_nodes_cpp_native/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "4311884b4f0a75a4045e26a64e4a95c49f3937eb199aba59a50d9124670bcff7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/demo-nodes-cpp/default.nix
+++ b/distros/foxy/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-demo-nodes-cpp";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/demo_nodes_cpp/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "df808a65ddef9088b6ec57d219712be082ada282ff28d554a31a06a9c9240a1b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/demo_nodes_cpp/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "2e58144a7f22097a27776c01c378c0406aa47a924850819ed9081e9ed2ff232b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/demo-nodes-py/default.nix
+++ b/distros/foxy/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-demo-nodes-py";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/demo_nodes_py/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "0d5d5a6a942764e89cef5d7c683ba8e08a79cd1ef298900fab10f7922caebdd4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/demo_nodes_py/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "1fa2326b06f4efb8548b6476d2cefa65902e78000e1ab13e21c50867a1c58fc6";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/dummy-map-server/default.nix
+++ b/distros/foxy/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-dummy-map-server";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/dummy_map_server/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "fc3dd724bf6b7efad7f0087e55041711799e598f75bd6aa675de7ee106c094f8";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/dummy_map_server/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "4f3fddbf708f424f978c584430f0707a8243bbc4cc3226201ed6b4e8946ef32e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dummy-robot-bringup/default.nix
+++ b/distros/foxy/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-foxy-dummy-robot-bringup";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/dummy_robot_bringup/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "95c029262a4e3c6f96bb375cb6be6ff9a231a02f3b33c5f9d9642e390e74298b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/dummy_robot_bringup/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "20f2b4cb814f001a2be132d668c6e8bea8dbdb518b8eb829b31386c68c19b18c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dummy-sensors/default.nix
+++ b/distros/foxy/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dummy-sensors";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/dummy_sensors/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "803abc65c58c7af83296bc886fd387ecf82c0721d0bbeadaaed1426d5e578c45";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/dummy_sensors/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "e56dde37970e438fab53919b8862b8ce528ea5deb3fbda60a1a41738aa95816f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.7-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.7-1.tar.gz";
-    name = "2.7.7-1.tar.gz";
-    sha256 = "be06d935b2e1b088e110f17a8e623f8d6fbfe37ada3b5763600961dc2e61332f";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "ba266a1a0cb6ee60975437edc781005cde747848f297c3b73157842534203f5f";
   };
 
   buildType = "cmake";

--- a/distros/foxy/image-tools/default.nix
+++ b/distros/foxy/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-image-tools";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/image_tools/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "fa6275372573c17bb7784c24caa06f9a81be1c59e6f4856ac9ffe162e11617d0";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/image_tools/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "fec375d02308d9ee1ae15cf7a4389b8959df276217fb7edd56f026b3ee7308b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/intra-process-demo/default.nix
+++ b/distros/foxy/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-intra-process-demo";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/intra_process_demo/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "9cbc836e7d71be3c9d7a89feeb33d24eeee92d4da6dd493ea4834ab3eb060f8d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/intra_process_demo/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "2e58b507a97b578570ea24fed0698f547f0dc40e9e30864cf8f667da2e32c58c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/lifecycle/default.nix
+++ b/distros/foxy/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-lifecycle";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/lifecycle/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "c81530e6eea1a58452025a9d24558c064e9ea80b57700ae2ff3161df3e0dee69";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/lifecycle/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "6f82541ef6be771e6b2bd7bcd950e803b66f5e8dc78a77fff8104516d45b45bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/logging-demo/default.nix
+++ b/distros/foxy/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-logging-demo";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/logging_demo/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "3b28a3c87a26aa056b7fdcae279c3ddddfbbb52b7d09ddd4e2ada722de09e6c6";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/logging_demo/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "3e32f44fab474883a8ce8cc5ec94fb1d68c471119063248a27d110fe147ded0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-integration/default.nix
+++ b/distros/foxy/maliput-integration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-pytest, gflags, libyamlcpp, maliput, maliput-dragway, maliput-malidrive, maliput-multilane, maliput-object, maliput-py }:
 buildRosPackage {
   pname = "ros-foxy-maliput-integration";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "54e86e33967c31a35f8e9cf103ca887fa1e6009d714e3c17f8a639d7f5814861";
+    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "680d41f5ee7388f4b33538097f6387109f220d3d0f67d769b64d6977dc7124d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-py/default.nix
+++ b/distros/foxy/maliput-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput, python3, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-maliput-py";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_py-release/archive/release/foxy/maliput_py/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "2bc757970ac2532515772d7a2f7494c43938c8e36ee7a3281a61da6c8b9b49a1";
+    url = "https://github.com/ros2-gbp/maliput_py-release/archive/release/foxy/maliput_py/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "f26d74e39bd5e61c0bcc61aabaa0816372914296d998c00e03601bbf5ee53367";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput/default.nix
+++ b/distros/foxy/maliput/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp }:
 buildRosPackage {
   pname = "ros-foxy-maliput";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "fbb5918c21d8a93b9cca9e5a74e929c10bc8d9d0cb762e47585eb3f60b4ac316";
+    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "dff3f91cbea3f95d04092096aba2912d87ca4a835c4ead1c51f0475adb43953b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mcap-vendor/default.nix
+++ b/distros/foxy/mcap-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-foxy-mcap-vendor";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/mcap_vendor/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "6ed8100bdc3ad75c0c89c2b3cc1656990d6ff38c0a7f0a736df961a3af9163cb";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/mcap_vendor/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "fd80d3964423381c9ce2ec6065ba3adfcf1e6b58a57d283d8f82e43b3c65a1d3";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''mcap vendor package'';

--- a/distros/foxy/orocos-kdl/default.nix
+++ b/distros/foxy/orocos-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cppunit, eigen, eigen3-cmake-module, pkg-config }:
 buildRosPackage {
   pname = "ros-foxy-orocos-kdl";
-  version = "3.3.2-r1";
+  version = "3.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/foxy/orocos_kdl/3.3.2-1.tar.gz";
-    name = "3.3.2-1.tar.gz";
-    sha256 = "98db0b3f2f98694048993f760461db36c01c9ee1cb2cf413ab061dd3882aa5cd";
+    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/foxy/orocos_kdl/3.3.4-1.tar.gz";
+    name = "3.3.4-1.tar.gz";
+    sha256 = "833a045a938048afc42fc7f73466b686961d98d5763a8a2a05d0df29fa6dd704";
   };
 
   buildType = "cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
   meta = {
     description = ''This package contains a recent version of the Kinematics and Dynamics
     Library (KDL), distributed by the Orocos Project.'';
-    license = with lib.licenses; [ "LGPL" ];
+    license = with lib.licenses; [ "LGPL-2.1-or-later" ];
   };
 }

--- a/distros/foxy/pendulum-control/default.nix
+++ b/distros/foxy/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-foxy-pendulum-control";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/pendulum_control/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "31054b12c38ba4717b013dfc9f55aeea9989c6af02401d717421a354c1cda4c4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/pendulum_control/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "863ce27f01834250fca91abc76fc448b716fc8c0c8c2882020509ea525e54e5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pendulum-msgs/default.nix
+++ b/distros/foxy/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-pendulum-msgs";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/pendulum_msgs/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "13a8a51654484523a0a39fa739e5feb2ed90c4d77bf9c9232ef73ac9f7a4f599";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/pendulum_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "fe5d0b6af44b9323879d8588c354ed7539fb986462669b95b9d7623a84abecc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/performance-test-fixture/default.nix
+++ b/distros/foxy/performance-test-fixture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-export-targets, ament-cmake-google-benchmark, ament-cmake-test, ament-lint-auto, ament-lint-common, google-benchmark-vendor, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-foxy-performance-test-fixture";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/foxy/performance_test_fixture/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "64cd6290440fee8c847b270ef62ff2d2827328485727b1376e2427b599e115df";
+    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/foxy/performance_test_fixture/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "796a5e4aca50c9a1afed499bdc3af6972e2401b100f2993f2226e760f123e33b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.5.0-r1";
+  version = "3.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "5d4be39f01bc0c2c6970d9ab928c31c4247c82db04378b4d5bc8d21d33e49af8";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.5.1-1.tar.gz";
+    name = "3.5.1-1.tar.gz";
+    sha256 = "357cac3cc9e3db8e2249559d5f0030717c28ac6f3fcb8f23de7ab3f0cdcb05ba";
   };
 
   buildType = "ament_cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''PlotJuggler: juggle with data'';
-    license = with lib.licenses; [ lgpl3Only ];
+    license = with lib.licenses; [ mpl20 ];
   };
 }

--- a/distros/foxy/quality-of-service-demo-cpp/default.nix
+++ b/distros/foxy/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rcutils, rmw, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-quality-of-service-demo-cpp";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/quality_of_service_demo_cpp/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "c76cd5d1254785321211f60542a9d5f8b7f091385587ed2e8570a4174eed50a8";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/quality_of_service_demo_cpp/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "cef05dc84137d4e658675ba4d4b6ad031c378b7039a5fe1a40ed463f9d24e4fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/quality-of-service-demo-py/default.nix
+++ b/distros/foxy/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-quality-of-service-demo-py";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/quality_of_service_demo_py/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "1aa870cbb1acffdf0123e51e96cadff24a70a0665436069ba1298b34b75c90e7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/quality_of_service_demo_py/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "5d359325990ef368ce4c95b4228a6ef58c720c6d770a156c703693c65d3c9be7";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/raspimouse-msgs/default.nix
+++ b/distros/foxy/raspimouse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-raspimouse-msgs";
-  version = "1.0.2-r1";
+  version = "1.1.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/rt-net/raspimouse2-release/archive/release/foxy/raspimouse_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "a27e607fbda45931b237e08575a1c821f21b255e4ea6191c200b915036011c7f";
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/foxy/raspimouse_msgs/1.1.0-4.tar.gz";
+    name = "1.1.0-4.tar.gz";
+    sha256 = "0ae01769bf1c313fe9a10e6b8b0974ff656a930f79e3dbe6be22aa964d4ed6ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raspimouse/default.nix
+++ b/distros/foxy/raspimouse/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav-msgs, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-raspimouse";
-  version = "1.0.2-r1";
+  version = "1.1.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/rt-net/raspimouse2-release/archive/release/foxy/raspimouse/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "47a383d3662d097bcecbbc0435bbaad12fa5fc32c05db7b7894c6cbcdeba80df";
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/foxy/raspimouse/1.1.0-4.tar.gz";
+    name = "1.1.0-4.tar.gz";
+    sha256 = "04e6f28ef5fa167d80e849e7665ecc658be8ca24c4660b2c02a0970164ebd98b";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs nav-msgs raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs tf2 tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs lifecycle-msgs nav-msgs raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "655751eb402fe9ec39a89ea1ed6fd6b869989fbf90452e90625e827a894c3d2e";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "a9b503b6e3a4ba56dc7836e74df736a71db71b209c651aaa319cbdcc472e1479";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "5610196b8f65a5f00b0760cfe6b4b1024b428a20aa1f93d35812f0f5864d8c78";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "d11117d7fd48995ac12a64794fd8f6a12cf916747da22728fd1140aaf1d11252";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "0d0c0be72a6b88ef4f341bf4ac2a045995d087c4c675c57b9cf4ee1138324e15";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "6e3c7bf84c4c47de543669bd64b0d653af39f47f19ab2da9b48685d4d5179835";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "7a7ae8c98022818f109284ae97323e9e3f0facb88106222fd9ade5c89abc76df";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "3df5ac418335d1a6b9172273e788555a647f33f98c88312e705dfccf50645703";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-action/default.nix
+++ b/distros/foxy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-action";
-  version = "2.4.1-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "ac56942cd66355dbec0f61777319b2a0bca5964ff6bf951b9dec3630b6572374";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "39e3abdf2001cd8671547b55ebb907302eddfaf12c1b57f21a7c211481a25722";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-components/default.nix
+++ b/distros/foxy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-components";
-  version = "2.4.1-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "e0aa605d1ab620af52e8a4e6cda53c1782e4e9a0ac47d03048095f270daa17eb";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "05cd4ee2ddc0ba33e249a8b91a7f741f03de5d0ed821d76f7988fbc948b1606c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-lifecycle/default.nix
+++ b/distros/foxy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-lifecycle";
-  version = "2.4.1-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "a1ce5483d008de946962689448e589b25a9d9d9676aa8e8d16ef14f4b8d98a41";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "773a84b12ae819be7019f800593f994ce10286cd078c0c817fdab05fdb020e4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp/default.nix
+++ b/distros/foxy/rclcpp/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp";
-  version = "2.4.1-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "baff91f75078596207bc09e67f2abceadbb71f23febe5d4fc6925c755576f590";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "0707ac6d64ba4b7b518e31044d7877b77f7560c1782aaa0d20d5c1f65b2ee6f8";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor performance-test-fixture rmw rmw-implementation-cmake rosidl-default-generators test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-google-benchmark ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor performance-test-fixture rmw rmw-implementation-cmake rosidl-default-generators test-msgs ];
   propagatedBuildInputs = [ builtin-interfaces libstatistics-collector rcl rcl-interfaces rcl-yaml-param-parser rcpputils rcutils rmw rosgraph-msgs rosidl-runtime-cpp rosidl-typesupport-c rosidl-typesupport-cpp statistics-msgs tracetools ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/foxy/rcutils/default.nix
+++ b/distros/foxy/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-rcutils";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/foxy/rcutils/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "4c6206bfebf5686a888d7fc0adcfb7aa863f9d9eb7fbca9849dc2954d833adef";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/foxy/rcutils/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "d946a8ab99a8abce8f229b10321a3fa4987a37cecd8b9ebd707cd29d951c5290";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/foxy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-cyclonedds-cpp";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "d513e3bb0794179fbf86f255631023c05e495f5903483d4da3d3712462868111";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "87b1f0df60b69954233c6f6c941043353625648c585a911adca39387eb7ddfbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-cpp";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "1fac8bd35bd405fd191a087c461e5b833b5f417c30670617cae40d99d088cad2";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "a4728def65732bfe146f65cd60c688bcd6ab155c22a2b748047812f8fce415b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-dynamic-cpp";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "77bf1a0458b559aece07ad238c7fd6790d09234c57de2d5026fc0ae147935e0e";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "a2fb3ca5ecf41315c03db29937bb873aaa4c00f37c18a06a59ea804b42777030";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-shared-cpp";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "a1c3bd08767ed732376838996d98529af69c7d34c2e42fcba5a69aa4fe169142";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "cbf19d45e787728d546c1d8be12133a5b7e01d8aac7ff8012b23e030209204e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros-environment/default.nix
+++ b/distros/foxy/ros-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ros-environment";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_environment-release/archive/release/foxy/ros_environment/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "8b05844856b38b6501c6425570167c9862fc1e4e9464e18324408d8788f35064";
+    url = "https://github.com/ros2-gbp/ros_environment-release/archive/release/foxy/ros_environment/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "8d594c0fd0788f084b93283c11cf3991e5bdaf76b666c1b602b4df7ca7019ce8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage-mcap/default.nix
+++ b/distros/foxy/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage-mcap";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/rosbag2_storage_mcap/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "709d83331da130c452606c4293bbbd02bc424da8d644dbb09e783fae96398bda";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/rosbag2_storage_mcap/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "1f58e12a4adc5c5223a19cb6b6c6682f6beb1da643b3bd18874c9c4703c6cfbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-generator-py/default.nix
+++ b/distros/foxy/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-connext-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-generator-py";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/foxy/rosidl_generator_py/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "f91eb1355a4cd8200be78c7c55275d16033276db4c991baddd71d70b128cfd31";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/foxy/rosidl_generator_py/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "ac70640eefea88a701766979f4afa8ae63cefcab6fd898edb993332c81c68eb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/topic-monitor/default.nix
+++ b/distros/foxy/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-topic-monitor";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/topic_monitor/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "440fe29f6cd4ae4b0a3b026151110ffa602fc36d798dde9b031b1911c3761307";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/foxy/topic_monitor/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "ab7b36f2d05bb919fa146660186e9abf3696e01e3bb2d156138ed6e950ec60f2";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/turtlesim/default.nix
+++ b/distros/foxy/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, geometry-msgs, qt5, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-turtlesim";
-  version = "1.2.5-r1";
+  version = "1.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/foxy/turtlesim/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "3249a3dc938596b17f2a809dec6fef5a2a2d05d363d0e1a84ed1a0136a62284d";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/foxy/turtlesim/1.2.6-1.tar.gz";
+    name = "1.2.6-1.tar.gz";
+    sha256 = "4635433559f2b32c3a439ec39b6f7fbde68471c17f61540383c712492d50c1f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/eigenpy/default.nix
+++ b/distros/galactic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-eigenpy";
-  version = "2.7.7-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.7-1.tar.gz";
-    name = "2.7.7-1.tar.gz";
-    sha256 = "9357d8db0a07420fe4e0fd471f2fafb46dcae3ca26b3e84e41bb6c5dc9072098";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "c62dc03f1886b6dbc17712e7eb4c57cb3b54beb2a28892df4bd3e6176cc90b0c";
   };
 
   buildType = "cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -500,6 +500,8 @@ self: super: {
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
+ hpp-fcl = self.callPackage ./hpp-fcl {};
+
  iceoryx-binding-c = self.callPackage ./iceoryx-binding-c {};
 
  iceoryx-posh = self.callPackage ./iceoryx-posh {};

--- a/distros/galactic/hpp-fcl/default.nix
+++ b/distros/galactic/hpp-fcl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-galactic-hpp-fcl";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/galactic/hpp-fcl/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "6c175f1a418b4cce5e11e6ab14948a9144b42c746bf8e0fd115d1d7d2b4f48c4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git python3Packages.lxml ];
+  propagatedBuildInputs = [ assimp boost eigen eigenpy octomap python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''An extension of the Flexible Collision Library.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/mcap-vendor/default.nix
+++ b/distros/galactic/mcap-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-galactic-mcap-vendor";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/mcap_vendor/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "a790bdb6a37b11938b791004e3849954f47a88dd1526380f92030a9e10c6e0ad";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/mcap_vendor/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "0371a237420c1be21a3c513a8d51af68a56c5dce864b08ec4772bb1b934df9da";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''mcap vendor package'';

--- a/distros/galactic/orocos-kdl/default.nix
+++ b/distros/galactic/orocos-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cppunit, eigen, eigen3-cmake-module, pkg-config }:
 buildRosPackage {
   pname = "ros-galactic-orocos-kdl";
-  version = "3.3.3-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/galactic/orocos_kdl/3.3.3-2.tar.gz";
-    name = "3.3.3-2.tar.gz";
-    sha256 = "206b66355ec5806700ad2e95d334e9778b3e239e0a90c379583c82c0078f0fde";
+    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/galactic/orocos_kdl/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "a05fa79711b5301584f34e7e4107fbaec8239f90249608ff8f0842a4171982a2";
   };
 
   buildType = "cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
   meta = {
     description = ''This package contains a recent version of the Kinematics and Dynamics
     Library (KDL), distributed by the Orocos Project.'';
-    license = with lib.licenses; [ "LGPL" ];
+    license = with lib.licenses; [ "LGPL-2.1-or-later" ];
   };
 }

--- a/distros/galactic/performance-test-fixture/default.nix
+++ b/distros/galactic/performance-test-fixture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-export-targets, ament-cmake-google-benchmark, ament-cmake-test, ament-lint-auto, ament-lint-common, google-benchmark-vendor, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-galactic-performance-test-fixture";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/galactic/performance_test_fixture/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "9324dde4251b70c1e2d6442358e5a92ff60b1d3d9ef98f0812820de20154aaed";
+    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/galactic/performance_test_fixture/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "d6cf56a5901d8425fe70d3a201ade32ae33dbe92315a49cb92631a6b50d30fe1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.5.0-r1";
+  version = "3.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "7ec0eac90188417ec8414d3f9fec2ba17c3cb92170e62b690e562f28e2ca7102";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.5.1-1.tar.gz";
+    name = "3.5.1-1.tar.gz";
+    sha256 = "98215cd4099f4e7dd15d92fa4a76d2768e13b165bf7266fd2b1ea3e4c63bc375";
   };
 
   buildType = "ament_cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''PlotJuggler: juggle with data'';
-    license = with lib.licenses; [ lgpl3Only ];
+    license = with lib.licenses; [ mpl20 ];
   };
 }

--- a/distros/galactic/rosbag2-storage-mcap/default.nix
+++ b/distros/galactic/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-storage-mcap";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "dd309854f8f0e0581b028e8e1cf52c28c6fe9369c663a2ffd386e659a48884ab";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "84119106046eeabd3696d74951668c3695fa0cd690aa1fca505da1bffd708225";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-generator-py/default.nix
+++ b/distros/galactic/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-generator-py";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "8b1b68d2a58b68e4501069eb05b81136d21feb632a3d60ad952b4743c6c1411a";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "cd7b8b1f7ad74ceb6d1c2571cc19b882b9d5b179601e0857cec18540917d7836";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/chomp-motion-planner/default.nix
+++ b/distros/humble/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, rclcpp, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-chomp-motion-planner";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/chomp_motion_planner/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "8e2511b82a9552087a4f97f6a86563e4c6b23b3709a01dc9d6af00f490be4b86";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/chomp_motion_planner/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "8edadff7483615e25fd9aee1107748593795dbaa05a3d6c35faabdb9be166e89";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-eigenpy";
-  version = "2.7.7-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.7.7-1.tar.gz";
-    name = "2.7.7-1.tar.gz";
-    sha256 = "06634b9f4d5f5be07ced394692443ddd5cfa5e4952ace4a1f99988e9d9859b39";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "60b7b9c3f0f8e815b76db2b9f5bf3e316e73c5249b4e44f325b4f6924b4f3f17";
   };
 
   buildType = "cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -452,6 +452,8 @@ self: super: {
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
+ hpp-fcl = self.callPackage ./hpp-fcl {};
+
  iceoryx-binding-c = self.callPackage ./iceoryx-binding-c {};
 
  iceoryx-hoofs = self.callPackage ./iceoryx-hoofs {};
@@ -732,7 +734,17 @@ self: super: {
 
  moveit-servo = self.callPackage ./moveit-servo {};
 
+ moveit-setup-app-plugins = self.callPackage ./moveit-setup-app-plugins {};
+
  moveit-setup-assistant = self.callPackage ./moveit-setup-assistant {};
+
+ moveit-setup-controllers = self.callPackage ./moveit-setup-controllers {};
+
+ moveit-setup-core-plugins = self.callPackage ./moveit-setup-core-plugins {};
+
+ moveit-setup-framework = self.callPackage ./moveit-setup-framework {};
+
+ moveit-setup-srdf-plugins = self.callPackage ./moveit-setup-srdf-plugins {};
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 

--- a/distros/humble/hpp-fcl/default.nix
+++ b/distros/humble/hpp-fcl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-hpp-fcl";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5e279d564b5ef012da158c8576453e72a99d71507fd010860db4ba7642f26d6e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git python3Packages.lxml ];
+  propagatedBuildInputs = [ assimp boost eigen eigenpy octomap python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''An extension of the Flexible Collision Library.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/mcap_vendor/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "41b008ec18f383157c888e72b1c18baed1b1dede0c067c462488cdea1b0cde6d";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/mcap_vendor/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "fcbc3cc2f71546583a7f0aa80b3728a8fa6a719a43d337ec3750d37c312ad605";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''mcap vendor package'';

--- a/distros/humble/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/humble/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-moveit-chomp-optimizer-adapter";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_chomp_optimizer_adapter/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "85581e6a9e0196e12b4eec4a37abd3de132ccbaffc80ed1021ebea066cb897d5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_chomp_optimizer_adapter/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "2fc94e56b8279e93f817f10e6572cba046231640eb4b486c96f6ce406a561e97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-common/default.nix
+++ b/distros/humble/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, backward-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-common";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_common/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "878bfc1484bb6f2eb2e56c0fe4786629447fa651b9b2832401fe943b7b10bdab";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_common/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "175c41ba7337d2702a2f4dc44c4644e6fe3bc01f7d88f075ca1457a93677f184";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-configs-utils/default.nix
+++ b/distros/humble/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-humble-moveit-configs-utils";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_configs_utils/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "c98fc5777918649253bbd5ee0aeb90eb33d37ffa070278317bcd0da704548a22";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_configs_utils/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "c1b3f7e0435e1f050e0c1eea62d83c5b173fd2329d8176b3d8be805dbf1454e6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/moveit-core/default.nix
+++ b/distros/humble/moveit-core/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-core";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_core/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "8ef78cadb4023434d50f272b29b8e733a03a6580c6e6f21334e17ae6e6ee8a4e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_core/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "46a802842a450a62c6522c5ebbb0d047132e9f5507028a351e06f59e4c68e587";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl-vendor tf2-kdl ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl-vendor tf2-kdl ];
   propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-common moveit-msgs octomap octomap-msgs pluginlib pybind11-vendor random-numbers rclcpp ruckig sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module pkg-config ];
 

--- a/distros/humble/moveit-hybrid-planning/default.nix
+++ b/distros/humble/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-hybrid-planning";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_hybrid_planning/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "aa44a7ffc9494436e863bed87770f198b3bbb99a4bd1a2476a6b9fab02923211";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_hybrid_planning/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "f362f8e9d5967b4baaf1274c4d57db0e68458970ee111c8b4a1528de5286a6fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-kinematics/default.nix
+++ b/distros/humble/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-humble-moveit-kinematics";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_kinematics/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "7c6260d40ec7e8c24de8ed87a2e9c99288b5ffa1641f63b8fdf64a356d2f0c1a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_kinematics/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "8c79913306967a491c1094c1e66e5859cdaaa0e6b1c09f4197ff3015d07616df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-planners-chomp/default.nix
+++ b/distros/humble/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-moveit-planners-chomp";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_planners_chomp/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "2c911ef9bfeedab118e3b1b009acd7f44602f98e40c5922c153fcc88bd01ae2d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_planners_chomp/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "2a940b8fdb23924a3e785871d6045f93d8afa2d1bb5eaaa4f8df2919e588afb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-planners-ompl/default.nix
+++ b/distros/humble/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-planners-ompl";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_planners_ompl/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "6723049320f48193f92d1bea7dfb6b934e9f0f97f985b70609b6d563513b7beb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_planners_ompl/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "37dcf4899f10959c4a77208d5257f0d67c3c27d94181ffc66954b9983831d3cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-planners/default.nix
+++ b/distros/humble/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-humble-moveit-planners";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_planners/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "4ffcc746df398cad428b35a4fbbf3edd2a1a69316bbac13f43db26bba56a7338";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_planners/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "27a08125628f76b617546c1aa3b7a623ffd1e655b971cf74bf146a60f3eb88ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-plugins/default.nix
+++ b/distros/humble/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-humble-moveit-plugins";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_plugins/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "207bdf9d1e84eb9294fc2f09c93f7daefed182933d31205ba2cf424496cd598e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_plugins/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "b1ffb725836575ba771b51c641d5d2d3b4f3509327ec2250c2704c38ec55214a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/humble/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_ikfast_manipulator_plugin/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "86debf5c351cbee4f2116eb9c31215b560aeddca0f80be238b42d44a41768348";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_ikfast_manipulator_plugin/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "2c6847e0436f772789f0e274e54b4f19c52f136b0d73fd40d04fdf3818abb66b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/humble/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-moveit-config";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_moveit_config/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "12f309a5b16593620eb76a9a1e2e7018cd3fbebd1239a4c8945d866303dfdc53";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_moveit_config/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "f78ba7bb3bb38da69d355915273cabdf19e2b91c7f60051a335f21c7a27ecfd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/humble/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-pg70-support";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_pg70_support/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "e05f9abcfffe90909120980fb8dff7b1d50cff1b04f5fd2b040eaa1f8c61a2f6";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_pg70_support/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "1c420b88c5469001c74eb567bcc877698aed5ffaa9ef23ed01f1aba9521f8969";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-support/default.nix
+++ b/distros/humble/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-support";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_support/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "b6a86d19f0514b757c319ad5408174e5f71a9256642b14bb6aa4256db6321c7e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_resources_prbt_support/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "cd6689decb3fd3bad59001868fa8758a135ebc41840b3293a918c8ee9f718eb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-benchmarks/default.nix
+++ b/distros/humble/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-benchmarks";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_benchmarks/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "517ee74a61f8a5793bfad9d9c932b11aa3b26565c03b306738a9e4a27f10345e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_benchmarks/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "6a5a839f4ddc5deab55b931d7c94ad127420b93b884dc5e1d5463a5096fbd371";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-control-interface/default.nix
+++ b/distros/humble/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-control-interface";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_control_interface/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "41826b3a782c74ffecff4230b24605578bd018a7d03876df686c48526931848b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_control_interface/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "579605f7b444034cd50f112734288f915140c36a0c82e596ffcf05320381ec58";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-move-group/default.nix
+++ b/distros/humble/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-move-group";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_move_group/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "87d7ee754b15625b78bebc9a50b0c1954e07f5fc1d2d79085655f1fc3ec63e88";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_move_group/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "9f0f4982209735670586b3776bcea333b5a0b3169750bd5dd8439c0ab5126521";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/humble/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-occupancy-map-monitor";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_occupancy_map_monitor/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "0c680e09605c2b3e75fc01409750f7510febfb7990a8f9cf8bb0020fee28b010";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_occupancy_map_monitor/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "88301112d9ad7945249ba758515644eb17a86e9ce50a230a6efaf91cd6668cb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-perception/default.nix
+++ b/distros/humble/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-perception";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_perception/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "4ca50390b2c51ec2dc7b90b34a25282dede99a17b5169965bcfea81f71a6d7f8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_perception/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "09d73c750d69df6d4b3d77f841940ca876cc78203b20f1bc5a940eb59ca632d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-planning-interface/default.nix
+++ b/distros/humble/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-planning-interface";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_planning_interface/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "6ab4c501d9bbe8dd7ba482604da6bb43abe541707a58fe51349a54f61c34547a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_planning_interface/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "9f11dd06ccd7e31dc5efa40077593783c9e94e395f91013bb184acb0b43a0f98";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-planning/default.nix
+++ b/distros/humble/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, ros-testing, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-planning";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_planning/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "f49e9ad55f63ac984e189fd24e4351dd24f78a4ccbb90c6e294dc01249407d44";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_planning/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "8bd74ee5b90e25083bcfae9a9d5a34c38883b7a7dc5c24360c5c451c0e7e5b86";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-robot-interaction/default.nix
+++ b/distros/humble/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-robot-interaction";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_robot_interaction/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "125cc84a33227e1cd9a7956b77f4ce0232b2aa1459ba156cf8f53d9693435f05";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_robot_interaction/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "293f8167b64bcd1bfdc131d69eefa69c78b7f6ca8b18ab219bd5f7f8ca6b2df8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-visualization/default.nix
+++ b/distros/humble/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-visualization";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_visualization/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "89568425718d19e7dac9f79d2245bca3d42ae5ae6a01da0eb389ad1ac9e2a03c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_visualization/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "2c12d4d129511ca753302036c8f01971bcc2e8c9791ed61207a6b00665efa5e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-warehouse/default.nix
+++ b/distros/humble/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-warehouse";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_warehouse/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "8d401e92a7c86026fa4e6335c801712ea9c215f8f7d823154d34f095ed7cea54";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros_warehouse/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "5437fa522398c8a8459d60b2bb463d618443d4064e3650d571074d1d2f404679";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros/default.nix
+++ b/distros/humble/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "8caeb2efebbb1f2ef2de34af5896a8dae13f0ae7bd414287681feed8bc70ae74";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_ros/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "0b7e8210197480d267dc5493435a392dd4e482b260df35e9db0951d82a5de3ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-runtime/default.nix
+++ b/distros/humble/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-humble-moveit-runtime";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_runtime/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "7b059d5b47b6ab83be005cd805fbe2f4a13c5f2967d859b6957b1d11d5aa3c57";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_runtime/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "e090ce5ea53fc353d03028b4a70b347595d5a41eb25c2948e571a336e451ff87";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-servo/default.nix
+++ b/distros/humble/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-manager, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, pluginlib, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-servo";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_servo/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "04bb046e49aca0bafe10597b9fa9452135061d972dff180c037befacaa67c764";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_servo/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "8a93cca44bd902fddaff98dabe0b852b89e1ae20c29ca12a916a27bf8b6f3328";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-setup-app-plugins/default.nix
+++ b/distros/humble/moveit-setup-app-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-moveit-setup-app-plugins";
+  version = "2.5.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_setup_app_plugins/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "ee391b0aa2d4d2d008ea80ae90debb09f8dba9ee576c76758f064865ff691a1a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-clang-format ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ament-index-cpp moveit-ros-visualization moveit-setup-framework pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Various specialty plugins for MoveIt Setup Assistant'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/moveit-setup-assistant/default.nix
+++ b/distros/humble/moveit-setup-assistant/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, libyamlcpp, moveit-common, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ompl, rclcpp, srdfdom, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-moveit-setup-assistant";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_setup_assistant/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "c3891cd13211e189c94d49b7b27e91ebca0cd121e224bd6a82e92a377b32cb47";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_setup_assistant/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "8915504c987a66253c8d7ac19885cf0d77225feb34f8336e35b5daa59c310253";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ompl ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
-  propagatedBuildInputs = [ ament-index-cpp libyamlcpp moveit-common moveit-core moveit-ros-planning moveit-ros-visualization rclcpp srdfdom urdf xacro ];
+  checkInputs = [ ament-clang-format ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto moveit-resources-panda-moveit-config ];
+  propagatedBuildInputs = [ ament-index-cpp moveit-setup-app-plugins moveit-setup-controllers moveit-setup-core-plugins moveit-setup-framework moveit-setup-srdf-plugins pluginlib qt5.qtbase rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/moveit-setup-controllers/default.nix
+++ b/distros/humble/moveit-setup-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-moveit-setup-controllers";
+  version = "2.5.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_setup_controllers/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "d4955e14762f790dbe07fb40734db17f2459e26c7fb2d5b9fcc895ebe7d0c89d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-clang-format ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config ];
+  propagatedBuildInputs = [ ament-index-cpp moveit-setup-framework pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''MoveIt Setup Steps for ROS 2 Control'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/moveit-setup-core-plugins/default.nix
+++ b/distros/humble/moveit-setup-core-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
+buildRosPackage {
+  pname = "ros-humble-moveit-setup-core-plugins";
+  version = "2.5.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_setup_core_plugins/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "dd8016df735704d28b9980dfb1d27724a1fee8e1e0af8f2604073ec236a139fd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-clang-format ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ament-index-cpp moveit-ros-visualization moveit-setup-framework pluginlib rclcpp srdfdom urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Core (meta) plugins for MoveIt Setup Assistant'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/moveit-setup-framework/default.nix
+++ b/distros/humble/moveit-setup-framework/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
+buildRosPackage {
+  pname = "ros-humble-moveit-setup-framework";
+  version = "2.5.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_setup_framework/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "04e69c5e413723a78ad05495208ff721ac5a20ffbce7de7522336d5e51df0296";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-clang-format ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ament-index-cpp moveit-common moveit-core moveit-ros-planning moveit-ros-visualization pluginlib rclcpp rviz-common rviz-rendering srdfdom urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ Interface for defining setup steps for MoveIt Setup Assistant'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/moveit-setup-srdf-plugins/default.nix
+++ b/distros/humble/moveit-setup-srdf-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
+buildRosPackage {
+  pname = "ros-humble-moveit-setup-srdf-plugins";
+  version = "2.5.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_setup_srdf_plugins/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "b959f2e6e4862da8e9644bec81ac2879752c7b5a91276c8ad5a5bdfd1f00d94d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-clang-format ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto moveit-resources-fanuc-description ];
+  propagatedBuildInputs = [ moveit-setup-framework pluginlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''SRDF-based plugins for MoveIt Setup Assistant'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/moveit-simple-controller-manager/default.nix
+++ b/distros/humble/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-moveit-simple-controller-manager";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_simple_controller_manager/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "ee4bb51247a6c9a5438686dde915570e736dc2cb0b8491cabd8a66dc900b23ce";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit_simple_controller_manager/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "77d5bd40ae0d0473c4d19eb34dbb89763ed58e58d981925aa721f49ac59dc49f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit/default.nix
+++ b/distros/humble/moveit/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-humble-moveit";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "b996e559fec91607434904086d2d6f90c773301414d791593ae9a3959fa77367";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/moveit/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "cae406b4e1ee3fdf0c6836305fd26a0691dca832f0b94850a10d9da0f336ab79";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-core moveit-planners moveit-plugins moveit-ros ];
+  propagatedBuildInputs = [ moveit-core moveit-planners moveit-plugins moveit-ros moveit-setup-assistant ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/performance-test-fixture/default.nix
+++ b/distros/humble/performance-test-fixture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-export-targets, ament-cmake-google-benchmark, ament-cmake-test, ament-lint-auto, ament-lint-common, google-benchmark-vendor, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-humble-performance-test-fixture";
-  version = "0.0.8-r3";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/humble/performance_test_fixture/0.0.8-3.tar.gz";
-    name = "0.0.8-3.tar.gz";
-    sha256 = "48d526251f1ff9ba20dd10d885d7cc92731708990ec7259767661e28f0fe1f0a";
+    url = "https://github.com/ros2-gbp/performance_test_fixture-release/archive/release/humble/performance_test_fixture/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "ea1d573bd815dd78bfeade5ea6c7665cd7a3ce7d6f2c531c8f61abe0baf3db86";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/humble/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-humble-pilz-industrial-motion-planner-testutils";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/pilz_industrial_motion_planner_testutils/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "292943ba1f5726b8e9d6a5a145f897c7395e58f644220f98ab328d1d840f615c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/pilz_industrial_motion_planner_testutils/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "7c5a90d20e1697504fef3951ced7779bae8306ea83381a9618ba5d08edcf31b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pilz-industrial-motion-planner/default.nix
+++ b/distros/humble/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-pilz-industrial-motion-planner";
-  version = "2.5.1-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/humble/pilz_industrial_motion_planner/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "2fedfcbfbb4797ae1ea24a06356df0e7a0ed977d032ec93dc3877799659204f6";
+    url = "https://github.com/moveit/moveit2-release/archive/release/humble/pilz_industrial_motion_planner/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "7142e95c34b104a37c9ac45965fc68ffccdb10476d8d967a7538382bceb7051b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.5.0-r1";
+  version = "3.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "00dbc8be0f111b5945f2bca06562d5e560045a7d8cb4550c4daa6dc7f91c3410";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.5.1-1.tar.gz";
+    name = "3.5.1-1.tar.gz";
+    sha256 = "bcc9232806caaa4729171b1243bb4d7aa7568e29ccc37fc5606e87f772902747";
   };
 
   buildType = "ament_cmake";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''PlotJuggler: juggle with data'';
-    license = with lib.licenses; [ lgpl3Only ];
+    license = with lib.licenses; [ mpl20 ];
   };
 }

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/rosbag2_storage_mcap/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "b54e022827b83571789b425454f228cb6071126903863110e8aaa05818e73255";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/rosbag2_storage_mcap/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "7cb1cc93ea8a603e82d46ba99b03addf450115428bdf26fcf3c6483013e4fed1";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/costmap-cspace-rviz-plugins/default.nix
+++ b/distros/melodic/costmap-cspace-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, qt5, roscpp, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-melodic-costmap-cspace-rviz-plugins";
+  version = "0.11.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/costmap_cspace_rviz_plugins/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "bcd73822b9dd77d03b425ddad5918adea6d64ac3e9b7bbe8f4605ef9048af760";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ costmap-cspace-msgs qt5.qtbase roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rviz plugins for costmap_cspace_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.7-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.7-1.tar.gz";
-    name = "2.7.7-1.tar.gz";
-    sha256 = "527591d8fc3c0c759a54e72db95fab3ce9d10e53701ee72ff086819d53c760cb";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "58be02613eb996296b1c554f183355e187df7c99c851904bf064bfe9aad41ef4";
   };
 
   buildType = "cmake";

--- a/distros/melodic/executive-smach-visualization/default.nix
+++ b/distros/melodic/executive-smach-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach-viewer }:
 buildRosPackage {
   pname = "ros-melodic-executive-smach-visualization";
-  version = "3.0.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/executive_smach_visualization/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ee755a0a534f5e577f3b6bd6a5af3eb30a8056f2e2a7544d0cf50455ad60a73a";
+    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/executive_smach_visualization/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "f72a55befe9ec51a6bee5dcbc14ce19af04fb88ecf524a39d98df1742e4cde37";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -602,6 +602,8 @@ self: super: {
 
  costmap-cspace-msgs = self.callPackage ./costmap-cspace-msgs {};
 
+ costmap-cspace-rviz-plugins = self.callPackage ./costmap-cspace-rviz-plugins {};
+
  costmap-queue = self.callPackage ./costmap-queue {};
 
  costmap-tf-layer = self.callPackage ./costmap-tf-layer {};
@@ -2001,6 +2003,8 @@ self: super: {
  log-view = self.callPackage ./log-view {};
 
  lpg-planner = self.callPackage ./lpg-planner {};
+
+ lsc-ros-driver = self.callPackage ./lsc-ros-driver {};
 
  lusb = self.callPackage ./lusb {};
 

--- a/distros/melodic/lsc-ros-driver/default.nix
+++ b/distros/melodic/lsc-ros-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, self-test, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-lsc-ros-driver";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release/archive/release/melodic/lsc_ros_driver/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "32a1896f2074ea84a3cd92299deabc1e3303ec42744cd6a2c6064c857ed52e12";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ diagnostic-updater self-test ];
+  propagatedBuildInputs = [ roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS driver package for LSC-C Series'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/neonavigation-rviz-plugins/default.nix
+++ b/distros/melodic/neonavigation-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-rviz-plugins";
-  version = "0.3.1-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/neonavigation_rviz_plugins/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "efbd6174a16e29df8e466ced2540eec708abe8686309344b04114587a28de764";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/neonavigation_rviz_plugins/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "79c1f10964f90287b135a6ffaf4b990828625d5f68ed97e4d8ec7773b2c8832e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.5.0-r1";
+  version = "3.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "b0436fcfbf375334b35ac5e009a2cd3cb10f586c25f8bc9032391cca8b918899";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.5.1-2.tar.gz";
+    name = "3.5.1-2.tar.gz";
+    sha256 = "c915ebe101c59b3d2426b480dc8bcbf8cc6ff6929c0c5dd5bc67eb71adc50534";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''PlotJuggler: juggle with data'';
-    license = with lib.licenses; [ lgpl3Only ];
+    license = with lib.licenses; [ mpl20 ];
   };
 }

--- a/distros/melodic/smach-viewer/default.nix
+++ b/distros/melodic/smach-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, graphviz, gtk3, pythonPackages, rostest, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-smach-viewer";
-  version = "3.0.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/smach_viewer/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "3c1e52156a43502a70f04507cac74ffc2c97193edf6a303728baad68e08bf00b";
+    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/smach_viewer/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "68cc752215169fa316ad09f15ee2f0afcb3d480ddfdc4b8ab5855f6722925aa7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker-rviz-plugins/default.nix
+++ b/distros/melodic/trajectory-tracker-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rviz, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker-rviz-plugins";
-  version = "0.3.1-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/trajectory_tracker_rviz_plugins/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "88610d9daa40e3d207bbfb52ef01f29b097544c6ab33557caad96f9eae15c273";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/trajectory_tracker_rviz_plugins/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "644e1c112888474dc2bee1a80c94dfa76798cfeca77fad982e691b88088d220d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace-rviz-plugins/default.nix
+++ b/distros/noetic/costmap-cspace-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, qt5, roscpp, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-costmap-cspace-rviz-plugins";
+  version = "0.11.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/costmap_cspace_rviz_plugins/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "6c2f6975ca322e23f1254669e5744fffdebe59cefbca478728e34cb73f4b2dce";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ costmap-cspace-msgs qt5.qtbase roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rviz plugins for costmap_cspace_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.7-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.7-1.tar.gz";
-    name = "2.7.7-1.tar.gz";
-    sha256 = "171f78bdac72ab9e7da8dfad5638669d7ceae4cfcd4e7a8db5e59b84b014f5c8";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "6d3446c492c75bebed54a39833b2cbb6da51357aa564863fc07eed2437130301";
   };
 
   buildType = "cmake";

--- a/distros/noetic/executive-smach-visualization/default.nix
+++ b/distros/noetic/executive-smach-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach-viewer }:
 buildRosPackage {
   pname = "ros-noetic-executive-smach-visualization";
-  version = "3.0.1-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/noetic/executive_smach_visualization/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "7f467c3aeb0f2d0b13e3b216c8e61a4c63307ef7c4e93d58fdb35bd020394ec6";
+    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/noetic/executive_smach_visualization/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "e51d31da1fdaa1406fdd97da0ff022caa5e69f0fc2cc792ec40a6967e0be37a5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -482,6 +482,8 @@ self: super: {
 
  costmap-cspace-msgs = self.callPackage ./costmap-cspace-msgs {};
 
+ costmap-cspace-rviz-plugins = self.callPackage ./costmap-cspace-rviz-plugins {};
+
  costmap-queue = self.callPackage ./costmap-queue {};
 
  cpp-common = self.callPackage ./cpp-common {};

--- a/distros/noetic/neonavigation-rviz-plugins/default.nix
+++ b/distros/noetic/neonavigation-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-rviz-plugins";
-  version = "0.3.1-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/neonavigation_rviz_plugins/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "3f2df4ea596e0f1a3c4660efd924e969b7d255c4f1190ab8bda0b91e1f3fb8f4";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/neonavigation_rviz_plugins/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "effd352b1933ebc8ec68464755b7be27b2e701f36bfa13b1d4afe44bc12c81e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.5.0-r1";
+  version = "3.5.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "353b5412b138cab459ec9039fe6a2e501393fb03a62f4e64f0430ec7a8fa9a28";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.5.1-3.tar.gz";
+    name = "3.5.1-3.tar.gz";
+    sha256 = "644d421ca13b7120f0d8b370546411a326a2b308d8ef37f9f7e604e65adb314c";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''PlotJuggler: juggle with data'';
-    license = with lib.licenses; [ lgpl3Only ];
+    license = with lib.licenses; [ mpl20 ];
   };
 }

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
-  version = "2.7.3-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.3-1.tar.gz";
-    name = "2.7.3-1.tar.gz";
-    sha256 = "8698f935ea320a63e0e4c8ec45938e6d7ee2067b163dcda0fd0c67bb9d2e4b60";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "6518a9a73a1c4e5046366b74aa9c0f586089535676b4a644085c633ec6447431";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation python3Packages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ angles cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/smach-viewer/default.nix
+++ b/distros/noetic/smach-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, graphviz, gtk3, pythonPackages, rostest, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-noetic-smach-viewer";
-  version = "3.0.1-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/noetic/smach_viewer/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "a95f02adf13d5498bd088ccbd370fb31eb2fefaaf8dfe8ef702c74385beec500";
+    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/noetic/smach_viewer/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "9278df7babf2e3ccb008f0dd7e3bbfc858dc5891441be80136932a34e37e388e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker-rviz-plugins/default.nix
+++ b/distros/noetic/trajectory-tracker-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rviz, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker-rviz-plugins";
-  version = "0.3.1-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/trajectory_tracker_rviz_plugins/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "b1c054a77f6707ace27435bc0659f4a7ac799fcef55e45de8f5fd0dfea8697d9";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/trajectory_tracker_rviz_plugins/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "74cefaa38f778b4300bc792456ff65dfc5741afa6a8a6d5aee8d56a75591107b";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit cc4692525681a554690f350df2f4273d7cf242f1.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *action-tutorials-cpp 0.9.3-r1 --> 0.9.4-r1*
* *action-tutorials-interfaces 0.9.3-r1 --> 0.9.4-r1*
* *action-tutorials-py 0.9.3-r1 --> 0.9.4-r1*
* *ament-clang-format 0.9.6-r1 --> 0.9.7-r1*
* *ament-clang-tidy 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-auto 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-clang-format 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-clang-tidy 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-copyright 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-core 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-cppcheck 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-cpplint 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-export-definitions 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-export-dependencies 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-export-include-directories 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-export-interfaces 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-export-libraries 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-export-link-flags 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-export-targets 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-flake8 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-gmock 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-google-benchmark 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-gtest 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-include-directories 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-libraries 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-lint-cmake 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-mypy 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-nose 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-pclint 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-pep257 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-pycodestyle 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-pyflakes 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-pytest 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-python 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-target-dependencies 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-test 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-uncrustify 0.9.6-r1 --> 0.9.7-r1*
* *ament-cmake-version 0.9.9-r1 --> 0.9.10-r1*
* *ament-cmake-xmllint 0.9.6-r1 --> 0.9.7-r1*
* *ament-copyright 0.9.6-r1 --> 0.9.7-r1*
* *ament-cppcheck 0.9.6-r1 --> 0.9.7-r1*
* *ament-cpplint 0.9.6-r1 --> 0.9.7-r1*
* *ament-flake8 0.9.6-r1 --> 0.9.7-r1*
* *ament-lint 0.9.6-r1 --> 0.9.7-r1*
* *ament-lint-auto 0.9.6-r1 --> 0.9.7-r1*
* *ament-lint-cmake 0.9.6-r1 --> 0.9.7-r1*
* *ament-lint-common 0.9.6-r1 --> 0.9.7-r1*
* *ament-mypy 0.9.6-r1 --> 0.9.7-r1*
* *ament-pclint 0.9.6-r1 --> 0.9.7-r1*
* *ament-pep257 0.9.6-r1 --> 0.9.7-r1*
* *ament-pycodestyle 0.9.6-r1 --> 0.9.7-r1*
* *ament-pyflakes 0.9.6-r1 --> 0.9.7-r1*
* *ament-uncrustify 0.9.6-r1 --> 0.9.7-r1*
* *ament-xmllint 0.9.6-r1 --> 0.9.7-r1*
* *class-loader 2.0.2-r1 --> 2.0.3-r1*
* *composition 0.9.3-r1 --> 0.9.4-r1*
* *demo-nodes-cpp 0.9.3-r1 --> 0.9.4-r1*
* *demo-nodes-cpp-native 0.9.3-r1 --> 0.9.4-r1*
* *demo-nodes-py 0.9.3-r1 --> 0.9.4-r1*
* *dummy-map-server 0.9.3-r1 --> 0.9.4-r1*
* *dummy-robot-bringup 0.9.3-r1 --> 0.9.4-r1*
* *dummy-sensors 0.9.3-r1 --> 0.9.4-r1*
* *eigenpy 2.7.7-r1 --> 2.7.10-r1*
* *image-tools 0.9.3-r1 --> 0.9.4-r1*
* *intra-process-demo 0.9.3-r1 --> 0.9.4-r1*
* *lifecycle 0.9.3-r1 --> 0.9.4-r1*
* *logging-demo 0.9.3-r1 --> 0.9.4-r1*
* *maliput 1.0.4-r1 --> 1.0.5-r1*
* *maliput-integration 0.1.0-r1 --> 0.1.1-r1*
* *maliput-py 0.1.1-r1 --> 0.1.2-r1*
* *mcap-vendor 0.1.5-r1 --> 0.1.6-r1*
* *orocos-kdl 3.3.2-r1 --> 3.3.4-r1*
* *pendulum-control 0.9.3-r1 --> 0.9.4-r1*
* *pendulum-msgs 0.9.3-r1 --> 0.9.4-r1*
* *performance-test-fixture 0.0.8-r1 --> 0.0.9-r1*
* *plotjuggler 3.5.0-r1 --> 3.5.1-r1*
* *quality-of-service-demo-cpp 0.9.3-r1 --> 0.9.4-r1*
* *quality-of-service-demo-py 0.9.3-r1 --> 0.9.4-r1*
* *raspimouse 1.0.2-r1 --> 1.1.0-r4*
* *raspimouse-msgs 1.0.2-r1 --> 1.1.0-r4*
* *rcl 1.1.13-r1 --> 1.1.14-r1*
* *rcl-action 1.1.13-r1 --> 1.1.14-r1*
* *rcl-lifecycle 1.1.13-r1 --> 1.1.14-r1*
* *rcl-yaml-param-parser 1.1.13-r1 --> 1.1.14-r1*
* *rclcpp 2.4.1-r1 --> 2.4.2-r1*
* *rclcpp-action 2.4.1-r1 --> 2.4.2-r1*
* *rclcpp-components 2.4.1-r1 --> 2.4.2-r1*
* *rclcpp-lifecycle 2.4.1-r1 --> 2.4.2-r1*
* *rcutils 1.1.3-r1 --> 1.1.4-r1*
* *rmw-cyclonedds-cpp 0.7.8-r1 --> 0.7.9-r1*
* *rmw-fastrtps-cpp 1.3.0-r1 --> 1.3.1-r1*
* *rmw-fastrtps-dynamic-cpp 1.3.0-r1 --> 1.3.1-r1*
* *rmw-fastrtps-shared-cpp 1.3.0-r1 --> 1.3.1-r1*
* *ros-environment 2.5.0-r1 --> 2.5.1-r1*
* *rosbag2-storage-mcap 0.1.5-r1 --> 0.1.6-r1*
* *rosidl-generator-py 0.9.5-r1 --> 0.9.6-r1*
* *topic-monitor 0.9.3-r1 --> 0.9.4-r1*
* *turtlesim 1.2.5-r1 --> 1.2.6-r1*

Galactic Changes:
-----------------
* *eigenpy 2.7.7-r1 --> 2.7.10-r1*
* *hpp-fcl 2.1.1-r1*
* *mcap-vendor 0.1.5-r1 --> 0.1.6-r1*
* *orocos-kdl 3.3.3-r2 --> 3.4.0-r1*
* *performance-test-fixture 0.0.8-r1 --> 0.0.9-r1*
* *plotjuggler 3.5.0-r1 --> 3.5.1-r1*
* *rosbag2-storage-mcap 0.1.5-r1 --> 0.1.6-r1*
* *rosidl-generator-py 0.11.2-r1 --> 0.11.3-r1*

Humble Changes:
---------------
* *chomp-motion-planner 2.5.1-r1 --> 2.5.3-r1*
* *eigenpy 2.7.7-r1 --> 2.7.10-r1*
* *hpp-fcl 2.1.1-r1*
* *mcap-vendor 0.1.5-r1 --> 0.1.6-r1*
* *moveit 2.5.1-r1 --> 2.5.3-r1*
* *moveit-chomp-optimizer-adapter 2.5.1-r1 --> 2.5.3-r1*
* *moveit-common 2.5.1-r1 --> 2.5.3-r1*
* *moveit-configs-utils 2.5.1-r1 --> 2.5.3-r1*
* *moveit-core 2.5.1-r1 --> 2.5.3-r1*
* *moveit-hybrid-planning 2.5.1-r1 --> 2.5.3-r1*
* *moveit-kinematics 2.5.1-r1 --> 2.5.3-r1*
* *moveit-planners 2.5.1-r1 --> 2.5.3-r1*
* *moveit-planners-chomp 2.5.1-r1 --> 2.5.3-r1*
* *moveit-planners-ompl 2.5.1-r1 --> 2.5.3-r1*
* *moveit-plugins 2.5.1-r1 --> 2.5.3-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.5.1-r1 --> 2.5.3-r1*
* *moveit-resources-prbt-moveit-config 2.5.1-r1 --> 2.5.3-r1*
* *moveit-resources-prbt-pg70-support 2.5.1-r1 --> 2.5.3-r1*
* *moveit-resources-prbt-support 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-benchmarks 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-control-interface 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-move-group 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-occupancy-map-monitor 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-perception 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-planning 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-planning-interface 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-robot-interaction 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-visualization 2.5.1-r1 --> 2.5.3-r1*
* *moveit-ros-warehouse 2.5.1-r1 --> 2.5.3-r1*
* *moveit-runtime 2.5.1-r1 --> 2.5.3-r1*
* *moveit-servo 2.5.1-r1 --> 2.5.3-r1*
* *moveit-setup-app-plugins 2.5.3-r1*
* *moveit-setup-assistant 2.5.1-r1 --> 2.5.3-r1*
* *moveit-setup-controllers 2.5.3-r1*
* *moveit-setup-core-plugins 2.5.3-r1*
* *moveit-setup-framework 2.5.3-r1*
* *moveit-setup-srdf-plugins 2.5.3-r1*
* *moveit-simple-controller-manager 2.5.1-r1 --> 2.5.3-r1*
* *performance-test-fixture 0.0.8-r3 --> 0.0.9-r1*
* *pilz-industrial-motion-planner 2.5.1-r1 --> 2.5.3-r1*
* *pilz-industrial-motion-planner-testutils 2.5.1-r1 --> 2.5.3-r1*
* *plotjuggler 3.5.0-r1 --> 3.5.1-r1*
* *rosbag2-storage-mcap 0.1.5-r1 --> 0.1.6-r1*

Melodic Changes:
----------------
* *costmap-cspace-rviz-plugins 0.11.6-r1*
* *eigenpy 2.7.7-r1 --> 2.7.10-r1*
* *executive-smach-visualization 3.0.0-r1 --> 4.0.0-r1*
* *lsc-ros-driver 1.0.2-r1*
* *neonavigation-rviz-plugins 0.3.1-r1 --> 0.11.6-r1*
* *plotjuggler 3.5.0-r1 --> 3.5.1-r2*
* *smach-viewer 3.0.0-r1 --> 4.0.0-r1*
* *trajectory-tracker-rviz-plugins 0.3.1-r1 --> 0.11.6-r1*

Noetic Changes:
---------------
* *costmap-cspace-rviz-plugins 0.11.6-r1*
* *eigenpy 2.7.7-r1 --> 2.7.10-r1*
* *executive-smach-visualization 3.0.1-r1 --> 4.0.0-r1*
* *neonavigation-rviz-plugins 0.3.1-r1 --> 0.11.6-r1*
* *plotjuggler 3.5.0-r1 --> 3.5.1-r3*
* *robot-localization 2.7.3-r1 --> 2.7.4-r1*
* *smach-viewer 3.0.1-r1 --> 4.0.0-r1*
* *trajectory-tracker-rviz-plugins 0.3.1-r1 --> 0.11.6-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-pytest-timeout
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-websocket
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

