### PR TITLE
rosdistro sync, Wed Aug 17 00:13:41 2022

### DIFF
--- a/distros/foxy/depthai-bridge/default.nix
+++ b/distros/foxy/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-depthai-bridge";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai_bridge/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "8eee7148e6355d6ad8208fdc40944c4c7601423d7658fa9a09a33d9ef8bbeff4";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai_bridge/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "6d064df6b638fcf2f0c0aa97221f2fd778656c5d50ad55695f4963ea2376bb0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/depthai-examples/default.nix
+++ b/distros/foxy/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-depthai-examples";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai_examples/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "1278abb9153f99bb5392ed008501468ded789dc94c25da205161d98cbe6f58ac";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai_examples/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "6a7a51d633437c1a9e92be7df6fb882f17de769187069ad855faba50ed90ae59";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/depthai-ros-msgs/default.nix
+++ b/distros/foxy/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-depthai-ros-msgs";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai_ros_msgs/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "a2aa597a9ba9ad6931228274f44d70b5e145d3711db05633527b337202af1cd4";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai_ros_msgs/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "3065ad1a95530c35f2be8b5fb471b06c4f3fbad88fa8c8faf51440880036f62e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/depthai-ros/default.nix
+++ b/distros/foxy/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-examples, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-foxy-depthai-ros";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai-ros/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "9a62df11b7e668b4ce987434b9c53fbdef7b50e79d77faaf115ced6b4d958079";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/foxy/depthai-ros/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "2f94db0a1598e46d6b88b60e9bcb58bf528e677b5ef898abd3434c01201b8319";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.10-r2";
+  version = "2.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.10-2.tar.gz";
-    name = "2.7.10-2.tar.gz";
-    sha256 = "07ba722a7df61bc5814f9e837b08da0924e541f006d4683aa22c460c40704cb9";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.11-1.tar.gz";
+    name = "2.7.11-1.tar.gz";
+    sha256 = "1600ac8e1b063479f0e2ac9827691f148e7a729f1ea247e52b477f93a48a6442";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -608,6 +608,8 @@ self: super: {
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
+ hpp-fcl = self.callPackage ./hpp-fcl {};
+
  husky-base = self.callPackage ./husky-base {};
 
  husky-bringup = self.callPackage ./husky-bringup {};
@@ -1104,6 +1106,8 @@ self: super: {
 
  picknik-ament-copyright = self.callPackage ./picknik-ament-copyright {};
 
+ pinocchio = self.callPackage ./pinocchio {};
+
  plansys2-bringup = self.callPackage ./plansys2-bringup {};
 
  plansys2-bt-actions = self.callPackage ./plansys2-bt-actions {};
@@ -1217,6 +1221,8 @@ self: super: {
  raspimouse-description = self.callPackage ./raspimouse-description {};
 
  raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
+
+ raspimouse-ros2-examples = self.callPackage ./raspimouse-ros2-examples {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -1705,6 +1711,8 @@ self: super: {
  sick-safetyscanners-base = self.callPackage ./sick-safetyscanners-base {};
 
  sick-scan2 = self.callPackage ./sick-scan2 {};
+
+ simple-actions = self.callPackage ./simple-actions {};
 
  simple-launch = self.callPackage ./simple-launch {};
 

--- a/distros/foxy/hpp-fcl/default.nix
+++ b/distros/foxy/hpp-fcl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-foxy-hpp-fcl";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/foxy/hpp-fcl/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "7d5d7046ec31f5dba8d071b2ec24459a4ae0f4dda7e094cde166ca1750934402";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git python3Packages.lxml ];
+  propagatedBuildInputs = [ assimp boost eigen eigenpy octomap python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''An extension of the Flexible Collision Library.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/maliput-integration/default.nix
+++ b/distros/foxy/maliput-integration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-pytest, gflags, libyamlcpp, maliput, maliput-dragway, maliput-malidrive, maliput-multilane, maliput-object, maliput-py }:
 buildRosPackage {
   pname = "ros-foxy-maliput-integration";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "680d41f5ee7388f4b33538097f6387109f220d3d0f67d769b64d6977dc7124d4";
+    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "bfe61831578011ebad7a133288d3c4793af965447b4707e0752cec020c977e33";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-object/default.nix
+++ b/distros/foxy/maliput-object/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp, maliput }:
 buildRosPackage {
   pname = "ros-foxy-maliput-object";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_object-release/archive/release/foxy/maliput_object/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "d487931ef4294cd8b3bff7dfdc18e3dccb67e71ab5894a1d3b35818c05f2cb48";
+    url = "https://github.com/ros2-gbp/maliput_object-release/archive/release/foxy/maliput_object/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "f45fa4db39dd785b45e8676924007534472e63590d1cc2ba5c2ef2c67ffd5e48";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput/default.nix
+++ b/distros/foxy/maliput/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp }:
 buildRosPackage {
   pname = "ros-foxy-maliput";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "dff3f91cbea3f95d04092096aba2912d87ca4a835c4ead1c51f0475adb43953b";
+    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "02071a4e53c7fe14386ca99407151aec18698093e2b87af47263ac5bb3991f4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mcap-vendor/default.nix
+++ b/distros/foxy/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-foxy-mcap-vendor";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/mcap_vendor/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "fd80d3964423381c9ce2ec6065ba3adfcf1e6b58a57d283d8f82e43b3c65a1d3";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/mcap_vendor/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "c4f93c8e9fc3f0f38a8c39cb9b6bfdfe23f71ab935bccd73a896662892bf1720";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ntrip-client/default.nix
+++ b/distros/foxy/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ntrip-client";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "e069a266132e088eaf0c3a7ee220905a2a3729d9fb602994a8d8a1e469c37c6f";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/foxy/ntrip_client/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "877f06e1439f249ffbb640401fb9f724173f1d2ed9efb520e182ae4d9f345a93";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/pinocchio/default.nix
+++ b/distros/foxy/pinocchio/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
+buildRosPackage {
+  pname = "ros-foxy-pinocchio";
+  version = "2.6.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/foxy/pinocchio/2.6.9-1.tar.gz";
+    name = "2.6.9-1.tar.gz";
+    sha256 = "c895981011ba3a50a9f34c5afed893c0ef203c55fd21930327ee92e0fd91a867";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy urdfdom ];
+  nativeBuildInputs = [ clang cmake ];
+
+  meta = {
+    description = ''A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.5.2-r1";
+  version = "3.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "68dc9674e5a69acfc35eac6484e0e56ab4c227e052b04dbce651cbcb836ff677";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.6.0-1.tar.gz";
+    name = "3.6.0-1.tar.gz";
+    sha256 = "8a96a76749e2e5617ff5d095a2752ed3b53682b1f642da97101ee276b233cef9";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp ];
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq fastcdr lz4 qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp zstd ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/raspimouse-ros2-examples/default.nix
+++ b/distros/foxy/raspimouse-ros2-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, v4l-utils }:
+buildRosPackage {
+  pname = "ros-foxy-raspimouse-ros2-examples";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/foxy/raspimouse_ros2_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a6279ae1b455a48c4b296ebca57c9c2381bd761925fdb0db03611b97742165de";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs v4l-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Raspberry Pi Mouse examples'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rosbag2-storage-mcap/default.nix
+++ b/distros/foxy/rosbag2-storage-mcap/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage-mcap";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/rosbag2_storage_mcap/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "1f58e12a4adc5c5223a19cb6b6c6682f6beb1da643b3bd18874c9c4703c6cfbc";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/foxy/rosbag2_storage_mcap/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "4378d87c90207dafb3adf214bee747b3859099bca96d43d7f3b0455e586ca123";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rcpputils rosbag2-cpp rosbag2-test-common std-msgs ];
   propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/simple-actions/default.nix
+++ b/distros/foxy/simple-actions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
+buildRosPackage {
+  pname = "ros-foxy-simple-actions";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/simple_actions-release/archive/release/foxy/simple_actions/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "c842b4e43dd1ecb1950292fab948ef022c182396a252eccd364907245dd19d93";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
+  propagatedBuildInputs = [ action-msgs rclcpp rclcpp-action rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Simple library for using the `rclpy/rclcpp` action libraries'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/depthai-bridge/default.nix
+++ b/distros/galactic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-galactic-depthai-bridge";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai_bridge/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "be9769fc458073501a355a8bba77acf2958f0eea34be711d40421a90eb3b96ee";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai_bridge/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "1efc2fadbc204ba51ce3a1727b2008e45c94737d3a2de592474554c31f406496";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai-examples/default.nix
+++ b/distros/galactic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-galactic-depthai-examples";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai_examples/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "f3f3d6cb8efca3792b5356a0a394f7e4ad2cffb129a8e061c7c044875689d7b7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai_examples/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "35e68f40efb878b6d6afb1094553925ed1be6de0b59cd3f74bffdeb8cd13c8ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai-ros-msgs/default.nix
+++ b/distros/galactic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-galactic-depthai-ros-msgs";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai_ros_msgs/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "5f2ac0c88f91cf3458b4e2eddf043e040220e20f496ec14c813cadb30af057b1";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai_ros_msgs/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "af060ae0e740562582cd76c2c6953cbcd0df4f74fbb1fcfb7efa2f6a380cc5bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai-ros/default.nix
+++ b/distros/galactic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-examples, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-galactic-depthai-ros";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai-ros/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "2b3ea334485048935cf9ecad697e65e1af841284566e7677c523c4cd6bdbf31c";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/galactic/depthai-ros/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "d05958abad07b6830d1bee0fde71ea1c5b6ca8474d9ada2c1e9c737fdbfafe04";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/eigenpy/default.nix
+++ b/distros/galactic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-eigenpy";
-  version = "2.7.10-r2";
+  version = "2.7.11-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.10-2.tar.gz";
-    name = "2.7.10-2.tar.gz";
-    sha256 = "48edca79168f111e2855d32e4b11805eafedae309c3ea7bd5909c6b12bd1a6c3";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.11-2.tar.gz";
+    name = "2.7.11-2.tar.gz";
+    sha256 = "d7a24ee5388c3976d2dd5d84d224572bac92da1ad91b9c3d7e3f150323885bfb";
   };
 
   buildType = "cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -984,6 +984,8 @@ self: super: {
 
  pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
 
+ pinocchio = self.callPackage ./pinocchio {};
+
  plansys2-bringup = self.callPackage ./plansys2-bringup {};
 
  plansys2-bt-actions = self.callPackage ./plansys2-bt-actions {};
@@ -1535,6 +1537,8 @@ self: super: {
  sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};
 
  sick-safetyscanners-base = self.callPackage ./sick-safetyscanners-base {};
+
+ simple-actions = self.callPackage ./simple-actions {};
 
  simple-launch = self.callPackage ./simple-launch {};
 

--- a/distros/galactic/hpp-fcl/default.nix
+++ b/distros/galactic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-hpp-fcl";
-  version = "2.1.2-r1";
+  version = "2.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/galactic/hpp-fcl/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "756f9738ecb04148206c2b261e8213044b91e4254b311fd032a538fe0a79e021";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/galactic/hpp-fcl/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "b82849eab526970ade3e8d931dfb52203828860ba4bf79d023915e58324a4856";
   };
 
   buildType = "cmake";

--- a/distros/galactic/mcap-vendor/default.nix
+++ b/distros/galactic/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-galactic-mcap-vendor";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/mcap_vendor/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "0371a237420c1be21a3c513a8d51af68a56c5dce864b08ec4772bb1b934df9da";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/mcap_vendor/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "bc382c1091d08fb53eb3a6900c0db01b44345c3821ecc8b51f18ad07b5f7dadf";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ntrip-client/default.nix
+++ b/distros/galactic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ntrip-client";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "7570f2721665d8066542644ce300ad0ad2c808e77408395060a70e8040952ef8";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/galactic/ntrip_client/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b2380bd91a6c8c5efabb0bb12ad9224e72accccc3a618d9032267b26f0e5cd02";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/pinocchio/default.nix
+++ b/distros/galactic/pinocchio/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
+buildRosPackage {
+  pname = "ros-galactic-pinocchio";
+  version = "2.6.9-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/galactic/pinocchio/2.6.9-2.tar.gz";
+    name = "2.6.9-2.tar.gz";
+    sha256 = "236757c2d8bea58db73c137067b35c86bac2cf4ca83b0681f32364b0e499095b";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy urdfdom ];
+  nativeBuildInputs = [ clang cmake ];
+
+  meta = {
+    description = ''A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.5.2-r1";
+  version = "3.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "a34d1373b81d3672ecaafc2cb5498e12d63244051336ccfb41b7ac6ba43d2dd2";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.6.0-1.tar.gz";
+    name = "3.6.0-1.tar.gz";
+    sha256 = "d350c06f58ccd070148bc5b5bc74fc5d7f2a99f307385055ddac4f41e508e271";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp ];
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq fastcdr lz4 qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp zstd ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rosbag2-storage-mcap/default.nix
+++ b/distros/galactic/rosbag2-storage-mcap/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-storage-mcap";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "84119106046eeabd3696d74951668c3695fa0cd690aa1fca505da1bffd708225";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/galactic/rosbag2_storage_mcap/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "bf9bd3afda0b558033764bc59242e9a2a51b8a31ddb9467cb6d5ee007ebd4343";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rcpputils rosbag2-cpp rosbag2-test-common std-msgs ];
   propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/galactic/simple-actions/default.nix
+++ b/distros/galactic/simple-actions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
+buildRosPackage {
+  pname = "ros-galactic-simple-actions";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/simple_actions-release/archive/release/galactic/simple_actions/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "fdf174b66edb31ed304a4cf4c74f08f8a1abbbb02a3d7c2d1c3bfc9aa36b32b2";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
+  propagatedBuildInputs = [ action-msgs rclcpp rclcpp-action rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Simple library for using the `rclpy/rclcpp` action libraries'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1222,13 +1222,23 @@ self: super: {
 
  ros2acceleration = self.callPackage ./ros2acceleration {};
 
+ ros2action = self.callPackage ./ros2action {};
+
  ros2bag = self.callPackage ./ros2bag {};
+
+ ros2cli = self.callPackage ./ros2cli {};
 
  ros2cli-common-extensions = self.callPackage ./ros2cli-common-extensions {};
 
  ros2cli-test-interfaces = self.callPackage ./ros2cli-test-interfaces {};
 
+ ros2component = self.callPackage ./ros2component {};
+
  ros2controlcli = self.callPackage ./ros2controlcli {};
+
+ ros2doctor = self.callPackage ./ros2doctor {};
+
+ ros2interface = self.callPackage ./ros2interface {};
 
  ros2launch = self.callPackage ./ros2launch {};
 
@@ -1236,11 +1246,27 @@ self: super: {
 
  ros2launch-security-examples = self.callPackage ./ros2launch-security-examples {};
 
+ ros2lifecycle = self.callPackage ./ros2lifecycle {};
+
  ros2lifecycle-test-fixtures = self.callPackage ./ros2lifecycle-test-fixtures {};
+
+ ros2multicast = self.callPackage ./ros2multicast {};
+
+ ros2node = self.callPackage ./ros2node {};
 
  ros2nodl = self.callPackage ./ros2nodl {};
 
+ ros2param = self.callPackage ./ros2param {};
+
+ ros2pkg = self.callPackage ./ros2pkg {};
+
+ ros2run = self.callPackage ./ros2run {};
+
+ ros2service = self.callPackage ./ros2service {};
+
  ros2test = self.callPackage ./ros2test {};
+
+ ros2topic = self.callPackage ./ros2topic {};
 
  ros2trace = self.callPackage ./ros2trace {};
 

--- a/distros/humble/ros2action/default.nix
+++ b/distros/humble/ros2action/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2action";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "e8dcfedde84283bc50df28aade321e43fd7faba104cd62df25e1e6ee04ecab69";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest test-msgs ];
+  propagatedBuildInputs = [ action-msgs ament-index-python rclpy ros2cli rosidl-runtime-py ];
+
+  meta = {
+    description = ''The action command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2cli/default.nix
+++ b/distros/humble/ros2cli/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2cli";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "4550252bd716c362a8ab8c43a7f22ac381feb1fd972781a7f3fd6fe96859a1d0";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest-timeout pythonPackages.pytest test-msgs ];
+  propagatedBuildInputs = [ python3Packages.argcomplete python3Packages.importlib-metadata python3Packages.netifaces python3Packages.packaging python3Packages.setuptools rclpy ];
+
+  meta = {
+    description = ''Framework for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2component/default.nix
+++ b/distros/humble/ros2component/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
+buildRosPackage {
+  pname = "ros-humble-ros2component";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "a9a7146e57122b4f83ffc464691070a11108964697385919189b8fa648b8eb41";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest-timeout pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python composition-interfaces rcl-interfaces rclcpp-components rclpy ros2cli ros2node ros2param ros2pkg ];
+
+  meta = {
+    description = ''The component command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2doctor/default.nix
+++ b/distros/humble/ros2doctor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2doctor";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "9848fefd4c7844b1e62b46c8a8453a37d454cd171db6567a73b7e897575a2428";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-ros launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest std-msgs ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.catkin-pkg python3Packages.importlib-metadata python3Packages.psutil python3Packages.rosdistro rclpy ros-environment ros2cli ];
+
+  meta = {
+    description = ''A command line tool to check potential issues in a ROS 2 system'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2interface/default.nix
+++ b/distros/humble/ros2interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2interface";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "e296b26a1b1cd7de5be2078af45d577112a64b3d551c4dd4ed15765f1283d283";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest ros2cli-test-interfaces test-msgs ];
+  propagatedBuildInputs = [ ament-index-python ros2cli rosidl-runtime-py ];
+
+  meta = {
+    description = ''The interface command for ROS 2 command line tools'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2lifecycle/default.nix
+++ b/distros/humble/ros2lifecycle/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
+buildRosPackage {
+  pname = "ros-humble-ros2lifecycle";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "b5fc8309f4a84b8c7f900d7ef6eeee4a5e6049a4d34f396ee82f91cb27d2d673";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-ros launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest ros2lifecycle-test-fixtures ];
+  propagatedBuildInputs = [ lifecycle-msgs rclpy ros2cli ros2node ros2service ];
+
+  meta = {
+    description = ''The lifecycle command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2multicast/default.nix
+++ b/distros/humble/ros2multicast/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
+buildRosPackage {
+  pname = "ros-humble-ros2multicast";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "3023bbf11b7a3e02786c0b61399bb5f48349bbf143944e92472371229d849a19";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest-timeout pythonPackages.pytest ];
+  propagatedBuildInputs = [ ros2cli ];
+
+  meta = {
+    description = ''The multicast command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2node/default.nix
+++ b/distros/humble/ros2node/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2node";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "56f238f7061fed239f48a7bb6d1bb51b8d03f0bfc183461586f30579f004ac8f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-ros launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest rclpy test-msgs ];
+  propagatedBuildInputs = [ ros2cli ];
+
+  meta = {
+    description = ''The node command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2param/default.nix
+++ b/distros/humble/ros2param/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
+buildRosPackage {
+  pname = "ros-humble-ros2param";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "38f92fe54e1a06b8c92d76ad3c955e2eee0f5e7652e59a84ee6e5b09c0fc6fae";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-ros launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest ];
+  propagatedBuildInputs = [ rcl-interfaces rclpy ros2cli ros2node ros2service ];
+
+  meta = {
+    description = ''The param command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2pkg/default.nix
+++ b/distros/humble/ros2pkg/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
+buildRosPackage {
+  pname = "ros-humble-ros2pkg";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "eb3e98266f6543b9da6cf6de3e809cb06dd76289601f14c045ccdc8ade2da56c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 ament-xmllint launch launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-copyright ament-index-python python3Packages.catkin-pkg python3Packages.empy python3Packages.importlib-resources python3Packages.setuptools ros2cli ];
+
+  meta = {
+    description = ''The pkg command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2run/default.nix
+++ b/distros/humble/ros2run/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
+buildRosPackage {
+  pname = "ros-humble-ros2run";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "90d26cb5ddd10f9738e6d841e3f074d17171b0985e5ef43f95864b89e525a04c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest-timeout pythonPackages.pytest ];
+  propagatedBuildInputs = [ ros2cli ros2pkg ];
+
+  meta = {
+    description = ''The run command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2service/default.nix
+++ b/distros/humble/ros2service/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2service";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "9cb7dac5fa7f12a78e359a2181d29193696c17f8f4f2241f7bedcf1236c5b299";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch launch-ros launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest test-msgs ];
+  propagatedBuildInputs = [ python3Packages.pyyaml rclpy ros2cli rosidl-runtime-py ];
+
+  meta = {
+    description = ''The service command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2topic/default.nix
+++ b/distros/humble/ros2topic/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, std-msgs, test-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros2topic";
+  version = "0.18.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.3-2.tar.gz";
+    name = "0.18.3-2.tar.gz";
+    sha256 = "4df168b942222d59eb962c8881c266d06c5c799a3a547ef085648531d38fa356";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint geometry-msgs launch launch-ros launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest std-msgs test-msgs ];
+  propagatedBuildInputs = [ python3Packages.numpy python3Packages.pyyaml rclpy ros2cli rosidl-runtime-py ];
+
+  meta = {
+    description = ''The topic command for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 bsd3 ];
+  };
+}

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.10-r1";
+  version = "2.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.10-1.tar.gz";
-    name = "2.7.10-1.tar.gz";
-    sha256 = "58be02613eb996296b1c554f183355e187df7c99c851904bf064bfe9aad41ef4";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.11-1.tar.gz";
+    name = "2.7.11-1.tar.gz";
+    sha256 = "844ba74addb63ecf579bae07fdf3084729d0245193e70b4f881987c594fb7e15";
   };
 
   buildType = "cmake";

--- a/distros/melodic/ntrip-client/default.nix
+++ b/distros/melodic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ntrip-client";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0eadc0bcc6f8dd8f6b5c00f6e3c66a9b8ac0eba1c09a4193a0a54179f42866aa";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/melodic/ntrip_client/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "46f7a64d03163ae022bfee817e0400668b25902071e87b30740b921396da3ea9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.6.8-r1";
+  version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.8-1.tar.gz";
-    name = "2.6.8-1.tar.gz";
-    sha256 = "f93d7f291c2c822e6c46498e1dbfb31355e82c4ba8ff0aa8632bfe97c9ad7ef8";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.9-1.tar.gz";
+    name = "2.6.9-1.tar.gz";
+    sha256 = "f347e40497624bf4da24fe9fe07af5f3de8ed4f837c02f4a162719b3b2729d52";
   };
 
   buildType = "cmake";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, qt5, roscpp, roslib, zstd }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.5.2-r1";
+  version = "3.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "c15afb30c09177e2b7b52a5636ccc445c190f0c47d9373125f9da32d5e4427d1";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.6.0-1.tar.gz";
+    name = "3.6.0-1.tar.gz";
+    sha256 = "4c121e9e05c06a734773f922bb792853ac950889143cfd134deaaa36045b3a0b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib ];
+  propagatedBuildInputs = [ binutils boost cppzmq lz4 qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib zstd ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.27-r1";
+  version = "1.13.29-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.27-1.tar.gz";
-    name = "1.13.27-1.tar.gz";
-    sha256 = "ee644051045a40ef6b889b9687d7ee2d64451f085b5e3ded3e76aad981df588e";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.29-1.tar.gz";
+    name = "1.13.29-1.tar.gz";
+    sha256 = "355e851ad2bcf6e28e189c56e312b38039e7929a77ba33f007c412765b9e14f1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "360fabe753968d591ba60ac2c8d3c96f1d412b0f88d6300f2edecbb69aa6bde2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "48385dce4792e5e91638822c6f89bed063f60de83940a5bd7d39a2b2680ca134";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "73801372a9388a8e97882b189a47187566eefbf257cbc5e835b0abdb200f0b63";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "edf6207f6f31210aace57db787018c6d9018f5bd980edb4bc3befb73209ce304";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "39c233da6c70186b0c87cedf53ecd87ad7cf8fe1c2c0f1aa6d77837b2685e4f8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "4d78472bab64daf71294237e094ee6e8d8af86f0fa8b4894aef1ff0dd6d779d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-examples, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "1ac37cbc1d1a78b1e51c30371c9cff1328fdc0b8ba1fb63fc582d6e4340e43e1";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "178efffc5af6e70fbe9387e1fc664ab280c6ec8e4318677b94042e32a39021b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.10-r1";
+  version = "2.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.10-1.tar.gz";
-    name = "2.7.10-1.tar.gz";
-    sha256 = "6d3446c492c75bebed54a39833b2cbb6da51357aa564863fc07eed2437130301";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.11-1.tar.gz";
+    name = "2.7.11-1.tar.gz";
+    sha256 = "72f5d17bb6ff42ff160ceac1fd63bfa6591d53d06b4189a09fb46f88c700a88e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ntrip-client/default.nix
+++ b/distros/noetic/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ntrip-client";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "580598ce99c0642c956718997d12bfe65ec9966a1f4ef39f434b887103ca98b1";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "0066bb6efb9cfa6af71bb37d32f95c2daef51fd4f16aab44ba186bf29b9d3e77";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.8-r1";
+  version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.8-1.tar.gz";
-    name = "2.6.8-1.tar.gz";
-    sha256 = "b73d9917f5cb441feffe2ebc72f49ee31d1d8acb52164d85f4ff7f8ad0b6e503";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.9-1.tar.gz";
+    name = "2.6.9-1.tar.gz";
+    sha256 = "9158a307246502443623f1a2c84e3226922906f1bf4bc8592371ea1e04ebd0e8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roscpp, roslib }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, qt5, roscpp, roslib, zstd }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.5.2-r1";
+  version = "3.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "524d1be71a5c999fbf018b8d4c714035f79afa7de1390b1a00277d038e607d1c";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.6.0-1.tar.gz";
+    name = "3.6.0-1.tar.gz";
+    sha256 = "d8bf1819254a0f6a6d505791548c87658f7238ec2d3a68e8c27809d4d6b32c65";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib ];
+  propagatedBuildInputs = [ binutils boost cppzmq lz4 qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib zstd ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.16-r1";
+  version = "1.14.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.16-1.tar.gz";
-    name = "1.14.16-1.tar.gz";
-    sha256 = "59a6d06da3dfed7e41e34bb8d9d8e23e32d295bd01b715a164993f5e448fe4da";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.19-1.tar.gz";
+    name = "1.14.19-1.tar.gz";
+    sha256 = "8f59c493ab20bb607a61e49ea37243542a1267b7c9066215602bc5c35d458fad";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit ac07c183e7ccaa532fdb060f686c63095682c9c8.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *depthai-bridge 2.5.2-r1 --> 2.5.3-r1*
* *depthai-examples 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros-msgs 2.5.2-r1 --> 2.5.3-r1*
* *eigenpy 2.7.10-r2 --> 2.7.11-r1*
* *hpp-fcl 2.1.2-r1*
* *maliput 1.0.5-r1 --> 1.0.6-r1*
* *maliput-integration 0.1.1-r1 --> 0.1.2-r1*
* *maliput-object 0.1.1-r1 --> 0.1.2-r1*
* *mcap-vendor 0.1.6-r1 --> 0.1.7-r1*
* *ntrip-client 1.1.0-r1 --> 1.2.0-r1*
* *pinocchio 2.6.9-r1*
* *plotjuggler 3.5.2-r1 --> 3.6.0-r1*
* *raspimouse-ros2-examples 1.0.0-r1*
* *rosbag2-storage-mcap 0.1.6-r1 --> 0.1.7-r1*
* *simple-actions 0.2.1-r1*

Galactic Changes:
-----------------
* *depthai-bridge 2.5.2-r1 --> 2.5.3-r1*
* *depthai-examples 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros-msgs 2.5.2-r1 --> 2.5.3-r1*
* *eigenpy 2.7.10-r2 --> 2.7.11-r2*
* *hpp-fcl 2.1.2-r1 --> 2.1.2-r2*
* *mcap-vendor 0.1.6-r1 --> 0.1.7-r1*
* *ntrip-client 1.1.0-r1 --> 1.2.0-r1*
* *pinocchio 2.6.9-r2*
* *plotjuggler 3.5.2-r1 --> 3.6.0-r1*
* *rosbag2-storage-mcap 0.1.6-r1 --> 0.1.7-r1*
* *simple-actions 0.2.1-r1*

Humble Changes:
---------------
* *ros2action 0.18.3-r2*
* *ros2cli 0.18.3-r2*
* *ros2component 0.18.3-r2*
* *ros2doctor 0.18.3-r2*
* *ros2interface 0.18.3-r2*
* *ros2lifecycle 0.18.3-r2*
* *ros2multicast 0.18.3-r2*
* *ros2node 0.18.3-r2*
* *ros2param 0.18.3-r2*
* *ros2pkg 0.18.3-r2*
* *ros2run 0.18.3-r2*
* *ros2service 0.18.3-r2*
* *ros2topic 0.18.3-r2*

Melodic Changes:
----------------
* *eigenpy 2.7.10-r1 --> 2.7.11-r1*
* *ntrip-client 1.1.0-r1 --> 1.2.0-r1*
* *pinocchio 2.6.8-r1 --> 2.6.9-r1*
* *plotjuggler 3.5.2-r1 --> 3.6.0-r1*
* *rviz 1.13.27-r1 --> 1.13.29-r1*

Noetic Changes:
---------------
* *depthai-bridge 2.5.2-r1 --> 2.5.3-r1*
* *depthai-examples 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros-msgs 2.5.2-r1 --> 2.5.3-r1*
* *eigenpy 2.7.10-r1 --> 2.7.11-r1*
* *ntrip-client 1.1.0-r1 --> 1.2.0-r1*
* *pinocchio 2.6.8-r1 --> 2.6.9-r1*
* *plotjuggler 3.5.2-r1 --> 3.6.0-r1*
* *rviz 1.14.16-r1 --> 1.14.19-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-xdot
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-typeguard
 * [ ] python3-websocket
 * [ ] python3-xdot
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

