### PR TITLE
rosdistro sync, Fri Aug 12 14:45:56 2022

### DIFF
--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "414e2e84c320397867e3cc8c8a00f92360cd9a478ce7b005ca4b123654377220";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "03dc7edc25cb6a65dbe5d612813c527bbe40be83e41ff3eba422762b4ab2f177";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "06f238af7bfe03c95e09e85af394d7bdd333eb69e7ff1eae3f4b21085d158963";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "352bc1691a1bee337ebd71a29b937780a7790ca111e28f1006cb79d14410d881";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "460b0bbef845782a4c22abd9c97bdb2b8b0317f505f6ed2bfd1c2d70f1aa306a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "0add7e3275e2a73878493d6ec1cf2c85aa92669018ddfdee29b03665d3509ebd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "fde6a805cbf012bd7418dbc17c136f94a2d420ff6ae0c0a1ae4fa1f74a472978";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "664e0dcde3649c1d2c6143f2a55fd53b4413dbe1054f00ccc9c24992be6cba8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "b02c889e98f4539ad4205b1cbfdd91a20ff76f105c9770cdf691dbd8a91c23ac";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "66ee583204a554bd268153d46d95a11721b4fb74112d6d59fa1bd0bd13fdbc53";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.10-r1";
+  version = "2.7.10-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.10-1.tar.gz";
-    name = "2.7.10-1.tar.gz";
-    sha256 = "ba266a1a0cb6ee60975437edc781005cde747848f297c3b73157842534203f5f";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.10-2.tar.gz";
+    name = "2.7.10-2.tar.gz";
+    sha256 = "07ba722a7df61bc5814f9e837b08da0924e541f006d4683aa22c460c40704cb9";
   };
 
   buildType = "cmake";

--- a/distros/foxy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/foxy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-force-torque-sensor-broadcaster";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "49173033d195f4962a0b4b68faabfa41bcfbcc264d77c939929a3bebafcb805b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "276c06c81185dc4adc7ef82117e1081d4e2f29c5ff2deef679937dde598201c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "75413c24ffd5bcb853f581574387a04b22e12e1953e6a541690b3ecdca8b6071";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "b9354aea0004d2b2eef00fdacc63914a5d57e55280180e7f64f5f579ed70a6d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gripper-controllers/default.nix
+++ b/distros/foxy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-gripper-controllers";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "c2035cb2279782b493daafa840b3f5d00cc6c454620556f2d1d54568b257d376";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "25727bffe6f4a4e3880170699d3be80860aefad82cf2acd91c8fdd88ddaf22ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "a03e180f5f997d323b9d2ed9ccb85c51859ef4e7739db86b2240ff94055f6cd3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "529e5b4fc4ac3552187eeab903b980bc3798162b0a832821d9b90979af56221b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-sensor-broadcaster/default.nix
+++ b/distros/foxy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-sensor-broadcaster";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "d8ee09f55daa9aeaf9e5b8f81cc6d41128ca860f8b5043af7178e10009e5ab4d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "de5ffdaf72aa79b906069892ad4ba6bce748c4c6488a643b7825be0978cbee5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-broadcaster";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "137c5a34a77307220b625103279083033cf80da05e6973038793f0ccaee02f2b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "be98c862cba435259bbb249d8b5e535070cfd6db54079e462b930cf6f7bb0185";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "a524a9d7e94f9a2fe1e244014b00f9c1558174982d1c8cda7cda78a88bb5f4ee";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "19dc1fa4e88aca682ce49835c63d7cff7acd43d60e259bac3c027e328125d528";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "b659ba9f52b16797229602a84270cd4039479f947f5989e290e08b005c40a6c5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "e8dff5c5c72264a84aee04109c732be6f72db60d96f0c96eab11ba83bc6f931f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
 buildRosPackage {
   pname = "ros-foxy-maliput-multilane";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "bbb58467ea2752e8ddea5494fdc03fef593e0327761740cbc9971bce1d5081f7";
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "92216df5931c058328c520ebe596eb07fbe8d6b45f9c43f5d7c3c4a537e2da7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2022.3.3-r1";
+  version = "2022.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2022.3.3-1.tar.gz";
-    name = "2022.3.3-1.tar.gz";
-    sha256 = "2206076e39973e5c844dd5dc7f1c38da3c8aec2f5f96511cb0bea63618f21ad6";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2022.8.8-1.tar.gz";
+    name = "2022.8.8-1.tar.gz";
+    sha256 = "602d24f02f95d35e23623a42b7c2b651adafd84002bcbf1fd3c025591e98f559";
   };
 
   buildType = "cmake";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "357cac3cc9e3db8e2249559d5f0030717c28ac6f3fcb8f23de7ab3f0cdcb05ba";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "68dc9674e5a69acfc35eac6484e0e56ab4c227e052b04dbce651cbcb836ff677";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ab208f879c5fb74a22b272ee1f290aa665ba264579019e71790efea1373aad99";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "71bebb911ae84b16542e2a08a514dfe0f0125ed122942256c0b968397b8abd9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/r2r-spl-7/default.nix
+++ b/distros/foxy/r2r-spl-7/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, splsm-7-conversion }:
 buildRosPackage {
   pname = "ros-foxy-r2r-spl-7";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/r2r_spl_7/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "c2348077462eff96b3e9976066da446704e1df6879e492f8e9856685809a0920";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/r2r_spl_7/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "5c6bcfdea32ca4f932d3368007c266a821538565faf6d1f79e1e4ff7790ee0a4";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros-workspace/default.nix
+++ b/distros/foxy/ros-workspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-package, cmake }:
 buildRosPackage {
   pname = "ros-foxy-ros-workspace";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_workspace-release/archive/release/foxy/ros_workspace/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "decafbf4c498c03d4a8f711413674c575af456e008c4f2fc8790618b1492cd40";
+    url = "https://github.com/ros2-gbp/ros_workspace-release/archive/release/foxy/ros_workspace/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "e3797244bf456109aa2752c797d1f45d2875c576631cfa6291bc66a29abcc652";
   };
 
   buildType = "cmake";

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "4ac5f81cb2cca4d9f83e2d1524144bc6d0dfdcdf0befbde99532abdf3e516ff9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "dd351b46efaf5ef394378704c9a16e77e27b3bff5a8c76018793b663536286ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "791201d2e8959243666451b08b3995b7309615ea85067e0fb79e8b2d0caa0b0a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "a07f274f21a59b7bcf2376f2b0f2296c00242734b4bb384a8aa6f7654e2c59e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "7599b8ea8818f0b6682890f488c8bec758df6f4c990a488969fbd25bad8e55e4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "047e243bf5d2db2a195d7352f9ea44c21fb8c0816d69735721edd22fba680008";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "9f4fcd90c60d5d8cc196920b4c771478b445cae6bde0ac789325cfaa4420a4a5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "38ecf5735292de1b8762bc851d355735873807a159e895a32c612e4bdf059908";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-publisher/default.nix
+++ b/distros/foxy/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-publisher";
-  version = "1.1.3-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "87e69813d50f6ef700d02075257d47b712f3ecf26d8abc2257786f1a461308ea";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "df8496cf5bca3a68c09c2375d4708df96f422b6ef03497eceaa085f68caf64b0";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/splsm-7-conversion/default.nix
+++ b/distros/foxy/splsm-7-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, splsm-7 }:
 buildRosPackage {
   pname = "ros-foxy-splsm-7-conversion";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/splsm_7_conversion/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "647f7ebe1e0192a54fb31c3f25c492fb47331a4e9d57a268fe536547687d43fd";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/splsm_7_conversion/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "1c64923a9353dec5e25355f67abeb5be4214aaa7aea09fd820a18aefff2a839e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/splsm-7/default.nix
+++ b/distros/foxy/splsm-7/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-splsm-7";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/splsm_7/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "9a9f8090ce847e013a4e4cf3763b84a2abca6ff033c78e59d2a5752ed3a9f611";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/foxy/splsm_7/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "1d317dfd35dab465b9c0c49c98d1a5c18eb14e7972207f0fe7b11d6c50ae6dde";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.10.1-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.10.1-1.tar.gz";
-    name = "0.10.1-1.tar.gz";
-    sha256 = "c37764664e18faba91ce89c46dd502736e732d5495da1faf1b7485de9ad07ede";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "67b06775276e270b5b8aca63582f05daf3a5aa7d1ebf6e4d8b84000927193931";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-bringup/default.nix
+++ b/distros/foxy/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, controller-manager, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, moveit-ros-move-group, moveit-simple-controller-manager, robot-state-publisher, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-bringup";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_bringup/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "e70163dce9e7974137f91459f542ceaf7f670a13ad7e4b1b41c27cea99b24c7a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_bringup/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "abb4c199aa880f10d34ac99a798c60bc0e3c232f1dc775bbc2df75a8798e08be";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-controllers/default.nix
+++ b/distros/foxy/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ur-controllers";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_controllers/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "67b2398dda46eb9e32ecda788cf65efc559e43534849a22ad32161246f3b64cf";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_controllers/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "504e4388ae67a2b0c2e973b8612cd06c6c0e9d63b80234ca93133f9829414ac1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-dashboard-msgs/default.nix
+++ b/distros/foxy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-ur-dashboard-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_dashboard_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8f8322e2c48bd8d7be981d119b0dc52783cdfe4a562b2caf02e81001c6859e86";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_dashboard_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "26d405770c4d0dc9c24a19672b8eb4be60c5432e309dd5eb425e1311f7ccfab5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-description/default.nix
+++ b/distros/foxy/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, launch, launch-ros, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9f1d52bce3d024f6fdfc54a9a33151fabf820ef2cfe5c453355dfeabc079f855";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_description/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "164e84cc2c3bf21047765f0b08c9482f779e7e9d92dc4b18263798edd4f78528";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-moveit-config/default.nix
+++ b/distros/foxy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-kinematics, moveit-planners-ompl, moveit-ros-visualization, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-moveit-config";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_moveit_config/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "571964e3b94d01486f041aeb45faf7963b653c629a3177df49c2fa361ac1816d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_moveit_config/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "657a1bb747f891bb180aeb4fb01b87b642d859f19aeb517ec9f70ef1710eb29d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-robot-driver/default.nix
+++ b/distros/foxy/ur-robot-driver/default.nix
@@ -5,16 +5,16 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, rclpy, std-msgs, std-srvs, ur-bringup, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ur-robot-driver";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_robot_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "ef2983d39583f206c6c2ecede5dab1b71da7a78d62f3cdaab8f6571cd7255a26";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_robot_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "41eaa6477f3c1c3e709b144f5f4febe3cc5a5c5c669d91fb55109b6ebfbe37f3";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ launch-testing-ament-cmake rclpy ];
+  checkInputs = [ launch-testing-ament-cmake rclpy ur-bringup ];
   propagatedBuildInputs = [ controller-manager controller-manager-msgs geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle std-msgs std-srvs ur-bringup ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "48ccf1d9b71c07449f425987f6ad2e69322b6483a8a364cc2ae892d8542a8447";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "346038de94dda66ae6fd5ce2c7260885e53a9b679ebbaf408a43b108bc194c31";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-controller-interface";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "b4c98658281cbb15eb5b942bd7ce07f6f1a7069581b5f31788053861e40dc1a8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "389d34fe4f539410ff0a8e7ec8d19f3614cf6215d80d984f48afc64a1d990508";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager-msgs";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "26e7fa510f6b3f8e75cd8f362d13d697de6bf0fce2a57e63eb6d5a846bb1986e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "25e23e15eccd25cbcd0278bc9c39fa244a78c87d1ee428927531439a4923044f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-controller-manager";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "5f9a5fed6d87a872ade6947a43e1f24ce38deebfac0ad18eefbbbbf7ce32a631";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "6f654dc85ad886626ea8ee6f80046883f7ff71c3c2431ba49088099d4caebe76";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diff-drive-controller/default.nix
+++ b/distros/galactic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diff-drive-controller";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "6423626416240b411c4d96034673bda119fbd4757678314b41ad20825de54fd0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9e6f316e4de95329d9180b54ab6011350e2734810d7fe61d9d6ff564b46215f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/effort-controllers/default.nix
+++ b/distros/galactic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-effort-controllers";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "0b8d85be7c90e42982ec128f81f50696d0f83ab0627820ab47dec301df6b7ed0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ad9c53e726e45133b4b9609cf19d2b8672f6f40b1fe42e6cb38d01f64303f657";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/eigenpy/default.nix
+++ b/distros/galactic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-eigenpy";
-  version = "2.7.10-r1";
+  version = "2.7.10-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.10-1.tar.gz";
-    name = "2.7.10-1.tar.gz";
-    sha256 = "c62dc03f1886b6dbc17712e7eb4c57cb3b54beb2a28892df4bd3e6176cc90b0c";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.10-2.tar.gz";
+    name = "2.7.10-2.tar.gz";
+    sha256 = "48edca79168f111e2855d32e4b11805eafedae309c3ea7bd5909c6b12bd1a6c3";
   };
 
   buildType = "cmake";

--- a/distros/galactic/force-torque-sensor-broadcaster/default.nix
+++ b/distros/galactic/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-force-torque-sensor-broadcaster";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2e9cf0ad9dffac4b96f7314948f6e4a3f140aabde97a9949118aa476143815ca";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "1a55023eb252e8b1c4f095e3aa2ac82fa828dacaff598d553be0a466246deb09";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/forward-command-controller/default.nix
+++ b/distros/galactic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-forward-command-controller";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "8137050c5416328fb968d82397ebb070124ff385a351c7d39ada21f03f25b47b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "6dc1f04d629f593c82492212d34585f52482206a69c5f4cc5c05dadebb1291df";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gripper-controllers/default.nix
+++ b/distros/galactic/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-gripper-controllers";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "236fd56c7de46f61cfafba861090a1d1dd9b03ea6b3ea766e6874c7968e775de";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "6a9ebaa4a8ca0425d48c44ab021dfe8ff941e2c46cc9e44825fd84c3967ac2eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-galactic-hardware-interface";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "9a34ff4d199a331171e6d092daac9bed50965634b2b73ce64fbb0284e16c24f7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "e9a6e0f570d7e5b22f94fecaf7cf3851866771c69de53c3f7070a9f84e37a476";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/hpp-fcl/default.nix
+++ b/distros/galactic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-hpp-fcl";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/galactic/hpp-fcl/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "6c175f1a418b4cce5e11e6ab14948a9144b42c746bf8e0fd115d1d7d2b4f48c4";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/galactic/hpp-fcl/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "756f9738ecb04148206c2b261e8213044b91e4254b311fd032a538fe0a79e021";
   };
 
   buildType = "cmake";

--- a/distros/galactic/imu-sensor-broadcaster/default.nix
+++ b/distros/galactic/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-imu-sensor-broadcaster";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "80f15691393af7e152f501011c2fe18a09591c9d548da1f78655385fe19588f4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "bd06ed16295678f3af373243ccc32d9b8a9737ec2a2f02476bf87c60dd477019";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/joint-state-broadcaster/default.nix
+++ b/distros/galactic/joint-state-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-state-broadcaster";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "75e96059b0768cbe0181dfef3e28d2678c6bc1f7aaa2e526d7ae9e267861b771";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "39e5513e5aba499733c1eec5acb4c93a15b968ed02b87c33a89245f86c2e192f";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock controller-manager rclcpp ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp-lifecycle rcutils sensor-msgs ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/joint-trajectory-controller/default.nix
+++ b/distros/galactic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-joint-trajectory-controller";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "feba8ec01f1e88001cf843dfc9717d492539a0064d397b710fe63f893c503b86";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "2866c5b60f0f9e948412fe4bc7a0c988c549069fc3bb94cfdc8b872f1ba152b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/log-view/default.nix
+++ b/distros/galactic/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip }:
 buildRosPackage {
   pname = "ros-galactic-log-view";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/hatchbed/log_view-release/archive/release/galactic/log_view/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "781f8752d3cb932e45943a800019cfdf176d0439e2090bc20a2be58ae81e49dc";
+    url = "https://github.com/hatchbed/log_view-release/archive/release/galactic/log_view/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "55c2303791e76491663e055ee27be106349e75c0789973bd9ba4eebef2f9857f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavlink/default.nix
+++ b/distros/galactic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mavlink";
-  version = "2022.3.3-r1";
+  version = "2022.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2022.3.3-1.tar.gz";
-    name = "2022.3.3-1.tar.gz";
-    sha256 = "8ea5950b0b03c85325d4298fb33cd6cfd1c969019c75b9d9c6357502577f9ec6";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2022.8.8-1.tar.gz";
+    name = "2022.8.8-1.tar.gz";
+    sha256 = "0182deb7d656489f7b6f1417162c950fb4883c774d799ae44ea82a495d5b8c26";
   };
 
   buildType = "cmake";

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.5.1-r1";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "98215cd4099f4e7dd15d92fa4a76d2768e13b165bf7266fd2b1ea3e4c63bc375";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "a34d1373b81d3672ecaafc2cb5498e12d63244051336ccfb41b7ac6ba43d2dd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/position-controllers/default.nix
+++ b/distros/galactic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-position-controllers";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "1031183774f47708e630a713e8fe5c6a308b43c8f531cf963934d70b1ff08105";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "0c712a3259795150291275b8e933a953c9545da03f24e2352d707a07499b9a87";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/r2r-spl-7/default.nix
+++ b/distros/galactic/r2r-spl-7/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, splsm-7-conversion }:
 buildRosPackage {
   pname = "ros-galactic-r2r-spl-7";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/r2r_spl_7/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b88780b8ba42db5986f23f7e3fe9244f24cbe3edad56b75868fdd1c4be128585";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/r2r_spl_7/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d102f7a313333d6b1ff1b73273f57dbadb59a668a85d6622192ae75d6906476e";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control-test-assets";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "dcece321dc3ebb87c17f76fdde5a8d2312f4bb2919b229fe8243b9064711424f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "05ca47ea6c870718e22a21c72e724aa2282019065bd32a0ec85c838ee441b4f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-galactic-ros2-control";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "7c7865979821d6ab9b8d79b57651ea1d8c68b7f3af1f3e57eb8eff8a4bcccd48";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "d069ce3b34310aa74274fc05e3e31de0efffd100abb1fdc0ddebcbc7666e8f50";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-controllers-test-nodes/default.nix
+++ b/distros/galactic/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ros2-controllers-test-nodes";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers_test_nodes/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "470098336b64996691a49be6c105b221ba078c1f6473bdacd1e48846b019f0b2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers_test_nodes/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "7ead9df1d0e154cfbe948abed5f78921510638b8b9a2cc1255d72901493d55bd";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/ros2-controllers/default.nix
+++ b/distros/galactic/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-galactic-ros2-controllers";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ead11a67983f72e3a9c2ec51115d02dd324814e1df675fc9979e28f23d63fadc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9a125f493f58df3f45abb1db2fc4bee94895776546188b986a5a1bbaf950e630";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-galactic-ros2controlcli";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "53d990a45168a0573134fbc6eb39ff9cc8c9244cd9c6aeb3d841cb5f089d49f7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "93ba0ce33ea0c04930210435902536162927acc63569cef87e1e7dbdb6906b0e";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-image-overlay-layer/default.nix
+++ b/distros/galactic/rqt-image-overlay-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, message-filters, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rqt-image-overlay-layer";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "a65a299e252ed5703a06ff96682392554b008f0cdffc8ea67b2cff433a243739";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay_layer/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "22f81b6706562d2cf059f5311597a2f06d04e0edee28f5e05458e0bd94aa5ff1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-image-overlay/default.nix
+++ b/distros/galactic/rqt-image-overlay/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, compressed-image-transport, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rqt-image-overlay";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "415c0090251217dd9503669119a722c040de91193ceebef6fc4437cb6c151170";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/galactic/rqt_image_overlay/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "22fc1ce260bda8ac80b0eb75bb2021eb7c132bc9f8ba81447ae632bf4986f778";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/splsm-7-conversion/default.nix
+++ b/distros/galactic/splsm-7-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, splsm-7 }:
 buildRosPackage {
   pname = "ros-galactic-splsm-7-conversion";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/splsm_7_conversion/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ae32436a045de9b5bed13dfe71949c70f0e5051bdd5a7678558b7689a09108e5";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/splsm_7_conversion/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9525ea20d229485fdc38c3eb11c0b80b762007b68e3b5f9f93a67e917d3352ce";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/splsm-7/default.nix
+++ b/distros/galactic/splsm-7/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-splsm-7";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/splsm_7/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "db5d85eec05a8dc47f9b6dca33f40941bf66eb2653cca957d88346ec9a6a86ff";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/galactic/splsm_7/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f89c83c7944f57dd4b071165504e467c3048b579b6d8044472fca4505b87a64f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-galactic-transmission-interface";
-  version = "1.5.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "928c20f4eabd83fbf173e9b28cc8df5151054234be3ac30cbfd3eae5cc4c2bd3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "8286d3b3871bcc067a55d0696cd4c10f19bd559a75f2d5401ba492d72d3ecc7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ur-bringup/default.nix
+++ b/distros/galactic/ur-bringup/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-publisher, launch, launch-ros, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-description, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-galactic-ur-bringup";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_bringup/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "afebcc8207a1710f6a844e05e6467cca847251afedee67f4628f063e630fe7dd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_bringup/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "74b6af89435ffbff32510a1b09340097f6c57563076faaa00631721622a429cf";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ controller-manager force-torque-sensor-broadcaster joint-state-publisher launch launch-ros rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 ur-description urdf xacro ];
+  propagatedBuildInputs = [ controller-manager force-torque-sensor-broadcaster joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros position-controllers rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 ur-controllers ur-description urdf velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/galactic/ur-calibration/default.nix
+++ b/distros/galactic/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-galactic-ur-calibration";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_calibration/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "7ae6b267ee730bed8faf9c9ddc93a1c482dfe968f15032c4506978703b2362ed";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_calibration/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "cff13c3ba6c50f0ce60117f5f24dcb0c4f95869170617ee17655dafe06caf2f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ur-controllers/default.nix
+++ b/distros/galactic/ur-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, angles, control-msgs, controller-interface, geometry-msgs, joint-trajectory-controller, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, sensor-msgs, std-msgs, std-srvs, ur-client-library, ur-dashboard-msgs, ur-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ur-controllers";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_controllers/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "36cb3d8a13f946359ec0ef00813aa73ee1b39f281f4feb44ac977f72c9de3d5f";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_controllers/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "fa153a2befa17050d828cab2b78ab668e5c535476e0c0a4a0af8b9953dcae60f";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ angles control-msgs controller-interface geometry-msgs joint-trajectory-controller pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs std-msgs std-srvs ur-client-library ur-dashboard-msgs ur-msgs ];
+  propagatedBuildInputs = [ angles controller-interface joint-trajectory-controller lifecycle-msgs pluginlib rclcpp-lifecycle rcutils realtime-tools std-msgs std-srvs ur-dashboard-msgs ur-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/ur-dashboard-msgs/default.nix
+++ b/distros/galactic/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-ur-dashboard-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_dashboard_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "3757b89103709b4ee4046b73b36165566f95edfc19334b6555b40e5f3da04095";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_dashboard_msgs/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "596971e660369abe842730627cc0e66e5c370f594f4e991c14597bdb5a13274b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ur-moveit-config/default.nix
+++ b/distros/galactic/ur-moveit-config/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-ros-move-group, moveit-servo, rviz2, ur-description, urdf, warehouse-ros-mongo, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-galactic-ur-moveit-config";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_moveit_config/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "f81632674372bc9fa6e5a4854842e56dd4b1a2c6a3f922bc0db8a23325fb7188";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_moveit_config/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "ea68ce6b81f5cde65aa2f6839176df62a1df6da91acfa0a2fc624a2a24752386";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ launch launch-ros moveit-ros-move-group moveit-servo rviz2 ur-description urdf warehouse-ros-mongo xacro ];
+  propagatedBuildInputs = [ launch launch-ros moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-servo moveit-simple-controller-manager rviz2 ur-description urdf warehouse-ros-mongo xacro ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/galactic/ur-robot-driver/default.nix
+++ b/distros/galactic/ur-robot-driver/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, launch-testing-ament-cmake, pluginlib, rclcpp, rclpy, std-msgs, std-srvs, tf2-geometry-msgs, ur-bringup, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, rclpy, std-msgs, std-srvs, tf2-geometry-msgs, ur-bringup, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ur-robot-driver";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_robot_driver/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "2eaa518ce247099a29c81ed87799df67b2a9b2aa3ca5a1550afd5f61f0a45c72";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/galactic/ur_robot_driver/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "a9fad5ce4af1c8b72d8a2f6341937d488faf0b5d7cc0fdb01008cc69e4f78e38";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ controller-manager controller-manager-msgs geometry-msgs hardware-interface launch-testing-ament-cmake pluginlib rclcpp rclpy std-msgs std-srvs tf2-geometry-msgs ur-bringup ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs ];
+  checkInputs = [ launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ controller-manager controller-manager-msgs geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle rclpy std-msgs std-srvs tf2-geometry-msgs ur-bringup ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/galactic/velocity-controllers/default.nix
+++ b/distros/galactic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-galactic-velocity-controllers";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "9cfd3a7f843538565f32450d98b94bd83a17eaff2a8eedeecd68820e3b1087c4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "1dc04877e01f742c7aca5c01b0debe1ea5417b471a4c27c908081db32fab24b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/control-msgs/default.nix
+++ b/distros/humble/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-control-msgs";
-  version = "3.0.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/humble/control_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0de7994ca4d0720995fd982d6f239e32fea1c32fea553cc275874bfe2a30d814";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/humble/control_msgs/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "0c0f3041e7cb83d3dbc25f2a6658155401b4fb9d71e29240a28a09e303a3d4bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "eb9f4b18f85ecc73dd7c7f4d0a111bea03ddd0db1d2a4f6691e0bf85ff8be54e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "5bf3082a97fb872360616e1600073fd3b7f5313ab15b8b2895eb8b5c8d79a9cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1aa76228bdd8bd5756a2eaef5652ce295de7d1d0b022070d85aa6215739b705e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "07d5c539275255c2e46dd0c80e892f68a329cf74d9c49e1148d938255824d97d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1c103626cab226004f3c80b99752a55a7d69312138b419abc62112d35b0b7ed4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "26270b6b3311b9cb4798c45fced33eb7c8691fa84f876d6e84fde4128c9a7b91";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "4276efb171ee3f2dd789e832dc81c6ab6af788df9c1a0c17cbdbf56572c28e6a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "f19c3d319bb1f52ebf6c9a763220a69ff6d5a6c7074c448da42eaecee6770444";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "ce8a2a72232602f4da553e9fda8fce2abda3fba89fd5d1966b8d979bdb55a7e3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "9b9fe225987da10ba74b7fd561f2f83e637917bf9e1a9b8b0e4cb0ab5860f118";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-eigenpy";
-  version = "2.7.10-r1";
+  version = "2.7.10-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.7.10-1.tar.gz";
-    name = "2.7.10-1.tar.gz";
-    sha256 = "60b7b9c3f0f8e815b76db2b9f5bf3e316e73c5249b4e44f325b4f6924b4f3f17";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.7.10-2.tar.gz";
+    name = "2.7.10-2.tar.gz";
+    sha256 = "691b7a14b929ca2aa62e745e80acece845739c91275ad52e1e70cfb6c1d65989";
   };
 
   buildType = "cmake";

--- a/distros/humble/examples-tf2-py/default.nix
+++ b/distros/humble/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-examples-tf2-py";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "1e79b9813a8915eb6044de10653ff4f2c6343253e0f2fe309f78e1a501b5a3be";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "aaa981a3b81619da469513f79c976995ee605714978709771e8a8288735276ac";
   };
 
   buildType = "ament_python";

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fastrtps";
-  version = "2.6.1-r1";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "4f948972b61e7da146517b5e27e1821634e40187879504a7d5fbc4550eea7909";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "99561389f9dec137f597a4d5adb173c0c9eb7d4d3c6d976376db615f0c78e24c";
   };
 
   buildType = "cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "468ca1f95c1c59c4c61aa6218c22021deaadfa533be6a870c0531ffa24591e2a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "438dd66282947684cbf15c4deb4182b8b9d0c8db05fdeff09c70bd30eabec0dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "7a178d7da11106c3d02c55ee6fa22ddc9b70eaab09d446c888e7dbc87a662f64";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "975689a26bfaa7af788279c711bdb9ffa6181ec9a78cc4997ce46a764ac3f6ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-ros2-control-demos/default.nix
+++ b/distros/humble/gazebo-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control-demos";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "b8cf8c95348da5483c788b6daa445d1cc86548ec10c4c4224ad2df2a09fcad74";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "ee4189b08b3bbf24b09afd12260d7c66ca02967d81f4d7fd53aa40e1a73e8bad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-ros2-control/default.nix
+++ b/distros/humble/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "59367809fc062d7b3da80908314c073692c1486a8b99e8ccac016fcde583c6b1";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b549f9311a704006adf5ce23688fa1cf13850284ed19ea87f8a143af57ac8858";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-example/default.nix
+++ b/distros/humble/generate-parameter-library-example/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-generate-parameter-library-example";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "abff6cae0538471850a56d0b0a7bd5f90630add97cdafe018de011be78f101a1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-core generate-parameter-library rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, tcb-span }:
+buildRosPackage {
+  pname = "ros-humble-generate-parameter-library";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "58a4e0c55a174c8f512641305088669daea58c734e3e0dcdb4c9bfd9d4e83b45";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ fmt generate-parameter-library-py parameter-traits rclcpp rclcpp-lifecycle tcb-span ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CMake to generate ROS parameter library.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -406,6 +406,10 @@ self: super: {
 
  gc-spl-2022 = self.callPackage ./gc-spl-2022 {};
 
+ generate-parameter-library = self.callPackage ./generate-parameter-library {};
+
+ generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
+
  geodesy = self.callPackage ./geodesy {};
 
  geographic-info = self.callPackage ./geographic-info {};
@@ -572,11 +576,17 @@ self: super: {
 
  leo = self.callPackage ./leo {};
 
+ leo-bringup = self.callPackage ./leo-bringup {};
+
  leo-description = self.callPackage ./leo-description {};
 
  leo-desktop = self.callPackage ./leo-desktop {};
 
+ leo-fw = self.callPackage ./leo-fw {};
+
  leo-msgs = self.callPackage ./leo-msgs {};
+
+ leo-robot = self.callPackage ./leo-robot {};
 
  leo-teleop = self.callPackage ./leo-teleop {};
 
@@ -875,6 +885,8 @@ self: super: {
  ouxt-common = self.callPackage ./ouxt-common {};
 
  ouxt-lint-common = self.callPackage ./ouxt-lint-common {};
+
+ parameter-traits = self.callPackage ./parameter-traits {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
@@ -1364,6 +1376,8 @@ self: super: {
 
  rqt-image-view = self.callPackage ./rqt-image-view {};
 
+ rqt-joint-trajectory-controller = self.callPackage ./rqt-joint-trajectory-controller {};
+
  rqt-moveit = self.callPackage ./rqt-moveit {};
 
  rqt-msg = self.callPackage ./rqt-msg {};
@@ -1540,6 +1554,8 @@ self: super: {
 
  tango-icons-vendor = self.callPackage ./tango-icons-vendor {};
 
+ tcb-span = self.callPackage ./tcb-span {};
+
  teleop-tools = self.callPackage ./teleop-tools {};
 
  teleop-tools-msgs = self.callPackage ./teleop-tools-msgs {};
@@ -1615,6 +1631,8 @@ self: super: {
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 
  transmission-interface = self.callPackage ./transmission-interface {};
+
+ tricycle-controller = self.callPackage ./tricycle-controller {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/humble/geometry2/default.nix
+++ b/distros/humble/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-humble-geometry2";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "f78efc03308317243f7ba31fc22435e69aea115a7624cf7cc636132f0ad07542";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "031e401773b7d82114e09caed4172e0a496acdf3e0a1eeeccc136e9e7d9c71ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "b36f8d2f30bf656f1dc9c7e41515a2b7f356446cbf6b4c81dc70aa8b4e7d0464";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "195d6d838b7b73e26dbb418b84ac6692b4e72c2929bd4c32c9fce319b2ba4839";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "5a6aea12bb6246794d04745f3fa733c51d53cc84f97ed42782c638a1dee29ac3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "533923a2b232f3506d6b8d2afa195257f110167cbc85f454abe8a6f9fa2e3d96";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hpp-fcl/default.nix
+++ b/distros/humble/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-hpp-fcl";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "5e279d564b5ef012da158c8576453e72a99d71507fd010860db4ba7642f26d6e";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "16165cca1d13ee762d1f77a8fbb7e1915f4fc35902379faa447f743832808ad1";
   };
 
   buildType = "cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "3eebc2229b47e992730b15cf22c9d52e4e90b9ad69c133480906436b7717b7cd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "b40b1c58b774c6b2b3bb283f8a4a9db6eca431293bbe73dcd0d813bc678e9ba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "0442245a960d277054ebfe540f2fc51d66bda201d4846f09492106234aada6e7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "45d5d7bbfd78b2a6ea7b21e1bde59398fea452641ba526494ee754f79f7c910f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "c6eef3c5b8160f8461cc2470ef8acf48f26e007c57de787c6662fb6ec30eeb39";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "818897330bc3f6323cc175aa546912f6a65854bd96ad287de995ddc463dd4972";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "f94c3bc85c19aa51980e27348926fa4e930a73872dea21a320a68037a3c376f1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "198909b9cc57978e478b16c8adecd473de946f6479cbda3976e5777889fef61e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kdl-parser/default.nix
+++ b/distros/humble/kdl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, orocos-kdl-vendor, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-humble-kdl-parser";
-  version = "2.6.2-r2";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kdl_parser-release/archive/release/humble/kdl_parser/2.6.2-2.tar.gz";
-    name = "2.6.2-2.tar.gz";
-    sha256 = "a820e616e4ea626e1aeb2b97d4135b48228158b3fb56b4406b1b26aff44566eb";
+    url = "https://github.com/ros2-gbp/kdl_parser-release/archive/release/humble/kdl_parser/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "d87acdd7d4ad38d2525bfec1f7e0a91f558e8a97d7f4aa915899e46e47ae23ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-bringup/default.nix
+++ b/distros/humble/leo-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, xacro }:
+buildRosPackage {
+  pname = "ros-humble-leo-bringup";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-ros2-release/archive/release/humble/leo_bringup/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b70e5dd406fcddda92373f90be796c9878fe415a52de1f0fdfec50e1633ac9cc";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ geometry-msgs leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Scripts and launch files for starting basic Leo Rover functionalities.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/leo-fw/default.nix
+++ b/distros/humble/leo-fw/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-leo-fw";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-ros2-release/archive/release/humble/leo_fw/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9df27c3471c2870b9011429055fda2f3d8df25a145da956062e5c5284fbbc346";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-index-python geometry-msgs leo-msgs nav-msgs python3Packages.dbus-python python3Packages.pyyaml python3Packages.whichcraft rclcpp rclcpp-components rclpy sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Binary releases of Leo Rover firmware and related utilities'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/leo-robot/default.nix
+++ b/distros/humble/leo-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-fw }:
+buildRosPackage {
+  pname = "ros-humble-leo-robot";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-ros2-release/archive/release/humble/leo_robot/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c21d474d040f3aa548d01054db887eb41397a09d48f9eb48ddfe1e74ec3bcd3f";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ leo leo-bringup leo-fw ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software to install on Leo Rover.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mavlink";
-  version = "2022.6.27-r1";
+  version = "2022.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.6.27-1.tar.gz";
-    name = "2022.6.27-1.tar.gz";
-    sha256 = "6c2d7e176a4e4f0cddf67d5c385a8b3f2ec2d5b7bb64bab84b1672b55bc36970";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2022.8.8-1.tar.gz";
+    name = "2022.8.8-1.tar.gz";
+    sha256 = "a03cd42db382fde7d5334d4001484e911337ef3c3c443c338201863fd4336ee9";
   };
 
   buildType = "cmake";

--- a/distros/humble/orocos-kdl-vendor/default.nix
+++ b/distros/humble/orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, git, orocos-kdl }:
 buildRosPackage {
   pname = "ros-humble-orocos-kdl-vendor";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/orocos_kdl_vendor/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "16b43362fa4ac66f83e3e10f09b4fcfdb994152a8b7e0f0ccd5a10022c0d4696";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/orocos_kdl_vendor/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "b6f80dd7f0b4e02e878b171c1316b74676d3f6a3be9366c448ad9ba87e81d86f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-parameter-traits";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/parameter_traits/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "7f1f573983d4178c8112b060d54270791e63d5f9f6de689b9575e94408c13772";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ fmt rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Functions and types for rclcpp::Parameter'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/plotjuggler-ros/default.nix
+++ b/distros/humble/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler-ros";
-  version = "1.7.1-r3";
+  version = "1.5.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/humble/plotjuggler_ros/1.7.1-3.tar.gz";
-    name = "1.7.1-3.tar.gz";
-    sha256 = "a0859904ec7094be45e1b05568231b31d13507d8493d1bd8d6c69ef2529cda63";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/humble/plotjuggler_ros/1.5.1-3.tar.gz";
+    name = "1.5.1-3.tar.gz";
+    sha256 = "12e2d2ff4df721386ed1417ffad4a2028c697cd22f125c99d59a55b8ed805ca9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "1e005325743b01929aa36a465652a6a9ba04410fcd2323a07deb891de1f46582";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "f6047954edd4e39540c48f4895fa8f62fcfb853f9df125809aa9e3374254e017";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/python-orocos-kdl-vendor/default.nix
+++ b/distros/humble/python-orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, orocos-kdl-vendor, pybind11-vendor, python-cmake-module, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-python-orocos-kdl-vendor";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/python_orocos_kdl_vendor/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "72815f58f8cb90a0e7d1c62a6a63a5f86a09bd51addf098d482f6f214becebde";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/humble/python_orocos_kdl_vendor/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "3bc6441df756cf500e9568f59647b06bea610f0afaf1d64c584e1aa540efd773";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/r2r-spl-7/default.nix
+++ b/distros/humble/r2r-spl-7/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, splsm-7-conversion }:
 buildRosPackage {
   pname = "ros-humble-r2r-spl-7";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/r2r_spl_7/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "f1a69085060ca09ac44c27177464c46ff36af826f5468ea55749f34bd9e34457";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/r2r_spl_7/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f5ca4a67fc245d933b43ebe7728fa4927c19327c078fda027874a7f59c9bd89c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "384211164a16ad708be18296538b458b3a378781b861109ece84c74f6616622a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "6a167c097d8080b02ed9c932e48270bbbcab7ab565ece355d379dc437cc55b98";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "a817cc0157eccff03e59e58eef0efbc8e8ea3c8419dc543080e4308354072ae2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "36f029dbbcdcd2ea72e79de5967ac7fa3cd4af04ea4adf86a87014737c8b1dd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "bc1fb4974bb45607d3b44081a069e859cbceff1de325f2d02a01ac898c8c6972";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "91e2f5618bc1d9597152206d636329cd1db20773be656bf14ebc8dd6243d84ad";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, tricycle-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "c1426d25c42f2324f82b1d5fd5b5507c2c082d011a386f52641840cb5500f6f7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "362c2c22b3623d4bf0c8c4c36250e019547d9ebd20fd3540f7db7e75d37622a8";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers velocity-controllers ];
+  propagatedBuildInputs = [ diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers tricycle-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "9e7d6cc88e961f505e961904fd9212962bd1f8c1a3578cdf880c8d05fbd418ee";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "e0750748a4f9620f8f7b9c35d16d06aad2eb0460911fbfa4b97d013a4499f877";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-image-overlay-layer/default.nix
+++ b/distros/humble/rqt-image-overlay-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, message-filters, pluginlib, qt5, rclcpp, rcpputils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-rqt-image-overlay-layer";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay_layer/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "00a8669b2da753054fe1b7080d8ed91376e8f5870dc28b648fe0ce06cf867bcd";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay_layer/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "8d8beb777a7ab9a97545e3b70fa7f7cbcb33f840c4647c7fb8d0ac8cc9299908";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-image-overlay/default.nix
+++ b/distros/humble/rqt-image-overlay/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, compressed-image-transport, image-transport, pluginlib, qt5, rclcpp, ros-image-to-qimage, rqt-gui-cpp, rqt-image-overlay-layer, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-image-overlay";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f7d4cab6b629671a9a9040a526fd35c57dc326079754986af2fc227ced478f3d";
+    url = "https://github.com/ros2-gbp/rqt_image_overlay-release/archive/release/humble/rqt_image_overlay/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "513c5b08d1c7da7b00202d3a04cfd658e8c5188dd0dbd72dc0be72e04aaaad25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-humble-rqt-joint-trajectory-controller";
+  version = "2.11.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "ce13baa8464429697c36680532b92fc682aa03d123106eec281503b1756907db";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py trajectory-msgs ];
+
+  meta = {
+    description = ''Graphical frontend for interacting with joint_trajectory_controller instances.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rqt-publisher/default.nix
+++ b/distros/humble/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-humble-rqt-publisher";
-  version = "1.1.3-r3";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/humble/rqt_publisher/1.1.3-3.tar.gz";
-    name = "1.1.3-3.tar.gz";
-    sha256 = "40368fe3bde04adec6e076aee18adc26cf5b0f905a77360a31de47f86cae7a12";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/humble/rqt_publisher/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "96f9ca2d88195de9faa4997076b6a935322fa9ef7defc6ff22b6111b29c99c64";
   };
 
   buildType = "ament_python";

--- a/distros/humble/splsm-7-conversion/default.nix
+++ b/distros/humble/splsm-7-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, splsm-7 }:
 buildRosPackage {
   pname = "ros-humble-splsm-7-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/splsm_7_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "b940f58b8609dd37df707d711db51b2728bf5251b43d5907a0b1b1906b54adc1";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/splsm_7_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "97c110fa5fdae2ca301118f7fc2a8db8dd21d9f94292e8dcd509ebfb45057fb6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/splsm-7/default.nix
+++ b/distros/humble/splsm-7/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-splsm-7";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/splsm_7/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8bad0253685ffcfab8dceb6aaa17faffba711e9c5e8bd708060f3a309fbadb3b";
+    url = "https://github.com/ros2-gbp/r2r_spl-release/archive/release/humble/splsm_7/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "7c0bd05c40b5b9dc85f09e0899a674b9f16c7bdbe29a7148422d6f7a987e3eba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tcb-span/default.nix
+++ b/distros/humble/tcb-span/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
+buildRosPackage {
+  pname = "ros-humble-tcb-span";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/tcb_span/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "4006169b3a8c62d99150568aa3b4a29d9267349378bf4117dffd2c66ea4c331e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Implementation of C++20's std::span'';
+    license = with lib.licenses; [ "BSL-1.0" ];
+  };
+}

--- a/distros/humble/tf2-bullet/default.nix
+++ b/distros/humble/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-bullet";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "16015fee5f3c37016922e61000c6b3197434afeabc1ab976c675a9fec5f7e219";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "93905b41fcbcf9a94779f786850062cdf806d7a2342a2fb66386dafa158ed27f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen-kdl/default.nix
+++ b/distros/humble/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen-kdl";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "dc37aec234e22cab4e4f86a4221486d9bd53516d3b49bfd9456c016b9bfa213a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "59b707152061d6072cc6ee2e5e314f1911892fff7f88dbec5c58597058a6b18e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen/default.nix
+++ b/distros/humble/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "1ee62ddf3cd9aef907ddc7f42bd6761d9628fea958e450e7f85808849492f409";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "9ee97213f9c91d21ce8a1a975a85416598ec44edc11aa34574bb745036f209fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-geometry-msgs/default.nix
+++ b/distros/humble/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-geometry-msgs";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "5db610803937f6f5e8673eb0c420090e0d5d4238566ee04159260abb9eef9f2c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "f019603ebb3c2579231c8f879d40213f87a00f8eab00e701c50ecd2c0838bb6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-kdl/default.nix
+++ b/distros/humble/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-kdl";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "8789d8c545633a752b9db66b776807f3bb51e81c5d231a541312d98422960884";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "3e691886bb095d4b7b1d4740a3de1d32a3cad3b1b04c8c0dae19332e9f2ed5bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-msgs/default.nix
+++ b/distros/humble/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-tf2-msgs";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "08269dd9d740662ea95e3a9f6f96d6a3af4574a2b9fe7a669a719ee5712e17f9";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "9ce32b44eb4b289854ba0434dd19b96dff7e8dc33404499dc673427d83e08779";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-py/default.nix
+++ b/distros/humble/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-py";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "ee70ea19b7a81e7a27804634e2f3b66abc5d518f20222744bb71207a2cd2019a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "28900084eba229098f2fdd3acc79843982d73c4406e8ba4aca67fa109ce35fc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-ros-py/default.nix
+++ b/distros/humble/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros-py";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "b26c75164269d8dece6629690176f74344badf41adfce34cfa7ff7713dde9ae5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "c846e18c1ce00bebf875f2c450687541f8e017d008c44f4d00b09d3054ddfbc0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-ros/default.nix
+++ b/distros/humble/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "086ea43fb8c7b7699994bea3cb34f3161f9fb586dea0fc0e1e74e90cca11892e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "3d7d2624849c032a5018c5acc79115da62d9bd0406d466bf0b6df0c9a5c48a53";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-sensor-msgs/default.nix
+++ b/distros/humble/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-sensor-msgs";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "dbfd90da3e0306fd7dde8ec7840aef8fe77c89884188205a4f9c5a293b32d11b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "92efb7f9a81400b441069c9fee904f6e2b20ee2e89c5f02817a0fa94b5b846cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-tools/default.nix
+++ b/distros/humble/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-tools";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "0016e5370371e8cd581db137567ca971f494b19a8b870e4d34a44bad7e226c42";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "e78b6d8bc7892588e864fe1deedf38a550bb67867a1d82583da3c4f93d164168";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2/default.nix
+++ b/distros/humble/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-tf2";
-  version = "0.25.0-r2";
+  version = "0.25.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.0-2.tar.gz";
-    name = "0.25.0-2.tar.gz";
-    sha256 = "dd4f015387a17f2d8d3b5a01dbc2c9db9111379be10c5f891dc6cf12202237cb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.1-1.tar.gz";
+    name = "0.25.1-1.tar.gz";
+    sha256 = "71db8e8d02d5ca97bcfdcfa22f15d7264e3bbd1f4fbdf6d73f585eaa7a45df6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.12.1-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "402299d4a1347b8b98428551701dc3d1c279ecde1ae89c37e10e3195407505e0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "e608bc966caf4c0acbda6c634e1d983f16841654f81a9f1b14977365106a4a77";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-humble-tricycle-controller";
+  version = "2.11.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "fcb8bda974d3c622283f86681fb1f91960f1e94ff46bfeddca885476de08d551";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ ackermann-msgs controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller for a tricycle drive mobile base'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "ddc448885d87663bf53c367f97951eb6ade9a73e2ac709fa131671de5a4c1e37";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "41d765b114e8a2300dcaa28d8b51b329481a4460d28aec51444540cde00c505f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "dc0c2a21ff540948f3cc4fa0212e2740d35c1f5b057bc94e1aed7398621578b8";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "4fe32a5a3e58339d84e5e4d256f01b980282bc9c5242b63b386b458fecfb4a94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "03efe222a5b41a9c2162c86ee5fb45cf1fd5c6b73f65722d20664e7f190249b0";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "dbcb5cb5be0b8f57d7447e0edcd61176c448e3eb79766c98a3b5f00a2e9f505e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "604202b502a65fde044743abb56a87294e59f8f91f0d8180e76c44e9a0e5738a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "5f041563ca1d78d43d1ee8549b4574ab212f4d33d47dbaf48de6fc9e8ad7ac4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "110665b9a12576963fdfbd51e99717e945353e078a02285aca596c91f5dbf625";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ef3e3fdff9f209d7b801c250f88d8864f81c14569c26d9877ea253802b61c70c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-robot-driver";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "58dd4062c0b70f1f4f6c9a815947b5334794837d5f81536a1b0ff06dbd317199";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "8052360920e461f9b37e0664f7013ba53506df75f19c573a3c2814ffd621602c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "adb00447e2ca801b3a9dfceb6928929502efaebecc7a96f81d97b7ee6d0784e7";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "aa3d0425d8d429335d4ad7308307b9d10bdab4d5af68201e57f161783251ae62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.9.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "df3560c715554bc59a71363499293a4a33a864ea6fad2fc80db0d5780a8663d5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "ed07c9fb583f6c8eebe70db898a78a6b32dc4d2014c4449c3d7e33b93ead73f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "d59e3de47f5f91cffc04b496c2118019068e785c2898db983adc534fbfe29a0e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "7c917c353b17e528306a81197feee890b07b65e8aa230f4cb2ad8fc97473ecf9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ess-imu-ros1-uart-driver/default.nix
+++ b/distros/melodic/ess-imu-ros1-uart-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-melodic-ess-imu-ros1-uart-driver";
+  version = "1.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release/archive/release/melodic/ess_imu_ros1_uart_driver/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "fecf02b078b267bde1db3f1011d7504da248eeb5da7a8f4d174b09f8e2c62b96";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs std-msgs tf2 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Epson IMU Driver using UART interface for ROS package'';
+    license = with lib.licenses; [ bsdOriginal "PD" ];
+  };
+}

--- a/distros/melodic/executive-smach-visualization/default.nix
+++ b/distros/melodic/executive-smach-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach-viewer }:
 buildRosPackage {
   pname = "ros-melodic-executive-smach-visualization";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/executive_smach_visualization/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "f72a55befe9ec51a6bee5dcbc14ce19af04fb88ecf524a39d98df1742e4cde37";
+    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/executive_smach_visualization/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "247e6d778d9108aa3ba0c47233c603d8c0e2cf17badbbebb519894ee3672135d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -950,6 +950,8 @@ self: super: {
 
  er-public-msgs = self.callPackage ./er-public-msgs {};
 
+ ess-imu-ros1-uart-driver = self.callPackage ./ess-imu-ros1-uart-driver {};
+
  ethercat-grant = self.callPackage ./ethercat-grant {};
 
  ethercat-hardware = self.callPackage ./ethercat-hardware {};
@@ -2035,6 +2037,8 @@ self: super: {
  marti-data-structures = self.callPackage ./marti-data-structures {};
 
  marti-dbw-msgs = self.callPackage ./marti-dbw-msgs {};
+
+ marti-introspection-msgs = self.callPackage ./marti-introspection-msgs {};
 
  marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
 
@@ -3949,8 +3953,6 @@ self: super: {
  smach-msgs = self.callPackage ./smach-msgs {};
 
  smach-ros = self.callPackage ./smach-ros {};
-
- smach-viewer = self.callPackage ./smach-viewer {};
 
  smclib = self.callPackage ./smclib {};
 

--- a/distros/melodic/hpp-fcl/default.nix
+++ b/distros/melodic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-hpp-fcl";
-  version = "1.8.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/1.8.1-1.tar.gz";
-    name = "1.8.1-1.tar.gz";
-    sha256 = "594d688b680ff946d06f8ddd0ccebd41ea887af0ad261efc5a097b10b4a97e8b";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "a7e3aa9e0d272bc7af7229b9036d1417ec49ec51469b8a718d910f9f1928bda1";
   };
 
   buildType = "cmake";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "82c3ffe715f43c374082ff221c3929e0dc2bd62b1339ba86c6780318af557d2d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "7d4a26f4ce4c19bd29e782e160b81c8da6ae7aaee19eded8b9933185e7e4e7c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "f332f7aec5dfcb61a9a378f5b62ce58b44da29fb963143fb61eb3e71742e9eb5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "b14f11a6d730610d0fc2ca2d77fd5da482285b5f315e4fb770edc009c3c87686";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-can-msgs/default.nix
+++ b/distros/melodic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-can-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "b6450f1cc6b5efad8ec970461249180c2ed668459ed2015ddfb8e3756aeaa009";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "5b41c4e23ab23c3321ad449fe70467c468b311876780d1af1baa6f51095f58f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-common-msgs/default.nix
+++ b/distros/melodic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-common-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "2b71a0d94ad970b6926032586facedd0df0026c3ca9ca5cc11f31531041bbbc7";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "cfcf1054bea3cf47aaf3e7478bc64ab645d2edcf388029351c5a800461ee4738";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-dbw-msgs/default.nix
+++ b/distros/melodic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-dbw-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "83c3ee9c15967c011c8d0e8df55d630b8fdaac1ff1b7963136805521f926805f";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "930449541c51660f375fbd6bd2a81caea21a4ea53828e1a7c89f99d1d3af4164";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-introspection-msgs/default.nix
+++ b/distros/melodic/marti-introspection-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-marti-introspection-msgs";
+  version = "0.11.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_introspection_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "7b8b3360932a31eed1aa5b5f247abad3dffe30fdc92d7c0bf64234d024588669";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_introspection_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/marti-nav-msgs/default.nix
+++ b/distros/melodic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-nav-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "68eb07c92aa1502639be1bd7e4212b5372d08db9269bf263addf510a6a9119c1";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "b9ed0dc9d56bcfd39415c971ffcc4e2bb782e560f2e9e2f03f4afaa93c0ed96d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-perception-msgs/default.nix
+++ b/distros/melodic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-perception-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "91113e28b14b3c9635313969df9660cd5c8154b5839736e1540405d17b22b204";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "9066c41d34b4fb442ac19c2f73f9f5d69872893ab11297acce4b43c72c4dd8eb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-sensor-msgs/default.nix
+++ b/distros/melodic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-sensor-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "572beda2b36523772af99c1f7beb4f16a5008c7fa66fa19390b35ba77b959ad3";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "f2ff5295a9a0526e358610199fda8b0fc319702460b35d572e6c48a77fb6df58";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-status-msgs/default.nix
+++ b/distros/melodic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-status-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "445f3a4f31c7907f32701b1061eb355fa825c54803c4d6c567e491bce5ab8fe0";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "4c8f476ab9fa2d8fb489ad944176c6a22e8f7577f2e6fd92d08c08136d91cb58";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-visualization-msgs/default.nix
+++ b/distros/melodic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-visualization-msgs";
-  version = "0.10.0-r3";
+  version = "0.11.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.10.0-3.tar.gz";
-    name = "0.10.0-3.tar.gz";
-    sha256 = "4335c670a2f171fd62259d7aaf3d4df23f29b4ba0c175fa5b2995c1874afbf02";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.11.0-3.tar.gz";
+    name = "0.11.0-3.tar.gz";
+    sha256 = "02e9a6ab25371b160e200dd8e71f6eb09b5922099f38faa57b50c3e7e6f8600d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2022.3.3-r1";
+  version = "2022.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.3.3-1.tar.gz";
-    name = "2022.3.3-1.tar.gz";
-    sha256 = "5c587284e9bc5f352e6d968ddfd1d3ff1c36b97c56f7ac5612a1addb46f9d571";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2022.8.8-1.tar.gz";
+    name = "2022.8.8-1.tar.gz";
+    sha256 = "cbc013107000bf682f9fe98750668ad8ff7a402859d6f8c84d049323a10ebb43";
   };
 
   buildType = "cmake";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "ad5eaaa8bdf00484fb0a2491467c2ff09cb08ca84a6d4bfa850a59e7f0192cd6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "c5acf47b70a75ec7c26849cfec0d33fb9191f076e670537c11d94bd024baeb31";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "2d0e70c41b1166d74eac8be05284d09630ecab2242be326d217ed88e7ed80a6c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "38543bce0951edb4404e41ea512521aa37d116cb45aacbf721eed2889d077a68";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "b8f186e8f7d1793373b898ce204884a1f2148f5e308f20da7e6f7328d8bee186";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "a0e933aa2d894686d607acf95f1e63d11633782a89502d0529369efa3d257baf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "1392cf82e43d5b8ba62485eb503210d947aad768f6fc32561148b248fccfb17a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "ca49610fc5875ccd8ac2965fb13775780376ed7e7ba12e34af0be293dc2afbf4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "21f1e16e0703dcd1478c899655a9d44d9648c7dbc3f77c1bd51103b416888719";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "4205e3b004fac5a4307d30285ccdaba929f3371871d13404882a94db2f9a4902";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.5.1-r2";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.5.1-2.tar.gz";
-    name = "3.5.1-2.tar.gz";
-    sha256 = "c915ebe101c59b3d2426b480dc8bcbf8cc6ff6929c0c5dd5bc67eb71adc50534";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "c15afb30c09177e2b7b52a5636ccc445c190f0c47d9373125f9da32d5e4427d1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-localization/default.nix
+++ b/distros/melodic/robot-localization/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-robot-localization";
-  version = "2.6.11-r1";
+  version = "2.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.11-1.tar.gz";
-    name = "2.6.11-1.tar.gz";
-    sha256 = "460ae8491dd7487f761ebb69e2bc052d836502abcf682f9174b28c6493828693";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.12-1.tar.gz";
+    name = "2.6.12-1.tar.gz";
+    sha256 = "9335cdc8055565d1d2011eca64a358b37d97bd7eac74f53396e45a9f27a9c30f";
   };
 
   buildType = "catkin";
-  buildInputs = [ geographiclib message-generation pythonPackages.catkin-pkg roslint ];
+  buildInputs = [ message-generation pythonPackages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rosbag-snapshot-msgs/default.nix
+++ b/distros/melodic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-snapshot-msgs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "7dfcfda926b100b95b36509fd0e05e2988d23fcdde8f2c116802da67d96c4bc9";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot_msgs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "39f0bb1c63f100662d2e0adb8a8f60dd498c164974c6febc848cccdea9b7414f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-snapshot/default.nix
+++ b/distros/melodic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-snapshot";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "1e6ebfa8f2773794f99a2379a42b9ca80ad6aea174b24626f6f5a32044f3c23a";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "3e14fb72af8e6f077fd2c6982e9d4b6737d01fa361168e3130d27e1c3c74be33";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.25-r1";
+  version = "1.13.27-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.25-1.tar.gz";
-    name = "1.13.25-1.tar.gz";
-    sha256 = "2a6a6bc6a63a29fb1400de83aea753c4e8b3b80be99b8e346114ad3557cba7ba";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.27-1.tar.gz";
+    name = "1.13.27-1.tar.gz";
+    sha256 = "ee644051045a40ef6b889b9687d7ee2d64451f085b5e3ded3e76aad981df588e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "a79a9d1fb06f38309765346cab87c3278a27623c74b6914134f92d95731a6886";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "ed7d2dabb807d1554ee33c2f70d693d2ee6ff629daf997c8f3179b78bc0a06b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "2989ba04194669a597c7e1e4117b2241696e3d3d02dfa2cde72bf3aae1398ed7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "76ef5d19cd6f6a48073d3e091df23b61801208f36bc810e74eeff49da77b92ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "d8618ac352b517ab035fa6ce716fec1671d2b7c2bfcb95f6e7cd7da2be1d0ae5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "b45fc77880950760b87365dd18a00bebcb59d6276f5f91c8470a4cc4faff43c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-3d-mapping-msgs/default.nix
+++ b/distros/noetic/cob-3d-mapping-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-object-detection-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-3d-mapping-msgs";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_3d_mapping_msgs/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "4beb7a4528d3e4f36e77ff78e2b4a24db1bf30a52fb3379378d28250a2d0ce55";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_3d_mapping_msgs/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "8b92297cbf0b9b29fe7ab6ab41dec0971d2982eafaf994131d64a23d760b81e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-actions/default.nix
+++ b/distros/noetic/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-actions";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "c24526eee854445bde1d739ced3151f1376038f4e40a6c23516b148e9b519228";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "3b6e6a6d4a3ba976bcde2c76c69f24fcd752961e88550d912d0cdad0445abe06";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-msgs/default.nix
+++ b/distros/noetic/cob-android-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-msgs";
-  version = "0.1.9-r1";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_msgs/0.1.9-1.tar.gz";
-    name = "0.1.9-1.tar.gz";
-    sha256 = "3d6a2621ee90143c6097bd4df0eda5d07bf6c0c0965ed112b62044044a20b6e0";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_msgs/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "aaf0b59312ca1282c2344fc7ed2f338d55e7711d2f03e90b14f2985d924ddb75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-resource-server/default.nix
+++ b/distros/noetic/cob-android-resource-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-resource-server";
-  version = "0.1.9-r1";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_resource_server/0.1.9-1.tar.gz";
-    name = "0.1.9-1.tar.gz";
-    sha256 = "ca6dd7d3adbaf9e4d12501a872b6847c1816236b19d08a909bd70fd4e6cb8c08";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_resource_server/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "259bfab83811916e28ae201e2bb4aeb2961509844c722584b375203ebb8c5697";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-script-server/default.nix
+++ b/distros/noetic/cob-android-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-android-msgs, cob-script-server, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-script-server";
-  version = "0.1.9-r1";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_script_server/0.1.9-1.tar.gz";
-    name = "0.1.9-1.tar.gz";
-    sha256 = "05276ffb13f85de759737489736680976ec21fd7e4af525b7d2a9f35218fcc8c";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_script_server/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "ce3448c78c5d5239a142baed1c050904d157b5f60823ddc7cc23c7ee49fd86ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-settings/default.nix
+++ b/distros/noetic/cob-android-settings/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-settings";
-  version = "0.1.9-r1";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_settings/0.1.9-1.tar.gz";
-    name = "0.1.9-1.tar.gz";
-    sha256 = "82b42376f687b02e6091933fbfef35118386a6889641bc667a5cbafacf8d34d3";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_settings/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "e4038140c231cf067a0de76b46b2d902bf15f4aad761bd4b03422c0acd2b9214";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android/default.nix
+++ b/distros/noetic/cob-android/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-android-msgs, cob-android-resource-server, cob-android-script-server, cob-android-settings }:
 buildRosPackage {
   pname = "ros-noetic-cob-android";
-  version = "0.1.9-r1";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android/0.1.9-1.tar.gz";
-    name = "0.1.9-1.tar.gz";
-    sha256 = "3d21f4dde5859c7cb668a1b26e437f5e3488a9240d19ddd01ce4d99eb8237284";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "99c030bef5a2dda143c534296504d8e7badb84353c2cb83aac676b0e93fa42e6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-controller-utils/default.nix
+++ b/distros/noetic/cob-base-controller-utils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, rospy, std-msgs, std-srvs, tf, tf2, urdf }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, rospy, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-controller-utils";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "4fed5d1ba62fd94417d584f6b7bc4736c1760c0fa55a9573dfffbfc5cb0289ca";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "f09f8753635c89f785ef3e437b3d194c4ab8bb08ceded2271b1aee1f4d9f5f7d";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime nav-msgs roscpp rospy std-msgs std-srvs tf tf2 urdf ];
+  propagatedBuildInputs = [ controller-manager-msgs geometry-msgs message-runtime nav-msgs roscpp rospy std-msgs std-srvs tf tf2 urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/cob-base-drive-chain/default.nix
+++ b/distros/noetic/cob-base-drive-chain/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-canopen-motor, cob-generic-can, cob-utilities, control-msgs, diagnostic-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-drive-chain";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "e37fea92c6147baeefd85572c5ce77dfbf4ff9bf63ece189c0ec3c991758f1e5";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "12daa984d8d33153b8deaf596e6f4caf411f5910a0cc3fedb2d8f7fa500513ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-velocity-smoother/default.nix
+++ b/distros/noetic/cob-base-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-velocity-smoother";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "090f77dbfe0fabe55b0224f8ee05b64d3867876de29a2c5e82dda9afe8856458";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "188c555b58492fdbe8f7e8a3505bd99ce2ab5a2a1a850a88ca2bcf450c53069b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bms-driver/default.nix
+++ b/distros/noetic/cob-bms-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, python3Packages, roscpp, rospy, socketcan-interface, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, python3Packages, roscpp, rospy, sensor-msgs, socketcan-interface, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-bms-driver";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "3a320f76d580a236ce06577a1df7b20ef79fa0f19b1c0911119aa8efd6dc691e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "65b7ee006ea1c96d25ce380ed3a92f8678361d8535db803e016049e0234f9277";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cob-msgs cob-srvs diagnostic-msgs diagnostic-updater python3Packages.numpy roscpp rospy socketcan-interface std-msgs ];
+  propagatedBuildInputs = [ cob-msgs cob-srvs diagnostic-msgs diagnostic-updater python3Packages.numpy roscpp rospy sensor-msgs socketcan-interface std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/cob-bringup-sim/default.nix
+++ b/distros/noetic/cob-bringup-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config, cob-default-robot-config, cob-gazebo, cob-gazebo-worlds, cob-supported-robots, gazebo-ros, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-bringup-sim";
-  version = "0.7.5-r2";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_bringup_sim/0.7.5-2.tar.gz";
-    name = "0.7.5-2.tar.gz";
-    sha256 = "7f37d1f5eb547ad959305eb7e6ffb12d8c848a6b57199198fc0a0032100af1aa";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_bringup_sim/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "ef8347f2708c8f49fc87acbcbe510fdc70dbc3be97e7764c4d79429292bfbd91";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bringup/default.nix
+++ b/distros/noetic/cob-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cob-android-script-server, cob-base-controller-utils, cob-base-velocity-smoother, cob-bms-driver, cob-calibration-data, cob-cam3d-throttle, cob-collision-monitor, cob-collision-velocity-filter, cob-command-gui, cob-control-mode-adapter, cob-dashboard, cob-default-env-config, cob-default-robot-behavior, cob-default-robot-config, cob-docker-control, cob-frame-tracker, cob-hand-bridge, cob-hardware-config, cob-helper-tools, cob-image-flip, cob-light, cob-linear-nav, cob-mecanum-controller, cob-mimic, cob-monitoring, cob-moveit-config, cob-obstacle-distance, cob-omni-drive-controller, cob-phidget-em-state, cob-phidget-power-state, cob-phidgets, cob-reflector-referencing, cob-safety-controller, cob-scan-unifier, cob-script-server, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-supported-robots, cob-teleop, cob-twist-controller, cob-voltage-control, compressed-depth-image-transport, compressed-image-transport, controller-manager, costmap-2d, diagnostic-aggregator, generic-throttle, image-proc, joint-state-controller, joint-state-publisher, joint-trajectory-controller, joy, laser-filters, nodelet, openni2-launch, position-controllers, realsense2-camera, rgbd-launch, robot-state-publisher, roslaunch, rosserial-python, rosserial-server, rostopic, rviz, spacenav-node, tf2-ros, theora-image-transport, topic-tools, twist-mux, usb-cam, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-cob-bringup";
-  version = "0.7.6-r4";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_bringup/0.7.6-4.tar.gz";
-    name = "0.7.6-4.tar.gz";
-    sha256 = "1e48c88721cb3ee02da7e39301e3f813d637131fc18e45e79270cb136b6085a2";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_bringup/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "db94e83d5ac91e88ed5c4ae183e2a2ab8897e48f0cba80489fc4a31598a1914f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-calibration-data/default.nix
+++ b/distros/noetic/cob-calibration-data/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-calibration-data";
-  version = "0.6.16-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/noetic/cob_calibration_data/0.6.16-1.tar.gz";
-    name = "0.6.16-1.tar.gz";
-    sha256 = "8f38e820b614d84bfc6a9f5c8f75b11db223c613a6f4f98b3fc62c0544b7a646";
+    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/noetic/cob_calibration_data/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "1f65682dfbc71f12d820fcfccf533b01ee8216fb8ca4dbcfee247288e4f529e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cam3d-throttle/default.nix
+++ b/distros/noetic/cob-cam3d-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, nodelet, pluginlib, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-cam3d-throttle";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_cam3d_throttle/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "ac433834395c2d0928182e13403da1911c7c97b315c5faa7044932dc415deaa1";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_cam3d_throttle/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "3401f950f372a490fe11b3128a01e9b531d1f6a5c6c1ed27d0ddefdbd76acac0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-canopen-motor/default.nix
+++ b/distros/noetic/cob-canopen-motor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-generic-can, cob-utilities, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-canopen-motor";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "0c2bedf468849a49ccd6bdb63b0a1bc2e09326ecd48171aa108c80e626116475";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "69d6967e9cbb3f053503e35d8600be4f08bb38b9e0d622f1dbff6286366dcc57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cartesian-controller/default.nix
+++ b/distros/noetic/cob-cartesian-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-frame-tracker, cob-script-server, cob-srvs, cob-twist-controller, geometry-msgs, message-generation, message-runtime, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, std-msgs, std-srvs, tf, topic-tools, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-cartesian-controller";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "7150569910dba69499a9bbf1d20c951ef086bf122b4367c876c67fb1bcb3f4c1";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "bf76567003bf03b69ea6b6a3091863ef4e132fb50cad0b1837185455c84ef797";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-monitor/default.nix
+++ b/distros/noetic/cob-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-moveit-config, moveit-ros-move-group, moveit-ros-planning, pluginlib, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-monitor";
-  version = "0.7.6-r2";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.6-2.tar.gz";
-    name = "0.7.6-2.tar.gz";
-    sha256 = "e1970e334d7bd63e4020fd2513e792bada61910c3561ebc71dfcdf4fdf653154";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "4c80e266153a19cb2b424355a6cd5b825a4a53bf1300f82389ef149e4d2517f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-velocity-filter/default.nix
+++ b/distros/noetic/cob-collision-velocity-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-footprint-observer, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, tf, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-velocity-filter";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "45891e4921ef07e04c77b650656477b19250989f6df640eff9909a3571ca4d53";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "15da1c3701196f99973c27d7d93e4b335dced1b8b6ee70d81853d6b675603c9b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-gui/default.nix
+++ b/distros/noetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, python3Packages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-gui";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "c349c9543b1f66316c4d13657225b1e47f66a3e188529e39ee4d0453911b4f45";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "1d1495840dea59092204f4b46f1e0a3aaae229c928a1cf1d4b4d09518a1288b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-tools/default.nix
+++ b/distros/noetic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-tools";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "de67fa56a27a0ee296a68bdedea01ec5fa789d607b0d863a97f3126521647c6a";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "376800c395a7fcbfd6a3e19b6b98f2e581d8e3aa63fdeed98a6b5cc57dfe3332";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-common/default.nix
+++ b/distros/noetic/cob-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
 buildRosPackage {
   pname = "ros-noetic-cob-common";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "c6f9ef0ed9e0b363c43a81a7d091999e37e854eaa9d20dd4773bc5c07f2573fb";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "107d9ddf164b8d0bb175b49675311c97558a5b5f84cba6555c2bb15544595acc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-mode-adapter/default.nix
+++ b/distros/noetic/cob-control-mode-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-manager-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-mode-adapter";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "0b178541cf7d1bb1e7e3e95e525bce64aab6b4044f449baf906782ad810a75da";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "833aab5fb71e71912ebceaf48b37976c060e662ab851c1159331a84a09ea781e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-msgs/default.nix
+++ b/distros/noetic/cob-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-msgs";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "a057d496c0a50eb5d4e126fd2aa3dadd1a556a57acb49020492b3f2dd24916ab";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "155ed798d03d9535d8b946fb0c02e459198f62c6c7b52608e0c1ab17902850de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control/default.nix
+++ b/distros/noetic/cob-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-controller-utils, cob-base-velocity-smoother, cob-cartesian-controller, cob-collision-velocity-filter, cob-control-mode-adapter, cob-control-msgs, cob-footprint-observer, cob-frame-tracker, cob-hardware-emulation, cob-mecanum-controller, cob-model-identifier, cob-obstacle-distance, cob-omni-drive-controller, cob-trajectory-controller, cob-tricycle-controller, cob-twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-control";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "d10c9de7c124617266c9de4b66fb2b6d66b7b40dc0bda18843e706e6e95c4beb";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "572f7cc37bbc316711874105d1c6afe7ffb1e8a2d12607d86b0654c875f63d62";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-dashboard/default.nix
+++ b/distros/noetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-noetic-cob-dashboard";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "e983c504aa63fef672e0968cd066a8c02fc09832ba6278ee76a9395485f8669f";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "3ac991ff50d19f10b09ceebf807aba46bbb4f929a29907fec1339a2b75de28f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-env-config/default.nix
+++ b/distros/noetic/cob-default-env-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-env-config";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_default_env_config/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "25bf7d51166ad5d395862797d4ea5ecfbfa8a075d542af97b88b734150d1a390";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_default_env_config/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "6cde5633df93fa2800618827ee773455398dc8cd7da437f0ae49b363a12d9a7b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-behavior/default.nix
+++ b/distros/noetic/cob-default-robot-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-light, cob-script-server, python3Packages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-behavior";
-  version = "0.7.6-r4";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.6-4.tar.gz";
-    name = "0.7.6-4.tar.gz";
-    sha256 = "4ac6bc3ee9caeb9d9298eb234290e7f68b6e1581bcaf230db4d5489fad342707";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "74cb5afa288fd0f80e6d37b49a661506f3cdbfbdd26b381017e92c1e21ba81d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-config/default.nix
+++ b/distros/noetic/cob-default-robot-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-config";
-  version = "0.7.6-r4";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.6-4.tar.gz";
-    name = "0.7.6-4.tar.gz";
-    sha256 = "b784b13ad0033bcc9337fa8054809e33b90de0f583268b6a738a1e1d7efd3edf";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "aeb0fd9cec54df5c8f3f158afbeb5c419d7d9122db683ce94f9881dfa457a317";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-description/default.nix
+++ b/distros/noetic/cob-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-description";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "1e3bb38e77b0a1f48c596d4e78ff320cb6d63c460817a0837ebd534e396b5050";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "ce971c4a6a08880102a23b90812eb0f97f7ee4f03a03887fc8d216a910e7231e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-docker-control/default.nix
+++ b/distros/noetic/cob-docker-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-docker-control";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_docker_control/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "ad5a16604e8089ac8a4b548ac74fb924de9a980ec73965f28e1e304cb0809b66";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_docker_control/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "184596b166694089649886c56c4209805fcab2af3be203793b4a38f200736061";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-driver/default.nix
+++ b/distros/noetic/cob-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-drive-chain, cob-bms-driver, cob-canopen-motor, cob-elmo-homing, cob-generic-can, cob-light, cob-mimic, cob-phidgets, cob-relayboard, cob-scan-unifier, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-undercarriage-ctrl, cob-utilities, cob-voltage-control }:
 buildRosPackage {
   pname = "ros-noetic-cob-driver";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "ce40aa8995aa3141142921c703ef1e3fc796ab5eb1a10f8f4c8d82d2e33cd7f6";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "7a195a6d4e970bd16f733e6d0e925aac8c470b3819f74338a00f6f3bc405118e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-elmo-homing/default.nix
+++ b/distros/noetic/cob-elmo-homing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-402, catkin, pluginlib, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-elmo-homing";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "8a405af15992138b050df31bea236ad5ee25ed5d559e035d3c36a186b1f0f95a";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "8ccb4c40128ce0a8db87adbde2e27776f8cde8a6c51a8a595ac0078ffe9334e6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-environments/default.nix
+++ b/distros/noetic/cob-environments/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config }:
 buildRosPackage {
   pname = "ros-noetic-cob-environments";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_environments/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "67db40949f37cbee3164eb4cb75dff2010d196651aceddb91edc5ab0efe2905e";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_environments/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "f6056d5196ddb7a95f096a3fa54a62bf18614e51b30a3e185df9bfb60fa36498";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-extern/default.nix
+++ b/distros/noetic/cob-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libdlib, libntcan, libpcan, libphidgets, opengm }:
 buildRosPackage {
   pname = "ros-noetic-cob-extern";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/cob_extern/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "19c8711acff2bcaee5b6cd917a43fbf2ac953af44d18ef9609fd13fe84cde14b";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/cob_extern/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "97e887c73b8759c68eea45d53b7ff0473908de639d557b8c88ea428aa88df5d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-footprint-observer/default.nix
+++ b/distros/noetic/cob-footprint-observer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-footprint-observer";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "16fe875891cf2a6b7ec49182cb2356a2736ce74aa9a05973d075cc92d26dd149";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "77d382df110e8618f5b725f269c772fb3c3d2529adf9beaeb6faf6ac97f5966a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-frame-tracker/default.nix
+++ b/distros/noetic/cob-frame-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-srvs, control-toolbox, dynamic-reconfigure, geometry-msgs, interactive-markers, kdl-conversions, kdl-parser, message-generation, message-runtime, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-frame-tracker";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "b012cf74c31c3a651a60a63450a20f530071ce0ff67bd1f1f0be3113a708c875";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "e7bd773112cc84473c0948489e8212c779283f6574335cdd97c0f078d1c3b04c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-objects/default.nix
+++ b/distros/noetic/cob-gazebo-objects/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-objects";
-  version = "0.7.5-r2";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_objects/0.7.5-2.tar.gz";
-    name = "0.7.5-2.tar.gz";
-    sha256 = "f9ebb9e972375cabb72ebd0b075ba0c58e102d0415fbd042ed761a6874726dc2";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_objects/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "8ae54baf00927db2c1bc5c8aee5670c6ebb7af9232b8f296db5b5257b3c69ce9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-plugins/default.nix
+++ b/distros/noetic/cob-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-plugins";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_plugins/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "96c90d97757244d423ef5e969a25ba2ef054db9d2adf6c8068bedd4efecb4280";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_plugins/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "41e7a4febc5a00ef86017729f5bf1b89896fa406578b7903cc388dc715606e15";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-ros-control/default.nix
+++ b/distros/noetic/cob-gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo, gazebo-ros, gazebo-ros-control, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-ros-control";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_ros_control/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "b2627cb7fccd19d984612a57013acafa2745bf6e7c9b5549fb360240af119add";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_ros_control/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "fd49e81694642749589b62ad73957b9e4504ca1f3beb0b7350fb77e1440863db";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-tools/default.nix
+++ b/distros/noetic/cob-gazebo-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, geometry-msgs, python3Packages, roslib, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-tools";
-  version = "0.7.5-r2";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_tools/0.7.5-2.tar.gz";
-    name = "0.7.5-2.tar.gz";
-    sha256 = "8f429c820e04807d1437af5913bf6c681ee1fb7457c43fa9ed24906e51cb54a2";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_tools/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "d354f1ae9181425d0b36e10ae73180830a90739ed58842ea92853047eba47985";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-worlds/default.nix
+++ b/distros/noetic/cob-gazebo-worlds/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-default-env-config, controller-manager, gazebo-msgs, gazebo-ros, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rospy, rostest, std-msgs, tf, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-default-env-config, controller-manager, gazebo-msgs, gazebo-ros, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rospy, rostest, std-msgs, tf, tf2-ros, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-worlds";
-  version = "0.7.5-r2";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_worlds/0.7.5-2.tar.gz";
-    name = "0.7.5-2.tar.gz";
-    sha256 = "200a22d3573d5e4b172e1f1ebc5a45a982a2c558d7574bbe11efca62222ac357";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_worlds/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "3cdd4b11daf900c8536a5d186f129d5269defe1d8d532fe3117dc9460880541f";
   };
 
   buildType = "catkin";
   checkInputs = [ cob-default-env-config roslaunch rostest ];
-  propagatedBuildInputs = [ cob-default-env-config controller-manager gazebo-msgs gazebo-ros gazebo-ros-control joint-state-controller joint-state-publisher position-controllers robot-state-publisher rospy std-msgs tf velocity-controllers xacro ];
+  propagatedBuildInputs = [ cob-default-env-config controller-manager gazebo-msgs gazebo-ros gazebo-ros-control joint-state-controller joint-state-publisher position-controllers robot-state-publisher rospy std-msgs tf tf2-ros velocity-controllers xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/cob-gazebo/default.nix
+++ b/distros/noetic/cob-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup, cob-default-robot-config, cob-gazebo-ros-control, cob-hardware-config, cob-script-server, cob-supported-robots, control-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, roslaunch, rospy, rostest, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo";
-  version = "0.7.5-r2";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo/0.7.5-2.tar.gz";
-    name = "0.7.5-2.tar.gz";
-    sha256 = "aa8890823d1ce3a3beca56e223cde29f9892b53913a73329811e41f669b8bfd0";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "fccbdaaee37073d405016ca4d3d75a1b46a7c7b9b12daf5a186f79526d5fdffc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-generic-can/default.nix
+++ b/distros/noetic/cob-generic-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-utilities, libntcan, libpcan, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-generic-can";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "2b73d86994723020f160a2e08094299bfe0cf11edf50574b879c21da66a1e6b4";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "87c0e9cdd291d716b53455db892a3118d4db98b0c4f71e5929dee31aa7fedd3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-grasp-generation/default.nix
+++ b/distros/noetic/cob-grasp-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-description, cob-manipulation-msgs, geometry-msgs, moveit-msgs, python3Packages, robot-state-publisher, roslib, rospy, rviz, schunk-description, sensor-msgs, std-msgs, tf, tf2-ros, trajectory-msgs, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-grasp-generation";
-  version = "0.7.6-r2";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.6-2.tar.gz";
-    name = "0.7.6-2.tar.gz";
-    sha256 = "deb00a4b93f97cc79223f04bcd589dc2da6544751c8f6ad9d14032ab99322bd9";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "1e4af3b7808b40ffd3e1493ed190554496055255a46c103db3e291c92bdb9f36";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hand-bridge/default.nix
+++ b/distros/noetic/cob-hand-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, control-msgs, diagnostic-updater, message-generation, message-runtime, rosserial-python, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-hand-bridge";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand_bridge/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "8e2b373b55092457bd19c230679bbeaca383e9384b3116994292d8a8c9f4b097";
+    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand_bridge/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "1f91d2568bc33a99e5fe3548714a1f6525890811228c74477a5418651ed8c528";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hand/default.nix
+++ b/distros/noetic/cob-hand/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-hand-bridge }:
 buildRosPackage {
   pname = "ros-noetic-cob-hand";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "80b3f611a8be6ea90a1f9f1df5c704a035a347b3419f743f757b1b6138224d04";
+    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "def20ffe69e0af6e5d173018e5d5e7fdb287a80eecb71217dc8fb7ceaf721899";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-config/default.nix
+++ b/distros/noetic/cob-hardware-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-calibration-data, cob-description, cob-omni-drive-controller, cob-supported-robots, costmap-2d, diagnostic-aggregator, joint-state-controller, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, laser-filters, position-controllers, raw-description, robot-state-publisher, roslaunch, rostest, rviz, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-config";
-  version = "0.7.6-r4";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.6-4.tar.gz";
-    name = "0.7.6-4.tar.gz";
-    sha256 = "004e7782371c933b213222f26fcf28d16a643cc0cc1438e70d847396e6eab375";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "abd28ec1757cfff0bd13263d263fae7be57fdacea82e49c50dfeee9257b5e3bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-emulation/default.nix
+++ b/distros/noetic/cob-hardware-emulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, move-base-msgs, nav-msgs, roscpp, rosgraph-msgs, rospy, sensor-msgs, std-srvs, tf-conversions, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-emulation";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "7234af66f2491c9e7f360af91f62995e1157390def16f627f3fc8e86cd3a1d74";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "5a7a01d0e9a11ffba547a8040c3bf3dfc13fd2ddd1c947b5b5a2a59123ab2c5f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-helper-tools/default.nix
+++ b/distros/noetic/cob-helper-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, python3Packages, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-helper-tools";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "d55444a29d13c290027f931cd468b5a1e3089f225818fa6c47423f8b19890c4f";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "4704689a1cb32b476b30b62add3cc9c23bec5819df8ff08af663f11a0b54002c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-image-flip/default.nix
+++ b/distros/noetic/cob-image-flip/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-perception-msgs, cv-bridge, geometry-msgs, image-transport, nodelet, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-image-flip";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_image_flip/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "8ed43b175e6c293491d2e20e0a89e8a6fe9d3f0e8ce03ac1b0d344f1d41ceb63";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_image_flip/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "c99621835873ca678c8ae4e5311c5667f66c9f142a97f310d058604319a09ac8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-interactive-teleop/default.nix
+++ b/distros/noetic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-interactive-teleop";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "7fe8effaabdd68e5318f486f75e992cecb44b8c1ad04df2d4746783f551a6514";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "cbdee81c7b4a445e769051a43dd64e3ae3d58c53dce90759fcd1d38a176adaa0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-light/default.nix
+++ b/distros/noetic/cob-light/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-light";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "954f88b2c70e4d635491bcc7bbf034d4764a3b5d6d22747f95be4b964a50ec0c";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "27f209fb96bec02eedc5893c15a6103a257ea129acf79a3c96437fe7efb68bbd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-linear-nav/default.nix
+++ b/distros/noetic/cob-linear-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cob-srvs, geometry-msgs, move-base-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-linear-nav";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_linear_nav/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "c5960f0f81f66ef448f648382f5a154a915c171cf8b9eda1ec0cc76fc9be0ce0";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_linear_nav/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "713e99b6492a0821b52b9e6baa08dc6b109d5bf10395cca74a8f6e1eaa5d7dba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-lookat-action/default.nix
+++ b/distros/noetic/cob-lookat-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, angles, catkin, control-msgs, geometry-msgs, kdl-conversions, kdl-parser, message-generation, message-runtime, move-base-msgs, orocos-kdl, roscpp, rospy, sensor-msgs, tf, tf-conversions, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-lookat-action";
-  version = "0.7.6-r2";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.6-2.tar.gz";
-    name = "0.7.6-2.tar.gz";
-    sha256 = "fa11fd115afb0152e90c75d4aea9b4fdc0279a98216e72a84116b7544596cd17";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "9416d9ec5db5b45e4a9606a4cc679a6a89ca911e76ad8b6bf4d0ea6fa3724254";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-manipulation-msgs/default.nix
+++ b/distros/noetic/cob-manipulation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, moveit-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-manipulation-msgs";
-  version = "0.7.6-r2";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation_msgs/0.7.6-2.tar.gz";
-    name = "0.7.6-2.tar.gz";
-    sha256 = "316c86387cf2b7fac6d808ca2ba90f93476576cd36951284e9d7d4223f102231";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation_msgs/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "abacddc3016ee4a538ffcb6f6e86a13cd6937428f6aed1fa8c3eaa676b1869b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-manipulation/default.nix
+++ b/distros/noetic/cob-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-collision-monitor, cob-grasp-generation, cob-lookat-action, cob-manipulation-msgs, cob-moveit-bringup, cob-moveit-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-manipulation";
-  version = "0.7.6-r2";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation/0.7.6-2.tar.gz";
-    name = "0.7.6-2.tar.gz";
-    sha256 = "17578b27ceca783a6f5982bbca3ccf2fec46087ce58295932506c62ab4f4f08c";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "654eecbac177bcfc3d3e049d98747b987bed67feba09377aac7163838898e5a4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-map-accessibility-analysis/default.nix
+++ b/distros/noetic/cob-map-accessibility-analysis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-3d-mapping-msgs, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, nav-msgs, opencv, pcl, pcl-ros, python3Packages, roscpp, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-map-accessibility-analysis";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_map_accessibility_analysis/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "84f29ecb5205454a098c7ec3029f20ccced67c710f3977baa3a36d435cfc5b47";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_map_accessibility_analysis/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "a35e3f416d74dde0074be244b44ca72dc7ebcec934d42cf22e71e08320963202";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mapping-slam/default.nix
+++ b/distros/noetic/cob-mapping-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-navigation-global, cob-supported-robots, gmapping, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-mapping-slam";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_mapping_slam/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "fa9715cf6d686b08d24e9fd971251f0a01a7911b88ada1b58d31231744fcf816";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_mapping_slam/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "0babda24aa46428095fdd3a8c2ac17bd85edac062da85c8b25ac27d86634219a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mecanum-controller/default.nix
+++ b/distros/noetic/cob-mecanum-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-mecanum-controller";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "ee1df045e8e3772d7958a2ef09c253989a857427a91e7f335587ecc15ff6d3b5";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "c9f0399d34126e974cc50cb38077d7117d288c262144e1a2a2a226da3067a665";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mimic/default.nix
+++ b/distros/noetic/cob-mimic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, diagnostic-updater, message-generation, message-runtime, roscpp, roslib, rospy, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-mimic";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "bf582da8f64999af038380d0eed98ddd80ff5c35dc42af07cf6162bfe76a34c0";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "e8d0b81c7dc31fa57ab72d20265e0c69a5ae00780e25513dacfd93c0057fe690";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-model-identifier/default.nix
+++ b/distros/noetic/cob-model-identifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, geometry-msgs, kdl-parser, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-model-identifier";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "fa9ac2dbc5ce0579e9b23289e1a3d315ab1a5a6fa3139df8a2e1801f4d404fb1";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "16b736944910d562038d3ff57e48cf264ef42d860b377287043fc8c80efa263c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-monitoring/default.nix
+++ b/distros/noetic/cob-monitoring/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, python3Packages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-monitoring";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "becc61990ebb04602238bcbedc341cdbd0528b8c6a6f00beee6543d806cd6121";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "8406aeae2a7a2b8d1e4b54be514b813302320bf270f4c997c5ebf530896a80f5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-bringup/default.nix
+++ b/distros/noetic/cob-moveit-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-hardware-config, cob-moveit-config, joint-state-publisher, moveit-planners-ompl, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, moveit-setup-assistant, robot-state-publisher, rviz, tf, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-bringup";
-  version = "0.7.6-r2";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.6-2.tar.gz";
-    name = "0.7.6-2.tar.gz";
-    sha256 = "32f3c3e7547fb673fada3892f6fffc4ae411a695b9fb32d3b87d0a6dc702d033";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "3661f3fac58130b8c00172d3be7c1be4292e46d1cee7d775bf36b2fcee974e1f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-config/default.nix
+++ b/distros/noetic/cob-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-config";
-  version = "0.7.6-r4";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.6-4.tar.gz";
-    name = "0.7.6-4.tar.gz";
-    sha256 = "aae8fb9e574992a4b2657d32106055e4f8133f2aec1a7fc21d8c462573b312cf";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "9a7536d93c48cb9508dc87cbae20d5a6530b7336c05e97e1d6f533787a4f460d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-interface/default.nix
+++ b/distros/noetic/cob-moveit-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-script-server, geometry-msgs, moveit-commander, python3Packages, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-interface";
-  version = "0.7.6-r2";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.6-2.tar.gz";
-    name = "0.7.6-2.tar.gz";
-    sha256 = "b23e016544bda94934e7aafc143d32f33be4be7208481755b7ddf0759a9c3144";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "38d484d7b5c2eb4916448b15d3ff49c81cda6d6e8190bc8b16a659f54f9a3d05";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-msgs/default.nix
+++ b/distros/noetic/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-msgs";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "0e4d104ae4477f6c0e8f94c57894201b18fe9395caba4d4e334d71b2f22d47ef";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "e871d7c85cfe1b83c13d3102365ec95e0d3741fa9820ea10b47a26aea9829571";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-config/default.nix
+++ b/distros/noetic/cob-navigation-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-config";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_config/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "75314196a7d593581b1c1705a7908bbb6a14dbf88fd5f3bfe7b9c90e6014b2c7";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_config/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "7bd8380ec54e08b901b93eac51e96993f667abe16229df31593fd71cbc34fb21";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-global/default.nix
+++ b/distros/noetic/cob-navigation-global/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, cob-default-env-config, cob-linear-nav, cob-navigation-config, cob-scan-unifier, cob-supported-robots, dwa-local-planner, map-server, move-base, roslaunch, rviz, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-global";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_global/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "f93dd0df9a50e8ce3a4b633487d0169f9ca168cbed6651218243e7ad68f8a257";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_global/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "7e3b3ccaf428da57d016882cea7f84a716afc91183157be722137e8db7057a17";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-local/default.nix
+++ b/distros/noetic/cob-navigation-local/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-navigation-config, cob-supported-robots, dwa-local-planner, move-base, roslaunch, rviz }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-local";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_local/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "571daaf3c127c4047266506731334e6e4ff8f599d0a744c559a2c70a6aa2a5fc";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_local/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "150eb6e0c9a3365780db8804ad3f26a890efc754d231abc682fed8d42adac12c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-slam/default.nix
+++ b/distros/noetic/cob-navigation-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-mapping-slam, cob-navigation-config, cob-navigation-global, cob-supported-robots, roslaunch, rviz }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-slam";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_slam/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "741e655b5e49cfe839acbe839176c238b3825bc2e11ec056374203930121516d";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_slam/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "1454b5ece53c1d29e516e8b47c13b3242edbc4d1912cb0f34b14e62644244e3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation/default.nix
+++ b/distros/noetic/cob-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-linear-nav, cob-map-accessibility-analysis, cob-mapping-slam, cob-navigation-config, cob-navigation-global, cob-navigation-local, cob-navigation-slam }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "bb54c0664945c8fb0b011ee69a4eb5a12360276698668e4f44ec9ca134e51a8c";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "6a4d2b7d7b118e176f6f433a6c4d77162d7fa1520f2c3e615e794cb0996a65e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-object-detection-msgs/default.nix
+++ b/distros/noetic/cob-object-detection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-object-detection-msgs";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_msgs/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "0220523d29b16b9c82bcee66e50b8ac983e3d57e63ad32d984a3d690e277eeca";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_msgs/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "3545063cd63a307c29456b39f68ab1fcd842b90423e61da31d08942c5d093888";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-object-detection-visualizer/default.nix
+++ b/distros/noetic/cob-object-detection-visualizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-object-detection-msgs, cv-bridge, eigen-conversions, image-transport, message-filters, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-object-detection-visualizer";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_visualizer/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "be19c1e5964b12bcfcc6596a11b176a7eab6466a93ebe0057f6f95660c10b935";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_visualizer/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "70c64219bb8f8f7bd3316550733227c9defcdbace1172268308370caf34bc925";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-obstacle-distance/default.nix
+++ b/distros/noetic/cob-obstacle-distance/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cob-control-msgs, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, fcl, geometry-msgs, interactive-markers, joint-state-publisher, kdl-conversions, kdl-parser, moveit-msgs, orocos-kdl, pkg-config, robot-state-publisher, roscpp, roslib, roslint, rospy, rviz, sensor-msgs, shape-msgs, std-msgs, tf, tf-conversions, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-obstacle-distance";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "61d001ed2bdf818bc02d3db5ab62284cde5517b760509212d15ad18ae5c248c4";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "562962aeac35064d98ae91ec9af8b3e2670ce5f8630ef6435bed4bdd48b85b81";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-omni-drive-controller/default.nix
+++ b/distros/noetic/cob-omni-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-omni-drive-controller";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "010674b5961b5ee0f348697227aa134c78e804370d3b014446e2015feeb48d93";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "3fd7d6eba9de9efb6e8bd665aa82f24f0b3e6c7cc0fe423ed5c533cf5188b08f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-perception-common/default.nix
+++ b/distros/noetic/cob-perception-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-3d-mapping-msgs, cob-cam3d-throttle, cob-image-flip, cob-object-detection-msgs, cob-object-detection-visualizer, cob-perception-msgs, cob-vision-utils }:
 buildRosPackage {
   pname = "ros-noetic-cob-perception-common";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_common/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "c2b674122e1ee467ca4e5b647e734ff569bc3aaebe17cb141aa614c1e0226bbb";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_common/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "f5cd06f99e618d50e13e1a5c79858d58d464414ebcf3db9c90feb4082ef8bcaa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-perception-msgs/default.nix
+++ b/distros/noetic/cob-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-perception-msgs";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_msgs/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "b101f92b078465cbbe5672f6022d1d64a6150e1d8468f65d4794e7fc8f44c71f";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_msgs/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "c46c5760c1ea6f9494679c6673872abac8b25e4ea6b4f698263eacf2106cabaa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-em-state/default.nix
+++ b/distros/noetic/cob-phidget-em-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-em-state";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "a9b9bffec2e0c8aae911378e859b94e0e5a3884c3ad27ec206fd7b0e7e971031";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "d8c4cf6c5d30d3724aa47551d2914530cebd44cd26f34069471fcac34628f872";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-power-state/default.nix
+++ b/distros/noetic/cob-phidget-power-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-power-state";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "17a971678bd07f4861f9e73c81570346058a5f60d63b39202351fe793b512ded";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "b3d3e4b3e28fcc091d29920eae3d239ff25eee51fdd8eb8d0f7e6aa57185331f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidgets/default.nix
+++ b/distros/noetic/cob-phidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidgets, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidgets";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "9b5f9e9e5b9c812257fd171e5e8c901f34eeb4530c2a98bf328037ca9a0b530f";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "f6bb6aacbcaa5dddd522c6e53143d6b37cd2b73e440f30cf13ae3a10ebfea09a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-reflector-referencing/default.nix
+++ b/distros/noetic/cob-reflector-referencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-reflector-referencing";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_reflector_referencing/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "053bef87c9fbbbdc25cc44ad820aede0bf4c0ad2c1598f537aa76ce157fcba5b";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_reflector_referencing/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "6631e274bff81a1e2b68c33d055157ed3dfd0c80c7af0feb9fd9eebaeb6454b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-relayboard/default.nix
+++ b/distros/noetic/cob-relayboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-relayboard";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "9590bbd1bc74f6d9138aa0d0e29c2f31f8e05587b77c6ddac21a7ee3e9f3a032";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "88f530ca79d1f55bac1341165a760ec588252f8befca533b7a3917a2a11b064b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-robots/default.nix
+++ b/distros/noetic/cob-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup, cob-default-robot-behavior, cob-default-robot-config, cob-hardware-config, cob-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-cob-robots";
-  version = "0.7.6-r4";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_robots/0.7.6-4.tar.gz";
-    name = "0.7.6-4.tar.gz";
-    sha256 = "108d2d5764ed228e6aea25c0a03b4210fd6bf409fe6e55c6ac03767bef409a7f";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_robots/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "9c87bc8c182e029bebc24a97ee626fa7ecca185cf66adaf3646b0f23657dc6ef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-safety-controller/default.nix
+++ b/distros/noetic/cob-safety-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-safety-controller";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_safety_controller/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "4be7cda7abf295591cc373314f4e05f2aec6e9d7d8798a381f49fc0b36ac7d3d";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_safety_controller/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "747c9afba9892dabb5d2be7cf75d8c48294badb4125098fd6304a6dae434838a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-scan-unifier/default.nix
+++ b/distros/noetic/cob-scan-unifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-scan-unifier";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "50f997ad8177f29546d531461923f86344d024f97526168cc46ae7f189dbdc54";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "79113863fd5f9f8216dde3def40dda64d480414581b6de3664bc18a7535b632c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-script-server/default.nix
+++ b/distros/noetic/cob-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-noetic-cob-script-server";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "1143ba075358fb31c5792ca553dd31ae5b8f033da31ced72af42b23ce0105920";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "e82ccbefa9f9c95ee781051b66a55c8b3fe3494d441147834458af1d70edbc06";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-lms1xx/default.nix
+++ b/distros/noetic/cob-sick-lms1xx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-lms1xx";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "6ae3458ea6b81f42df2846935d28faf2d9706fa188720258575a04f1a5aee92e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "b8ddc5152b6f07caa06c23f0b7f935621532188982a993a6938e1871e2d03465";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-s300/default.nix
+++ b/distros/noetic/cob-sick-s300/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-s300";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "488690eee681032788e6e5b419f86fe12ddf04377769e6af7232cc6e6882a885";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "22cf92128deb44b82975f01a526409e35267dfbe0c9158fc12eb6f23a41b9365";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-simulation/default.nix
+++ b/distros/noetic/cob-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup-sim, cob-gazebo, cob-gazebo-objects, cob-gazebo-tools, cob-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-noetic-cob-simulation";
-  version = "0.7.5-r2";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_simulation/0.7.5-2.tar.gz";
-    name = "0.7.5-2.tar.gz";
-    sha256 = "eddfe760bd0aa94909ece4da9ef0758fdc0e5fc3516f64c279ae8bfa73a08b4a";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_simulation/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "c99f3a562752d04de2a51d85ccb2ef9417111d556dc3c9492935e5ed11124b2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sound/default.nix
+++ b/distros/noetic/cob-sound/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsaOss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-sound";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "af70146549c996710814d04c64c3891969dff78453d78c30e112aef2f6c07ad6";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "dc3fca6d6e6ec40d6c55580afb3c3dbdd9712fbd2abb115d37027c51d2d05eeb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-srvs/default.nix
+++ b/distros/noetic/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-srvs";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "8dc0c4c966e4763fb8d443a647069a343e3d08f9e28ece2184fe38615997187c";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "de7cbdbbd0eb14c1b9753b5e398fea1a492f63458de1b91beeec89e56d7e62e7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-substitute/default.nix
+++ b/distros/noetic/cob-substitute/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-docker-control, cob-reflector-referencing, cob-safety-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-substitute";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_substitute/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "9f6abb857678e7be1f7ca7870eafdb8e6c1311246d12e6a88bdb0f0c216c7e32";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_substitute/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "a14002b4ff9ddf10ae68616f6c2b9bc23d5c390f987e902332cb9d5d7bc68fde";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-supported-robots/default.nix
+++ b/distros/noetic/cob-supported-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-supported-robots";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/noetic/cob_supported_robots/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "2ce0e4b4b56c74b35c96a7f164889146a9b04afc2869c983d4c5852aa9d70fb2";
+    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/noetic/cob_supported_robots/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "e276d79787be46fd66f33af637b8e4a28050b98d6e02cbd9a4e2073f0f68bdd2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-teleop/default.nix
+++ b/distros/noetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-teleop";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "6c0af771ae8da51ebe1b8bff718166782ae254444c08ea6e233377fb9825d10e";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "229d251662be957b3fc631e0d53ff99236646867e46ce29820d4d71102ec10ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-trajectory-controller/default.nix
+++ b/distros/noetic/cob-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-srvs, control-msgs, dynamic-reconfigure, roscpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-trajectory-controller";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "68824e4698488025b31c1957ad9f86d5c23ec5e143d0b63703f73c029ce68215";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "68b32d64ba54b193a0047da5214a3de4a695892efbe97a68684a12e2b8d69925";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-tricycle-controller/default.nix
+++ b/distros/noetic/cob-tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-tricycle-controller";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "d3c6c791150dff4d2e4c2e4be618501719e4bc09af869ba5dbe226adac7a5555";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "e74df75fb46b458214a45556c9b981c7e260e1215088e2bdaf9771dd4ac2699e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-twist-controller/default.nix
+++ b/distros/noetic/cob-twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-script-server, cob-srvs, control-msgs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-twist-controller";
-  version = "0.8.18-r1";
+  version = "0.8.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.18-1.tar.gz";
-    name = "0.8.18-1.tar.gz";
-    sha256 = "2297c4169f1fc82ee55f57d67ba550036c413bcac51e0611f905e30fd59deb62";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.19-1.tar.gz";
+    name = "0.8.19-1.tar.gz";
+    sha256 = "833dc1e2bcf5faa7f86a9c2dcdb888c850bc6bbbf41a4aa328edd49fc4bbc1cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-undercarriage-ctrl/default.nix
+++ b/distros/noetic/cob-undercarriage-ctrl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-utilities, control-msgs, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-undercarriage-ctrl";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "39ff226d9f5531983edaffb6b9fe7a0e93e2446295451e63f8a2f731e6f58192";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "d6583454925742522185987ec67c1cf41c9d102beec3cfb054bdeb02f668a6fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-utilities/default.nix
+++ b/distros/noetic/cob-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-utilities";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "ef506b51f990915a1ae7be96f173d0de203d70f547702589419867058272b132";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "e27eb1c3c376c6701986b478acf4e8825292af2a5a4eb7a6bf46d507fc5e0fde";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-vision-utils/default.nix
+++ b/distros/noetic/cob-vision-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, roscpp, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-vision-utils";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_vision_utils/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "de18b314f11dc4cdd3d182874f242139503d834a0067fb8f7bebad47604dd3f9";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_vision_utils/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "48ed5233202433f45c6c541e46a0cad2f5ae1c352498fcd9584300050d8897bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-voltage-control/default.nix
+++ b/distros/noetic/cob-voltage-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, dynamic-reconfigure, python3Packages, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-voltage-control";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "bd21f7c884b3d25318f342bceaf6618fd61efc6b73e25827cb96c1593c0e9518";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "17dc18b78c2358d6ae1af394d859df2f6186fa815bc4464e780b7e5f426da8c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "0a4f0fef84c681b2433f00d4a615ef584ea86c0cf565170f8b49851dc0491365";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "efec10685a4a0fcaa41f82998f83ef4d76e7e38266f681d62c2539249b2777d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ess-imu-ros1-uart-driver/default.nix
+++ b/distros/noetic/ess-imu-ros1-uart-driver/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-ess-imu-ros1-uart-driver";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release/archive/release/noetic/ess_imu_ros1_uart_driver/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "a9f2be612ea0357d970ab88231b35436add0c5fd95467a6c1449922fab7a12b1";
+    url = "https://github.com/cubicleguy/ess_imu_ros1_uart_driver-release/archive/release/noetic/ess_imu_ros1_uart_driver/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "01905810b6dac9f0eb5d220c674f31ad5c95c0bf65bd7d056ab1b535d688ba69";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ roscpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs std-msgs tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The Epson IMU Driver using UART interface for ROS package'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsdOriginal "PD" ];
   };
 }

--- a/distros/noetic/executive-smach-visualization/default.nix
+++ b/distros/noetic/executive-smach-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach-viewer }:
 buildRosPackage {
   pname = "ros-noetic-executive-smach-visualization";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/noetic/executive_smach_visualization/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "e51d31da1fdaa1406fdd97da0ff022caa5e69f0fc2cc792ec40a6967e0be37a5";
+    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/noetic/executive_smach_visualization/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "937ce2d673fa25af3af7ef9f7200827bedbefac86e3e347519e4c405c408ebff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1240,6 +1240,8 @@ self: super: {
 
  ifm3d-core = self.callPackage ./ifm3d-core {};
 
+ ign-ros-control-demos = self.callPackage ./ign-ros-control-demos {};
+
  image-cb-detector = self.callPackage ./image-cb-detector {};
 
  image-common = self.callPackage ./image-common {};
@@ -1657,6 +1659,8 @@ self: super: {
  marti-data-structures = self.callPackage ./marti-data-structures {};
 
  marti-dbw-msgs = self.callPackage ./marti-dbw-msgs {};
+
+ marti-introspection-msgs = self.callPackage ./marti-introspection-msgs {};
 
  marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
 
@@ -3101,8 +3105,6 @@ self: super: {
  smach-msgs = self.callPackage ./smach-msgs {};
 
  smach-ros = self.callPackage ./smach-ros {};
-
- smach-viewer = self.callPackage ./smach-viewer {};
 
  smclib = self.callPackage ./smclib {};
 

--- a/distros/noetic/generic-throttle/default.nix
+++ b/distros/noetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, python3Packages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-generic-throttle";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "74169e90b370d0f20dd47018e96edc590010a23b975349d169d1f600ddde07cd";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "27c49b5b9796642998d198a5af6484f9a6432096e5d164694954c869965611b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hpp-fcl/default.nix
+++ b/distros/noetic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-hpp-fcl";
-  version = "1.8.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/1.8.1-1.tar.gz";
-    name = "1.8.1-1.tar.gz";
-    sha256 = "0e77963fcce64b51ec4f27c9a196757af2d0783feb5463b784b87a1e8fc62399";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "6638c9e5e5ad0517eefe6abc79b008af595b6f2acf3d13d65cf434d7dba5bbc9";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ign-ros-control-demos/default.nix
+++ b/distros/noetic/ign-ros-control-demos/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, effort-controllers, ign-ros-control, joint-state-controller, joint-state-publisher, position-controllers, python3Packages, ros-ign-gazebo, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-ign-ros-control-demos";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ign_ros_control-release/archive/release/noetic/ign_ros_control_demos/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "34e65328c8fd74ad40ba8e29b8ce4a4c0ba91a40b8768707f479b95aec5fe3fc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ effort-controllers ign-ros-control joint-state-controller joint-state-publisher position-controllers ros-ign-gazebo velocity-controllers xacro ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Ignition ros_control package demos.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ipa-3d-fov-visualization/default.nix
+++ b/distros/noetic/ipa-3d-fov-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ipa-3d-fov-visualization";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/ipa_3d_fov_visualization/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "3a0784f2c54df8fe9965d0e2ea9f248b3a8b19ff9a54fe82ada73e452b45891c";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/ipa_3d_fov_visualization/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "e4baf608248141a7a93ec5f72b1316a6e2a37ab884126be6754b1c425c060136";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ipa-differential-docking/default.nix
+++ b/distros/noetic/ipa-differential-docking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-ipa-differential-docking";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/ipa_differential_docking/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "09b554178afbb3ad4f95ac879fb9f1186e7cdb5a48e3400b9483969416f74468";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/ipa_differential_docking/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "1702147d1a9b120c18f7c2ee3a821566be140039abbe5013ed217d8383e8e0b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "5d583fa7d7e99eb64f3f48fd31579a5dfba9b5b9581bb382f5a5d7726f867d54";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "d7c299727627ba66e5285bdadf317a2db6c1dfc4a7f291beda8f96dbb10c518d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-scan-densifier/default.nix
+++ b/distros/noetic/laser-scan-densifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-scan-densifier";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "7efdb98150f84c6bc67f5416fe08325e05e65b1b590f1b7d0b2845375336536e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "3a0d6b605bc5ecfff80d8bb97b00a8971698a86700825a002278012770b43dfd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libdlib/default.nix
+++ b/distros/noetic/libdlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-libdlib";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libdlib/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "704258cc1b7c08346fb6a622edfeac3a1575bfdf2d586039f83baa2d65a792f0";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libdlib/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "217bb8d8c749b3c2d3235183c0ee685a1bb0310ab92391a8b2a4b1e37a748f7c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libntcan/default.nix
+++ b/distros/noetic/libntcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dpkg }:
 buildRosPackage {
   pname = "ros-noetic-libntcan";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libntcan/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "98ea696c9ecf7b235e565db4b6f2f7a85112ad2e61f5128eb3776214b73f5192";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libntcan/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "d7723026b5cf16ace323ad374e6d327cdbd887cf2735d4aa691322458da20659";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libpcan/default.nix
+++ b/distros/noetic/libpcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-libpcan";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libpcan/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "2fe5ad3a5608e48eedb6c3e4bbcd846635f5193cd634dd45e3a1df902a00eaeb";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libpcan/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "634d7fe32f5cdda1a70fd01d76ec7538948cf891bf037594f8358eafbf9ea091";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libphidgets/default.nix
+++ b/distros/noetic/libphidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidgets";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libphidgets/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "29fbbbf43e53763c863dedcec0390465376f129591ec58870312be669e462462";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libphidgets/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "8819ed4fdd6d7f69744ef34c7d5573aee979beb11e64714897e5d9a3cc55e910";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "530dc00bed79a129f769b3fbc9601d735a6e8d9e7e43e6a366eedcfc586e60cf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "a9640cc8e1953a173b4a05404d9e6f7e5feab1fe8829314a8ed5006c0338210c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-can-msgs/default.nix
+++ b/distros/noetic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-can-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "7d456986304ed2e108fd6838a60ead6d038937b91ed1170342a24d1db2e3fc0a";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "babb64d0980f74a1fb67a3cf8ad983f6fbe758a16f3dc0aa9de22088fef9ad45";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-common-msgs/default.nix
+++ b/distros/noetic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-common-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "d4057234d2b8ce47a77e50ddadca21d73cdba428d7b4d0569beaf61622364447";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "38e5ad3a372eb954c413d2fc26f114a933779a82b1f0b3dce70743d5071c5e2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-dbw-msgs/default.nix
+++ b/distros/noetic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-dbw-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_dbw_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "d2fe821a58922635f36ac9e0907878c57bc45fada41eaf463885429453546323";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_dbw_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "176be07b25ce1ad4e6cbfe8812797d1848b25d42880657c7bce29808f50ecc2e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-introspection-msgs/default.nix
+++ b/distros/noetic/marti-introspection-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-introspection-msgs";
+  version = "0.11.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_introspection_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "14b01f49d4c7e7dc1a8222fc3ca5c59f9601d36f6bbf4999130b69456e81cf0d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_introspection_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-nav-msgs/default.nix
+++ b/distros/noetic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-nav-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "f2cd5a9914a145472de4a1dae618e48a24f165b216da806aacc1ab9058854e5b";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "627500b5a3c69d00602711b61539bd702377189cf529c2d6e6a94699e5a1a1b1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-perception-msgs/default.nix
+++ b/distros/noetic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-perception-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "fb116694e6760dbb6109113b6441c5b6a40e1c24dc2ca264c8126f5b99da2132";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "8b4d5f2e4791ee54f675c83203deb0df09fd6b2c70729f334e78480c82461961";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-sensor-msgs/default.nix
+++ b/distros/noetic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-sensor-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "60a36252c0114342d9e9df22dccac7353a1f5a294ee689e9a58b497e95402c11";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "7b78aebe19a212b2e6d22dd7181dd376173adb82b8f74f6a228d658c3d91f290";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-status-msgs/default.nix
+++ b/distros/noetic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-status-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "3e29dcb9e0b84a53805c0ee0706a690074777ead1828f58930db27f86c448d2b";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "34816e459b00b84a94b060aa87ed3da13500e9a20a04df80ce26094f3da85621";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-visualization-msgs/default.nix
+++ b/distros/noetic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-visualization-msgs";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "4796fb7dcef22b7d41e1680ad04a55c4b291e4402d608dc318d29419a88d31ab";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "729340251387b7c85d1e1143eb90c6978ad90202521033a6fd98403ff541d499";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2022.3.3-r1";
+  version = "2022.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.3.3-1.tar.gz";
-    name = "2022.3.3-1.tar.gz";
-    sha256 = "1b43282c412bb02003e41c25a1de724b1c1530b5fb4ec63cb561dcd77f48f223";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2022.8.8-1.tar.gz";
+    name = "2022.8.8-1.tar.gz";
+    sha256 = "c42148c98b55c0566c38ab044d5db5d38bae20420414552e2940fb6d025258c1";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mqtt-client/default.nix
+++ b/distros/noetic/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nodelet, paho-mqtt-cpp, roscpp, std-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mqtt-client";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "3bab95f04ff712f92303cb59a3746d95362bdd8387ab1ec295418fd24ee2cf0f";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "642c67b60915f0fcac58ef555f000180ff14f9f9137ff5b20a772fa517dfb0fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "af726ba868b2a9460acc4adb100f470adc48458a27b7c7a73056f6c6f19d81fd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "5610b34cb3941e18490cf8b89baba9d817aa43703e54e1422b46d430850ea95e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "5decc58e1f516ee9e83e9043a5472501af2fe83b5468322fa591106c9e35fa97";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "98aa063f9e6bbdc6b4534a42c0288442c5c44008da07d0b41d750441a280d740";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "44968d444c3ac9e8314e6b7324add87acb34125152623d64dc95b27bce5eefa9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "6e8eaf5e14bb76e6a6fbeeed53226d37c861b8a292c433e875970dd5fad7d06e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "a3f7925e5107021f59670fc22db60a7121628626949a920e9101dac77f06a0e2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "4d6cdfd09e36a8a3e71d90576da20d46493d8958cd5818f977fada7906d9ff50";
   };
 
   buildType = "catkin";

--- a/distros/noetic/opengm/default.nix
+++ b/distros/noetic/opengm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-opengm";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/opengm/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "016b0c5281f1a0207277774024c80ce74f2a08e858e409430a45a243151de243";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/opengm/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "5c29a653bbc69cc079bdf853a7298bb82844abc10dd215b66374c60b697eb128";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "ed72b5a43aea58fdeb080a51947dd7626b2a7b01f5275d87267e2298c0a5b918";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "0ff34c867306699822b834b25f46e17a9c102ad94469aa85d0121ee09cc1acd5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.5.1-r3";
+  version = "3.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.5.1-3.tar.gz";
-    name = "3.5.1-3.tar.gz";
-    sha256 = "644d421ca13b7120f0d8b370546411a326a2b308d8ef37f9f7e604e65adb314c";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.5.2-1.tar.gz";
+    name = "3.5.2-1.tar.gz";
+    sha256 = "524d1be71a5c999fbf018b8d4c714035f79afa7de1390b1a00277d038e607d1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/raw-description/default.nix
+++ b/distros/noetic/raw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-raw-description";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "0abf310c464787041f5a67fc91c74b1e15e451f2bc6a80fae072a587ab29d40e";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "68ac3ce6ad532c9ef2b4cf20e439b1294ec71ec76db56eac92376e8661ea2e9b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-snapshot-msgs/default.nix
+++ b/distros/noetic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-snapshot-msgs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "f43930793890f754f95889a127475ee48672b05660aaaf28cf2ed6d962288fad";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot_msgs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "753504bb1f1d792be57ea96c9b060f32508b1005d6d7f18311b93e59d8ebca1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-snapshot/default.nix
+++ b/distros/noetic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-snapshot";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "aeeacd6ab144acbc737b6f5cb8d6199f7d822dcd0887f176b3766f495952e060";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "6faa6bf1c0a94506e8911affaf60852ce7a73c13d3431c94d449a1f895c04fe9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.14-r1";
+  version = "1.14.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.14-1.tar.gz";
-    name = "1.14.14-1.tar.gz";
-    sha256 = "11c239574d5773e8565989cbe525c5f1ae44658092fabc6b59d68a388e613738";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.16-1.tar.gz";
+    name = "1.14.16-1.tar.gz";
+    sha256 = "59a6d06da3dfed7e41e34bb8d9d8e23e32d295bd01b715a164993f5e448fe4da";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "26a7b28ef387881b03caa3e234776e1815d6c9bbd816d0418a271887604cef61";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "436d52843815d224364857e9c4b261a361d02ead03bc990788a9a97a431cd2a6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/scenario-test-tools/default.nix
+++ b/distros/noetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, python3Packages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-scenario-test-tools";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "0f39ed997daa9de1ad0a07509a0af60843ad019ba4b02cb16d98e08411a5c85c";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "8863013b3c7baa63ff236706dc1cb9248450945e22af48758602111570b6c279";
   };
 
   buildType = "catkin";

--- a/distros/noetic/service-tools/default.nix
+++ b/distros/noetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-noetic-service-tools";
-  version = "0.6.28-r1";
+  version = "0.6.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.28-1.tar.gz";
-    name = "0.6.28-1.tar.gz";
-    sha256 = "d2034fc00f35f266c74c3c1f33d379f83be2496a1741c46851b535d84c17c905";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.29-1.tar.gz";
+    name = "0.6.29-1.tar.gz";
+    sha256 = "d7331f9f3ba86ff6e63ec9fd7a6a1448151fb042f45e68873718293c0cf4e3f5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "2a9d4b0f9f22fa88171edf02d591671ee0eb9b96b3abeff6a1e7f65ed73ea3f8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "da7e3bec9c601e76bf1ea39cb24b28768d188ba90816c2bf82cdc08e7159afee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "03d870a4ac8be7401832978edd34e6755664443521c996c1fa72dc288ab951d5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "d437cb6ea37f6d72214cb14bd9479801cbda4fbb584f2b0125f17e158fde6e6f";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit 22efb906cedbec3c99abdd478725a6949f706481.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *controller-interface 0.10.1-r1 --> 0.11.0-r1*
* *controller-manager 0.10.1-r1 --> 0.11.0-r1*
* *controller-manager-msgs 0.10.1-r1 --> 0.11.0-r1*
* *diff-drive-controller 0.8.0-r1 --> 0.8.1-r1*
* *effort-controllers 0.8.0-r1 --> 0.8.1-r1*
* *eigenpy 2.7.10-r1 --> 2.7.10-r2*
* *force-torque-sensor-broadcaster 0.8.0-r1 --> 0.8.1-r1*
* *forward-command-controller 0.8.0-r1 --> 0.8.1-r1*
* *gripper-controllers 0.8.0-r1 --> 0.8.1-r1*
* *hardware-interface 0.10.1-r1 --> 0.11.0-r1*
* *imu-sensor-broadcaster 0.8.0-r1 --> 0.8.1-r1*
* *joint-state-broadcaster 0.8.0-r1 --> 0.8.1-r1*
* *joint-state-controller 0.8.0-r1 --> 0.8.1-r1*
* *joint-trajectory-controller 0.8.0-r1 --> 0.8.1-r1*
* *maliput-multilane 0.1.1-r1 --> 0.1.2-r1*
* *mavlink 2022.3.3-r1 --> 2022.8.8-r1*
* *plotjuggler 3.5.1-r1 --> 3.5.2-r1*
* *position-controllers 0.8.0-r1 --> 0.8.1-r1*
* *r2r-spl-7 0.0.1-r1 --> 0.0.2-r1*
* *ros-workspace 1.0.1-r1 --> 1.0.2-r1*
* *ros2-control 0.10.1-r1 --> 0.11.0-r1*
* *ros2-control-test-assets 0.10.1-r1 --> 0.11.0-r1*
* *ros2-controllers 0.8.0-r1 --> 0.8.1-r1*
* *ros2controlcli 0.10.1-r1 --> 0.11.0-r1*
* *rqt-publisher 1.1.3-r1 --> 1.3.0-r1*
* *splsm-7 0.0.1-r1 --> 0.0.2-r1*
* *splsm-7-conversion 0.0.1-r1 --> 0.0.2-r1*
* *transmission-interface 0.10.1-r1 --> 0.11.0-r1*
* *ur-bringup 2.0.0-r1 --> 2.0.1-r1*
* *ur-controllers 2.0.0-r1 --> 2.0.1-r1*
* *ur-dashboard-msgs 2.0.0-r1 --> 2.0.1-r1*
* *ur-description 2.0.0-r1 --> 2.0.1-r1*
* *ur-moveit-config 2.0.0-r1 --> 2.0.1-r1*
* *ur-robot-driver 2.0.0-r1 --> 2.0.1-r1*
* *velocity-controllers 0.8.0-r1 --> 0.8.1-r1*

Galactic Changes:
-----------------
* *controller-interface 1.5.1-r1 --> 1.6.0-r1*
* *controller-manager 1.5.1-r1 --> 1.6.0-r1*
* *controller-manager-msgs 1.5.1-r1 --> 1.6.0-r1*
* *diff-drive-controller 1.4.0-r1 --> 1.5.0-r1*
* *effort-controllers 1.4.0-r1 --> 1.5.0-r1*
* *eigenpy 2.7.10-r1 --> 2.7.10-r2*
* *force-torque-sensor-broadcaster 1.4.0-r1 --> 1.5.0-r1*
* *forward-command-controller 1.4.0-r1 --> 1.5.0-r1*
* *gripper-controllers 1.4.0-r1 --> 1.5.0-r1*
* *hardware-interface 1.5.1-r1 --> 1.6.0-r1*
* *hpp-fcl 2.1.1-r1 --> 2.1.2-r1*
* *imu-sensor-broadcaster 1.4.0-r1 --> 1.5.0-r1*
* *joint-state-broadcaster 1.4.0-r1 --> 1.5.0-r1*
* *joint-trajectory-controller 1.4.0-r1 --> 1.5.0-r1*
* *log-view 0.2.1-r1 --> 0.2.2-r1*
* *mavlink 2022.3.3-r1 --> 2022.8.8-r1*
* *plotjuggler 3.5.1-r1 --> 3.5.2-r1*
* *position-controllers 1.4.0-r1 --> 1.5.0-r1*
* *r2r-spl-7 1.0.0-r1 --> 1.0.1-r1*
* *ros2-control 1.5.1-r1 --> 1.6.0-r1*
* *ros2-control-test-assets 1.5.1-r1 --> 1.6.0-r1*
* *ros2-controllers 1.4.0-r1 --> 1.5.0-r1*
* *ros2-controllers-test-nodes 1.4.0-r1 --> 1.5.0-r1*
* *ros2controlcli 1.5.1-r1 --> 1.6.0-r1*
* *rqt-image-overlay 0.0.6-r1 --> 0.0.7-r1*
* *rqt-image-overlay-layer 0.0.6-r1 --> 0.0.7-r1*
* *splsm-7 1.0.0-r1 --> 1.0.1-r1*
* *splsm-7-conversion 1.0.0-r1 --> 1.0.1-r1*
* *transmission-interface 1.5.1-r1 --> 1.6.0-r1*
* *ur-bringup 2.1.1-r1 --> 2.1.2-r1*
* *ur-calibration 2.1.1-r1 --> 2.1.2-r1*
* *ur-controllers 2.1.1-r1 --> 2.1.2-r1*
* *ur-dashboard-msgs 2.1.1-r1 --> 2.1.2-r1*
* *ur-moveit-config 2.1.1-r1 --> 2.1.2-r1*
* *ur-robot-driver 2.1.1-r1 --> 2.1.2-r1*
* *velocity-controllers 1.4.0-r1 --> 1.5.0-r1*

Humble Changes:
---------------
* *control-msgs 3.0.0-r1 --> 4.0.0-r1*
* *controller-interface 2.12.1-r1 --> 2.13.0-r1*
* *controller-manager 2.12.1-r1 --> 2.13.0-r1*
* *controller-manager-msgs 2.12.1-r1 --> 2.13.0-r1*
* *diff-drive-controller 2.9.0-r1 --> 2.11.0-r1*
* *effort-controllers 2.9.0-r1 --> 2.11.0-r1*
* *eigenpy 2.7.10-r1 --> 2.7.10-r2*
* *examples-tf2-py 0.25.0-r2 --> 0.25.1-r1*
* *fastrtps 2.6.1-r1 --> 2.6.2-r1*
* *force-torque-sensor-broadcaster 2.9.0-r1 --> 2.11.0-r1*
* *forward-command-controller 2.9.0-r1 --> 2.11.0-r1*
* *gazebo-ros2-control 0.3.0-r1 --> 0.4.0-r1*
* *gazebo-ros2-control-demos 0.3.0-r1 --> 0.4.0-r1*
* *generate-parameter-library 0.2.3-r1*
* *generate-parameter-library-example 0.2.3-r1*
* *geometry2 0.25.0-r2 --> 0.25.1-r1*
* *gripper-controllers 2.9.0-r1 --> 2.11.0-r1*
* *hardware-interface 2.12.1-r1 --> 2.13.0-r1*
* *hpp-fcl 2.1.1-r1 --> 2.1.2-r1*
* *imu-sensor-broadcaster 2.9.0-r1 --> 2.11.0-r1*
* *joint-limits 2.12.1-r1 --> 2.13.0-r1*
* *joint-state-broadcaster 2.9.0-r1 --> 2.11.0-r1*
* *joint-trajectory-controller 2.9.0-r1 --> 2.11.0-r1*
* *kdl-parser 2.6.2-r2 --> 2.6.3-r1*
* *leo-bringup 1.0.1-r1*
* *leo-fw 1.0.1-r1*
* *leo-robot 1.0.1-r1*
* *mavlink 2022.6.27-r1 --> 2022.8.8-r1*
* *orocos-kdl-vendor 0.2.3-r1 --> 0.2.4-r1*
* *parameter-traits 0.2.3-r1*
* *plotjuggler-ros 1.7.1-r3 --> 1.5.1-r3*
* *position-controllers 2.9.0-r1 --> 2.11.0-r1*
* *python-orocos-kdl-vendor 0.2.3-r1 --> 0.2.4-r1*
* *r2r-spl-7 2.0.0-r1 --> 2.0.1-r1*
* *ros2-control 2.12.1-r1 --> 2.13.0-r1*
* *ros2-control-test-assets 2.12.1-r1 --> 2.13.0-r1*
* *ros2-controllers 2.9.0-r1 --> 2.11.0-r1*
* *ros2-controllers-test-nodes 2.9.0-r1 --> 2.11.0-r1*
* *ros2controlcli 2.12.1-r1 --> 2.13.0-r1*
* *rqt-image-overlay 0.1.0-r1 --> 0.1.1-r1*
* *rqt-image-overlay-layer 0.1.0-r1 --> 0.1.1-r1*
* *rqt-joint-trajectory-controller 2.11.0-r1*
* *rqt-publisher 1.1.3-r3 --> 1.5.0-r1*
* *splsm-7 2.0.0-r1 --> 2.0.1-r1*
* *splsm-7-conversion 2.0.0-r1 --> 2.0.1-r1*
* *tcb-span 0.2.3-r1*
* *tf2 0.25.0-r2 --> 0.25.1-r1*
* *tf2-bullet 0.25.0-r2 --> 0.25.1-r1*
* *tf2-eigen 0.25.0-r2 --> 0.25.1-r1*
* *tf2-eigen-kdl 0.25.0-r2 --> 0.25.1-r1*
* *tf2-geometry-msgs 0.25.0-r2 --> 0.25.1-r1*
* *tf2-kdl 0.25.0-r2 --> 0.25.1-r1*
* *tf2-msgs 0.25.0-r2 --> 0.25.1-r1*
* *tf2-py 0.25.0-r2 --> 0.25.1-r1*
* *tf2-ros 0.25.0-r2 --> 0.25.1-r1*
* *tf2-ros-py 0.25.0-r2 --> 0.25.1-r1*
* *tf2-sensor-msgs 0.25.0-r2 --> 0.25.1-r1*
* *tf2-tools 0.25.0-r2 --> 0.25.1-r1*
* *transmission-interface 2.12.1-r1 --> 2.13.0-r1*
* *tricycle-controller 2.11.0-r1*
* *ur 2.2.2-r1 --> 2.2.3-r1*
* *ur-bringup 2.2.2-r1 --> 2.2.3-r1*
* *ur-calibration 2.2.2-r1 --> 2.2.3-r1*
* *ur-controllers 2.2.2-r1 --> 2.2.3-r1*
* *ur-dashboard-msgs 2.2.2-r1 --> 2.2.3-r1*
* *ur-moveit-config 2.2.2-r1 --> 2.2.3-r1*
* *ur-robot-driver 2.2.2-r1 --> 2.2.3-r1*
* *velocity-controllers 2.9.0-r1 --> 2.11.0-r1*

Melodic Changes:
----------------
* *costmap-cspace 0.11.6-r1 --> 0.11.7-r1*
* *ess-imu-ros1-uart-driver 1.3.2-r1*
* *executive-smach-visualization 4.0.0-r1 --> 4.0.1-r1*
* *hpp-fcl 1.8.1-r1 --> 2.1.2-r1*
* *joystick-interrupt 0.11.6-r1 --> 0.11.7-r1*
* *map-organizer 0.11.6-r1 --> 0.11.7-r1*
* *marti-can-msgs 0.10.0-r3 --> 0.11.0-r3*
* *marti-common-msgs 0.10.0-r3 --> 0.11.0-r3*
* *marti-dbw-msgs 0.10.0-r3 --> 0.11.0-r3*
* *marti-introspection-msgs 0.11.0-r3*
* *marti-nav-msgs 0.10.0-r3 --> 0.11.0-r3*
* *marti-perception-msgs 0.10.0-r3 --> 0.11.0-r3*
* *marti-sensor-msgs 0.10.0-r3 --> 0.11.0-r3*
* *marti-status-msgs 0.10.0-r3 --> 0.11.0-r3*
* *marti-visualization-msgs 0.10.0-r3 --> 0.11.0-r3*
* *mavlink 2022.3.3-r1 --> 2022.8.8-r1*
* *neonavigation 0.11.6-r1 --> 0.11.7-r1*
* *neonavigation-common 0.11.6-r1 --> 0.11.7-r1*
* *neonavigation-launch 0.11.6-r1 --> 0.11.7-r1*
* *obj-to-pointcloud 0.11.6-r1 --> 0.11.7-r1*
* *planner-cspace 0.11.6-r1 --> 0.11.7-r1*
* *plotjuggler 3.5.1-r2 --> 3.5.2-r1*
* *robot-localization 2.6.11-r1 --> 2.6.12-r1*
* *rosbag-snapshot 1.0.3-r1 --> 1.0.4-r1*
* *rosbag-snapshot-msgs 1.0.3-r1 --> 1.0.4-r1*
* *rviz 1.13.25-r1 --> 1.13.27-r1*
* *safety-limiter 0.11.6-r1 --> 0.11.7-r1*
* *track-odometry 0.11.6-r1 --> 0.11.7-r1*
* *trajectory-tracker 0.11.6-r1 --> 0.11.7-r1*

Noetic Changes:
---------------
* *cob-3d-mapping-msgs 0.6.18-r1 --> 0.6.19-r1*
* *cob-actions 0.7.7-r1 --> 0.7.8-r1*
* *cob-android 0.1.9-r1 --> 0.1.10-r1*
* *cob-android-msgs 0.1.9-r1 --> 0.1.10-r1*
* *cob-android-resource-server 0.1.9-r1 --> 0.1.10-r1*
* *cob-android-script-server 0.1.9-r1 --> 0.1.10-r1*
* *cob-android-settings 0.1.9-r1 --> 0.1.10-r1*
* *cob-base-controller-utils 0.8.18-r1 --> 0.8.19-r1*
* *cob-base-drive-chain 0.7.12-r1 --> 0.7.13-r1*
* *cob-base-velocity-smoother 0.8.18-r1 --> 0.8.19-r1*
* *cob-bms-driver 0.7.12-r1 --> 0.7.13-r1*
* *cob-bringup 0.7.6-r4 --> 0.7.7-r1*
* *cob-bringup-sim 0.7.5-r2 --> 0.7.6-r1*
* *cob-calibration-data 0.6.16-r1 --> 0.6.17-r1*
* *cob-cam3d-throttle 0.6.18-r1 --> 0.6.19-r1*
* *cob-canopen-motor 0.7.12-r1 --> 0.7.13-r1*
* *cob-cartesian-controller 0.8.18-r1 --> 0.8.19-r1*
* *cob-collision-monitor 0.7.6-r2 --> 0.7.7-r1*
* *cob-collision-velocity-filter 0.8.18-r1 --> 0.8.19-r1*
* *cob-command-gui 0.6.28-r1 --> 0.6.29-r1*
* *cob-command-tools 0.6.28-r1 --> 0.6.29-r1*
* *cob-common 0.7.7-r1 --> 0.7.8-r1*
* *cob-control 0.8.18-r1 --> 0.8.19-r1*
* *cob-control-mode-adapter 0.8.18-r1 --> 0.8.19-r1*
* *cob-control-msgs 0.8.18-r1 --> 0.8.19-r1*
* *cob-dashboard 0.6.28-r1 --> 0.6.29-r1*
* *cob-default-env-config 0.6.12-r1 --> 0.6.13-r1*
* *cob-default-robot-behavior 0.7.6-r4 --> 0.7.7-r1*
* *cob-default-robot-config 0.7.6-r4 --> 0.7.7-r1*
* *cob-description 0.7.7-r1 --> 0.7.8-r1*
* *cob-docker-control 0.6.11-r1 --> 0.6.12-r1*
* *cob-driver 0.7.12-r1 --> 0.7.13-r1*
* *cob-elmo-homing 0.7.12-r1 --> 0.7.13-r1*
* *cob-environments 0.6.12-r1 --> 0.6.13-r1*
* *cob-extern 0.6.17-r1 --> 0.6.18-r1*
* *cob-footprint-observer 0.8.18-r1 --> 0.8.19-r1*
* *cob-frame-tracker 0.8.18-r1 --> 0.8.19-r1*
* *cob-gazebo 0.7.5-r2 --> 0.7.6-r1*
* *cob-gazebo-objects 0.7.5-r2 --> 0.7.6-r1*
* *cob-gazebo-plugins 0.7.6-r1 --> 0.7.7-r1*
* *cob-gazebo-ros-control 0.7.6-r1 --> 0.7.7-r1*
* *cob-gazebo-tools 0.7.5-r2 --> 0.7.6-r1*
* *cob-gazebo-worlds 0.7.5-r2 --> 0.7.6-r1*
* *cob-generic-can 0.7.12-r1 --> 0.7.13-r1*
* *cob-grasp-generation 0.7.6-r2 --> 0.7.7-r1*
* *cob-hand 0.6.9-r1 --> 0.6.10-r1*
* *cob-hand-bridge 0.6.9-r1 --> 0.6.10-r1*
* *cob-hardware-config 0.7.6-r4 --> 0.7.7-r1*
* *cob-hardware-emulation 0.8.18-r1 --> 0.8.19-r1*
* *cob-helper-tools 0.6.28-r1 --> 0.6.29-r1*
* *cob-image-flip 0.6.18-r1 --> 0.6.19-r1*
* *cob-interactive-teleop 0.6.28-r1 --> 0.6.29-r1*
* *cob-light 0.7.12-r1 --> 0.7.13-r1*
* *cob-linear-nav 0.6.12-r1 --> 0.6.13-r1*
* *cob-lookat-action 0.7.6-r2 --> 0.7.7-r1*
* *cob-manipulation 0.7.6-r2 --> 0.7.7-r1*
* *cob-manipulation-msgs 0.7.6-r2 --> 0.7.7-r1*
* *cob-map-accessibility-analysis 0.6.12-r1 --> 0.6.13-r1*
* *cob-mapping-slam 0.6.12-r1 --> 0.6.13-r1*
* *cob-mecanum-controller 0.8.18-r1 --> 0.8.19-r1*
* *cob-mimic 0.7.12-r1 --> 0.7.13-r1*
* *cob-model-identifier 0.8.18-r1 --> 0.8.19-r1*
* *cob-monitoring 0.6.28-r1 --> 0.6.29-r1*
* *cob-moveit-bringup 0.7.6-r2 --> 0.7.7-r1*
* *cob-moveit-config 0.7.6-r4 --> 0.7.7-r1*
* *cob-moveit-interface 0.7.6-r2 --> 0.7.7-r1*
* *cob-msgs 0.7.7-r1 --> 0.7.8-r1*
* *cob-navigation 0.6.12-r1 --> 0.6.13-r1*
* *cob-navigation-config 0.6.12-r1 --> 0.6.13-r1*
* *cob-navigation-global 0.6.12-r1 --> 0.6.13-r1*
* *cob-navigation-local 0.6.12-r1 --> 0.6.13-r1*
* *cob-navigation-slam 0.6.12-r1 --> 0.6.13-r1*
* *cob-object-detection-msgs 0.6.18-r1 --> 0.6.19-r1*
* *cob-object-detection-visualizer 0.6.18-r1 --> 0.6.19-r1*
* *cob-obstacle-distance 0.8.18-r1 --> 0.8.19-r1*
* *cob-omni-drive-controller 0.8.18-r1 --> 0.8.19-r1*
* *cob-perception-common 0.6.18-r1 --> 0.6.19-r1*
* *cob-perception-msgs 0.6.18-r1 --> 0.6.19-r1*
* *cob-phidget-em-state 0.7.12-r1 --> 0.7.13-r1*
* *cob-phidget-power-state 0.7.12-r1 --> 0.7.13-r1*
* *cob-phidgets 0.7.12-r1 --> 0.7.13-r1*
* *cob-reflector-referencing 0.6.11-r1 --> 0.6.12-r1*
* *cob-relayboard 0.7.12-r1 --> 0.7.13-r1*
* *cob-robots 0.7.6-r4 --> 0.7.7-r1*
* *cob-safety-controller 0.6.11-r1 --> 0.6.12-r1*
* *cob-scan-unifier 0.7.12-r1 --> 0.7.13-r1*
* *cob-script-server 0.6.28-r1 --> 0.6.29-r1*
* *cob-sick-lms1xx 0.7.12-r1 --> 0.7.13-r1*
* *cob-sick-s300 0.7.12-r1 --> 0.7.13-r1*
* *cob-simulation 0.7.5-r2 --> 0.7.6-r1*
* *cob-sound 0.7.12-r1 --> 0.7.13-r1*
* *cob-srvs 0.7.7-r1 --> 0.7.8-r1*
* *cob-substitute 0.6.11-r1 --> 0.6.12-r1*
* *cob-supported-robots 0.6.15-r1 --> 0.6.16-r1*
* *cob-teleop 0.6.28-r1 --> 0.6.29-r1*
* *cob-trajectory-controller 0.8.18-r1 --> 0.8.19-r1*
* *cob-tricycle-controller 0.8.18-r1 --> 0.8.19-r1*
* *cob-twist-controller 0.8.18-r1 --> 0.8.19-r1*
* *cob-undercarriage-ctrl 0.7.12-r1 --> 0.7.13-r1*
* *cob-utilities 0.7.12-r1 --> 0.7.13-r1*
* *cob-vision-utils 0.6.18-r1 --> 0.6.19-r1*
* *cob-voltage-control 0.7.12-r1 --> 0.7.13-r1*
* *costmap-cspace 0.11.6-r1 --> 0.11.7-r1*
* *ess-imu-ros1-uart-driver 1.3.1-r1 --> 1.3.2-r1*
* *executive-smach-visualization 4.0.0-r1 --> 4.0.1-r1*
* *generic-throttle 0.6.28-r1 --> 0.6.29-r1*
* *hpp-fcl 1.8.1-r1 --> 2.1.2-r1*
* *ign-ros-control-demos 0.0.1-r1*
* *ipa-3d-fov-visualization 0.6.18-r1 --> 0.6.19-r1*
* *ipa-differential-docking 0.6.11-r1 --> 0.6.12-r1*
* *joystick-interrupt 0.11.6-r1 --> 0.11.7-r1*
* *laser-scan-densifier 0.7.12-r1 --> 0.7.13-r1*
* *libdlib 0.6.17-r1 --> 0.6.18-r1*
* *libntcan 0.6.17-r1 --> 0.6.18-r1*
* *libpcan 0.6.17-r1 --> 0.6.18-r1*
* *libphidgets 0.6.17-r1 --> 0.6.18-r1*
* *map-organizer 0.11.6-r1 --> 0.11.7-r1*
* *marti-can-msgs 0.10.0-r1 --> 0.11.0-r1*
* *marti-common-msgs 0.10.0-r1 --> 0.11.0-r1*
* *marti-dbw-msgs 0.10.0-r1 --> 0.11.0-r1*
* *marti-introspection-msgs 0.11.0-r1*
* *marti-nav-msgs 0.10.0-r1 --> 0.11.0-r1*
* *marti-perception-msgs 0.10.0-r1 --> 0.11.0-r1*
* *marti-sensor-msgs 0.10.0-r1 --> 0.11.0-r1*
* *marti-status-msgs 0.10.0-r1 --> 0.11.0-r1*
* *marti-visualization-msgs 0.10.0-r1 --> 0.11.0-r1*
* *mavlink 2022.3.3-r1 --> 2022.8.8-r1*
* *mqtt-client 1.0.0-r1 --> 1.0.1-r1*
* *neonavigation 0.11.6-r1 --> 0.11.7-r1*
* *neonavigation-common 0.11.6-r1 --> 0.11.7-r1*
* *neonavigation-launch 0.11.6-r1 --> 0.11.7-r1*
* *obj-to-pointcloud 0.11.6-r1 --> 0.11.7-r1*
* *opengm 0.6.17-r1 --> 0.6.18-r1*
* *planner-cspace 0.11.6-r1 --> 0.11.7-r1*
* *plotjuggler 3.5.1-r3 --> 3.5.2-r1*
* *raw-description 0.7.7-r1 --> 0.7.8-r1*
* *rosbag-snapshot 1.0.3-r1 --> 1.0.4-r1*
* *rosbag-snapshot-msgs 1.0.3-r1 --> 1.0.4-r1*
* *rviz 1.14.14-r1 --> 1.14.16-r1*
* *safety-limiter 0.11.6-r1 --> 0.11.7-r1*
* *scenario-test-tools 0.6.28-r1 --> 0.6.29-r1*
* *service-tools 0.6.28-r1 --> 0.6.29-r1*
* *track-odometry 0.11.6-r1 --> 0.11.7-r1*
* *trajectory-tracker 0.11.6-r1 --> 0.11.7-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-xdot
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-pytest-timeout
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-typeguard
 * [ ] python3-websocket
 * [ ] python3-xdot
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

