### PR TITLE
Fix humble packages for darwin platform and add turtlesim example

### DIFF
--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1200,6 +1200,8 @@ self: super: {
 
  ros2bag = self.callPackage ./ros2bag {};
 
+ ros2cli = self.callPackage ./ros2cli {};
+
  ros2cli-common-extensions = self.callPackage ./ros2cli-common-extensions {};
 
  ros2cli-test-interfaces = self.callPackage ./ros2cli-test-interfaces {};
@@ -1215,6 +1217,10 @@ self: super: {
  ros2lifecycle-test-fixtures = self.callPackage ./ros2lifecycle-test-fixtures {};
 
  ros2nodl = self.callPackage ./ros2nodl {};
+
+ ros2pkg = self.callPackage ./ros2pkg {};
+
+ ros2run = self.callPackage ./ros2run {};
 
  ros2test = self.callPackage ./ros2test {};
 

--- a/distros/humble/iceoryx-hoofs/default.nix
+++ b/distros/humble/iceoryx-hoofs/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, acl, cmake }:
+{ lib, stdenv, buildRosPackage, fetchurl, acl, cmake }:
 buildRosPackage {
   pname = "ros-humble-iceoryx-hoofs";
   version = "2.0.2-r3";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ acl ];
+  propagatedBuildInputs = lib.optional stdenv.isLinux [ acl ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/ros2cli/default.nix
+++ b/distros/humble/ros2cli/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2cli";
+  version = "0.18.3-2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "sha256-RVAlK9cWw2Koq4xDp/Iqw4H+sf2XJ4Gn8/1v6WhZodA=";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest test-msgs ];
+  propagatedBuildInputs = [ python3Packages.argcomplete python3Packages.importlib-metadata python3Packages.netifaces python3Packages.packaging python3Packages.setuptools rclpy ];
+
+  meta = {
+    description = ''Framework for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2pkg/default.nix
+++ b/distros/humble/ros2pkg/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros-testing, ros2cli }:
+buildRosPackage {
+  pname = "ros-humble-ros2pkg";
+  version = "0.18.3-2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "sha256-6z6YJm9lQ7nabPbePoCcsG3XYolgHxTARczcit4tpWw=";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ros-testing ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.catkin-pkg python3Packages.empy python3Packages.importlib-resources python3Packages.setuptools ros2cli ];
+
+  meta = {
+    description = ''The pkg command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2run/default.nix
+++ b/distros/humble/ros2run/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
+buildRosPackage {
+  pname = "ros-humble-ros2run";
+  version = "0.18.3-2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "sha256-kNJstd3RD5c45thB4/B00XFxsJheXvQ/lYZLieUloEw=";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ ros2cli ros2pkg ];
+
+  meta = {
+    description = ''The run command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/examples/turtlesim.nix
+++ b/examples/turtlesim.nix
@@ -1,0 +1,21 @@
+let
+    pkgs = import <nixpkgs> { overlays = [ (import ../overlay.nix) ]; };
+
+in
+
+    pkgs.mkShell {
+        nativeBuildInputs = with pkgs.rosPackages.humble; [
+            (buildEnv {
+                paths = [
+                    turtlesim
+                    ros2run
+                ];
+            })
+        ];
+
+        shellHook = ''
+            echo 'Welcome to turtlesim example, please run following commands it two shells:'
+            echo '  ros2 run turtlesim turtlesim_node'
+            echo '  ros2 run turtlesim turtle_teleop_key'
+        '';
+    }


### PR DESCRIPTION
Trying to use this overlay in darwin, and found some missing packages for `humble` distro: `ros2pkg`, `ros2cli`, `ros2run` (but it seems that I added them wrong - according to README.md they autogenerated, but I didn't understand how to add this packages to autogenerator).

Also I've added most simple turtlesim example so people can quickly check if everything works fine.