### PR TITLE
rosdistro sync, Sat Aug 20 01:33:08 2022

### DIFF
--- a/distros/foxy/rosapi-msgs/default.nix
+++ b/distros/foxy/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rosapi-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ed946c0f7c841aa7cb3a620816c040592d480e62e86f690f6612186922eff08c";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7fdec377d59827130155d2fecfd6cf24c21c72dfea20a31e5afef33fe4864b3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosapi/default.nix
+++ b/distros/foxy/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosapi";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "45a7e99ed56de40e8307996f1a3120b15ac9574d905a7a82c19ec7aea050c2de";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "410075d13f7ea187f9e1f48a34297932ee9ab72276cd693b242a6286f58cdee6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-library/default.nix
+++ b/distros/foxy/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-library";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a5c388e8dfef69dace99484b8028803afdc83e7ed950e083f8d0680636105280";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8a076f48eb5c23217fb72b6888573732bff6eb7d5cfa9ebd2791e5385d8c7af6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-msgs/default.nix
+++ b/distros/foxy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "cba48aa69785cd70baf1df3448157d9c7d84349e7d037bd96112ea8e6cbf5b24";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0041f2106220dabb62ca8c31e6fb7852e7f06e1a78b300154b80c48be4e58d08";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-server/default.nix
+++ b/distros/foxy/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-server";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "cf2f3295bf850ea26712b1c6b0f3354730171f33f5ddb0aa9c07199a2e37a887";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "81187798d4f0dabc0317a5116f14d35bba0b60b5a724debd3b9c6a6615034758";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-suite/default.nix
+++ b/distros/foxy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-suite";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "552275e9d325f1c4b84c7841a76da750ad93e72277049fffb554f89aceee7591";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8c3095df3fa6b27d8d62e9208c82fa3d99a163cba2c05a333b2013f9028c32e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-test-msgs/default.nix
+++ b/distros/foxy/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-test-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_test_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "feeab43b51e22d6ed10c319cfa54d186a3b19b0186a35490ead37d34dabb8246";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_test_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b362a3e150b1180706da074774248efb400bbbb81de1f1f944fcee2d9bb10803";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosapi-msgs/default.nix
+++ b/distros/galactic/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosapi-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "21e0d1377f2c0237b88ad0c884b6c30428fa9983d4c49a757977ad5d5b35fdc2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "eea92e62f51256b168aa38d75cd0a43fd1086e0c5eed7cb3261eb7810d1ddd3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosapi/default.nix
+++ b/distros/galactic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosapi";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ea20baa28a13a709808c9c04360c3eb5620ccc31288fb4a5a83cb4cb7dd4bf8f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1cb473deee797aff5b04bbb83155b53b358981f53c107a6f3837e0cd36c4e67a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-library/default.nix
+++ b/distros/galactic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-library";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2e7260c5000fc9282780c7df91945923d498615ddb6a7e0b609df2d615a30bc7";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8a6403406c5dc85c9c6f23c176da543d9387c8b6c35ae21047e0b0bdcadff25a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-msgs/default.nix
+++ b/distros/galactic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "189239f10d96bdcdde13d451130c88774bf1005e026e264967483c54520a8ef1";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b789dd1035825fc8eaa0d67f5f9a58fd57b05037ee4f5c561e2fcf4ecfae867c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-server/default.nix
+++ b/distros/galactic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-server";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "dae6534cfa6ae915c34da76651518b86a89dfb070b85a1c35947342c340212a2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "bdeccd660dfa2df8b56854300d5095ccc2962e3c710c57c1e4a3ebc0167a06b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-suite/default.nix
+++ b/distros/galactic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-suite";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ca93dacd3d71963898a4c6bfd6ba04e2558b967273b196c48a1bd52691775f35";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "53acc3faf79074ea5639419e3a652bdc424bb45f5ae5d1f83084c3cd89ed7b88";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-test-msgs/default.nix
+++ b/distros/galactic/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-test-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_test_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "70fc7b0b766605aaec38d17abad1b72af0bd9d515493f7728933363e54dfa605";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_test_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "633116d9cd53a6d399545dfa91f6f022eff96e90c89a5412f937fd8cc1a92809";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/mcap_vendor/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "fcbc3cc2f71546583a7f0aa80b3728a8fa6a719a43d337ec3750d37c312ad605";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/mcap_vendor/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "73384861e91e5e69fd1c05ecc86168467ae0db3872d28019646ca7319c69d27f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/rosbag2_storage_mcap/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "7cb1cc93ea8a603e82d46ba99b03addf450115428bdf26fcf3c6483013e4fed1";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/rosbag2_storage_mcap/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "2a5f66158ec744a3973b4d288c8757a8b16fcb7360d99323fe2510c9fed6b908";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rcpputils rosbag2-cpp rosbag2-test-common std-msgs ];
   propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "eb0c1d00f163a0153263b81275aa8ab0014a406196d4a201d01f16ad8d9d63f1";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "982356667f22b8db8d8e9236ee986ab13facd6a866c383a13429130a69f7fa0e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "5afc90d19df7b952f315fff30132e1e1d12640748fe9f8d6f80139be09509b2b";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "6f79561dcda6976f6f038f578f12e9fae1d7e9c1fc4d4b403b771ae2d0567701";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "ba1a9d6405d72171f455d1f950f91d263619e9f2961ea66dcafd67051ce67de5";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "8af8d5894c066a3d3463edd35436bf2673a5ce9b3e624cd08336a4080f6518ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "59c3e9adb8200d6c296674e7405700e2bec35a2feba21605ed6bd19d5eeba6e4";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "3847020cbe3c3abdf6bda52dfce0244104cff25be517456205f8a70c1e4569bd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/panda-moveit-config/default.nix
+++ b/distros/melodic/panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-panda-moveit-config";
-  version = "0.7.4-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/panda_moveit_config-release/archive/release/melodic/panda_moveit_config/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "c454614f3ce06467e0b857c873262d0f00e26d8287c70b8a70f22ab6b08b7040";
+    url = "https://github.com/ros-gbp/panda_moveit_config-release/archive/release/melodic/panda_moveit_config/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "b142095d8aef1b73fa5f81ad6b57497669acd5e5a783d02725249189b6afedbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-mux/default.nix
+++ b/distros/melodic/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, geometry-msgs, roscpp, rospy, rostest, rostopic, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-twist-mux";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/melodic/twist_mux/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "be81c02f14eddcb14a8e4195b2c6318953efcfa2c92ff7cf7963ff616e0b3a8c";
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/melodic/twist_mux/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "f789b4f46623508b3c7e8071a4e2960788930e04a5795fc8d6bc323994a272cc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-capture/default.nix
+++ b/distros/noetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-capture";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "c7f8daa90674584dc7db5cea6f0fdc0a602fbd5169632988601bffb8a940b810";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "66af65793e560471b0d3d6065099232457c7a49195f4d3ff84c7bb0367278ecd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common-msgs/default.nix
+++ b/distros/noetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-audio-common-msgs";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "85b8bd7a7fd1348ea5fa0d84c05d9cca2e6f34c7b569e859cd606c8bd1c9e79f";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "7903968df9a75b4becdb4f25c868dcc88d7ea90a36cfac84d5d3298d7bcd4efc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common/default.nix
+++ b/distros/noetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-audio-common";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "43f53161d90023ce760af643e6a29757a868fff9a3e0330af5bc5d1bdd700f1b";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "6163cb17b55985171cfa70a3a333d7082121c41c7c60fbad14c65df0f2e465f1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-play/default.nix
+++ b/distros/noetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-play";
-  version = "0.3.13-r1";
+  version = "0.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "d8898cda69f7de2fa5d0fc3ce83c8281c1ecbb98c8399fd53843f46c883e8ab0";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.14-1.tar.gz";
+    name = "0.3.14-1.tar.gz";
+    sha256 = "232ba7f5bb0ccf8d0c22ece723a5e4e4af771d2e9a2713aa553a62d11d65d139";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.9-r1";
+  version = "2.6.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "9158a307246502443623f1a2c84e3226922906f1bf4bc8592371ea1e04ebd0e8";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.9-2.tar.gz";
+    name = "2.6.9-2.tar.gz";
+    sha256 = "1bcea25baae43a37c8ce8baee7aadbde490b06087c69190e03b6dd8575044c6e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/twist-mux/default.nix
+++ b/distros/noetic/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, geometry-msgs, roscpp, rospy, rostest, rostopic, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-twist-mux";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/noetic/twist_mux/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "8e34204ea1a225e4bf0610fb0ce3d0df6a107fa57d4a90111edee495367bce81";
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/noetic/twist_mux/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "47ddfc5486f4b5f3a1e2465be818860e8427b00a7dd483945cb55ba8eab08f6c";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit 624fc3c9767269d360d1b4895423ad6ff625be64.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *rosapi 1.2.0-r1 --> 1.3.0-r1*
* *rosapi-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-library 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-server 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-suite 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-test-msgs 1.2.0-r1 --> 1.3.0-r1*

Galactic Changes:
-----------------
* *rosapi 1.2.0-r1 --> 1.3.0-r1*
* *rosapi-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-library 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-server 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-suite 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-test-msgs 1.2.0-r1 --> 1.3.0-r1*

Humble Changes:
---------------
* *mcap-vendor 0.1.6-r1 --> 0.1.7-r1*
* *rosbag2-storage-mcap 0.1.6-r1 --> 0.1.7-r1*

Melodic Changes:
----------------
* *audio-capture 0.3.13-r1 --> 0.3.14-r1*
* *audio-common 0.3.13-r1 --> 0.3.14-r1*
* *audio-common-msgs 0.3.13-r1 --> 0.3.14-r1*
* *audio-play 0.3.13-r1 --> 0.3.14-r1*
* *panda-moveit-config 0.7.4-r1 --> 0.7.6-r1*
* *twist-mux 3.1.1-r1 --> 3.1.2-r1*

Noetic Changes:
---------------
* *audio-capture 0.3.13-r1 --> 0.3.14-r1*
* *audio-common 0.3.13-r1 --> 0.3.14-r1*
* *audio-common-msgs 0.3.13-r1 --> 0.3.14-r1*
* *audio-play 0.3.13-r1 --> 0.3.14-r1*
* *pinocchio 2.6.9-r1 --> 2.6.9-r2*
* *twist-mux 3.1.1-r1 --> 3.1.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] flite
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-git
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-xdot
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-typeguard
 * [ ] python3-websocket
 * [ ] python3-xdot
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

