### PR TITLE
rosdistro sync, Fri Sep  2 14:01:22 2022

### DIFF
--- a/distros/foxy/ament-cmake-auto/default.nix
+++ b/distros/foxy/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-auto";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_auto/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "2cd32be1d4b6e1ac63c2b6ca4114165d82dbc2cba9c04296e92919c2d4e0acba";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_auto/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "5c24986ae6c12ca27b06f5b079df2000209279041b1fba8c3ad0eada23c38806";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-core/default.nix
+++ b/distros/foxy/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-core";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_core/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "f5eb84aa16fd709b8e69c098e130d41d4231f7e8c2a22e63e9286cd6af8b16e5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_core/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "1c72f1240fb41ca6b6a801d2c8408b6b5aa20f529375d7c5acee8d424fa68850";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-definitions/default.nix
+++ b/distros/foxy/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-definitions";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_definitions/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "391ea12d6443c40e14dcf6a25b34ed5542ad18ad8f896cc020faf0c534d40527";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_definitions/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "54d5495db85f1f73fda6ef57ca20c6588834d203c2eae1c583ca725a118b6186";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-dependencies/default.nix
+++ b/distros/foxy/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-dependencies";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_dependencies/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "2fb2cd1cef9d4c2ac0ee36afea050a92974c11747775e8930ea112afeed68b67";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_dependencies/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "ef301d14628c07235f3f415d2386d4f4d214d027080f2943cab4bacd3a525652";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-include-directories/default.nix
+++ b/distros/foxy/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-include-directories";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_include_directories/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "33ace199325839f201cd5fe2b76e41e380d70930dd20e03ccd6bce4cf5fa4900";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_include_directories/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "5cc524a02af824b24731beed3d11a27b1126dcb3a7a463db3eeba0f4c689aa9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-interfaces/default.nix
+++ b/distros/foxy/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-interfaces";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_interfaces/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "0575b49e9d2ff075b1d421c105d6b2f6e1177510d7d8912129069aa469331c92";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_interfaces/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "17986042922de0e7cbce35f2e46435b9cb2d7cfa463bb6925d33aa97fed4333f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-libraries/default.nix
+++ b/distros/foxy/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-libraries";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_libraries/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "86738c847b492da5a90fdf5f19feecfb8f5e0f1a474871f5eee3b564c277f122";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_libraries/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "acd310b648e1b2cce13a09b49385c26eda5430700f40f806433a56ff10e9e69b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-link-flags/default.nix
+++ b/distros/foxy/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-link-flags";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_link_flags/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "d0605740f4e0484097cff7f47f34b85cfefcc34c73753e0c6f661ad51ac9848c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_link_flags/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "6d58244c42d7e96c7472b591d0dc80ab8502aacee7bb927c0f9483d6bfb92300";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-targets/default.nix
+++ b/distros/foxy/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-targets";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_targets/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "86f7ef9b3f767574b432922b784f682dbd1ac11ea38cf3c5271c65a6c489452d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_targets/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "2c3510e819b39a50154444be600f9dc3d4c6e58f899eaa0496dc0a850b912873";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-gmock/default.nix
+++ b/distros/foxy/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-gmock";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gmock/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "ad15e5567937da9268bbc395a6e282d5cda9572cb25a6e80ff6490ad695994f2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gmock/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "ff94ac0f177bfb0855e91bb6f99dab25883de40e03f117efd9441642d4b4dc6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-google-benchmark/default.nix
+++ b/distros/foxy/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-google-benchmark";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_google_benchmark/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "cd143598f57bcf2187bd44805af4429ed088c310b41211e345332f908fbace6f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_google_benchmark/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "455344a6166cc5dce39c9bad4731a4beb28c0734e6d628839ff3b846ac0f2c59";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-gtest/default.nix
+++ b/distros/foxy/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-gtest";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gtest/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "b0db6d2e8f8a285f4b708beed8a2e9feedf63d3832a5116c12f6c6d24b644ba8";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gtest/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "8e6613bf8f1cf57a5a8892e54e1551ef25e75009c63863a7971530af7672af1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-include-directories/default.nix
+++ b/distros/foxy/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-include-directories";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_include_directories/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "7538b89f0a3bb5606a3cf316f31a5a3f156c9b0b389ebbeb39d8de378688f9bf";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_include_directories/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "e93ca6207074043af76ee59520d58a67da986eda8101245c9567d0ea02927651";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-libraries/default.nix
+++ b/distros/foxy/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-libraries";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_libraries/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "76591081f263a7ead8d3359282f0dccf8d4e12af3a2834f2c7bb630a35bd576c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_libraries/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "f2686670476d658677a27714888a25e19066f4e7dd8e0a75829f1259ec00dd45";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-nose/default.nix
+++ b/distros/foxy/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-nose";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_nose/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "a5205968dde895f15cc44ca96c942220d42a2158eb2d430d603cef511bb4d031";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_nose/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "6a416f118b1c82afc76cdb90bb2e5e96996af2763f16da4f2ffa7f104a8e7a0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-pytest/default.nix
+++ b/distros/foxy/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-pytest";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_pytest/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "103f7a88bf8dd8c512d3f170f26296b1c8c28ebc87d3bd7c64c3f60e9190c301";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_pytest/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "fb22a6b48e7892c538852cbbffffbc1b2bcfa62106128498db1d9732b9defbe5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-python/default.nix
+++ b/distros/foxy/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-python";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_python/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "6713040b141740131fc51203199e9d01aa3f2fc80778d0a9ddac7ac8af1ec772";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_python/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "83d3d582ca1cf9a76368bcef6fc332e9d59c5a395db31647a18bf80caa18632b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-target-dependencies/default.nix
+++ b/distros/foxy/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-target-dependencies";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_target_dependencies/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "51f8516c0d4e88d535fa21a398cbd1f84c07f6633c4856686941d72dfc6d2412";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_target_dependencies/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "6acb41d7c77d9eea4497a44a5b2df165451f05401f731f83a29719cf062570f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-test/default.nix
+++ b/distros/foxy/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-test";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_test/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "662b122754c40355ab418cb01c4256cb3d74951a4673c9dc78aae89a78bd288f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_test/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "c1be7c5f4514bc126ada7c44d9be62e0694de6975d8c711fb30c323c1e3da7d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-version/default.nix
+++ b/distros/foxy/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-version";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_version/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "edbb6a5a0593612dd5df59e8bec07017351b592dd4477ea88a68fa74b7a33ea0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_version/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "337382371ec4e5f56379e5ce73eb44e4e148690eda85df9d139487b3c25941a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake/default.nix
+++ b/distros/foxy/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake";
-  version = "0.9.10-r1";
+  version = "0.9.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake/0.9.10-1.tar.gz";
-    name = "0.9.10-1.tar.gz";
-    sha256 = "89b49ff5a1896c7752e8398e929703fcf4e9210e84e62251e46c06aa964995ba";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake/0.9.11-1.tar.gz";
+    name = "0.9.11-1.tar.gz";
+    sha256 = "971ce41bb7b2380f12e3a8212d68129ed802760e2054ca629bc7721ea59dddc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/crane-plus-control/default.nix
+++ b/distros/foxy/crane-plus-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, crane-plus-description, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, ros2-controllers, ros2controlcli, xacro }:
 buildRosPackage {
   pname = "ros-foxy-crane-plus-control";
-  version = "1.0.0-r5";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_control/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "1f5882cc2e87191c137c572e1f1bb1bf9d73364c4fc7ad64f1ee56bcd48606f1";
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/foxy/crane_plus_control/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "317a6c7aa29ba9529c777ad3eba9c0790adbc4caf93d8d2b43d6c576ef74c1c5";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''CRANE+V2 control package'';
+    description = ''CRANE+ V2 control package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/crane-plus-description/default.nix
+++ b/distros/foxy/crane-plus-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-ros2-control, ign-ros2-control, joint-state-publisher-gui, launch, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-foxy-crane-plus-description";
-  version = "1.0.0-r5";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_description/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "f7bf068aacdbc11478e87d09e286c19f4547e821944015f1b64c6df1ea832753";
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/foxy/crane_plus_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7a17ffb77043cdd9e7468c6b215b35c43d29e434e4fe1768be9ac481b1d136a7";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = ''CRANE+V2 description package'';
+    description = ''CRANE+ V2 description package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/crane-plus-examples/default.nix
+++ b/distros/foxy/crane-plus-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, crane-plus-control, crane-plus-description, crane-plus-moveit-config, geometry-msgs, moveit-ros-planning-interface, rclcpp, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-crane-plus-examples";
-  version = "1.0.0-r5";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_examples/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "d6c55bae50f52d25bcf4022e959372dc13737d1412836b91ba63e65108ce1033";
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/foxy/crane_plus_examples/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "448b17d5228079c24888da7785432dd4e348f3437d43db30e74c22c472d1e57b";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''CRANE+V2 examples package'';
+    description = ''CRANE+ V2 examples package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/crane-plus-gazebo/default.nix
+++ b/distros/foxy/crane-plus-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, crane-plus-description, crane-plus-moveit-config, gazebo-ros-pkgs }:
 buildRosPackage {
   pname = "ros-foxy-crane-plus-gazebo";
-  version = "1.0.0-r5";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_gazebo/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "98f37c57f24200ccd4ae3d01e9ec57c1b30a4507fa78f2fc6a0e2757ec744916";
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/foxy/crane_plus_gazebo/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "133cbb139c0c36997ad77064355c8775b65600f60f1ad01698a422345413eb68";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''CRANE+V2 gazebo simulation package'';
+    description = ''CRANE+ V2 gazebo simulation package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/crane-plus-ignition/default.nix
+++ b/distros/foxy/crane-plus-ignition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, ros-ign }:
 buildRosPackage {
   pname = "ros-foxy-crane-plus-ignition";
-  version = "1.0.0-r5";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_ignition/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "e42e517d714f6c34fabf011ba942157d83272080e6f480e533abc2fb4cefe47b";
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/foxy/crane_plus_ignition/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "40023f28799b14eaf9388e724716835372bf74b9e46cf08feeb6df4236c348fd";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''CRANE+V2 ignition gazebo simulation package'';
+    description = ''CRANE+ V2 ignition gazebo simulation package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/crane-plus-moveit-config/default.nix
+++ b/distros/foxy/crane-plus-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit, robot-state-publisher, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-crane-plus-moveit-config";
-  version = "1.0.0-r5";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus_moveit_config/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "90ec7de52429a07afb6af56af934b7c65da4316551b1aaedb8cdf9c812c68ecd";
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/foxy/crane_plus_moveit_config/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e3a741f509a404ac89bd80d208b8ad609c2808a8d3f3c3cb8ea101117765324f";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''CRANE+V2 move_group config package'';
+    description = ''CRANE+ V2 move_group config package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/crane-plus/default.nix
+++ b/distros/foxy/crane-plus/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, crane-plus-control, crane-plus-description, crane-plus-examples, crane-plus-gazebo, crane-plus-moveit-config }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, crane-plus-control, crane-plus-description, crane-plus-examples, crane-plus-gazebo, crane-plus-ignition, crane-plus-moveit-config }:
 buildRosPackage {
   pname = "ros-foxy-crane-plus";
-  version = "1.0.0-r5";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/crane_plus-release/archive/release/foxy/crane_plus/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "62208f3af5c1a99c12b7153d15a1eef0b42d8c377dd2fddba05eaae9c31cc357";
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/foxy/crane_plus/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1f6c58c66155cc87879794b0bb41f355f7564b692fea8c6b9b6da06ffdee8346";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-examples crane-plus-gazebo crane-plus-moveit-config ];
+  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-examples crane-plus-gazebo crane-plus-ignition crane-plus-moveit-config ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''ROS 2 package suite of CRANE+V2'';
+    description = ''ROS 2 package suite of CRANE+ V2'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.11-r1";
+  version = "2.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.11-1.tar.gz";
-    name = "2.7.11-1.tar.gz";
-    sha256 = "1600ac8e1b063479f0e2ac9827691f148e7a729f1ea247e52b477f93a48a6442";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.12-1.tar.gz";
+    name = "2.7.12-1.tar.gz";
+    sha256 = "5e30d9a83dfabc3153003f6a6443aace91aab816278ca339e740cf0cf3dd0a25";
   };
 
   buildType = "cmake";

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "d2ab33b5abb26344f38b80fcb9e5d8de7d79ff4a9ec965e9607aeea5dfec5a68";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "16b983d6018e778aa240cc2430f17561c5415b7466cf067faea850065b5a716f";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -1222,7 +1222,13 @@ self: super: {
 
  raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
 
+ raspimouse-navigation = self.callPackage ./raspimouse-navigation {};
+
  raspimouse-ros2-examples = self.callPackage ./raspimouse-ros2-examples {};
+
+ raspimouse-slam = self.callPackage ./raspimouse-slam {};
+
+ raspimouse-slam-navigation = self.callPackage ./raspimouse-slam-navigation {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -1987,6 +1993,8 @@ self: super: {
  visualization-msgs = self.callPackage ./visualization-msgs {};
 
  vrpn = self.callPackage ./vrpn {};
+
+ vrpn-mocap = self.callPackage ./vrpn-mocap {};
 
  vrxperience-bridge = self.callPackage ./vrxperience-bridge {};
 

--- a/distros/foxy/gps-msgs/default.nix
+++ b/distros/foxy/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gps-msgs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gps_msgs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "69285e3ff853bc4c45d66c40ed63867c6ac17028a3f4251444b309cf87789c21";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gps_msgs/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
+    sha256 = "fc878a091b5085df4dd2eecdad1ca9db58c3106253bb257f12c6dd1a3c7ef4e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gps-tools/default.nix
+++ b/distros/foxy/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gps-tools";
-  version = "1.0.4-r1";
+  version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gps_tools/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "c3115d0322bc091bc0eef89b0d1ffd8e83a648994728c513291ee7403f9c17ff";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gps_tools/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
+    sha256 = "4458640091b1b64cf3436d7a2d30ba9a4a96589ef2583a7101e0443c79c342b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gps-umd/default.nix
+++ b/distros/foxy/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-foxy-gps-umd";
-  version = "1.0.4-r1";
+  version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gps_umd/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "6b75a1773d1c3eb6df536cf8ce25ab52380ac14c40fba16467d67982389a7b7e";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gps_umd/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
+    sha256 = "86c23d481a6c88e65e280af9892f9e8d34ee4b275475feb2bebbd125fcb9983b";
   };
 
   buildType = "catkin";

--- a/distros/foxy/gpsd-client/default.nix
+++ b/distros/foxy/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gpsd-client";
-  version = "1.0.4-r1";
+  version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gpsd_client/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "534decd269e69e65f9ea245fb54dfdc9810e89e996acde51fe303a055bfd45cf";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/foxy/gpsd_client/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
+    sha256 = "a872c9965501987d458367df6bc7290e631f2e9e0aec64567b21a9504a281754";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-description/default.nix
+++ b/distros/foxy/leo-description/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo_description/1.0.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_description/1.0.3-1.tar.gz";
     name = "1.0.3-1.tar.gz";
-    sha256 = "ef44e25fb969dd49f27d5d485259a2b5f99271e37c8bc159099e6845d1c3389b";
+    sha256 = "26987b31d9c8ac94af1b1aedf1ad0be1678d7e6faa7ddd207792f9ad146fbefb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-desktop/default.nix
+++ b/distros/foxy/leo-desktop/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_desktop/1.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/foxy/leo_desktop/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "4f34333148bab9701d44586849abe7bab78b12c3207345c37fd82f492587467a";
+    sha256 = "1496c86b10fea2bc29c9100b328e002245457934e130cfa0a753993474f0b41f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-msgs/default.nix
+++ b/distros/foxy/leo-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo_msgs/1.0.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_msgs/1.0.3-1.tar.gz";
     name = "1.0.3-1.tar.gz";
-    sha256 = "3d912fe5df89345bd77e96c405358944b79d28c4aec3b01025ed812271dae33c";
+    sha256 = "55d794cf544413a9eaa98f5482893c5d3550452dc730fc09c7bc3ace15e29a43";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-teleop/default.nix
+++ b/distros/foxy/leo-teleop/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo_teleop/1.0.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_teleop/1.0.3-1.tar.gz";
     name = "1.0.3-1.tar.gz";
-    sha256 = "5ada41d927756de6ef0d07f57a2afbfe7b8a0246861c1404383878b0339dfdd3";
+    sha256 = "fdee181385db554804a7deff7e1ff9ce93d4d896fddf0ad6c2789af6bf5a8a02";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-viz/default.nix
+++ b/distros/foxy/leo-viz/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/foxy/leo_viz/1.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/foxy/leo_viz/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "f1fe34a25448ceb368f97f35618d6f91c61ac2acb43238151bb63cf6d73c47aa";
+    sha256 = "043b980487e2e2da5b3b3b9e630b9ae36384d6c9a8425202c2d5548cf84ec087";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo/default.nix
+++ b/distros/foxy/leo/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/foxy/leo/1.0.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo/1.0.3-1.tar.gz";
     name = "1.0.3-1.tar.gz";
-    sha256 = "00b01002e0b0e01b78fde719446482fbbedca0879b8be77eb67171fc4dabfb40";
+    sha256 = "264b22427c0218bfe9af26a03ef5c585a457e6b58d3f30ffa03533a3d0731b45";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-object-py/default.nix
+++ b/distros/foxy/maliput-object-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-pytest, maliput-object, python3, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-maliput-object-py";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_object_py-release/archive/release/foxy/maliput_object_py/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "ea15fa26b9356f0634a11133d38b71c877ee6c147a0d30861a8df91ec005e5c8";
+    url = "https://github.com/ros2-gbp/maliput_object_py-release/archive/release/foxy/maliput_object_py/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "eddd031f0f260c2e51ded66c6c1d42d0cd63e54efb13685076c18ba0bd071844";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raspimouse-navigation/default.nix
+++ b/distros/foxy/raspimouse-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, nav2-bringup, raspimouse, raspimouse-slam, rplidar-ros, rviz2, urg-node }:
+buildRosPackage {
+  pname = "ros-foxy-raspimouse-navigation";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/foxy/raspimouse_navigation/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3d43298d5944eb355eaa6c0b8fac39b46be71d4ab337ca22dfcaef7cd19f374c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hls-lfcd-lds-driver nav2-bringup raspimouse raspimouse-slam rplidar-ros rviz2 urg-node ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Navigation package for Raspberry Pi Mouse'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/raspimouse-slam-navigation/default.nix
+++ b/distros/foxy/raspimouse-slam-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, raspimouse-navigation, raspimouse-slam }:
+buildRosPackage {
+  pname = "ros-foxy-raspimouse-slam-navigation";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/foxy/raspimouse_slam_navigation/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a722029f099573d81dc9e1a731199534ef038503579f035b7bbb24971982165d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ raspimouse-navigation raspimouse-slam ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''SLAM and navigation packages for Raspberry Pi Mouse V3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/raspimouse-slam/default.nix
+++ b/distros/foxy/raspimouse-slam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, joint-state-publisher, joy-linux, nav2-map-server, raspimouse, raspimouse-description, raspimouse-ros2-examples, robot-state-publisher, rplidar-ros, rviz2, slam-toolbox, urg-node, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-raspimouse-slam";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/foxy/raspimouse_slam/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e80cc0f7774846930638958c87e802bfbd1f03c9a7b8753616e7902d36e35fa9";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hls-lfcd-lds-driver joint-state-publisher joy-linux nav2-map-server raspimouse raspimouse-description raspimouse-ros2-examples robot-state-publisher rplidar-ros rviz2 slam-toolbox urg-node xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''SLAM package for Raspberry Pi Mouse'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rclpy/default.nix
+++ b/distros/foxy/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-yaml-param-parser, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclpy";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d2b0e477d702d9fba4f2d9f7b32a1bc283f3023923c4d12c44856e5201142b02";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "28081e04c7a01c4e7341f3c33d72211611b26cf965f2296533f7626ef7cb403e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosapi-msgs/default.nix
+++ b/distros/foxy/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rosapi-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ed946c0f7c841aa7cb3a620816c040592d480e62e86f690f6612186922eff08c";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7fdec377d59827130155d2fecfd6cf24c21c72dfea20a31e5afef33fe4864b3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosapi/default.nix
+++ b/distros/foxy/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosapi";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "45a7e99ed56de40e8307996f1a3120b15ac9574d905a7a82c19ec7aea050c2de";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "410075d13f7ea187f9e1f48a34297932ee9ab72276cd693b242a6286f58cdee6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-library/default.nix
+++ b/distros/foxy/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-library";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a5c388e8dfef69dace99484b8028803afdc83e7ed950e083f8d0680636105280";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8a076f48eb5c23217fb72b6888573732bff6eb7d5cfa9ebd2791e5385d8c7af6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-msgs/default.nix
+++ b/distros/foxy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "cba48aa69785cd70baf1df3448157d9c7d84349e7d037bd96112ea8e6cbf5b24";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0041f2106220dabb62ca8c31e6fb7852e7f06e1a78b300154b80c48be4e58d08";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-server/default.nix
+++ b/distros/foxy/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-server";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "cf2f3295bf850ea26712b1c6b0f3354730171f33f5ddb0aa9c07199a2e37a887";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "81187798d4f0dabc0317a5116f14d35bba0b60b5a724debd3b9c6a6615034758";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-suite/default.nix
+++ b/distros/foxy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-suite";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "552275e9d325f1c4b84c7841a76da750ad93e72277049fffb554f89aceee7591";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8c3095df3fa6b27d8d62e9208c82fa3d99a163cba2c05a333b2013f9028c32e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbridge-test-msgs/default.nix
+++ b/distros/foxy/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbridge-test-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_test_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "feeab43b51e22d6ed10c319cfa54d186a3b19b0186a35490ead37d34dabb8246";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_test_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b362a3e150b1180706da074774248efb400bbbb81de1f1f944fcee2d9bb10803";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/simple-launch/default.nix
+++ b/distros/foxy/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-simple-launch";
-  version = "1.4.1-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "d42d38532c922bf5bd79d2c2c35416f35cc4eec1053432c9a9067ece0d553694";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "df054ab1c48ba0b76463ea49c31e578f602d94e8f2b14b90091279da16294d47";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/tvm-vendor/default.nix
+++ b/distros/foxy/tvm-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, libxml2, openblas, ros-environment, spirv-headers, spirv-tools, vulkan-loader }:
 buildRosPackage {
   pname = "ros-foxy-tvm-vendor";
-  version = "0.8.2-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/foxy/tvm_vendor/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "30010442950003af8ce886741a95af0734f9fd23b055d39bc7ba4e5c0c662257";
+    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/foxy/tvm_vendor/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c3ab420263c5a232cf13ebb14ad9e0b2cd80791f374635764914ceb6eba195ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/vrpn-mocap/default.nix
+++ b/distros/foxy/vrpn-mocap/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, std-msgs, tf2, vrpn }:
+buildRosPackage {
+  pname = "ros-foxy-vrpn-mocap";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/vrpn_mocap-release/archive/release/foxy/vrpn_mocap/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7e2cf600915b00bdb04387d4d543bce6e49286a6ca53b93aee6ba99fde20a7b6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ eigen ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp std-msgs tf2 vrpn ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''ROS2 <a href="https://github.com/vrpn/vrpn">VRPN</a>
+    client built primarily to interface with motion
+    capture devices such as VICON and OptiTrack. A detailed list of
+    supported hardware can be found
+    <a href="https://github.com/vrpn/vrpn/wiki/Available-hardware-devices">here</a>.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/eigenpy/default.nix
+++ b/distros/galactic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-eigenpy";
-  version = "2.7.11-r2";
+  version = "2.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.11-2.tar.gz";
-    name = "2.7.11-2.tar.gz";
-    sha256 = "d7a24ee5388c3976d2dd5d84d224572bac92da1ad91b9c3d7e3f150323885bfb";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.12-1.tar.gz";
+    name = "2.7.12-1.tar.gz";
+    sha256 = "8db5e83f033d807ca0d31846a26e1a038690f239d292737088c434491bc67a61";
   };
 
   buildType = "cmake";

--- a/distros/galactic/fastrtps/default.nix
+++ b/distros/galactic/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-galactic-fastrtps";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/galactic/fastrtps/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "eddb31f507208251544e87541ec323e776d6094cb42bbfa2fb38aff6c9b6a82b";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/galactic/fastrtps/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "867110aadaafb52e4498d135253d6bb8b02269034d2042879f66207ae39b65e6";
   };
 
   buildType = "cmake";

--- a/distros/galactic/gps-msgs/default.nix
+++ b/distros/galactic/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-gps-msgs";
-  version = "1.0.4-r2";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gps_msgs/1.0.4-2.tar.gz";
-    name = "1.0.4-2.tar.gz";
-    sha256 = "e478714aa1490b645a21cb2fa9a9f4aa3ee8016266fe425cd13333d666aa010b";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gps_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "fc917e0a56a0704a851f765c48794122a5b1b8ba1fe8ad03eb90b1de95322d2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gps-tools/default.nix
+++ b/distros/galactic/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-gps-tools";
-  version = "1.0.4-r2";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gps_tools/1.0.4-2.tar.gz";
-    name = "1.0.4-2.tar.gz";
-    sha256 = "a02a3b395c5a7b8a71821245913c2d02cf376e377b2e762e631465155dc2dc0b";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gps_tools/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "a02d4dc21f45dfd0e854a28debb4493d35cdce3f6fdc842c82de186b8e501b1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/gps-umd/default.nix
+++ b/distros/galactic/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-galactic-gps-umd";
-  version = "1.0.4-r2";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gps_umd/1.0.4-2.tar.gz";
-    name = "1.0.4-2.tar.gz";
-    sha256 = "d7b9b44b6f1efa3dc98e031a80ac5f19823c9d15acaedb9bd9020150f84863b6";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gps_umd/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "352c0ee472661fd1088e7c3d965609ed95db1ae0ee1273f46fbfc9ecadd278d1";
   };
 
   buildType = "catkin";

--- a/distros/galactic/gpsd-client/default.nix
+++ b/distros/galactic/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-gpsd-client";
-  version = "1.0.4-r2";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gpsd_client/1.0.4-2.tar.gz";
-    name = "1.0.4-2.tar.gz";
-    sha256 = "19733dea2b8dd069ee7da776133b7e2dcfefbb8cdb954c8087b29389ee9a58f3";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/galactic/gpsd_client/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9bc7a7251e4bc8acd849c2e56b6b82fa08ada8cecdabf253ff8342a6588fe613";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realtime-tools/default.nix
+++ b/distros/galactic/realtime-tools/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-action, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-realtime-tools";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/galactic/realtime_tools/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4126ff1601cf3dd58c01280a4cf320d53b1350c389918853002332eb445e533b";
+    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/galactic/realtime_tools/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "9d535c4fe28b89835941594ba0cb99faad62b0be4d5a49c2edba45c8ac8b5929";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp-action test-msgs ];
+  checkInputs = [ rclcpp-action test-msgs ];
   propagatedBuildInputs = [ ament-cmake rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Contains a set of tools that can be used from a hard
     realtime thread, without breaking the realtime behavior.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "3-Clause-BSD" ];
   };
 }

--- a/distros/galactic/rosapi-msgs/default.nix
+++ b/distros/galactic/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosapi-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "21e0d1377f2c0237b88ad0c884b6c30428fa9983d4c49a757977ad5d5b35fdc2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "eea92e62f51256b168aa38d75cd0a43fd1086e0c5eed7cb3261eb7810d1ddd3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosapi/default.nix
+++ b/distros/galactic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosapi";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ea20baa28a13a709808c9c04360c3eb5620ccc31288fb4a5a83cb4cb7dd4bf8f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1cb473deee797aff5b04bbb83155b53b358981f53c107a6f3837e0cd36c4e67a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-library/default.nix
+++ b/distros/galactic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-library";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2e7260c5000fc9282780c7df91945923d498615ddb6a7e0b609df2d615a30bc7";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8a6403406c5dc85c9c6f23c176da543d9387c8b6c35ae21047e0b0bdcadff25a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-msgs/default.nix
+++ b/distros/galactic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "189239f10d96bdcdde13d451130c88774bf1005e026e264967483c54520a8ef1";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b789dd1035825fc8eaa0d67f5f9a58fd57b05037ee4f5c561e2fcf4ecfae867c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-server/default.nix
+++ b/distros/galactic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-server";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "dae6534cfa6ae915c34da76651518b86a89dfb070b85a1c35947342c340212a2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "bdeccd660dfa2df8b56854300d5095ccc2962e3c710c57c1e4a3ebc0167a06b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-suite/default.nix
+++ b/distros/galactic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-suite";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ca93dacd3d71963898a4c6bfd6ba04e2558b967273b196c48a1bd52691775f35";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "53acc3faf79074ea5639419e3a652bdc424bb45f5ae5d1f83084c3cd89ed7b88";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbridge-test-msgs/default.nix
+++ b/distros/galactic/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbridge-test-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_test_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "70fc7b0b766605aaec38d17abad1b72af0bd9d515493f7728933363e54dfa605";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_test_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "633116d9cd53a6d399545dfa91f6f022eff96e90c89a5412f937fd8cc1a92809";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rplidar-ros/default.nix
+++ b/distros/galactic/rplidar-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, rclcpp, rclcpp-components, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-rplidar-ros";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/allenh1/rplidar_ros-release/archive/release/galactic/rplidar_ros/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "4e8301703dea9714e4c1f09eb70c17fb60b3aaed447e7e822067725afae8595e";
+    url = "https://github.com/allenh1/rplidar_ros-release/archive/release/galactic/rplidar_ros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "0b9e41d23195ec90a01bd2018bad7a5858667fe8b068f26ec1fcdf43cf7a34af";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/simple-launch/default.nix
+++ b/distros/galactic/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-galactic-simple-launch";
-  version = "1.4.1-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/galactic/simple_launch/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "0d192826b6afaead3c5bcc5d73f1c12c969bc7df26e0ce6963d833b33bb08440";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/galactic/simple_launch/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ba376e83a9a06fc5782a48952c27d93267bff8f4f88c84cd9d9a8595104baa04";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/tvm-vendor/default.nix
+++ b/distros/galactic/tvm-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, libxml2, openblas, ros-environment, spirv-headers, spirv-tools, vulkan-loader }:
 buildRosPackage {
   pname = "ros-galactic-tvm-vendor";
-  version = "0.8.2-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/galactic/tvm_vendor/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "efdf5cc7eca03274071447deaace5760cd60b2caecdd6cbd92b948c6a9564429";
+    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/galactic/tvm_vendor/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "cc46f9dba1fe01bc62f76bf4192bc2d36defb0592885db97a1fef8b26122c95e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bond-core/default.nix
+++ b/distros/humble/bond-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, bond, bondcpp, smclib }:
 buildRosPackage {
   pname = "ros-humble-bond-core";
-  version = "3.0.2-r2";
+  version = "3.0.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/bond_core/3.0.2-2.tar.gz";
-    name = "3.0.2-2.tar.gz";
-    sha256 = "6da43215297629ee4a4567982a5c3be7725dd2bfb3214654d5e45de493aed7dc";
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/bond_core/3.0.2-3.tar.gz";
+    name = "3.0.2-3.tar.gz";
+    sha256 = "2bb1b178c64e46c3edced0368bb54ec256f1947ffa5748265a0ad0379515b329";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bond/default.nix
+++ b/distros/humble/bond/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-bond";
-  version = "3.0.2-r2";
+  version = "3.0.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/bond/3.0.2-2.tar.gz";
-    name = "3.0.2-2.tar.gz";
-    sha256 = "c7aa84ed76adfb6833662a976b265eb19c0b954c28a6a7ef2cff01588976c79a";
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/bond/3.0.2-3.tar.gz";
+    name = "3.0.2-3.tar.gz";
+    sha256 = "09410c19e20f66060b3b69deeafeca1c2aefe92a3c65cace2f97856325983caf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bondcpp/default.nix
+++ b/distros/humble/bondcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, pkg-config, rclcpp, rclcpp-lifecycle, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-humble-bondcpp";
-  version = "3.0.2-r2";
+  version = "3.0.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/bondcpp/3.0.2-2.tar.gz";
-    name = "3.0.2-2.tar.gz";
-    sha256 = "ccafdeeec444c68f8b7cfa14a25e1f0f098f32d4f1baf57e82e39a085513c7fc";
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/bondcpp/3.0.2-3.tar.gz";
+    name = "3.0.2-3.tar.gz";
+    sha256 = "65e77756a2b4492c7d793b06769e5706b29928589f9f99befa5b21d4fa8508b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "2257dc06249fe67c6244d98e9b55dadeffa07c49e9f789aa9b3f4c7682732de3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "4ffd9aa870ceebf497d786762074b1acc484dbc9992461d35274c729aac935dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "c38f51e072b88273375666d61e1684666ca334950221e851450e90c8331a3db7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "370db157b07fae810ea63f80e1afa92dafc86a4f2c640b02dd97b1c6f177fb6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "14c93fe36b5326c94de33314f051ca86e2cb884094461d69601e6fff4e48e6a2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "d915d980dee87c69c97523dc9e7a539bf7f5246cfb89c729e37d8503df9d2d41";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "f3a2c28c523a092621c948ce2c901218c93f3eabba43a2a637232c2781e3c584";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "34ac0f32360dd9d1e135c77bca00e6f4925dad9debf71dc474968eb371df3803";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-examples, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.5.2-r1";
+  version = "2.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "72acbceef4179b301bcb2f759fd2b96c171bfd85510c0bf9d5e1e82b4e4b9cbf";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.5.3-1.tar.gz";
+    name = "2.5.3-1.tar.gz";
+    sha256 = "440f463ca84077a479762b389444b9e9d51620ec392fe894c62b9752ba1966de";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "f19c3d319bb1f52ebf6c9a763220a69ff6d5a6c7074c448da42eaecee6770444";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "dca4f20d4f4375cc3f76e897ea9310b438311293895073e3ecb84d69b86ca57f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "3269e68154b71e277a2ddef8283c3bfb859c0dd9481ee4a2ce3ce5d0a89b7f06";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "31cd2581c5d58f59e9e92e8d4b1d68374eab481d278def00b10f6853ef0f8d24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "42afeac755c90e67ea81521ec570f919bd50f2e159f288833c900ade7fd9af73";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "2a68a387ca793eb5877a84887cbe23ddc484e6adb89e469ddd46c81206e6f76c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "955b9c1469a3a480fbf2201255ba82ab12baa30589af11ecf89f67b98e499416";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "dcafc52c977d1bf87e61b8c3e489bf9e27091367b3a4b8c5be868cbb3dbda627";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "b36f7a6b812359815edcecf9eba9ee3e401929e113378a76791be018cbcc76d2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "6a7a2e557446918694951fd6f8dfac590cad5b02801e58f545b640fa7fea0daf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "9b9fe225987da10ba74b7fd561f2f83e637917bf9e1a9b8b0e4cb0ab5860f118";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "7b6f0c82b7c9a04e0bc3a757da37dafeb6984f2f3eea29f30879d49fbe5970d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-eigenpy";
-  version = "2.7.10-r2";
+  version = "2.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.7.10-2.tar.gz";
-    name = "2.7.10-2.tar.gz";
-    sha256 = "691b7a14b929ca2aa62e745e80acece845739c91275ad52e1e70cfb6c1d65989";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.7.12-1.tar.gz";
+    name = "2.7.12-1.tar.gz";
+    sha256 = "d2ad8b6c06eae352497ef0a1d4e37637591167d96a56806329d0e8290d6f3fe7";
   };
 
   buildType = "cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "438dd66282947684cbf15c4deb4182b8b9d0c8db05fdeff09c70bd30eabec0dd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "aac12a423ecb5400ba4c35272f326b533cfc55182e824041be6cebd380d22f56";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ generate-parameter-library ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
   propagatedBuildInputs = [ controller-interface geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "975689a26bfaa7af788279c711bdb9ffa6181ec9a78cc4997ce46a764ac3f6ff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "30b8c85ba962e3dfaa29e67d28d9271292fecaad42fb9800ef3c3a226699ef5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-example/default.nix
+++ b/distros/humble/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-example";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "abff6cae0538471850a56d0b0a7bd5f90630add97cdafe018de011be78f101a1";
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "538e0e00f18c9e0c1be0232b7cb8c6307a6aa3c4ba621e66e36574c08d515111";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, tcb-span }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "58a4e0c55a174c8f512641305088669daea58c734e3e0dcdb4c9bfd9d4e83b45";
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "88a3956f90aaf4d8e648a407408aaa20a1a2a07844a60e1fedc837ff57b2f664";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -782,6 +782,8 @@ self: super: {
 
  nav2-bt-navigator = self.callPackage ./nav2-bt-navigator {};
 
+ nav2-collision-monitor = self.callPackage ./nav2-collision-monitor {};
+
  nav2-common = self.callPackage ./nav2-common {};
 
  nav2-constrained-smoother = self.callPackage ./nav2-constrained-smoother {};
@@ -821,6 +823,8 @@ self: super: {
  nav2-theta-star-planner = self.callPackage ./nav2-theta-star-planner {};
 
  nav2-util = self.callPackage ./nav2-util {};
+
+ nav2-velocity-smoother = self.callPackage ./nav2-velocity-smoother {};
 
  nav2-voxel-grid = self.callPackage ./nav2-voxel-grid {};
 
@@ -939,6 +943,8 @@ self: super: {
  pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
 
  pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
+
+ pinocchio = self.callPackage ./pinocchio {};
 
  plansys2-bringup = self.callPackage ./plansys2-bringup {};
 
@@ -1432,6 +1438,8 @@ self: super: {
 
  rqt-srv = self.callPackage ./rqt-srv {};
 
+ rqt-tf-tree = self.callPackage ./rqt-tf-tree {};
+
  rqt-topic = self.callPackage ./rqt-topic {};
 
  rt-manipulators-cpp = self.callPackage ./rt-manipulators-cpp {};
@@ -1487,6 +1495,8 @@ self: super: {
  sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};
 
  sick-safetyscanners-base = self.callPackage ./sick-safetyscanners-base {};
+
+ simple-actions = self.callPackage ./simple-actions {};
 
  simple-launch = self.callPackage ./simple-launch {};
 
@@ -1593,8 +1603,6 @@ self: super: {
  tensorrt-cmake-module = self.callPackage ./tensorrt-cmake-module {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
-
- test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 
@@ -1785,6 +1793,8 @@ self: super: {
  visp = self.callPackage ./visp {};
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
+
+ vrpn = self.callPackage ./vrpn {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
 

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "195d6d838b7b73e26dbb418b84ac6692b4e72c2929bd4c32c9fce319b2ba4839";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "4b25f53ba1f3f02518ee402cedaa485406f29c2e913f0f6b867aa5b100e175c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hpp-fcl/default.nix
+++ b/distros/humble/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-hpp-fcl";
-  version = "2.1.2-r1";
+  version = "2.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "16165cca1d13ee762d1f77a8fbb7e1915f4fc35902379faa447f743832808ad1";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.1.2-2.tar.gz";
+    name = "2.1.2-2.tar.gz";
+    sha256 = "acddc7d477e970a28c516726b2c17cfe04f176307cfa4cbebd82f6902593bc93";
   };
 
   buildType = "cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "b40b1c58b774c6b2b3bb283f8a4a9db6eca431293bbe73dcd0d813bc678e9ba7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "9eabd7543ece8eeb21bc47ac37dbdce2d856446a072035f9cf2739c014b8dc7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "818897330bc3f6323cc175aa546912f6a65854bd96ad287de995ddc463dd4972";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "a0e85d1f493030cd6958d5017d240e28f4e41c421f1c179653c6723fb1084905";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "198909b9cc57978e478b16c8adecd473de946f6479cbda3976e5777889fef61e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "ea5df195f8eff8f0b2134f633d8666b54e82c93dc1cec89c3bb4a0af940cd9ef";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/leo-bringup/default.nix
+++ b/distros/humble/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-bringup";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-ros2-release/archive/release/humble/leo_bringup/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "b70e5dd406fcddda92373f90be796c9878fe415a52de1f0fdfec50e1633ac9cc";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_bringup/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "fdec7e725450c9c440b58a2ed2f335e5b02974ede9c520e540bcd32860fdfb60";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-description/default.nix
+++ b/distros/humble/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-description";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/humble/leo_description/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "bcf623df4c39738e497f85883230a248053fb0330793cb710c441c92f9c5cfae";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a4b45eef10ddb7d7d1143c12fb9c3e596c52d0602e8a3e768a376a0b2c1908e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-desktop/default.nix
+++ b/distros/humble/leo-desktop/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/humble/leo_desktop/1.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/humble/leo_desktop/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "63334298c3f89973c53a81b343d3f07193e79fd2ee2d443aaeb27107f3f0f86e";
+    sha256 = "0f6f08b54c504342b3a4a2e42fe081ba30ccdaa4e39bc515b3d9649d8f1bedac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-fw/default.nix
+++ b/distros/humble/leo-fw/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, geometry-msgs, leo-msgs, libyamlcpp, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-leo-fw";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-ros2-release/archive/release/humble/leo_fw/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "9df27c3471c2870b9011429055fda2f3d8df25a145da956062e5c5284fbbc346";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_fw/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "bef5f4ad9c048fa933c75b12b05001b74ac6c8a1ad2fa8421f1d8f810f005618";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ libyamlcpp ];
   propagatedBuildInputs = [ ament-index-python geometry-msgs leo-msgs nav-msgs python3Packages.dbus-python python3Packages.pyyaml python3Packages.whichcraft rclcpp rclcpp-components rclpy sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/leo-msgs/default.nix
+++ b/distros/humble/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-leo-msgs";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/humble/leo_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "3d9f5f7f86fe2740813469ba8dc13137332772498f7eb815a93c9024413d2824";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4f1718b81a99294a2cdb5d87e20778ebdfc5e3a0de0c6c2d606c0ddbcb3aef76";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-robot/default.nix
+++ b/distros/humble/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-humble-leo-robot";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-ros2-release/archive/release/humble/leo_robot/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c21d474d040f3aa548d01054db887eb41397a09d48f9eb48ddfe1e74ec3bcd3f";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_robot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c996417ea50186864cda421c5ff5d3e947ea9ccf630b1f6ec1146234e8a99100";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-teleop/default.nix
+++ b/distros/humble/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-humble-leo-teleop";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/humble/leo_teleop/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "1b2953a3235ac6c857fcaf3adc0d39476ee84bd3ad7a0bba9059b540b0cfb095";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9c63228ed8a09142afd99c87a1923b779f710abd7a54104455f56a51662cc815";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-viz/default.nix
+++ b/distros/humble/leo-viz/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_desktop-ros2-release/archive/release/humble/leo_viz/1.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/humble/leo_viz/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "f8ab730ef7478c6542d58f09ebc2395f51b6dd9cec300ee5b25677aa685e3e39";
+    sha256 = "bad9f1d1bbdb87c3fa646a0d621b05435f75e00732e79c6d2f804406b6cfd9d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo/default.nix
+++ b/distros/humble/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-humble-leo";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-ros2-release/archive/release/humble/leo/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "d1ebcbe8285db5bb5de6211d01b18a1fb9a1cab1c928d37c6b32984d0c612880";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "900d6a07067d946020a317f32cb3db8dbb039f0ffa0d403df75d26bbd1dabe26";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/mcap_vendor/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "fcbc3cc2f71546583a7f0aa80b3728a8fa6a719a43d337ec3750d37c312ad605";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/mcap_vendor/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "73384861e91e5e69fd1c05ecc86168467ae0db3872d28019646ca7319c69d27f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/menge-vendor/default.nix
+++ b/distros/humble/menge-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pkg-config, tinyxml }:
 buildRosPackage {
   pname = "ros-humble-menge-vendor";
-  version = "1.0.0-r3";
+  version = "1.0.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/menge_vendor-release/archive/release/humble/menge_vendor/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "1a493234413178d9563413fbf8d5a564b472c280ae51b3a0aa15f939c4731e3b";
+    url = "https://github.com/ros2-gbp/menge_vendor-release/archive/release/humble/menge_vendor/1.0.0-4.tar.gz";
+    name = "1.0.0-4.tar.gz";
+    sha256 = "95fceaf5a214d236fb7d1f46761cf4a512689e5737d4a5a85aedcf6073702220";
   };
 
   buildType = "catkin";

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "415ea499f986fca0a8249004de7756c066a5bd8f1e422f1b137b50ab0ef75162";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "88ce46687f2a86683f48ed5f1e2efed307ee1e7056b977b03f9c02aab1b2d38a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "8ae33c1ea7b778043cd5d8a428955cf4ae6fae5701cc5964a85d5e12feb4c0cd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "e6802d8ba726c4e3c9820b8047e8887974026e0a569c1606b160e9dd92d540f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "8898699ff4f0bf0e9530dd760e0cac0ba0ea594833a10bf5bfcc987eb32b4999";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "db6dbcccf54fb41943a7244b970fd6b255583a2ca47fd8448f1fc37bd6f6d003";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "6fe9ad0389f3b2d291f36eb7d772ad97c8d8dff24919a30fa993fd54fd836692";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "554ecda7ad6e5ffca11fe326bff2b1d1a33fb53dc35ff18164086c5adbae05d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "2772050e2dfe49c7fb38218ac46c0bed7131d9934c4413d1cc6d65cfbfb8269b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "b7af0ed84ce55e00c6bc50e25a3180125429cff9dbbda7918accd3e35ed5d322";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "ff3ab250516f5ac9d0fbe50b96a0c9dfdf1a724b94aa86c43ed936bafea8037d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "5a46a308b2beb2a1c9038fb1433107a1b421b9b586dc779ad0d7952e6a57381e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "2c390d98813045ada1e53993a412330e32795ec119ffaf3d080351562296ead9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "347d7b12b34df88c206b413568b92bf70af7724928ef444648d00d2af9dff1ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-nav2-collision-monitor";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "db852d7419bde8e650eab06987498a709cd711bce68ef783eada89c773d7619d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav2-common nav2-costmap-2d nav2-util rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Collision Monitor'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "f8077acfe8a686e43c89260943244b11625ffcde4654544605a3dec76e6fc95d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "8436241aedf4d154d5b2164b1b2f69bce9d0d55423c8277319333259903a685b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "dae25f1de2f7cb0821d3b132fd9ac3b650721dfbb0b6c3edeadb9018afb56874";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f34917bb3b0d03892a1bf81729a86f00a145717dcc466d5700bb7b9a1262524f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "74e57372c87548c8717ad27e08aff3344213b282ff18075674dd200bc49e19e8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "98dfdac44324ba66deca0eda6a6ac4f97409c3f2154641cc09df693b8b52f7f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "8cd7052a7007604203b9af5e70f78207d5e9bd82b5b700026447b74099294127";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ddbe1aa3b2747e1ab5ac1c72677f6b79a36454d7a676187be9aad952a4674887";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "38d90e1ed4a3aba322a1084a56bcf758960866331c710001858ead0766fb100a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "1cd3d82231905e83acd27a2b7aeb745b143c0608eb048ee62a4b91fc7f43c304";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "3cc88a0e6fa0dae479bcf313b1313baeaa12bd6df312c001313b3d010d593e59";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "6ccaa5406a46a48331a086f66894cd66265099c7a1afb2f7551a600712805332";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "9cd512b7898059289a08173be2e71d3aacf7eece999fbb56c5ad39d9ace95bae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ea0fae009899c1b702274e7ff224f084b9f4fb1b4d8a41fb571f309b428e57c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "0d347d00bf90fcb6ecc37f5d363fd1b35ee24a1f87966689296f41a5b1a6b6b6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c40588b1ee00a12d77225defcaaaf75fbbbc5707c57869f6243361b0b1de5df7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "87a41ed38ec7c47cf77d4e1ee1be49daa0650dd36f0e3d2a50f5e55011a9a4a9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ad70ab3b4837feca683fee575b6dd4f96e7a4b8051a7dc69e8ab3b3b26b33de9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "aba211706d463802531a6f4c3b514836d1edee3038f0d7d58009e7b5261108a2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f258208c226f1e1a5c465450d974996defa24539d387c2c371641df1b7a13d38";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "9014b96149834bbb71264682f3e7f3838f8210ded979e8ef239b4681a4a5c0d4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "5e33b7c90f4d6db330f30df0cd0d815b76f925adf2a6e327af0d4db34c801a82";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "c84ff4c54ee0c6e3a90a8e47bc01594033059237bd23865088afb5356322584f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "49fe83dcb857526fee6a881de11e035fc466a07427c6d80e871dc9704703124e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "ed48dec681f47caa5316c0f9e374c49d89f7fdbc42d5310b2d23db9d27a4e5cd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "538daeb23632c45aa714d6c6240965637f50323da36ab65203f56d86510130c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "276f94e8f34f0805e678ac24038f482c03cf8aedeb8dbf34938fb0717e5f8d0b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "2d9973ad055c275ee2aabe29b87d26a97b66596de0268bf78a7f8e00a971cc8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "58089cf3754cf223bc6e0e6035e7f0c187c0677c7fbd9f9aa735345635d698b6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ebff2192d16136a77b6b3dfe55a4f8e6e438fc29f53d692aacf6b573be6748e8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "e1584d7b487eb30b3ab9001692a9fb3cb2f631ac3800413693c34b418aea182c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "db2643830fc48322482ee2f3f58d042f05ad1c49905b3a18ee5c240f55f31b52";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "67a438dae43544afa786a892750698d1511a7bcf8dfb7099c4cc15cae024b63d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "a19f3a022090134012ffb3ce1f574d3e213e7fb4fa8e15ba75dfb8ff33a71f6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "8786d2a23f84b6be0e88d70ce177e1a719332b581d326c672b022133fb28e39f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "9900464c615d924a2cbad864653211e91022aaf40134184566b6ccc71319d32a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "7f40f507f3fd850544e3770d3aac4ec6ff3e457bbc1af9ae6e9ecac673610a50";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "34995f6f7d37e04092a7406c28001bb0971c2f31910da4616283a0287f5a3a55";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "ab1eafd95a84a557de5ff227448d11c109e66c957a642fff09d33ba8df2b4166";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "1416eb6dc7e2d74dee20624ac735f7cefe1f969880bebcc49eb7f5055e573744";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-humble-nav2-velocity-smoother";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "db250626dc0fe150c2a9b50adf05030782584c475204eb8aa230e55f1ff3751e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ nav2-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav2-util rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Nav2's Output velocity smoother'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "896b7fa1d1cefd424335fc7f7ea412c5081ae0639070db0ec3e8381c1e831b03";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "48144cf1cd389be52edbabdac095d00e80b23d24cbb586a97ced04cc7e8f268a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "7a0ae307d2678434db28443346760c4807950478613ac5d81af3e7a960b0ef84";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "67f65c9d883428c2a28f68997a09c4f29efd2bbb0e4a8a2a55ad1f01e4c679e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.0-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "1305e781fcfb52038a318806cf01bccc63e3b095af75a7b4dffc74554c2dc02f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "98813c0a9aa5ba17b2f518ed9f1aaa3727753a84cc9b2054ccb9b5779c63ede9";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-behaviors nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-regulated-pure-pursuit-controller nav2-rotation-shim-controller nav2-rviz-plugins nav2-simple-commander nav2-smac-planner nav2-smoother nav2-theta-star-planner nav2-util nav2-voxel-grid nav2-waypoint-follower ];
+  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-behaviors nav2-bt-navigator nav2-constrained-smoother nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-regulated-pure-pursuit-controller nav2-rotation-shim-controller nav2-rviz-plugins nav2-simple-commander nav2-smac-planner nav2-smoother nav2-theta-star-planner nav2-util nav2-velocity-smoother nav2-voxel-grid nav2-waypoint-follower ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ntrip-client/default.nix
+++ b/distros/humble/ntrip-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ntrip-client";
-  version = "1.0.2-r2";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/humble/ntrip_client/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "2c04e04e206989bb7e5970fb590570feb5844971948ef07258535c7ebd7b5eb7";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/humble/ntrip_client/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "7516989ca6c25bdc5db576845a4156554a32076b2ca71f0455e22502eedd2232";
   };
 
   buildType = "ament_python";

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-parameter-traits";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/parameter_traits/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "7f1f573983d4178c8112b060d54270791e63d5f9f6de689b9575e94408c13772";
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/parameter_traits/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "062d9b8616d5c97dec7c1b078dc7f8d4bf7dfc4ead29b5fd133a6535a73f212d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pinocchio/default.nix
+++ b/distros/humble/pinocchio/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
+buildRosPackage {
+  pname = "ros-humble-pinocchio";
+  version = "2.6.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/2.6.9-1.tar.gz";
+    name = "2.6.9-1.tar.gz";
+    sha256 = "b087b892f8fffdad7ad51031962ad2f2ba506275a6e20e07d8c0b40bcd5f1830";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy urdfdom ];
+  nativeBuildInputs = [ clang cmake ];
+
+  meta = {
+    description = ''A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "f6047954edd4e39540c48f4895fa8f62fcfb853f9df125809aa9e3374254e017";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "e2ad164859bdc4afa8d380eca1bcc39a426807642435a7c5053bffdaf60bad6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-dotgraph/default.nix
+++ b/distros/humble/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-qt-dotgraph";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_dotgraph/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "a4d9200bda38eb24a35192e86a803928d963735b3a80cb36d5790e2b8423bf04";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_dotgraph/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "753fc64a982b8b34eee6cb986cbfcd10080630079b8613b0afd9e686d0d59908";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-app/default.nix
+++ b/distros/humble/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-app";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_app/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "c15db3f1925695b2e0f49aff027eab5be1ee98fe0b96aee04e06663a0168be4d";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_app/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "3f0e9fead7cc231ceb97b4dba8ed6613bbbfa30ff5a1f18a0475bfea86287f5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-core/default.nix
+++ b/distros/humble/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-core";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_core/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "611998e015e861ce8f7c8661294ac5dfa04431e05c520dc2120b41b7d7e2860b";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_core/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "49ca2bae45782d4ea180a05a182c685bfb296fd3cd05cd8be384b73024e4530b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-cpp/default.nix
+++ b/distros/humble/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, rcpputils, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-cpp";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_cpp/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "7938555784eea4ae74fa54751362ba47cf57b46b991f312a200db3a0b04893a2";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_cpp/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "3c8eb0beeea6bd18163938803a37b8a0b27a302612ddc6bd5e979f7a99284b7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-py-common/default.nix
+++ b/distros/humble/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-py-common";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_py_common/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "6ea3954c5163a80edb429096628b8b2324b8100c54e1bd433e241ea0389012c1";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_py_common/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "37deb0d66736b9ae1c1f29205e054765c0446bddd84574ca7eeacd9852d8d0e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui/default.nix
+++ b/distros/humble/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-humble-qt-gui";
-  version = "2.2.1-r2";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "0752226f4812eab1099c73a590b170c716301b64fc4ddb2d019ba33984380e8b";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "d4ab6a0ab03675365c44403333d4e2f832724cb9ca80dabc80cd55344b064854";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-controllers-interface/default.nix
+++ b/distros/humble/robot-controllers-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, pluginlib, rclcpp, rclcpp-action, robot-controllers-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-robot-controllers-interface";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_interface/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "539295fe2ee86178d68928a34ae807d098a4f8042f28a40b53d0d3e72e44b57c";
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_interface/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "0dabadd61f4c4577879d53502fb1ae826285e755bf08a03756c653f28da2d5da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-controllers-msgs/default.nix
+++ b/distros/humble/robot-controllers-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-robot-controllers-msgs";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_msgs/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "f23761f861321bb3f6789c6b817b58182eb8fa0c0915339c374339f8e37b50a0";
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers_msgs/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "dd8b03b0617a7e93dbcd175615138c8f2f4a793aab2be3bbd273c9cd5fdae18f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-controllers/default.nix
+++ b/distros/humble/robot-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-gtest, angles, control-msgs, geometry-msgs, kdl-parser, nav-msgs, orocos-kdl, pluginlib, rclcpp, rclcpp-action, robot-controllers-interface, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-humble-robot-controllers";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "a7889ac9763f3584fb5f992761432247ae72ede182c24083d59223e49a703e43";
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release/archive/release/humble/robot_controllers/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "801b0e3177664043f852d61324299b4ec592510b7d0059830446c4b5cb7c649a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "91e2f5618bc1d9597152206d636329cd1db20773be656bf14ebc8dd6243d84ad";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "42cdf7cf4a8adfaace15de4fab05dda8676063baf5bcec5dbc46f83ad97fb3de";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, tricycle-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "362c2c22b3623d4bf0c8c4c36250e019547d9ebd20fd3540f7db7e75d37622a8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "29f8a473db55d7b5668a8babb82fba64a86602410f2b5123749f5b1d0d5c37ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosapi-msgs/default.nix
+++ b/distros/humble/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosapi-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "c976558fb5e7373023584390be0b0c27340b4024d9adcb377a8cca0e5d8c8302";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "f027ba1273b85b7786153ef360ba6d860b723d65b1cf95f68df2a07b2520f5df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosapi/default.nix
+++ b/distros/humble/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosapi";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "8a38cc78fff9c7a1c1fd7a4048d9e2bc093259e8d80aafb096f25dc347ea5717";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "a0de3a97d6f471b10a768a0d1cc7ee86721c3f241c36c5f1f4a27fc9bd772565";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/rosbag2_storage_mcap/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "7cb1cc93ea8a603e82d46ba99b03addf450115428bdf26fcf3c6483013e4fed1";
+    url = "https://github.com/ros2-gbp/rosbag2_storage_mcap-release/archive/release/humble/rosbag2_storage_mcap/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "2a5f66158ec744a3973b4d288c8757a8b16fcb7360d99323fe2510c9fed6b908";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rcpputils rosbag2-cpp rosbag2-test-common std-msgs ];
   propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/rosbridge-library/default.nix
+++ b/distros/humble/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-library";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "9bcf920e144ea31d8fa50e4e1474a3948265c1415cde26532eb971e598074b45";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "342279cefbd049b8c227d295320f0b99558a72f4f98b2cb65854c13e73c9e2fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-msgs/default.nix
+++ b/distros/humble/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "c7d42e5edf22f3f204ae76b4d52c7201c8c7f2800e3b0b79754d6f96d680578a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "828b426e5cbb5104dc675efc9627110fea951408fa6d6c8a1eaf4237b09f671d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-server/default.nix
+++ b/distros/humble/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-server";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a6136874d356e6f9fa3503971d9de004aeda01ba42b25d3ba96bf6f24f03b795";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "2a3abdc3c95467dce6315f36ccd2647858b16a84f4bb637dea2da1b2938eb385";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-suite/default.nix
+++ b/distros/humble/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-suite";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "176ab51c324359e19abbd60468da3c09db0d10126790d524312bd53e10eedee7";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9e67eb6944ae03c7a9b2d2722b6284d9b4152f95beff7e8f3579c42baeff484d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-test-msgs/default.nix
+++ b/distros/humble/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-test-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "f4c324f4d09c6563b02b32c4eeda31907bf19c0d92e9ae66fc09af39de31c016";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "855c7125470f871134a540c0bcdc8ee8fee3e02cb6b5d003c77cb55308d4b432";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rplidar-ros/default.nix
+++ b/distros/humble/rplidar-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, rclcpp, rclcpp-components, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rplidar-ros";
-  version = "2.0.2-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rplidar_ros-release/archive/release/humble/rplidar_ros/2.0.2-3.tar.gz";
-    name = "2.0.2-3.tar.gz";
-    sha256 = "cb1ea13a6c09e85de043c3114902c6ddfdee9fba9631825effab892184ebfd88";
+    url = "https://github.com/ros2-gbp/rplidar_ros-release/archive/release/humble/rplidar_ros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "365e14223e415715cdbaf3340e03c5dc784153c591daf762db326f05a265b1b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "ce13baa8464429697c36680532b92fc682aa03d123106eec281503b1756907db";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "1b1f7fd8940cd4c8b2e3b18011a86b56c7fd70e5155e179e40f2d04cabca6945";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-tf-tree/default.nix
+++ b/distros/humble/rqt-tf-tree/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-rqt-tf-tree";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/humble/rqt_tf_tree/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "e1c9088f325151b29ff3f3d5b7192fa2ed8cf6c0718d86d14716238c143c11e2";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.mock ];
+  propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
+
+  meta = {
+    description = ''rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/simple-actions/default.nix
+++ b/distros/humble/simple-actions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-simple-actions";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/simple_actions-release/archive/release/humble/simple_actions/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "e2aa0228b96ceba99435d31820f0802cd986ff6bb06e8bc53cd27abc92b349ab";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
+  propagatedBuildInputs = [ action-msgs rclcpp rclcpp-action rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Simple library for using the `rclpy/rclcpp` action libraries'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/simple-launch/default.nix
+++ b/distros/humble/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-simple-launch";
-  version = "1.4.1-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "323335217360f26bea3981863b5848e0c0c1a953a5441bb2a2a3b8c6e2027c09";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "fc6d2a8160e06b28a1d3754f2370ee2a7d1f3db38bc937a030e0054785345100";
   };
 
   buildType = "ament_python";

--- a/distros/humble/slam-toolbox/default.nix
+++ b/distros/humble/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-slam-toolbox";
-  version = "2.6.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.0-2.tar.gz";
-    name = "2.6.0-2.tar.gz";
-    sha256 = "a1e3eb01e25d7059b7536acb52cf0e953ca94ac93dee576213ab15dc7f725d24";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e5228ae02aa1ce4934ea7d42afe3d86d4fa96fab8f7cb12b7e5b11635e07af4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/smclib/default.nix
+++ b/distros/humble/smclib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-smclib";
-  version = "3.0.2-r2";
+  version = "3.0.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/smclib/3.0.2-2.tar.gz";
-    name = "3.0.2-2.tar.gz";
-    sha256 = "a15fd1fa92e1e86fa3d0ac1029d6745ee3f605bf287742e99fbbafa02647e7a1";
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/humble/smclib/3.0.2-3.tar.gz";
+    name = "3.0.2-3.tar.gz";
+    sha256 = "b0caf26c1e49a1c1dae37f382723b283006a8fadb584f89e88953e88ae4adde1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tcb-span/default.nix
+++ b/distros/humble/tcb-span/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-tcb-span";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/tcb_span/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "4006169b3a8c62d99150568aa3b4a29d9267349378bf4117dffd2c66ea4c331e";
+    url = "https://github.com/PickNikRobotics/generate_parameter_library-release/archive/release/humble/tcb_span/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "0158977df984d0b3ed6fb873178994545393550fe9127d5ac927d0cb9bef6202";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "fcb8bda974d3c622283f86681fb1f91960f1e94ff46bfeddca885476de08d551";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "ce63b899fc26b011dd2254d886dc280a930506bd4d4c2b00837ea1454734c76c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tvm-vendor/default.nix
+++ b/distros/humble/tvm-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, libxml2, openblas, ros-environment, spirv-headers, spirv-tools, vulkan-loader }:
 buildRosPackage {
   pname = "ros-humble-tvm-vendor";
-  version = "0.8.2-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/humble/tvm_vendor/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "55aa0831784ed4050fd46e286e0d36a848d5f03705e0c50d5aecf604745f9ad6";
+    url = "https://github.com/ros2-gbp/tvm_vendor-release/archive/release/humble/tvm_vendor/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "4cfd12e3f24597039c56e7cdedb38544b7286e2e5a204595eb0132d5dcbe7acd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "ed07c9fb583f6c8eebe70db898a78a6b32dc4d2014c4449c3d7e33b93ead73f9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "f4e7f83db406f70b42a8de2e0fd4bd8d41fabf50e32ed5c23e924f659460d6bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/vrpn/default.nix
+++ b/distros/humble/vrpn/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
+buildRosPackage {
+  pname = "ros-humble-vrpn";
+  version = "7.35.0-r11";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/vrpn-release/archive/release/humble/vrpn/7.35.0-11.tar.gz";
+    name = "7.35.0-11.tar.gz";
+    sha256 = "70327fe398c88fd84af4117ae83f84c60cc6646560c370c5895445c5ec1ce422";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The VRPN is a library and set of servers that interfaces with virtual-reality systems, such as VICON, OptiTrack, and others.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/assisted-teleop/default.nix
+++ b/distros/melodic/assisted-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, base-local-planner, catkin, costmap-2d, eigen, filters, geometry-msgs, message-filters, move-base-msgs, pluginlib, roscpp, roslib, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-assisted-teleop";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/assisted_teleop/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "db8bba55cf2e596068f53c33bcb492ccf0c66ee9cbcd27405c10fa9aa1f00407";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/assisted_teleop/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "8c14bee07b65c46e88f2d955a18d3b116db10f02f4266963072950077b8aab2c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "eb0c1d00f163a0153263b81275aa8ab0014a406196d4a201d01f16ad8d9d63f1";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "3b011f26dae9279cc4f01688f0775cbe4606da2cafdab5415ace607f711f36c5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "5afc90d19df7b952f315fff30132e1e1d12640748fe9f8d6f80139be09509b2b";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "17fdb6ab600fc71d9c68618786824660a5aba4f4b0d27a21a0c07bcf087f3475";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "ba1a9d6405d72171f455d1f950f91d263619e9f2961ea66dcafd67051ce67de5";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "25fbdc3b8b59ed6301d87b55e4cf249fab4972dcf67eece12c71d8331bd0cb57";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "59c3e9adb8200d6c296674e7405700e2bec35a2feba21605ed6bd19d5eeba6e4";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "9befc86b77562b762538b038d9dc7b0da95121f565c15ac98862ad0fa7d6707c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.11-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.11-1.tar.gz";
-    name = "2.7.11-1.tar.gz";
-    sha256 = "844ba74addb63ecf579bae07fdf3084729d0245193e70b4f881987c594fb7e15";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "47858bb6feda73d45f258f788360159c31fdcb1f4547a1324c9a1bc7e402acb1";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2178,6 +2178,8 @@ self: super: {
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
+ mocap-nokov = self.callPackage ./mocap-nokov {};
+
  mocap-optitrack = self.callPackage ./mocap-optitrack {};
 
  mongodb-log = self.callPackage ./mongodb-log {};
@@ -3061,8 +3063,6 @@ self: super: {
  qb-device-description = self.callPackage ./qb-device-description {};
 
  qb-device-driver = self.callPackage ./qb-device-driver {};
-
- qb-device-gazebo = self.callPackage ./qb-device-gazebo {};
 
  qb-device-hardware-interface = self.callPackage ./qb-device-hardware-interface {};
 

--- a/distros/melodic/goal-passer/default.nix
+++ b/distros/melodic/goal-passer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, nav-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-goal-passer";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/goal_passer/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "8cbbf4230f8a3fec125d43ebd44745cbe25f73e5750a048db1be74cdcbfce06b";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/goal_passer/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "d68d61e5b36ed2c75022cb13f54ce924c91d187cc4d052eab864cdcf64844fb8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/graceful-controller-ros/default.nix
+++ b/distros/melodic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller-ros";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "4c7ec4845974f1fd1125416c9af67d0197d19e552ab0a185a26b191123bb0ff5";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "496862ecd860ae3113c7a2fa9ec41f1e6e50b5165a34d9a595262856bb99662e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/graceful-controller/default.nix
+++ b/distros/melodic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "44a363a6561d7b3c8a02c94964a19214f508eff1bcbfa07e5fa0bf71642696b9";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "3aa23114c250b8d019a6a45accf839fdb43796d552872ae37f26cf32ba19abd4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hpp-fcl/default.nix
+++ b/distros/melodic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-hpp-fcl";
-  version = "2.1.2-r1";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "a7e3aa9e0d272bc7af7229b9036d1417ec49ec51469b8a718d910f9f1928bda1";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "594d688b680ff946d06f8ddd0ccebd41ea887af0ad261efc5a097b10b4a97e8b";
   };
 
   buildType = "cmake";

--- a/distros/melodic/imu-complementary-filter/default.nix
+++ b/distros/melodic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-imu-complementary-filter";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "9a68b1c5a4b5cda44fe3b6b1852d8dfd91c104eaf42c1d9b3bb014ca685e784c";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "e8d4d45abd00848d2ded1185cd622ecb9171ae8d3a9666bdd16597d6ba1c2215";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-filter-madgwick/default.nix
+++ b/distros/melodic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-imu-filter-madgwick";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "e601d53201c05037df73d084e72ceeeefa6eb05d169b5086b1a97a9974dd528c";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "25547d4ccabc7c57147e48813727e7e34e87aef8076ed6880cfeb379a87de684";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-tools/default.nix
+++ b/distros/melodic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-imu-tools";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "79367a68fc44b74309f50e3edc06aec98a2990d872b6454a3e3c59a57eb2b487";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "baf641b93e413076f3d7400da14630442a225ebb16c5f20c9a117f7b415f4784";
   };
 
   buildType = "catkin";

--- a/distros/melodic/inorbit-republisher/default.nix
+++ b/distros/melodic/inorbit-republisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-inorbit-republisher";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/melodic/inorbit_republisher/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "018b3ac2250983f171e4b6f577e9a40ee1b8c56c8e7ffc33df8ae3a05ce603f6";
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/melodic/inorbit_republisher/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "11a7868e1e1b7cfd8c209179e0bce11a9339230d9afbf994ac72f0d4c7fe496c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mocap-nokov/default.nix
+++ b/distros/melodic/mocap-nokov/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
+buildRosPackage {
+  pname = "ros-melodic-mocap-nokov";
+  version = "0.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/melodic/mocap_nokov/0.0.2-2.tar.gz";
+    name = "0.0.2-2.tar.gz";
+    sha256 = "ddceda5c625d35fb10c8602945ad88f434de467009754fb9c1a8c841445fc333";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs nav-msgs roscpp tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Streaming of Nokov mocap data to tf
+    <p>
+    This package contains a node that translates motion capture data from an
+    nokov rig to tf transforms, poses and 2D poses.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/navigation-experimental/default.nix
+++ b/distros/melodic/navigation-experimental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assisted-teleop, catkin, goal-passer, pose-base-controller, pose-follower, sbpl-lattice-planner, sbpl-recovery, twist-recovery }:
 buildRosPackage {
   pname = "ros-melodic-navigation-experimental";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/navigation_experimental/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "3d5a94a36c11ba70d55bf05b923c1165b055f1d2b754ac28d2cacc1680cea961";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/navigation_experimental/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "67965b9d9247e010701e3ca6adf0599a8cabe7cf4711d92d4a60b5037d5e1406";
   };
 
   buildType = "catkin";

--- a/distros/melodic/panda-moveit-config/default.nix
+++ b/distros/melodic/panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-panda-moveit-config";
-  version = "0.7.4-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/panda_moveit_config-release/archive/release/melodic/panda_moveit_config/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "c454614f3ce06467e0b857c873262d0f00e26d8287c70b8a70f22ab6b08b7040";
+    url = "https://github.com/ros-gbp/panda_moveit_config-release/archive/release/melodic/panda_moveit_config/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "b142095d8aef1b73fa5f81ad6b57497669acd5e5a783d02725249189b6afedbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.6.9-r1";
+  version = "2.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "f347e40497624bf4da24fe9fe07af5f3de8ed4f837c02f4a162719b3b2729d52";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.8-1.tar.gz";
+    name = "2.6.8-1.tar.gz";
+    sha256 = "f93d7f291c2c822e6c46498e1dbfb31355e82c4ba8ff0aa8632bfe97c9ad7ef8";
   };
 
   buildType = "cmake";

--- a/distros/melodic/pose-base-controller/default.nix
+++ b/distros/melodic/pose-base-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, move-base-msgs, nav-msgs, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pose-base-controller";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_base_controller/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "dc8b3aae19934ec7bd206c78fd089edde0404e43c832e576928cad3251510d81";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_base_controller/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "c4b91b8662f7e704d08a4a4a18f11464df444907d10299a2883cd35b5f40552b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pose-follower/default.nix
+++ b/distros/melodic/pose-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, nav-core, nav-msgs, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pose-follower";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_follower/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "3d7469e679df65dbb213d895ea3297f9ca9e1df52c25e8edc8e561c08a38a14f";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/pose_follower/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "d2d883103ef47535e1dcf8c09c0473d1123354f8e6b19452ed95c1beeb771a57";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-bringup/default.nix
+++ b/distros/melodic/qb-device-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-bringup";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "81662c352d3fa32e5921ad7b369256dcfa2e75f7e65178a5ea611cd1fb8a9a2f";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "443a0556f062e710b5f7d7dc73d706cf568d89df0fd7ad5166709f879da7949b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-control/default.nix
+++ b/distros/melodic/qb-device-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, combined-robot-hw, control-msgs, controller-manager, qb-device-hardware-interface, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-control";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "b6c02de60209d47bf9c36a7fb666156c7288a40521a4411a0b2894524ee60379";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "aa15f86f450ad62174010eae97ce5ba325a52e62a638a01ae3b7a100ec406a6b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-description/default.nix
+++ b/distros/melodic/qb-device-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-description";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "e97366b8ad45040b9b0df0cfd4d90f1ad1ca5b11155ab8a175436fd2ba8177ea";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "68b1656670c1a86828fc13dd7ad3943209f3b95df25079c632717d2a3a326aea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-driver/default.nix
+++ b/distros/melodic/qb-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-srvs, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-driver";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "88165e642422e39a656dc437b119ad761d025fe87bc5b231b8e7aa8a4e58d929";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "5b3ec2c7b2ecf6aa8e1b99156423cb9f88208eb8d02024c2b30b8c6b1570e5d4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-hardware-interface/default.nix
+++ b/distros/melodic/qb-device-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-hardware-interface";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "122419019922e26fc861a51e23d1f004c6ef72d62972cb5724f815e3897c3581";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "16e0d28b4e8b145ae272049cdf232830fd7e6ffc50145bcb04a1570fa1e0f791";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-msgs/default.nix
+++ b/distros/melodic/qb-device-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-msgs";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "a63d3ea20ccf397ab3436495b3ef35a09e3fc0cd22b8593b2c54ba7c9581b063";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "0a101007de0e30caec152ebe1d7f6bd676382b6b9df4e8353acb6a061bb57ab6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-srvs/default.nix
+++ b/distros/melodic/qb-device-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-device-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-srvs";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "af9ceb93a063468004e50ed38ee47368ea55e4b76fbb1b04f204c146b6971474";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "3368262c75e15bb0fe756a1a54ae5dbef310d58c351c97e62766135641c68cab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-utils/default.nix
+++ b/distros/melodic/qb-device-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-utils";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "319d5dcb10146d13330e008e62df8314219d57778ecb29a6af8ebb5e60eec0cf";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "b7ece361d35ee477a65ab530192408ac5a4fb3f8813c52a48a911989568fd0cf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device/default.nix
+++ b/distros/melodic/qb-device/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-gazebo, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs, qb-device-utils }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device";
-  version = "3.0.4-r3";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "536c46cf7cfffb792c66af7ef6730bba94ae10487c9ff72ddf7f6fa77d143bc9";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "732baae03ff35decece845d122f21d7b7b86d2c31f726cfce269be208c306724";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-gazebo qb-device-hardware-interface qb-device-msgs qb-device-srvs qb-device-utils ];
+  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-hardware-interface qb-device-msgs qb-device-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rviz-imu-plugin/default.nix
+++ b/distros/melodic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-melodic-rviz-imu-plugin";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "65f36dcbfb2f5b9f8bced4165b8ffcd873823fbc8b7e12397f3d1f13b8b18ff3";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "5f05c06594a77f466543b305c493267af7366f3ac2c3f6b6aaf46eeb44ead605";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sbpl-lattice-planner/default.nix
+++ b/distros/melodic/sbpl-lattice-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, roscpp, sbpl, tf, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-sbpl-lattice-planner";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_lattice_planner/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "28cc0a3b8237491c92b65bf277ea73d41e077c64cbeb937e75a001f7fa483f53";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_lattice_planner/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "3e0c9722b80b6dabbe65028a6d9396b526294c540b59e7f4a5c49c29e3ec09d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sbpl-recovery/default.nix
+++ b/distros/melodic/sbpl-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, nav-core, pluginlib, pose-follower, roscpp, sbpl-lattice-planner, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-sbpl-recovery";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_recovery/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "740c25ade316477bc2ab37c5e138c35ae2122911d2a766fad2b39aa63a89e9e3";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/sbpl_recovery/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "2d38cd509a685ec31df2517ca2c45c79a424fb45ae76a29736f86168a4137ed6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-mux/default.nix
+++ b/distros/melodic/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, geometry-msgs, roscpp, rospy, rostest, rostopic, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-twist-mux";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/melodic/twist_mux/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "be81c02f14eddcb14a8e4195b2c6318953efcfa2c92ff7cf7963ff616e0b3a8c";
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/melodic/twist_mux/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "f789b4f46623508b3c7e8071a4e2960788930e04a5795fc8d6bc323994a272cc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-recovery/default.nix
+++ b/distros/melodic/twist-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, geometry-msgs, nav-core, pluginlib, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-twist-recovery";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/twist_recovery/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "dc76ad46cb3e96c0e8335fc419562933eba699b3a9270983f69355bf0a9cb592";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/melodic/twist_recovery/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "490d8eb344c2c9d14ece49b3993f764cb8a659738ecc72c25697b94c9f50d401";
   };
 
   buildType = "catkin";

--- a/distros/noetic/abb-driver/default.nix
+++ b/distros/noetic/abb-driver/default.nix
@@ -1,0 +1,31 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, industrial-robot-client, simple-message }:
+buildRosPackage {
+  pname = "ros-noetic-abb-driver";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb_driver-release/archive/release/noetic/abb_driver/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c5f09291bfcb18a477d3150f0abdb955be52dd69140ac3e417b0256a6f4aaec5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ simple-message ];
+  propagatedBuildInputs = [ industrial-robot-client ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+     ROS-Industrial nodes for interfacing with ABB robot controllers.
+   </p>
+   <p>
+     This package is part of the ROS-Industrial program and contains nodes 
+     for interfacing with ABB industrial robot controllers.
+   </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/assisted-teleop/default.nix
+++ b/distros/noetic/assisted-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, base-local-planner, catkin, costmap-2d, eigen, filters, geometry-msgs, message-filters, move-base-msgs, pluginlib, roscpp, roslib, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-assisted-teleop";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/assisted_teleop/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "4db7036fd5901f1e7a514966a4303ee7b1c9b6578164111de50b168d90d41c20";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/assisted_teleop/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "9e042f7baa2bde5b61167779213879d69fd495edc48afdb0ba4d407878256af2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-capture/default.nix
+++ b/distros/noetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-capture";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "c7f8daa90674584dc7db5cea6f0fdc0a602fbd5169632988601bffb8a940b810";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "e937e6466e168c3b96d0368f21e45621d240e5e62310e43be4936466d0e61863";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common-msgs/default.nix
+++ b/distros/noetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-audio-common-msgs";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "85b8bd7a7fd1348ea5fa0d84c05d9cca2e6f34c7b569e859cd606c8bd1c9e79f";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "7cc1bed2e28444fe18dd53076f6b744a734a2f141754259cefbf3efedfe7b54f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common/default.nix
+++ b/distros/noetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-audio-common";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "43f53161d90023ce760af643e6a29757a868fff9a3e0330af5bc5d1bdd700f1b";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "49c0ddb6d92c469fe7e357293988c6219fc5ccedb3f047232d54aa0d2ede60e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-play/default.nix
+++ b/distros/noetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-play";
-  version = "0.3.13-r1";
+  version = "0.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.13-1.tar.gz";
-    name = "0.3.13-1.tar.gz";
-    sha256 = "d8898cda69f7de2fa5d0fc3ce83c8281c1ecbb98c8399fd53843f46c883e8ab0";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.15-1.tar.gz";
+    name = "0.3.15-1.tar.gz";
+    sha256 = "1713387c598bc0a0fee2c12ca5004eeec8ffd3f433884b55df4743dd326a9315";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.11-r1";
+  version = "2.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.11-1.tar.gz";
-    name = "2.7.11-1.tar.gz";
-    sha256 = "72f5d17bb6ff42ff160ceac1fd63bfa6591d53d06b4189a09fb46f88c700a88e";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.12-1.tar.gz";
+    name = "2.7.12-1.tar.gz";
+    sha256 = "d4093ef0ee0376288e167dbf4e0e3d5b49b7a746cf9d4d4a7a174ceae6399664";
   };
 
   buildType = "cmake";

--- a/distros/noetic/franka-control/default.nix
+++ b/distros/noetic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, joint-trajectory-controller, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-control";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "46917738d8d13685d8e0bdecd910e881900227d2e05af23f5dd5eb645d6c4c9d";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "409e777e65b8003578ee54df9fe57b6422ce4d710aa6cc93624b92df74bca6cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-description/default.nix
+++ b/distros/noetic/franka-description/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-description";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "0eb74a8ab64bd4432f7deaea3e2de639d1ec19a6d40529b3bc3b49886fcb421a";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "c704110dcc354c33fdab5e26198fad37b5ba4fb41f6a19c95dca53ed493c97ea";
   };
 
   buildType = "catkin";
+  checkInputs = [ rosunit ];
   propagatedBuildInputs = [ xacro ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/franka-example-controllers/default.nix
+++ b/distros/noetic/franka-example-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, moveit-commander, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, joint-limits-interface, libfranka, message-generation, message-runtime, moveit-commander, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-example-controllers";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "82f27a07e4072b5b94973334f2fba6b17bda397ee3e93aed72022940a459ce1a";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "e80e71f07aa6629d36399556753e968c928a4a52616ae0607a59e959d9b83dbf";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen message-generation ];
-  propagatedBuildInputs = [ controller-interface dynamic-reconfigure eigen-conversions franka-control franka-description franka-gripper franka-hw geometry-msgs hardware-interface libfranka message-runtime moveit-commander panda-moveit-config pluginlib realtime-tools roscpp rospy tf tf-conversions ];
+  propagatedBuildInputs = [ controller-interface dynamic-reconfigure eigen-conversions franka-control franka-description franka-gripper franka-hw geometry-msgs hardware-interface joint-limits-interface libfranka message-runtime moveit-commander panda-moveit-config pluginlib realtime-tools roscpp rospy tf tf-conversions urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-gazebo/default.nix
+++ b/distros/noetic/franka-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, boost-sml, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-gazebo";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "1ad2d4c734d088942a44b5d19c8ec6991410ec61b00e1c084c09bf198bb00d7c";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "209133fd36e20fc9b689f92edb7ccb6f819164b8ec4b91fcd9b6ca71b50207ea";
   };
 
   buildType = "catkin";
   buildInputs = [ gazebo-dev ];
   checkInputs = [ geometry-msgs gtest rostest sensor-msgs ];
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp roslaunch rospy std-msgs transmission-interface urdf ];
+  propagatedBuildInputs = [ angles boost-sml control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp roslaunch rospy std-msgs transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-gripper/default.nix
+++ b/distros/noetic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-franka-gripper";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "2f47f8aacaa7c14ab9e144808b4251b04d65a3b0c21edfbb3e6f73a447f0178a";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "4c56232bb3a3070c01023fe478c03dbaaf2d4ce877e50a57a8743a299b264690";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-hw/default.nix
+++ b/distros/noetic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-hw";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e3fb18e603d6c90616136b887d09b047027b0aabf85e5cb5c0f9056e7932a247";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "5cbbc021cc60a020412910083ff3c5f719916b2118c59a3864b29ca6788cb309";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-msgs/default.nix
+++ b/distros/noetic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-msgs";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e0fda6c228ccf1a692dc951dcca53197c446070599c16b8bbbe67a9bc82395fd";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "d59821cbe6934dc85d2720446f7bd9570a69de11e5544b245fa818b0524be498";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-ros/default.nix
+++ b/distros/noetic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-franka-ros";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "f3c6821400ec368e35794d03054d8d0680819bc630baf553dfda1382f1c6da9d";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "3302b0a6b292356f1dec1873affe90cf1fc9641f57b067f23e25a33191963cc4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-visualization/default.nix
+++ b/distros/noetic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-visualization";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "a1da047e01bad191f935c70794cbad86971b5f134b26be18da9aa3253696fa7f";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "c97af62d4fab69a917f496433489f7fe4250e6dd1eefd9be0e056273cfe19c12";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -4,6 +4,8 @@
 
 self: super: {
 
+ abb-driver = self.callPackage ./abb-driver {};
+
  abb-egm-msgs = self.callPackage ./abb-egm-msgs {};
 
  abb-rapid-msgs = self.callPackage ./abb-rapid-msgs {};
@@ -1514,6 +1516,8 @@ self: super: {
 
  lanelet2-validation = self.callPackage ./lanelet2-validation {};
 
+ laptop-battery-monitor = self.callPackage ./laptop-battery-monitor {};
+
  laser-assembler = self.callPackage ./laser-assembler {};
 
  laser-cb-detector = self.callPackage ./laser-cb-detector {};
@@ -1608,11 +1612,15 @@ self: super: {
 
  librviz-tutorial = self.callPackage ./librviz-tutorial {};
 
+ libsensors-monitor = self.callPackage ./libsensors-monitor {};
+
  libsiftfast = self.callPackage ./libsiftfast {};
 
  libuvc-camera = self.callPackage ./libuvc-camera {};
 
  libuvc-ros = self.callPackage ./libuvc-ros {};
+
+ linux-peripheral-interfaces = self.callPackage ./linux-peripheral-interfaces {};
 
  lms1xx = self.callPackage ./lms1xx {};
 
@@ -2690,6 +2698,8 @@ self: super: {
 
  ros-realtime = self.callPackage ./ros-realtime {};
 
+ ros-system-fingerprint = self.callPackage ./ros-system-fingerprint {};
+
  ros-tutorials = self.callPackage ./ros-tutorials {};
 
  ros-type-introspection = self.callPackage ./ros-type-introspection {};
@@ -3163,6 +3173,8 @@ self: super: {
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
+
+ swri-cli-tools = self.callPackage ./swri-cli-tools {};
 
  swri-console = self.callPackage ./swri-console {};
 

--- a/distros/noetic/goal-passer/default.nix
+++ b/distros/noetic/goal-passer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, nav-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-goal-passer";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/goal_passer/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c35af8ad4759e84af61025a9d15d5b8c121d95a26df65a6910533e142109a6ad";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/goal_passer/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "3eaf495a78b86279c105d8bef4dd6af74ae3878289f2cc025762acc02444149d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller-ros/default.nix
+++ b/distros/noetic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller-ros";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "a45b8cccba427db5a9b267b01815424c13fc32861634149473941a8d7a1cc701";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "c9d5f843296b3b683ff14c7c90c127f844d8c9d3fe34fbed56e8e671c04f36d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller/default.nix
+++ b/distros/noetic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "9d021f2438fc3baf92eced76f0bdc7bfae43187403f9cf937b34b0ab398a49ec";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "9f0f06b69c01869280baa500abd76571b46262153bc33089e28065f4ed2fb12c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-complementary-filter/default.nix
+++ b/distros/noetic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, message-filters, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-imu-complementary-filter";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_complementary_filter/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "142c83020a468fc94249bb22a25d87af485d663b2e0f9ce713388747d514e7de";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_complementary_filter/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "a97788fe8767198ec5d00ca5d110ae90f43efa644f4fea5d70b20f6f27a265f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-filter-madgwick/default.nix
+++ b/distros/noetic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-imu-filter-madgwick";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_filter_madgwick/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "4ec47c1bd9321cda3de6e97cdfacf8c0ce4998a1a9b2c4f5c34126bf87c5219f";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_filter_madgwick/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "86a14bd1e8b9ef044f491442f3f79eb2cc07fe7421fb1128862a9da19b2926e8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-tools/default.nix
+++ b/distros/noetic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-noetic-imu-tools";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_tools/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "efff8b7a40704c52b99449f289963b2c8ad829aa308f92af05e6c7250aa0999d";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_tools/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "a8d6e0aa0c837e2d4da2f0285c0ffc59b31e28d89947cc196bba7464eac7077f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-core/default.nix
+++ b/distros/noetic/industrial-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, industrial-deprecated, industrial-msgs, industrial-robot-client, industrial-robot-simulator, industrial-trajectory-filters, industrial-utils, simple-message }:
 buildRosPackage {
   pname = "ros-noetic-industrial-core";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_core/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "b7fa93283d893e726a85796b29eec043d65708a23e06d8e2012c05d6454ab6a4";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_core/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "60aab3d3952f68fddc9185ae536eda925de829d5d996ee40c5a3c7f84f059979";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-deprecated/default.nix
+++ b/distros/noetic/industrial-deprecated/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-industrial-deprecated";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_deprecated/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "ab476be2bd0e900ec9c70ef67bae63ce78345d7479ef99a113e49f7195cd7708";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_deprecated/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "4345c60f457f58884c90b82ea6c79c4b3995e4ae38f45dad45cf7a6b3b3ad754";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-msgs/default.nix
+++ b/distros/noetic/industrial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-industrial-msgs";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_msgs/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "968eeecc295534a4e6fa948a2b3ee8af6b5999ac3b20d4be7130c7fe6a890b4c";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_msgs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "ea5238ae8b97af27a59353ae3686a1a4c6192ac816d07a1e789817b0a62e9c37";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-robot-client/default.nix
+++ b/distros/noetic/industrial-robot-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, industrial-msgs, industrial-utils, robot-state-publisher, roscpp, roslaunch, rosunit, sensor-msgs, simple-message, std-msgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-industrial-robot-client";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_robot_client/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "fa50889ec2478a27063557fd79b478bbca8346b55daa8a1998d82423aeb365c7";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_robot_client/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "92cd1be0741c338c15d72fa151dfc868dcd477efa6e3fd85dece98d1d726f4e6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-robot-simulator/default.nix
+++ b/distros/noetic/industrial-robot-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, industrial-msgs, industrial-robot-client, python3Packages, roslaunch, rospy, sensor-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-industrial-robot-simulator";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_robot_simulator/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "9b42aed833f10a4293af407e24802a1bac6509abc115b20a2ef25ec7f89ead19";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_robot_simulator/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "daf1437c8dce7a3064c9ac78c7a29b89e0ba36623b2c1105743305029244545c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-trajectory-filters/default.nix
+++ b/distros/noetic/industrial-trajectory-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, moveit-core, moveit-ros-planning, orocos-kdl, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-industrial-trajectory-filters";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_trajectory_filters/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "d4718f6eec2f53f7870a2c873e3d70e40416f30fcb96cdc116c4f5714a2b2e2e";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_trajectory_filters/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "d467861e4366fab2ca889080d9d33a88f28ea204efad5f4d20b19f523df92c11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-utils/default.nix
+++ b/distros/noetic/industrial-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosunit, urdf }:
 buildRosPackage {
   pname = "ros-noetic-industrial-utils";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_utils/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "1965c307f351ec1c4df257c92e7d36c6937f2a4b8f279c10155f5bc3cd66308b";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_utils/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "2925a8dd626167ea1bbefa502065157afffebebf3cb9a8cd4ff59de477537f8a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/inorbit-republisher/default.nix
+++ b/distros/noetic/inorbit-republisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, roslib, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-inorbit-republisher";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/noetic/inorbit_republisher/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "d7e9bd3a8fbf3a202a6177d5dd36a136b417028e12be0a085092b15fb2e3fc53";
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/noetic/inorbit_republisher/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "ab97b01aeeb56aeb52012f4a293f300fe793e250a9355ce211e50ec94312ed7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/iris-lama-ros/default.nix
+++ b/distros/noetic/iris-lama-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, iris-lama, message-filters, nav-msgs, rosbag, rosbag-storage, roscpp, std-srvs, tf, tf-conversions, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, iris-lama, libyamlcpp, message-filters, nav-msgs, rosbag, rosbag-storage, roscpp, std-srvs, tf, tf-conversions, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-iris-lama-ros";
-  version = "1.2.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/eupedrosa/iris_lama_ros-release/archive/release/noetic/iris_lama_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "d53c2064d66d9ed37d41db740666304d55caed042ea225f5a4baf57cb935ec95";
+    url = "https://github.com/eupedrosa/iris_lama_ros-release/archive/release/noetic/iris_lama_ros/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "47d0db0b2db22a1f7def7343df5c3420d021184a45d299dd0f75aa88eb8ac60d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs iris-lama message-filters nav-msgs rosbag rosbag-storage roscpp std-srvs tf tf-conversions visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs iris-lama libyamlcpp message-filters nav-msgs rosbag rosbag-storage roscpp std-srvs tf tf-conversions tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/iris-lama/default.nix
+++ b/distros/noetic/iris-lama/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen }:
+{ lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-noetic-iris-lama";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/noetic/iris_lama/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "e44735c6be4270290423282d6dcb8240c750373bcc2e2ce1e3adacff6c0be378";
+    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/noetic/iris_lama/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "52cf3a1c63f9c978519569624a45504d703b683b2ce52f11ec1fb42f2562b4be";
   };
 
-  buildType = "catkin";
-  propagatedBuildInputs = [ eigen ];
-  nativeBuildInputs = [ catkin ];
+  buildType = "cmake";
+  buildInputs = [ eigen ];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = ''IRIS package for Localization and Mapping (LaMa).

--- a/distros/noetic/laptop-battery-monitor/default.nix
+++ b/distros/noetic/laptop-battery-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, rospy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-laptop-battery-monitor";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/linux_peripheral_interfaces-release/archive/release/noetic/laptop_battery_monitor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "99f83a99cde03b74c19fc0ca4b6deb962001b6f2b2be34fb1e2ffbf6d4a905c3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple script to check battery status'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/leo-bringup/default.nix
+++ b/distros/noetic/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-bringup";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "c2b65e355f442839c47bc9ca49a83eeda7b47241552261818422f428707d32b8";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "0a554fd104fa5af59540f8fb510f1285d13b8f8a177ec6131bda309bccd37d32";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-description/default.nix
+++ b/distros/noetic/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "009938f8db58cb8fe633703ae590daa641028989d3c1b48f88d8d93572ff0be3";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d4a3687c06555c145d40a39ae81900503c4667728e32b1cf75af4fd47f998af6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, leo-msgs, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, leo-msgs, libyamlcpp, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-leo-fw";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "bd402157bdf1500ac393d5c0e7a8d0e7f719473cc7277df10220c0552630379d";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "bc87102d915f7bfd65aee57a81a942bd22a5729a7b77adbe308debf7238d8ee7";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ leo-msgs nav-msgs python3Packages.rospkg python3Packages.whichcraft roscpp rosgraph rosmon-msgs rosnode rospy rosservice sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ leo-msgs libyamlcpp nav-msgs python3Packages.numpy python3Packages.rospkg python3Packages.whichcraft roscpp rosgraph rosmon-msgs rosnode rospy rosservice sensor-msgs std-srvs ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/leo-msgs/default.nix
+++ b/distros/noetic/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-leo-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0e823c87c206d5bd3f169b8032b0458dd2fb8a95e7f24d4bc5519f00b337afad";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "58d2a15a9e8884bfc7e49de8c32d47ffc1a72a3f943cfb5b2b821fc1f8f6a3a0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-robot/default.nix
+++ b/distros/noetic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-noetic-leo-robot";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "c9204f7a7f97817e3d1a4a483094c5b5fff81eb803dead693f122832d152e2cc";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "f7c674eff3757145fb1caa61d2b52d73ab8eed0946b4ca35d983d8fa1910d372";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-teleop/default.nix
+++ b/distros/noetic/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-noetic-leo-teleop";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "3523ecad5dea33cec046a17b697451d9db9a3110d1835fb49bf94644678aaac3";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "bff115326eccbbc735783352e779c6e74e4f4af390c4ff38c220985b28eb62e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo/default.nix
+++ b/distros/noetic/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-noetic-leo";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "41e4d90e206731360b52414d9d82460ef06074e202e30e7a6a2a2cb573cc88cb";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f7ad600b2ac91137aad450f3c657041399a9a4d3d2239e3b8d7f93be7001a220";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libfranka/default.nix
+++ b/distros/noetic/libfranka/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, eigen, poco }:
 buildRosPackage {
   pname = "ros-noetic-libfranka";
-  version = "0.9.0-r2";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/libfranka-release/archive/release/noetic/libfranka/0.9.0-2.tar.gz";
-    name = "0.9.0-2.tar.gz";
-    sha256 = "50343f955f431915e488370fd0b278abf24d92db907ff3eb36ed11feda2f6b2a";
+    url = "https://github.com/frankaemika/libfranka-release/archive/release/noetic/libfranka/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "cdd15f0f3a4e032cb93c156240c122bea496a96e25a4ee434c9ca6c70da36fa3";
   };
 
   buildType = "cmake";

--- a/distros/noetic/libsensors-monitor/default.nix
+++ b/distros/noetic/libsensors-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, lm_sensors, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-libsensors-monitor";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/linux_peripheral_interfaces-release/archive/release/noetic/libsensors_monitor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "ecec8c4a61494b5d1682b34ce0e452a003156d73b9c41a0100e3ad10728b771e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-updater lm_sensors roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS node for using libsensors to provide diagnostics information about the sensors on a computer system.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/linux-peripheral-interfaces/default.nix
+++ b/distros/noetic/linux-peripheral-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, laptop-battery-monitor, libsensors-monitor }:
+buildRosPackage {
+  pname = "ros-noetic-linux-peripheral-interfaces";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/linux_peripheral_interfaces-release/archive/release/noetic/linux_peripheral_interfaces/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "c2da8bce0693ee4268de91e273dd47cc8e63bb4422e30b6445bbe51bfede833e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ laptop-battery-monitor libsensors-monitor ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple scripts which help utilise, monitor, interact with computer
+     hardware abstracted by a linux OS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/lsc-ros-driver/default.nix
+++ b/distros/noetic/lsc-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, self-test, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-lsc-ros-driver";
-  version = "1.0.1-r1";
+  version = "1.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release/archive/release/noetic/lsc_ros_driver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "27f3f20c333d932eeeb3113e5e1e8fffe71bc6eb4afd607075a49711c6774076";
+    url = "https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release/archive/release/noetic/lsc_ros_driver/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "42c98d9245a7adf469b21dba3a12a2be6a8d91567cb37ece7f285d394f1e78c9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-data-structures/default.nix
+++ b/distros/noetic/marti-data-structures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-marti-data-structures";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/marti_data_structures/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "72b00832577d69b06140a31b64fc718176bbdbf67501abdb3b1af1a2a4c5414a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/marti_data_structures/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "a67b17e049c3821463e666259f06639b15a73ee12e6a5e9aa1c477b9dfad4333";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mocap-nokov/default.nix
+++ b/distros/noetic/mocap-nokov/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-mocap-nokov";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/noetic/mocap_nokov/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "59aabc6a6fe038462221dc84bdb2f5f1b3562b194c7467740782b6c9519e4e72";
+    url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/noetic/mocap_nokov/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "63a3a439a048a0d9a09bad81fb283cb4697e552709be63b13b1b4dd3e6f0c6ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/navigation-experimental/default.nix
+++ b/distros/noetic/navigation-experimental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assisted-teleop, catkin, goal-passer, pose-base-controller, pose-follower, sbpl-lattice-planner, sbpl-recovery, twist-recovery }:
 buildRosPackage {
   pname = "ros-noetic-navigation-experimental";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/navigation_experimental/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "983a17e89402e54c4cb8dd6e895158f93a6d8ee9f453f28cd2ddd66da5482226";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/navigation_experimental/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5e6674894debf5c1f00023a40dc8f04f4b75b4ba5961bee56e5896c1cdd3a978";
   };
 
   buildType = "catkin";

--- a/distros/noetic/panda-moveit-config/default.nix
+++ b/distros/noetic/panda-moveit-config/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, franka-description, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, topic-tools, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, franka-description, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-panda-moveit-config";
-  version = "0.7.5-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/panda_moveit_config-release/archive/release/noetic/panda_moveit_config/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "8228c3553f40d55eb6b62a35d38198d449463108d29ab3b69f21a15e6e5c6b1e";
+    url = "https://github.com/ros-gbp/panda_moveit_config-release/archive/release/noetic/panda_moveit_config/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "00b81cde940e1913f9e7895fff73fa2397abcb513a2ecae2404f3359e04857c9";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ franka-description joint-state-publisher joint-state-publisher-gui moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher topic-tools xacro ];
+  propagatedBuildInputs = [ franka-description joint-state-publisher joint-state-publisher-gui moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz tf2-ros xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''An automatically generated package with all the configuration and launch files for using the panda with the MoveIt! Motion Planning Framework'';
+    description = ''An automatically generated package with all the configuration and launch files for using the panda with the MoveIt Motion Planning Framework'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.9-r1";
+  version = "2.6.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "9158a307246502443623f1a2c84e3226922906f1bf4bc8592371ea1e04ebd0e8";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.9-2.tar.gz";
+    name = "2.6.9-2.tar.gz";
+    sha256 = "1bcea25baae43a37c8ce8baee7aadbde490b06087c69190e03b6dd8575044c6e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pose-base-controller/default.nix
+++ b/distros/noetic/pose-base-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, move-base-msgs, nav-msgs, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pose-base-controller";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_base_controller/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "8f3cf09557eb016ea6cb2fa3e1877dd9ba475f2b2b669f6a45aafa8609036004";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_base_controller/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "b1849295bd12f2ab3acbaaa5878cf3c1b20fb08682e46bcaf7d7f6ec7388a93b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pose-follower/default.nix
+++ b/distros/noetic/pose-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, nav-core, nav-msgs, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pose-follower";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_follower/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "d37380604adbf15365d7e93126512fb0710e993c8c35fd03d5a2cd8167e2d57a";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/pose_follower/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "4125ce1012b62fd5713fd179a6de088aaa89009b6b7bc6c346be828004c43971";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "2fc8b5eb51d4318c8d6be0d08269ef39b3355f63e44d0a616e58fef8ba6d01a2";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "ef75a46d3b9dc1c835ca7b644e0f8ed36681ac0061a4afe78c46342d2c9b2d53";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ros-system-fingerprint/default.nix
+++ b/distros/noetic/ros-system-fingerprint/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib, rosnode, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-ros-system-fingerprint";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MetroRobots/ros_system_fingerprint-release/archive/release/noetic/ros_system_fingerprint/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "6501b19c0d916e475c39d39839cc65a449fd296d93b996af0da838e7ec1f29f4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.GitPython roslib rosnode rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ros_system_fingerprint package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rviz-imu-plugin/default.nix
+++ b/distros/noetic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-rviz-imu-plugin";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/rviz_imu_plugin/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "da043709e2e8e483082f6ac54b228471ed2071a236692473cd7fb9214c04f225";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/rviz_imu_plugin/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "3897796fc2ba1be442d6a350bf5257ffc679ff5b1f586f6bd48d0aba352ce40e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sbpl-lattice-planner/default.nix
+++ b/distros/noetic/sbpl-lattice-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, roscpp, sbpl, tf, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-sbpl-lattice-planner";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_lattice_planner/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "a6378d5a6b96b3cb01b050222567a96bbebb15bdffc0121df162a1bea90b6145";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_lattice_planner/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "418218d25809274f917a61e97ac8fedee565b61154fd28e76adb7301b57b4e13";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sbpl-recovery/default.nix
+++ b/distros/noetic/sbpl-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, nav-core, pluginlib, pose-follower, roscpp, sbpl-lattice-planner, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-sbpl-recovery";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_recovery/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "a49c0fc38311c59b0d800abd526710e6a101283aaea8c3c08cd97d954ff0fc6d";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/sbpl_recovery/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "bf115900248cdd509016fd0b15199fb39053ad16859e2d5d1b8156d1d7a2712c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/simple-message/default.nix
+++ b/distros/noetic/simple-message/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, industrial-msgs, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-simple-message";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/simple_message/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "fc93caccf7044efa6ece2d0bddc9b12d067b3cfee6ed63560a3635aae887829f";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/simple_message/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "5479552dd7252d441288fdf0cd59aeee88dfda365388dd3f0aa2844e279a78e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-cli-tools/default.nix
+++ b/distros/noetic/swri-cli-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, marti-introspection-msgs, rosgraph, rospy, rostopic }:
+buildRosPackage {
+  pname = "ros-noetic-swri-cli-tools";
+  version = "2.15.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_cli_tools/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "35b20dcb0abcac1bffda2f72b7151ce45ea9a46d3fa375f53b44a310ac653a14";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ marti-introspection-msgs rosgraph rospy rostopic ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rosman contains the rosman tool for introspecting ROS nodes'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-console-util/default.nix
+++ b/distros/noetic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
 buildRosPackage {
   pname = "ros-noetic-swri-console-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_console_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "ae6d2d8bd0e0b5fc768da211ed8410ab6c71171750439dae5e6248c4df79d353";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_console_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "a11c68708782868b4908759254507795fabfccc32fc61ce30be9813702723690";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-dbw-interface/default.nix
+++ b/distros/noetic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-swri-dbw-interface";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_dbw_interface/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "03247075e014dc9bdbfdf9a0422b59338241bdf4d168fe5dcb9e5513980efda6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_dbw_interface/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "425c4701169a6488a1194c203aecbccab0df86efed20514d33262a1bfe2e7993";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-geometry-util/default.nix
+++ b/distros/noetic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-noetic-swri-geometry-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_geometry_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "a6bdc7015efc6ba2030fbf3e638d044feecee48a2787467f2bfcc7d3fb470a19";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_geometry_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "629c6d619c9feec388641c26dae35e196fa12270dc9e38b59aed22f58561909d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-image-util/default.nix
+++ b/distros/noetic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-swri-image-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_image_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "0fdc6c0c789a31354eea1e1e6ce3054ec8a3294f424d7e2c5546686bcdd462ea";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_image_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "a5f902c36520303143781a5c53f544d5ef15f66cc5ad06f411f1f66b7c3d0eb8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-math-util/default.nix
+++ b/distros/noetic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-math-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_math_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "0c98cea1baa483b9750ab07bae100981286c2afaba614b064482a2c659deb0a4";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_math_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "a4e5b19bcae98a22ea9d831b53b25c3ec7978b25a6594cf781e6eecdb58d8687";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-nodelet/default.nix
+++ b/distros/noetic/swri-nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-swri-nodelet";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_nodelet/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "9b642da0060f64858033c0f7ba16fddc9a08ae6feddfc9f651742ecb6c1d9718";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_nodelet/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "e4569638c2b3528c9aa8837dd4eaaafd9ae571cd292684f14733198bb7879001";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-opencv-util/default.nix
+++ b/distros/noetic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-noetic-swri-opencv-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_opencv_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "7c0ec0b6be5f39d5f8a82a6ac7d1ad16dcd88c5b1a87df5fddf855a25e8ce94d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_opencv_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "88191075c951b11757814bb2515d9ea440c0635ce26ef71510951a03ecb17bdb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-prefix-tools/default.nix
+++ b/distros/noetic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-swri-prefix-tools";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_prefix_tools/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "514f4ac47048c0746945050375e266216639749219ed38584f7af094ca1a921b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_prefix_tools/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "48a69316dd816101ba5a6303d6505f665d94745d126727c27d6a2deef163e818";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-roscpp/default.nix
+++ b/distros/noetic/swri-roscpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, marti-introspection-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-swri-roscpp";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_roscpp/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "31d2b6529a54af0dafb18275bbfde3c30a0013ea64affb6c4ff6b187ba093226";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_roscpp/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "8249abbba7bcc983cc8cb7c527873080b7cd7c7e51499b30177c8dca65ca4da8";
   };
 
   buildType = "catkin";
   checkInputs = [ gtest message-generation message-runtime rostest rosunit ];
-  propagatedBuildInputs = [ boost diagnostic-updater dynamic-reconfigure libyamlcpp marti-common-msgs nav-msgs roscpp std-msgs std-srvs ];
+  propagatedBuildInputs = [ boost diagnostic-updater dynamic-reconfigure libyamlcpp marti-common-msgs marti-introspection-msgs nav-msgs roscpp std-msgs std-srvs ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/noetic/swri-rospy/default.nix
+++ b/distros/noetic/swri-rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-swri-rospy";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_rospy/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "62017d2ce986bc5b269ed391201136b5a04e02873e2c142086e53c818c1b2d81";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_rospy/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "fbedbd28cd710df0e01abdb494abf562ece6cff23f172489fac0ebaf5b46fecc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-route-util/default.nix
+++ b/distros/noetic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-swri-route-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_route_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "9650e1c4afead1744e8c281d8a1270c1ca633da5128072b035c97e9cdff8fad7";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_route_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "8d3b7bb7e6356611a443e919aca5be5159ab4f1f5254bdd1e4e482a50474ae40";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-serial-util/default.nix
+++ b/distros/noetic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-noetic-swri-serial-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_serial_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "2755513aea1665b4e42a35af49dc997b07e27b9951722412d585f3be5657b06c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_serial_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "dd1362d27361c7ce27bd26a51d8b44342ff55ba446db0ba309e689a926ab50d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-string-util/default.nix
+++ b/distros/noetic/swri-string-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-string-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_string_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "b08a5616c2ff1444288ebeb57de6a9e3171b168128d7d6fdba2824b10b47d624";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_string_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "e6a8cea407bfe527a0eca5c37b759a4d2d74d55eb6c784a57cdacae8f3219b3a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-system-util/default.nix
+++ b/distros/noetic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-system-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_system_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "4a21cabc92da5896dd0b30a021cd91320bccbf72e2dd353c5042422fcfd38945";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_system_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "a1a3dc26cefd19d3797fd561ea86a4bdb222affe1002cae62d1ca40770587cdc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-transform-util/default.nix
+++ b/distros/noetic/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, genpy, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, python3Packages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-swri-transform-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_transform_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "c2d80f11a288947a3dc8b177fc07b44ce1dac224ca948c597bb230893ad6952c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_transform_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "b13f9b412a95b3f02362ff166edbb3dcb90ddc1582d49de1962b1de983b526ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-yaml-util/default.nix
+++ b/distros/noetic/swri-yaml-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-swri-yaml-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_yaml_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "bd31252ddf73f39ebe6c7171e779c242505a18bc239df2beb334e051056f7206";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_yaml_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "f5c313869382f93b4beb71385bc63d0ac04ae1bd545bd67c1c02015bededc1a7";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ boost libyamlcpp ];
+  propagatedBuildInputs = [ boost libyamlcpp roscpp ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/noetic/tesseract-collision/default.nix
+++ b/distros/noetic/tesseract-collision/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, libyamlcpp, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-collision";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "9fddb20b329c9944b75f6d3c39fa26b76a5d2b9a9b50db2481939e6c6825fbaf";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "7f85f240dd0ff1434db1bcf4d63ccc71afc0baa99fcfbcb862c3e6c599ec0337";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, libyamlcpp, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "c1ae68273e615d8674706e93918beeae6a1c0abb629106ab61dc11587f1c03cc";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "677e179fdba277e75cf228e28217e0007e28758f070d51b9fb864c26dfd587e5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-environment/default.nix
+++ b/distros/noetic/tesseract-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-kinematics, tesseract-scene-graph, tesseract-srdf, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-environment";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "7723880ce1089b1c2c4542ef76bd37c551c2a2b183207b4f04e11638a8c17318";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "beddaed978f6a8196a93294c6af6f580d7423793859b74c9ce30b256e7d7142a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "223a60f3a2198a25a9fb670630f9e9a7920ee8af9d017971b95fd28cc6a5f3aa";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "aeb1d3e2b62c507e96322c46b9199c4edcde6d9374cd3b4349a8c21112ac9ff9";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, liblapack, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "c26800e1071d9d6d252e4ee6b0e8e92e6e2d0b36251a48ae4ed9295d3d0489e4";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "df2694129a3f671504011d8de2a6ee0544027aff42289ea9e880d084763f56aa";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "f0c423827f53a6e1c223d89bb8dcb005b93be789d4eb4bf8123e69033cb0d047";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "de5d652a6b5f6dda855da0a8507b7424127f1e89630835ddef8fbc88329ef0db";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "461c36be5fe17d4098ecba44b624919145d05152cf5a052b03b693c70aa8086a";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "cd42b66672df6a8762b723cc1010edcadded1ff9501aceddab2b623693b357b2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-state-solver/default.nix
+++ b/distros/noetic/tesseract-state-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-state-solver";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "ba8d1721abe0cdd5bdf212ed11afa95112179791d993d0a130f64289e8d23cdf";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "aca48c45bce6b7bd112c65bd35265fd24dc5bc7fec3e2175881434e0cf089747";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtest, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "f8d6b95012b572b247346d6299462853e1e4609398a7ee27802690d3f07dd85c";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "0936264ac05cde9e7b6fe227800a102fa3c5081cc97419ceefbe67921a80f147";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "5935cf6018f53546ff2f63a95c13cf3f26461a89a2a843dac021ee56cfaa8a38";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "8c525b3c18a39cf78c5c46fc83c7925c011866b9076497d4e76025c5e942b29f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.10.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "1f51efa4b56399d1f0f707757148cde5d84081b11cc44957195b904d7a3ca7e3";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "aebab2138cc877f5927cb92b82ffadebe043058c1faa32c2955fcff2a31c1f35";
   };
 
   buildType = "cmake";

--- a/distros/noetic/twist-mux/default.nix
+++ b/distros/noetic/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, geometry-msgs, roscpp, rospy, rostest, rostopic, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-twist-mux";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/noetic/twist_mux/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "8e34204ea1a225e4bf0610fb0ce3d0df6a107fa57d4a90111edee495367bce81";
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/noetic/twist_mux/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "47ddfc5486f4b5f3a1e2465be818860e8427b00a7dd483945cb55ba8eab08f6c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/twist-recovery/default.nix
+++ b/distros/noetic/twist-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, geometry-msgs, nav-core, pluginlib, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-twist-recovery";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/twist_recovery/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "efaf93a0fdec9670c8c0703c607b31d137d7d383a5d563257f78d3404f7634b5";
+    url = "https://github.com/ros-gbp/navigation_experimental-release/archive/release/noetic/twist_recovery/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "d13f9a52e05f8bd2a504d76a1147695378622cf1f3b0eaff84fe6607f6f36f4e";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit 624fc3c9767269d360d1b4895423ad6ff625be64.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *ament-cmake 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-auto 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-core 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-export-definitions 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-export-dependencies 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-export-include-directories 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-export-interfaces 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-export-libraries 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-export-link-flags 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-export-targets 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-gmock 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-google-benchmark 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-gtest 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-include-directories 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-libraries 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-nose 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-pytest 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-python 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-target-dependencies 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-test 0.9.10-r1 --> 0.9.11-r1*
* *ament-cmake-version 0.9.10-r1 --> 0.9.11-r1*
* *crane-plus 1.0.0-r5 --> 1.1.0-r1*
* *crane-plus-control 1.0.0-r5 --> 1.1.0-r1*
* *crane-plus-description 1.0.0-r5 --> 1.1.0-r1*
* *crane-plus-examples 1.0.0-r5 --> 1.1.0-r1*
* *crane-plus-gazebo 1.0.0-r5 --> 1.1.0-r1*
* *crane-plus-ignition 1.0.0-r5 --> 1.1.0-r1*
* *crane-plus-moveit-config 1.0.0-r5 --> 1.1.0-r1*
* *eigenpy 2.7.11-r1 --> 2.7.12-r1*
* *fastrtps 2.1.1-r1 --> 2.1.2-r1*
* *gps-msgs 1.0.4-r1 --> 1.0.5-r2*
* *gps-tools 1.0.4-r1 --> 1.0.5-r2*
* *gps-umd 1.0.4-r1 --> 1.0.5-r2*
* *gpsd-client 1.0.4-r1 --> 1.0.5-r2*
* *maliput-object-py 0.1.1-r1 --> 0.1.2-r1*
* *raspimouse-navigation 1.0.0-r1*
* *raspimouse-slam 1.0.0-r1*
* *raspimouse-slam-navigation 1.0.0-r1*
* *rclpy 1.0.8-r1 --> 1.0.9-r1*
* *rosapi 1.2.0-r1 --> 1.3.0-r1*
* *rosapi-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-library 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-server 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-suite 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-test-msgs 1.2.0-r1 --> 1.3.0-r1*
* *simple-launch 1.4.1-r1 --> 1.5.0-r1*
* *tvm-vendor 0.8.2-r1 --> 0.9.0-r1*
* *vrpn-mocap 1.0.3-r1*

Galactic Changes:
-----------------
* *eigenpy 2.7.11-r2 --> 2.7.12-r1*
* *fastrtps 2.3.4-r1 --> 2.3.5-r1*
* *gps-msgs 1.0.4-r2 --> 1.0.5-r1*
* *gps-tools 1.0.4-r2 --> 1.0.5-r1*
* *gps-umd 1.0.4-r2 --> 1.0.5-r1*
* *gpsd-client 1.0.4-r2 --> 1.0.5-r1*
* *realtime-tools 2.2.0-r1 --> 2.3.0-r1*
* *rosapi 1.2.0-r1 --> 1.3.0-r1*
* *rosapi-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-library 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-server 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-suite 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-test-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rplidar-ros 2.0.2-r1 --> 2.0.3-r1*
* *simple-launch 1.4.1-r1 --> 1.5.0-r1*
* *tvm-vendor 0.8.2-r1 --> 0.9.0-r1*

Humble Changes:
---------------
* *bond 3.0.2-r2 --> 3.0.2-r3*
* *bond-core 3.0.2-r2 --> 3.0.2-r3*
* *bondcpp 3.0.2-r2 --> 3.0.2-r3*
* *costmap-queue 1.1.0-r2 --> 1.1.2-r1*
* *depthai-bridge 2.5.2-r1 --> 2.5.3-r1*
* *depthai-examples 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros 2.5.2-r1 --> 2.5.3-r1*
* *depthai-ros-msgs 2.5.2-r1 --> 2.5.3-r1*
* *diff-drive-controller 2.11.0-r1 --> 2.12.0-r1*
* *dwb-core 1.1.0-r2 --> 1.1.2-r1*
* *dwb-critics 1.1.0-r2 --> 1.1.2-r1*
* *dwb-msgs 1.1.0-r2 --> 1.1.2-r1*
* *dwb-plugins 1.1.0-r2 --> 1.1.2-r1*
* *effort-controllers 2.11.0-r1 --> 2.12.0-r1*
* *eigenpy 2.7.10-r2 --> 2.7.12-r1*
* *force-torque-sensor-broadcaster 2.11.0-r1 --> 2.12.0-r1*
* *forward-command-controller 2.11.0-r1 --> 2.12.0-r1*
* *generate-parameter-library 0.2.3-r1 --> 0.2.4-r1*
* *generate-parameter-library-example 0.2.3-r1 --> 0.2.4-r1*
* *gripper-controllers 2.11.0-r1 --> 2.12.0-r1*
* *hpp-fcl 2.1.2-r1 --> 2.1.2-r2*
* *imu-sensor-broadcaster 2.11.0-r1 --> 2.12.0-r1*
* *joint-state-broadcaster 2.11.0-r1 --> 2.12.0-r1*
* *joint-trajectory-controller 2.11.0-r1 --> 2.12.0-r1*
* *leo 1.0.3-r1 --> 1.1.0-r1*
* *leo-bringup 1.0.1-r1 --> 1.1.0-r1*
* *leo-description 1.0.3-r1 --> 1.1.0-r1*
* *leo-fw 1.0.1-r1 --> 1.1.0-r1*
* *leo-msgs 1.0.3-r1 --> 1.1.0-r1*
* *leo-robot 1.0.1-r1 --> 1.1.0-r1*
* *leo-teleop 1.0.3-r1 --> 1.1.0-r1*
* *mcap-vendor 0.1.6-r1 --> 0.1.7-r1*
* *menge-vendor 1.0.0-r3 --> 1.0.0-r4*
* *nav-2d-msgs 1.1.0-r2 --> 1.1.2-r1*
* *nav-2d-utils 1.1.0-r2 --> 1.1.2-r1*
* *nav2-amcl 1.1.0-r2 --> 1.1.2-r1*
* *nav2-behavior-tree 1.1.0-r2 --> 1.1.2-r1*
* *nav2-behaviors 1.1.0-r2 --> 1.1.2-r1*
* *nav2-bringup 1.1.0-r2 --> 1.1.2-r1*
* *nav2-bt-navigator 1.1.0-r2 --> 1.1.2-r1*
* *nav2-collision-monitor 1.1.2-r1*
* *nav2-common 1.1.0-r2 --> 1.1.2-r1*
* *nav2-constrained-smoother 1.1.0-r2 --> 1.1.2-r1*
* *nav2-controller 1.1.0-r2 --> 1.1.2-r1*
* *nav2-core 1.1.0-r2 --> 1.1.2-r1*
* *nav2-costmap-2d 1.1.0-r2 --> 1.1.2-r1*
* *nav2-dwb-controller 1.1.0-r2 --> 1.1.2-r1*
* *nav2-lifecycle-manager 1.1.0-r2 --> 1.1.2-r1*
* *nav2-map-server 1.1.0-r2 --> 1.1.2-r1*
* *nav2-msgs 1.1.0-r2 --> 1.1.2-r1*
* *nav2-navfn-planner 1.1.0-r2 --> 1.1.2-r1*
* *nav2-planner 1.1.0-r2 --> 1.1.2-r1*
* *nav2-regulated-pure-pursuit-controller 1.1.0-r2 --> 1.1.2-r1*
* *nav2-rotation-shim-controller 1.1.0-r2 --> 1.1.2-r1*
* *nav2-rviz-plugins 1.1.0-r2 --> 1.1.2-r1*
* *nav2-simple-commander 1.1.0-r2 --> 1.1.2-r1*
* *nav2-smac-planner 1.1.0-r2 --> 1.1.2-r1*
* *nav2-smoother 1.1.0-r2 --> 1.1.2-r1*
* *nav2-system-tests 1.1.0-r2 --> 1.1.2-r1*
* *nav2-theta-star-planner 1.1.0-r2 --> 1.1.2-r1*
* *nav2-util 1.1.0-r2 --> 1.1.2-r1*
* *nav2-velocity-smoother 1.1.2-r1*
* *nav2-voxel-grid 1.1.0-r2 --> 1.1.2-r1*
* *nav2-waypoint-follower 1.1.0-r2 --> 1.1.2-r1*
* *navigation2 1.1.0-r2 --> 1.1.2-r1*
* *ntrip-client 1.0.2-r2 --> 1.2.0-r1*
* *parameter-traits 0.2.3-r1 --> 0.2.4-r1*
* *pinocchio 2.6.9-r1*
* *position-controllers 2.11.0-r1 --> 2.12.0-r1*
* *qt-dotgraph 2.2.1-r2 --> 2.2.2-r1*
* *qt-gui 2.2.1-r2 --> 2.2.2-r1*
* *qt-gui-app 2.2.1-r2 --> 2.2.2-r1*
* *qt-gui-core 2.2.1-r2 --> 2.2.2-r1*
* *qt-gui-cpp 2.2.1-r2 --> 2.2.2-r1*
* *qt-gui-py-common 2.2.1-r2 --> 2.2.2-r1*
* *robot-controllers 0.9.2-r1 --> 0.9.3-r1*
* *robot-controllers-interface 0.9.2-r1 --> 0.9.3-r1*
* *robot-controllers-msgs 0.9.2-r1 --> 0.9.3-r1*
* *ros2-controllers 2.11.0-r1 --> 2.12.0-r1*
* *ros2-controllers-test-nodes 2.11.0-r1 --> 2.12.0-r1*
* *rosapi 1.2.0-r1 --> 1.3.0-r1*
* *rosapi-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbag2-storage-mcap 0.1.6-r1 --> 0.1.7-r1*
* *rosbridge-library 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-server 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-suite 1.2.0-r1 --> 1.3.0-r1*
* *rosbridge-test-msgs 1.2.0-r1 --> 1.3.0-r1*
* *rplidar-ros 2.0.2-r3 --> 2.0.3-r1*
* *rqt-joint-trajectory-controller 2.11.0-r1 --> 2.12.0-r1*
* *rqt-tf-tree 1.0.4-r1*
* *simple-actions 0.2.1-r1*
* *simple-launch 1.4.1-r1 --> 1.5.0-r1*
* *slam-toolbox 2.6.0-r2 --> 2.6.1-r1*
* *smclib 3.0.2-r2 --> 3.0.2-r3*
* *tcb-span 0.2.3-r1 --> 0.2.4-r1*
* *tricycle-controller 2.11.0-r1 --> 2.12.0-r1*
* *tvm-vendor 0.8.2-r1 --> 0.9.0-r1*
* *velocity-controllers 2.11.0-r1 --> 2.12.0-r1*
* *vrpn 7.35.0-r11*

Melodic Changes:
----------------
* *assisted-teleop 0.3.5-r1 --> 0.3.6-r1*
* *audio-capture 0.3.13-r1 --> 0.3.15-r1*
* *audio-common 0.3.13-r1 --> 0.3.15-r1*
* *audio-common-msgs 0.3.13-r1 --> 0.3.15-r1*
* *audio-play 0.3.13-r1 --> 0.3.15-r1*
* *eigenpy 2.7.11-r1 --> 2.7.5-r1*
* *goal-passer 0.3.5-r1 --> 0.3.6-r1*
* *graceful-controller 0.4.3-r1 --> 0.4.4-r1*
* *graceful-controller-ros 0.4.3-r1 --> 0.4.4-r1*
* *hpp-fcl 2.1.2-r1 --> 1.8.1-r1*
* *imu-complementary-filter 1.2.4-r1 --> 1.2.5-r1*
* *imu-filter-madgwick 1.2.4-r1 --> 1.2.5-r1*
* *imu-tools 1.2.4-r1 --> 1.2.5-r1*
* *inorbit-republisher 0.2.4-r1 --> 0.2.5-r1*
* *mocap-nokov 0.0.2-r2*
* *navigation-experimental 0.3.5-r1 --> 0.3.6-r1*
* *panda-moveit-config 0.7.4-r1 --> 0.7.6-r1*
* *pinocchio 2.6.9-r1 --> 2.6.8-r1*
* *pose-base-controller 0.3.5-r1 --> 0.3.6-r1*
* *pose-follower 0.3.5-r1 --> 0.3.6-r1*
* *qb-device 3.0.4-r3 --> 2.0.1*
* *qb-device-bringup 3.0.4-r3 --> 2.0.1*
* *qb-device-control 3.0.4-r3 --> 2.0.1*
* *qb-device-description 3.0.4-r3 --> 2.0.1*
* *qb-device-driver 3.0.4-r3 --> 2.0.1*
* *qb-device-hardware-interface 3.0.4-r3 --> 2.0.1*
* *qb-device-msgs 3.0.4-r3 --> 2.0.1*
* *qb-device-srvs 3.0.4-r3 --> 2.0.1*
* *qb-device-utils 3.0.4-r3 --> 2.0.1*
* *rviz-imu-plugin 1.2.4-r1 --> 1.2.5-r1*
* *sbpl-lattice-planner 0.3.5-r1 --> 0.3.6-r1*
* *sbpl-recovery 0.3.5-r1 --> 0.3.6-r1*
* *twist-mux 3.1.1-r1 --> 3.1.2-r1*
* *twist-recovery 0.3.5-r1 --> 0.3.6-r1*

Noetic Changes:
---------------
* *abb-driver 1.4.0-r1*
* *assisted-teleop 0.4.0-r1 --> 0.4.1-r1*
* *audio-capture 0.3.13-r1 --> 0.3.15-r1*
* *audio-common 0.3.13-r1 --> 0.3.15-r1*
* *audio-common-msgs 0.3.13-r1 --> 0.3.15-r1*
* *audio-play 0.3.13-r1 --> 0.3.15-r1*
* *eigenpy 2.7.11-r1 --> 2.7.12-r1*
* *franka-control 0.9.0-r1 --> 0.9.1-r1*
* *franka-description 0.9.0-r1 --> 0.9.1-r1*
* *franka-example-controllers 0.9.0-r1 --> 0.9.1-r1*
* *franka-gazebo 0.9.0-r1 --> 0.9.1-r1*
* *franka-gripper 0.9.0-r1 --> 0.9.1-r1*
* *franka-hw 0.9.0-r1 --> 0.9.1-r1*
* *franka-msgs 0.9.0-r1 --> 0.9.1-r1*
* *franka-ros 0.9.0-r1 --> 0.9.1-r1*
* *franka-visualization 0.9.0-r1 --> 0.9.1-r1*
* *goal-passer 0.4.0-r1 --> 0.4.1-r1*
* *graceful-controller 0.4.3-r1 --> 0.4.4-r1*
* *graceful-controller-ros 0.4.3-r1 --> 0.4.4-r1*
* *imu-complementary-filter 1.2.4-r1 --> 1.2.5-r1*
* *imu-filter-madgwick 1.2.4-r1 --> 1.2.5-r1*
* *imu-tools 1.2.4-r1 --> 1.2.5-r1*
* *industrial-core 0.7.2-r1 --> 0.7.3-r1*
* *industrial-deprecated 0.7.2-r1 --> 0.7.3-r1*
* *industrial-msgs 0.7.2-r1 --> 0.7.3-r1*
* *industrial-robot-client 0.7.2-r1 --> 0.7.3-r1*
* *industrial-robot-simulator 0.7.2-r1 --> 0.7.3-r1*
* *industrial-trajectory-filters 0.7.2-r1 --> 0.7.3-r1*
* *industrial-utils 0.7.2-r1 --> 0.7.3-r1*
* *inorbit-republisher 0.2.4-r1 --> 0.2.5-r1*
* *iris-lama 1.2.0-r1 --> 1.3.0-r1*
* *iris-lama-ros 1.2.0-r1 --> 1.3.1-r1*
* *laptop-battery-monitor 0.2.2-r1*
* *leo 2.1.0-r1 --> 2.2.0-r1*
* *leo-bringup 2.2.0-r1 --> 2.3.0-r1*
* *leo-description 2.1.0-r1 --> 2.2.0-r1*
* *leo-fw 2.2.0-r1 --> 2.3.0-r1*
* *leo-msgs 2.1.0-r1 --> 2.2.0-r1*
* *leo-robot 2.2.0-r1 --> 2.3.0-r1*
* *leo-teleop 2.1.0-r1 --> 2.2.0-r1*
* *libfranka 0.9.0-r2 --> 0.9.2-r1*
* *libsensors-monitor 0.2.2-r1*
* *linux-peripheral-interfaces 0.2.2-r1*
* *lsc-ros-driver 1.0.1-r1 --> 1.0.2-r2*
* *marti-data-structures 2.14.2-r1 --> 2.15.2-r1*
* *mocap-nokov 0.0.1-r1 --> 0.0.2-r1*
* *navigation-experimental 0.4.0-r1 --> 0.4.1-r1*
* *panda-moveit-config 0.7.5-r1 --> 0.8.0-r1*
* *pinocchio 2.6.9-r1 --> 2.6.9-r2*
* *pose-base-controller 0.4.0-r1 --> 0.4.1-r1*
* *pose-follower 0.4.0-r1 --> 0.4.1-r1*
* *ros-industrial-cmake-boilerplate 0.3.0-r1 --> 0.3.1-r1*
* *ros-system-fingerprint 0.3.0-r1*
* *rviz-imu-plugin 1.2.4-r1 --> 1.2.5-r1*
* *sbpl-lattice-planner 0.4.0-r1 --> 0.4.1-r1*
* *sbpl-recovery 0.4.0-r1 --> 0.4.1-r1*
* *simple-message 0.7.2-r1 --> 0.7.3-r1*
* *swri-cli-tools 2.15.2-r1*
* *swri-console-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-dbw-interface 2.14.2-r1 --> 2.15.2-r1*
* *swri-geometry-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-image-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-math-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-nodelet 2.14.2-r1 --> 2.15.2-r1*
* *swri-opencv-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-prefix-tools 2.14.2-r1 --> 2.15.2-r1*
* *swri-roscpp 2.14.2-r1 --> 2.15.2-r1*
* *swri-rospy 2.14.2-r1 --> 2.15.2-r1*
* *swri-route-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-serial-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-string-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-system-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-transform-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-yaml-util 2.14.2-r1 --> 2.15.2-r1*
* *tesseract-collision 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-common 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-environment 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-geometry 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-kinematics 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-scene-graph 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-srdf 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-state-solver 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-support 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-urdf 0.10.0-r1 --> 0.13.1-r1*
* *tesseract-visualization 0.10.0-r1 --> 0.13.1-r1*
* *twist-mux 3.1.1-r1 --> 3.1.2-r1*
* *twist-recovery 0.4.0-r1 --> 0.4.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] flite
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-xdot
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-typeguard
 * [ ] python3-websocket
 * [ ] python3-xdot
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

