### PR TITLE
rosdistro sync, Fri Sep  9 14:03:04 2022

### DIFF
--- a/distros/foxy/bosch-locator-bridge/default.nix
+++ b/distros/foxy/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-bosch-locator-bridge";
-  version = "2.0.7-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "9e6f267e4f89e4a3a14f4a4bc7b88dbfe9acb31ee089d5de3258b3b063a3ef2e";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "e9b764b39a65a966c837ab3809903e957b3f4884a4be76fb5b675c11120a6b29";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/depthai/default.nix
+++ b/distros/foxy/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-depthai";
-  version = "2.17.0-r1";
+  version = "2.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.17.0-1.tar.gz";
-    name = "2.17.0-1.tar.gz";
-    sha256 = "f74a89ee0823cc61ebdddeb7c4253ab80297cf33d7b7822dd9770f0a95b87c17";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.17.3-1.tar.gz";
+    name = "2.17.3-1.tar.gz";
+    sha256 = "42d41421eef43b646bb5e924a63e8438ae44c79d5452965501b19c7c4d0f06f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamic-graph/default.nix
+++ b/distros/foxy/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-foxy-dynamic-graph";
-  version = "4.2.2-r1";
+  version = "4.4.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "9044a56f1b493709619b6ce9bf8db8156fa5687d681dfa08b847c271ee8d0559";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/foxy/dynamic-graph/4.4.3-2.tar.gz";
+    name = "4.4.3-2.tar.gz";
+    sha256 = "062cdbb24d7111dac5a149ce85438967a5019f9c478cdda33da9e862de89670c";
   };
 
   buildType = "cmake";

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.7.12-r1";
+  version = "2.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.12-1.tar.gz";
-    name = "2.7.12-1.tar.gz";
-    sha256 = "5e30d9a83dfabc3153003f6a6443aace91aab816278ca339e740cf0cf3dd0a25";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.7.13-1.tar.gz";
+    name = "2.7.13-1.tar.gz";
+    sha256 = "68eacf69c048182430aaff7695b54bb569ecd628b268139194d11f7df8fee2a1";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -942,6 +942,8 @@ self: super: {
 
  multires-image = self.callPackage ./multires-image {};
 
+ naoqi-libqi = self.callPackage ./naoqi-libqi {};
+
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
  nav2-behavior-tree = self.callPackage ./nav2-behavior-tree {};

--- a/distros/foxy/geometry-tutorials/default.nix
+++ b/distros/foxy/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-geometry-tutorials";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "5a29ad0953292cb6a4c228f73bf492e603a757eeedc464c328ef8e0e235368fb";
+    url = "https://github.com/ros2-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "c7ca2215f183b506554303d3ef14dad47f32d4d4195677021841b9bb0efa1b6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-description/default.nix
+++ b/distros/foxy/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-foxy-leo-description";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_description/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "26987b31d9c8ac94af1b1aedf1ad0be1678d7e6faa7ddd207792f9ad146fbefb";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "6da57acb9f9cdcf5e6f3e4ce2cef4cb6959f2dc1d401c6748287bb7ee07b89ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-msgs/default.nix
+++ b/distros/foxy/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-leo-msgs";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "55d794cf544413a9eaa98f5482893c5d3550452dc730fc09c7bc3ace15e29a43";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2ffd7fa4e43e30f0586fa9ae73ea15ef9fbc702b44d15f18b9697e71cd482a93";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo-teleop/default.nix
+++ b/distros/foxy/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-foxy-leo-teleop";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_teleop/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "fdee181385db554804a7deff7e1ff9ce93d4d896fddf0ad6c2789af6bf5a8a02";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo_teleop/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0e6f486ff13ac9fe45396394fa905a4fbf15c87a6779b09ecfa50a30185ed352";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/leo/default.nix
+++ b/distros/foxy/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-foxy-leo";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "264b22427c0218bfe9af26a03ef5c585a457e6b58d3f30ffa03533a3d0731b45";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/foxy/leo/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "20b2fdc32188a50de206d308dc75ba2e7b4b352c36ae2c140b82f05dbfaf0617";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/librealsense2/default.nix
+++ b/distros/foxy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-foxy-librealsense2";
-  version = "2.50.0-r2";
+  version = "2.51.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.50.0-2.tar.gz";
-    name = "2.50.0-2.tar.gz";
-    sha256 = "e42fbeda426e0be82aa345fe4dadf0091435e3634ef49791a563aa73db636354";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.51.1-1.tar.gz";
+    name = "2.51.1-1.tar.gz";
+    sha256 = "6c7e79620d096bf900d4d2349ce340e561b117bca764511cba04ae643114c0c0";
   };
 
   buildType = "ament_cmake";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400, L500 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
+    description = ''Library for controlling and capturing data from the Intel(R) RealSense(TM) D400 devices.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/naoqi-libqi/default.nix
+++ b/distros/foxy/naoqi-libqi/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, openssl }:
+buildRosPackage {
+  pname = "ros-foxy-naoqi-libqi";
+  version = "2.9.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/libqi-release/archive/release/foxy/naoqi_libqi/2.9.7-1.tar.gz";
+    name = "2.9.7-1.tar.gz";
+    sha256 = "47b7a2e6e0f67411140971721be83dbf3a1b8e10c6b4fb51dd75aba54d3c742a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost openssl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Aldebaran's libqi: a core library for NAOqiOS development'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/pal-statistics-msgs/default.nix
+++ b/distros/foxy/pal-statistics-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-lint-auto, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-pal-statistics-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/foxy/pal_statistics_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "b7cdb5a1ec454b21fed25258c57f226bc441a2246d874df73e54cc4bb65e7d77";
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/foxy/pal_statistics_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "a03ae26d1f588a3be67d74842ebe9480b03d7b4b9e830ec07924404fb662ecf2";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = ''Statistics msgs package'';

--- a/distros/foxy/pal-statistics/default.nix
+++ b/distros/foxy/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-pal-statistics";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/foxy/pal_statistics/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f43018efb414dc8d17aafb3999c31defe5c4efbeb09f977c6923c1d966c4180f";
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/foxy/pal_statistics/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "22f68620ffac68d0877998071324eb5ec40ec2c8d608597aac548ed830beec1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pose-cov-ops/default.nix
+++ b/distros/foxy/pose-cov-ops/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-pose-cov-ops";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/foxy/pose_cov_ops/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "e80d740474f638f97e0114004df1a00ebfd0d169e13058e99c91f72d8402c17e";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/foxy/pose_cov_ops/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "0fbc07f70b9b3afa4e5f3f585a985c45fbfb769b2b242456fd8905abb26534e7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-xmllint ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ geometry-msgs mrpt2 ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 tf2 ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/foxy/turtle-tf2-cpp/default.nix
+++ b/distros/foxy/turtle-tf2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, message-filters, rclcpp, tf2, tf2-geometry-msgs, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-cpp";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "02ee422d0cbe4096072a5d33a32132e614e88f2643dd871d616ab43c7071dc58";
+    url = "https://github.com/ros2-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "50ac602284182d7a5102afc5a1c42f4ca05f787221909c0bc2368c5855c93314";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtle-tf2-py/default.nix
+++ b/distros/foxy/turtle-tf2-py/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, python3Packages, pythonPackages, rclpy, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-py";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "07dc427ef64910124657ae6dc8a985d859b8c7d32836c63125f23cb08932fd52";
+    url = "https://github.com/ros2-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "204588e8ca123c818e5dbfa16252e7c36f19f0e32ee909810b88060cfdd5fb11";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclpy tf-transformations tf2-ros turtlesim ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros python3Packages.numpy rclpy tf2-ros turtlesim ];
 
   meta = {
     description = ''turtle_tf2_py demonstrates how to write a ROS2 Python tf2 broadcaster and listener with the turtlesim. The turtle_tf2_listener commands turtle2 to follow turtle1 around as you drive turtle1 using the keyboard.'';
-    license = with lib.licenses; [ asl20 ];
+    license = with lib.licenses; [ asl20 bsdOriginal ];
   };
 }

--- a/distros/foxy/v4l2-camera/default.nix
+++ b/distros/foxy/v4l2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-v4l2-camera";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_v4l2_camera-release/archive/release/foxy/v4l2_camera/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "08d6b00b59353d626745974898c115a49160396fd4282e50881d8fe9b528c330";
+    url = "https://github.com/ros2-gbp/ros2_v4l2_camera-release/archive/release/foxy/v4l2_camera/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "5113f32aaad8130e696901bed09af6b4a5b927733803281ddacbe4943e68f3b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/depthai/default.nix
+++ b/distros/galactic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-depthai";
-  version = "2.17.0-r1";
+  version = "2.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.17.0-1.tar.gz";
-    name = "2.17.0-1.tar.gz";
-    sha256 = "4115e30bead9e68dd945ad2444fdcd2ad48ee7b0fa688e920f838f3ec46c456a";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/galactic/depthai/2.17.3-1.tar.gz";
+    name = "2.17.3-1.tar.gz";
+    sha256 = "4139e0955cf07dd92f115bfa141c1ff0080d263c059c0ec1a6fddc62cd666a1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/eigenpy/default.nix
+++ b/distros/galactic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-eigenpy";
-  version = "2.7.12-r1";
+  version = "2.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.12-1.tar.gz";
-    name = "2.7.12-1.tar.gz";
-    sha256 = "8db5e83f033d807ca0d31846a26e1a038690f239d292737088c434491bc67a61";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/galactic/eigenpy/2.7.13-1.tar.gz";
+    name = "2.7.13-1.tar.gz";
+    sha256 = "34390790f6f6b06afc027ff8d3800e576e28e8716f1ae776a86dd10964fbdfeb";
   };
 
   buildType = "cmake";

--- a/distros/galactic/geometry-tutorials/default.nix
+++ b/distros/galactic/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-geometry-tutorials";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "f3d5c1efce5667e1642b2919b5519e15b77c933f58b7dd4df86dbbbdc98ac5f4";
+    url = "https://github.com/ros2-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "023f05748fa0d0f7b3d3862503e7e608f9f75d6240bfa3a716f1766390e3faac";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/pal-statistics-msgs/default.nix
+++ b/distros/galactic/pal-statistics-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-lint-auto, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-pal-statistics-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/galactic/pal_statistics_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "65391f495184534b1c8cac9b2ba4770c93f9dedc600e1d1deece7d5b86c8f15f";
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/galactic/pal_statistics_msgs/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "5cf73ff527598e395016ae99391570cc04aecf823e4f0bb53f68910f19ad9c8f";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = ''Statistics msgs package'';

--- a/distros/galactic/pal-statistics/default.nix
+++ b/distros/galactic/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-pal-statistics";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/galactic/pal_statistics/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "f30370c4b5edde30d3b3000f59635247c39ad516b1aa1bc97c2c997c2af8484e";
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/galactic/pal_statistics/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "f80eb7bfa7d12e8a86024a9f09fcd8ba21a107b3e1c223915452e8ec5df999eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/pose-cov-ops/default.nix
+++ b/distros/galactic/pose-cov-ops/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-pose-cov-ops";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/galactic/pose_cov_ops/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "2406d466b109c64d2ef3c4496b69d620119438382c7af94ab926bbde91413842";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/galactic/pose_cov_ops/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "9aba612f9121862ae678a61c3105c46c959d61eeea3d44ae49e61c2190bda272";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-xmllint ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ geometry-msgs mrpt2 ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 tf2 ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/galactic/rplidar-ros/default.nix
+++ b/distros/galactic/rplidar-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, rclcpp, rclcpp-components, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-rplidar-ros";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/allenh1/rplidar_ros-release/archive/release/galactic/rplidar_ros/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "0b9e41d23195ec90a01bd2018bad7a5858667fe8b068f26ec1fcdf43cf7a34af";
+    url = "https://github.com/ros2-gbp/rplidar_ros-release/archive/release/galactic/rplidar_ros/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "a83f7de32de30d21483e7fb12f51404c7bfaf5ab54c32e4c11a9be47bec6e323";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtle-tf2-cpp/default.nix
+++ b/distros/galactic/turtle-tf2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, message-filters, rclcpp, tf2, tf2-geometry-msgs, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-cpp";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "5ee80607c2c683b9247ffa4f8dc2e895e0af238d8a4a93051e17a22d5a61ff0a";
+    url = "https://github.com/ros2-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "19b78e007e1351d2c9591c6731cde318a244689288412c376a3bced6012e160e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtle-tf2-py/default.nix
+++ b/distros/galactic/turtle-tf2-py/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, python3Packages, pythonPackages, rclpy, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-py";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "0e430ea4379a34cd7c85e0c4a51ef3b41cb290e5a836762200fe0e6ce1d1f15f";
+    url = "https://github.com/ros2-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "e0b3e0ffde5eeeb052ba20d0901d11d26ca9b510d21fba0ed62651d30e473f39";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclpy tf-transformations tf2-ros turtlesim ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros python3Packages.numpy rclpy tf2-ros turtlesim ];
 
   meta = {
     description = ''turtle_tf2_py demonstrates how to write a ROS2 Python tf2 broadcaster and listener with the turtlesim. The turtle_tf2_listener commands turtle2 to follow turtle1 around as you drive turtle1 using the keyboard.'';
-    license = with lib.licenses; [ asl20 ];
+    license = with lib.licenses; [ asl20 bsdOriginal ];
   };
 }

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.17.0-r1";
+  version = "2.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.17.0-1.tar.gz";
-    name = "2.17.0-1.tar.gz";
-    sha256 = "df4e22d13b98f50d9927c490793166e32269ad8b3a25d7a242738cb256c2890b";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.17.3-1.tar.gz";
+    name = "2.17.3-1.tar.gz";
+    sha256 = "30844f8169a23ee8abb388ac99f1201b877abc8ce940fecd2596cf9ea0c244c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -890,6 +890,10 @@ self: super: {
 
  ouxt-lint-common = self.callPackage ./ouxt-lint-common {};
 
+ pal-statistics = self.callPackage ./pal-statistics {};
+
+ pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
+
  parameter-traits = self.callPackage ./parameter-traits {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};

--- a/distros/humble/pal-statistics-msgs/default.nix
+++ b/distros/humble/pal-statistics-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-pal-statistics-msgs";
+  version = "2.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "b937f1bb1421b7398ae7ec381b667ad740196e675964e925d6c92a59ff0307c6";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Statistics msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/pal-statistics/default.nix
+++ b/distros/humble/pal-statistics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-pal-statistics";
+  version = "2.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "7a744e36c0e3010028c986fec1ad1f6b5f50dbc2dcc58ae26008dfa510aff267";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost pal-statistics-msgs rclcpp rclpy ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''The pal_statistics package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/pose-cov-ops/default.nix
+++ b/distros/humble/pose-cov-ops/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-humble-pose-cov-ops";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "298e0ecc078c61cb172f85f2ef3e326e9803293ec0f7da266e7a8512dbf38504";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "d49d54650d5d1fd528d06cc5d386ed661aa8a26f40fdc9c65d4b30fb1568b039";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-xmllint ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ geometry-msgs mrpt2 ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 tf2 ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/rcl-action/default.nix
+++ b/distros/humble/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rcl-action";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "eb5a80cf896e66a14cce69d14db8d78aad0cf027c80a7d3ed09fb9265b9e36f6";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "b87df2ea6d1aef94ec8df1a77381d429a360fc7f0e880f1a16062a9913ba1f9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-lifecycle/default.nix
+++ b/distros/humble/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl-lifecycle";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "2aa1ee6823047304dd7f0e2ba7cf48896efebc78c355b73101f42d60913ac62f";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "4b1be8f45bde2e59fcc3071cb7a1bb022d1c0ea5efb856a9e0ef06138bbf40e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-yaml-param-parser/default.nix
+++ b/distros/humble/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-humble-rcl-yaml-param-parser";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "5a37883977aad4010640758ea924f7df355fb6b6fe2403191b5022611e12a5ac";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "315e39ba847d1af9ae7b3a2331a128fc69dea09a095c8bbad39f1c02640d0701";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl/default.nix
+++ b/distros/humble/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "9970d969b2c83912863aa01f430a7135a397918e8cee589db72d487275e95a0e";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "8751592186b383f1fb176c43ab16dcd017dab761561291d435c644f14838703f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/v4l2-camera/default.nix
+++ b/distros/humble/v4l2-camera/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-v4l2-camera";
-  version = "0.4.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_v4l2_camera-release/archive/release/humble/v4l2_camera/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "eadb59e200b532402534bf652356df3b144da912ecd5d311841fcffd307064db";
+    url = "https://github.com/ros2-gbp/ros2_v4l2_camera-release/archive/release/humble/v4l2_camera/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c551af6c9c6f8c2997942a2db02fe2745feb9b273beeebdd1736958c4e90d1bb";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ camera-info-manager image-transport rclcpp rclcpp-components sensor-msgs ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge image-transport rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/melodic/dynamic-graph-python/default.nix
+++ b/distros/melodic/dynamic-graph-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph-python";
-  version = "4.0.4-r1";
+  version = "4.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/melodic/dynamic-graph-python/4.0.4-1.tar.gz";
-    name = "4.0.4-1.tar.gz";
-    sha256 = "14ff1387e5d26054597d0f7d09515315ebc513ad86dfbc64ca69978a6b56386e";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/melodic/dynamic-graph-python/4.0.9-1.tar.gz";
+    name = "4.0.9-1.tar.gz";
+    sha256 = "757d3f4fbae33009578fe7e6c6cd1eec6f49a2d03220876e2f4b0598c0356bb7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/dynamic-graph-tutorial/default.nix
+++ b/distros/melodic/dynamic-graph-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, git }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph-tutorial";
-  version = "1.2.2-r1";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/melodic/dynamic-graph-tutorial/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "8295134fa254829a0fa3a9aa2280cb7c330ee30adf6990f4fd842ea57ae5949d";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/melodic/dynamic-graph-tutorial/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "d85ac43d800e7d74f365de3cf8d176bba7fbb47390ee7cffa0f540ccd2a8e327";
   };
 
   buildType = "cmake";

--- a/distros/melodic/dynamic-graph/default.nix
+++ b/distros/melodic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph";
-  version = "4.4.0-r1";
+  version = "4.4.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "595d95e92da27ce03d6c82999fb73b40f1fd8f50cdd72a4f7af5d6261a8a4ae9";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.4.3-2.tar.gz";
+    name = "4.4.3-2.tar.gz";
+    sha256 = "682d9e824e906f919778385d2244548da52656b31b1f34f9704c859c152fd001";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.7.5-r1";
+  version = "2.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "47858bb6feda73d45f258f788360159c31fdcb1f4547a1324c9a1bc7e402acb1";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.7.13-1.tar.gz";
+    name = "2.7.13-1.tar.gz";
+    sha256 = "4ce78ee8be1f14c45b60d525ea4af52f0b33d1d0d4f285ff8e1706ed5fbc1707";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eiquadprog/default.nix
+++ b/distros/melodic/eiquadprog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-melodic-eiquadprog";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/melodic/eiquadprog/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "7e0ba9f0b290dd7934fe2e4e66330edcc3434b4fb070f9636bd19b39c202310d";
+    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/melodic/eiquadprog/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "794c00af2e41e4656ce5bc539672653bf30515a12c514a510dcc7e9ef92c8b38";
   };
 
   buildType = "cmake";

--- a/distros/melodic/franka-control/default.nix
+++ b/distros/melodic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, joint-trajectory-controller, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-franka-control";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_control/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "7738232b7ebcef907cd344e07e74803c74710ae5a2ab62539719a890a1761205";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_control/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "653ce0772a06be174820884b4746795de093b8e4315c53746f6fc84d62740e50";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-description/default.nix
+++ b/distros/melodic/franka-description/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-franka-description";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_description/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "abb2bbef44671bb533c2d5b7cd6b3183296aa0eb6c3cab701e42ffc87856b24a";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_description/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "f5bc59b47b61c338caddf84f705f31b0e1ce9de37b4deca8dfc8c45e99cc83b3";
   };
 
   buildType = "catkin";
+  checkInputs = [ rosunit ];
   propagatedBuildInputs = [ xacro ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/franka-example-controllers/default.nix
+++ b/distros/melodic/franka-example-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, moveit-commander, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, joint-limits-interface, libfranka, message-generation, message-runtime, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-franka-example-controllers";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_example_controllers/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "acf398158efcf23d060ae3499f528516ef146c2714739e66a60807ca02c6370d";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_example_controllers/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "e2f67b536f923fe7b58c7d4f5da94a046f1ebdfbe59d88a3d19ba51c366ca2a5";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen message-generation ];
-  propagatedBuildInputs = [ controller-interface dynamic-reconfigure eigen-conversions franka-control franka-description franka-gripper franka-hw geometry-msgs hardware-interface libfranka message-runtime moveit-commander panda-moveit-config pluginlib realtime-tools roscpp rospy tf tf-conversions ];
+  propagatedBuildInputs = [ controller-interface dynamic-reconfigure eigen-conversions franka-control franka-description franka-gripper franka-hw geometry-msgs hardware-interface joint-limits-interface libfranka message-runtime pluginlib realtime-tools roscpp rospy tf tf-conversions urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/franka-gazebo/default.nix
+++ b/distros/melodic/franka-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, boost-sml, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-franka-gazebo";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gazebo/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "9def23d79e07383b50a8198b810d08cde38ca603aadbbc647a59c4064294d0cf";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gazebo/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "11397619571033c5aea9fbce69d28551882b71fae7199e1ccb279f19241f4d57";
   };
 
   buildType = "catkin";
   buildInputs = [ gazebo-dev ];
   checkInputs = [ geometry-msgs gtest rostest sensor-msgs ];
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp roslaunch rospy std-msgs transmission-interface urdf ];
+  propagatedBuildInputs = [ angles boost-sml control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp roslaunch rospy std-msgs transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/franka-gripper/default.nix
+++ b/distros/melodic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-franka-gripper";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gripper/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "f13d881ead890dd93f00328d0d8b081620e0a65bacf74873027e67186796fe0b";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gripper/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "8cfbc7e09f127f36ebd8358b29ae269f15575ff9912c0c329b1b7c00db9fff99";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-hw/default.nix
+++ b/distros/melodic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-franka-hw";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_hw/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "6afd452866f5b4e7bf162b5baed60713458694003fe973de32c15b74f6ac2d54";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_hw/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "b41675eb4a87e4c49e0ecc3e8258e107b4ea3eab7813aafaf4e4dba33f0f0708";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-msgs/default.nix
+++ b/distros/melodic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-franka-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "beaeedd4a028ea5e03b4abc05b6c2b06ee4c93967cb38ee18414fda4866037be";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "e1760cb6389465aeae5faf0b4f47b49bff5510395a3efbfa89563bb4bac14af8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-ros/default.nix
+++ b/distros/melodic/franka-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
+{ lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization }:
 buildRosPackage {
   pname = "ros-melodic-franka-ros";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_ros/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "0698e1aff8087bdd764d7a4ac350da73a6bafe85c54190fac5097bb2ae9fc692";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_ros/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "1172fb29df89a991296eb32276e852bc2282ceb17125cbf9c6e080ac1232d837";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ franka-control franka-description franka-example-controllers franka-gazebo franka-gripper franka-hw franka-msgs franka-visualization panda-moveit-config ];
+  propagatedBuildInputs = [ franka-control franka-description franka-example-controllers franka-gazebo franka-gripper franka-hw franka-msgs franka-visualization ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/franka-visualization/default.nix
+++ b/distros/melodic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-franka-visualization";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_visualization/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "d856dcc1a9380200475115faac6e20e63715c5a7d39264576fd5d12b68028aa4";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_visualization/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "3478c6424729273f0c4ef387706aff0a6788e7e3779503d3a806256b9949a65f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3064,6 +3064,8 @@ self: super: {
 
  qb-device-driver = self.callPackage ./qb-device-driver {};
 
+ qb-device-gazebo = self.callPackage ./qb-device-gazebo {};
+
  qb-device-hardware-interface = self.callPackage ./qb-device-hardware-interface {};
 
  qb-device-msgs = self.callPackage ./qb-device-msgs {};
@@ -4015,6 +4017,8 @@ self: super: {
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
  switchbot-ros = self.callPackage ./switchbot-ros {};
+
+ swri-cli-tools = self.callPackage ./swri-cli-tools {};
 
  swri-console = self.callPackage ./swri-console {};
 

--- a/distros/melodic/marti-data-structures/default.nix
+++ b/distros/melodic/marti-data-structures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-marti-data-structures";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/marti_data_structures/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "0b7896ecc220b8934e20e4c8060cead2520fb9e83f16dc8d6c08151fc098ccce";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/marti_data_structures/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "2811476a8833e718a397dbbda6c71fd78780f3804ef52bf13a205177c4950fdc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mocap-nokov/default.nix
+++ b/distros/melodic/mocap-nokov/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-melodic-mocap-nokov";
-  version = "0.0.2-r2";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/melodic/mocap_nokov/0.0.2-2.tar.gz";
-    name = "0.0.2-2.tar.gz";
-    sha256 = "ddceda5c625d35fb10c8602945ad88f434de467009754fb9c1a8c841445fc333";
+    url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/melodic/mocap_nokov/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "6ea0354ae9034d59f279a27bd066d453480ca565034f520cdc192447bbbb54b0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/naoqi-driver/default.nix
+++ b/distros/melodic/naoqi-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, diagnostic-updater, geometry-msgs, image-transport, kdl-parser, naoqi-bridge-msgs, naoqi-libqi, naoqi-libqicore, orocos-kdl, robot-state-publisher, rosbag-storage, rosconsole, rosgraph-msgs, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-naoqi-driver";
-  version = "0.5.11";
+  version = "0.5.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-naoqi/naoqi_driver-release/archive/release/melodic/naoqi_driver/0.5.11-0.tar.gz";
-    name = "0.5.11-0.tar.gz";
-    sha256 = "5992b46e789dece988fb22504472f7dc543f0785e0407119993a277ee8473895";
+    url = "https://github.com/ros-naoqi/naoqi_driver-release/archive/release/melodic/naoqi_driver/0.5.12-1.tar.gz";
+    name = "0.5.12-1.tar.gz";
+    sha256 = "1517ffa176b401ddd678425f053560707dd214d0371ed5d93472fad5f51ec665";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pose-cov-ops/default.nix
+++ b/distros/melodic/pose-cov-ops/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-pose-cov-ops";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "c0527d339121a324ca1b64e5353d6bd6b24b02a75267ffefe485b8b966a7e125";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/melodic/pose_cov_ops/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "f1bc88e04571b4f900da2d32a44f28dcb6819bbbabea31d3d944ab3d80284a01";
   };
 
   buildType = "catkin";
   buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp tf2 ];
   nativeBuildInputs = [ catkin cmake ];
 
   meta = {

--- a/distros/melodic/pr2-common/default.nix
+++ b/distros/melodic/pr2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-dashboard-aggregator, pr2-description, pr2-machine, pr2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pr2-common";
-  version = "1.12.4-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_common/1.12.4-1.tar.gz";
-    name = "1.12.4-1.tar.gz";
-    sha256 = "a079541b7d696b2a3755aaef63c34e720a67d9c5700fa0acc3a9fa9167745283";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_common/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "6edfb18191b7e0dfa2515d3cb3ee27c25d7199617beedc923494a7fd2e95bc89";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-dashboard-aggregator/default.nix
+++ b/distros/melodic/pr2-dashboard-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pr2-dashboard-aggregator";
-  version = "1.12.4-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_dashboard_aggregator/1.12.4-1.tar.gz";
-    name = "1.12.4-1.tar.gz";
-    sha256 = "59e2885baab0aae9d693d4fc6b659a37b4f88ea3331f3e9c38c2e9cc22878576";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_dashboard_aggregator/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "33e0d27029cd93024bf4ef3834a9d782f710206c87fd9e72e6b671618864df51";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-description/default.nix
+++ b/distros/melodic/pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, convex-decomposition, gtest, ivcon, rosbash, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-melodic-pr2-description";
-  version = "1.12.4-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_description/1.12.4-1.tar.gz";
-    name = "1.12.4-1.tar.gz";
-    sha256 = "8614f27c6963296dfcd6091bb406ac8cb85b3d3ddc240ad390b6da44363d341e";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_description/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "a7c187585634cc2b1ed1fc61e1466def6ec89254d5795f570b45617c06db0e48";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-machine/default.nix
+++ b/distros/melodic/pr2-machine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-pr2-machine";
-  version = "1.12.4-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_machine/1.12.4-1.tar.gz";
-    name = "1.12.4-1.tar.gz";
-    sha256 = "57a14290871112df082f51820a8adbd11dbacb0a38440c11968ec0ca80104ef4";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_machine/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "9833870b936c19b4a17be04b1220e7106f5f81463737c5d68690ed0b3e05471f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-msgs/default.nix
+++ b/distros/melodic/pr2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pr2-msgs";
-  version = "1.12.4-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_msgs/1.12.4-1.tar.gz";
-    name = "1.12.4-1.tar.gz";
-    sha256 = "c0553181a4afd5606bb87f39fa2710ac6c7c1a6afc99d99bfc657218cba9a7e4";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/melodic/pr2_msgs/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "8adba3825ebdcf37188406c2ee0c886418de51817be170a4d2e0bd35f59d3b24";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-bringup/default.nix
+++ b/distros/melodic/qb-device-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-bringup";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "443a0556f062e710b5f7d7dc73d706cf568d89df0fd7ad5166709f879da7949b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "ef37bb6951de3ed4e30df177d59b6731b188dc8838e3f64e1c05b8b7822a11ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-control/default.nix
+++ b/distros/melodic/qb-device-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, combined-robot-hw, control-msgs, controller-manager, qb-device-hardware-interface, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-control";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "aa15f86f450ad62174010eae97ce5ba325a52e62a638a01ae3b7a100ec406a6b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "53058139b5ef7a9a5fc3c2235a1253cffc710f5fa883bba47d1df38c8521ff29";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-description/default.nix
+++ b/distros/melodic/qb-device-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-description";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "68b1656670c1a86828fc13dd7ad3943209f3b95df25079c632717d2a3a326aea";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "98be9512c477e430b84659bfd38f568333815bca4c73b6203e0ea3a38e9e5e6a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-driver/default.nix
+++ b/distros/melodic/qb-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-srvs, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-driver";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "5b3ec2c7b2ecf6aa8e1b99156423cb9f88208eb8d02024c2b30b8c6b1570e5d4";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "b78fd47424931452f447585f15e4e9c097c1452c0687a3ebb07447011f3021e8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-gazebo/default.nix
+++ b/distros/melodic/qb-device-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-gazebo";
-  version = "3.0.4-r3";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_gazebo/3.0.4-3.tar.gz";
-    name = "3.0.4-3.tar.gz";
-    sha256 = "02b73c3b0ed2d31485b622f5bcaa2db7633752da7e366d2ffb1c47aab67a9388";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_gazebo/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "a45cbe6a017aeb024ff0c019e5bd6d39979e3545cadd8e71eec07cf1036f3804";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-hardware-interface/default.nix
+++ b/distros/melodic/qb-device-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-hardware-interface";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "16e0d28b4e8b145ae272049cdf232830fd7e6ffc50145bcb04a1570fa1e0f791";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "c369d7bd2b60b9fd20758680eef6479efb39ba220bff3b563d4a904c98c3bdd8";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ hardware-interface joint-limits-interface qb-device-msgs qb-device-srvs roscpp transmission-interface urdf ];
+  propagatedBuildInputs = [ control-msgs hardware-interface joint-limits-interface qb-device-msgs qb-device-srvs roscpp transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/qb-device-msgs/default.nix
+++ b/distros/melodic/qb-device-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-msgs";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "0a101007de0e30caec152ebe1d7f6bd676382b6b9df4e8353acb6a061bb57ab6";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d896687c1b065050953830cc34e9bbf05a1ab454985700425560a3f06b948aa8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-srvs/default.nix
+++ b/distros/melodic/qb-device-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-device-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-srvs";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "3368262c75e15bb0fe756a1a54ae5dbef310d58c351c97e62766135641c68cab";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "5a910644b51dd38a1ea98e864b4780d24f3d69eb0b78715d68e4c0e5f94f38ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-utils/default.nix
+++ b/distros/melodic/qb-device-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-utils";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "b7ece361d35ee477a65ab530192408ac5a4fb3f8813c52a48a911989568fd0cf";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "1bc8a2d83fbf4195ebe6f44819b2659c769c1da3895b280ee2a3021c83791748";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device/default.nix
+++ b/distros/melodic/qb-device/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-gazebo, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs, qb-device-utils }:
 buildRosPackage {
   pname = "ros-melodic-qb-device";
-  version = "2.0.1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "732baae03ff35decece845d122f21d7b7b86d2c31f726cfce269be208c306724";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "ddbcbbc0d53953dbfb54835b314b972dd3261ff7e58c5f7bf989462e5833b033";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-hardware-interface qb-device-msgs qb-device-srvs ];
+  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-gazebo qb-device-hardware-interface qb-device-msgs qb-device-srvs qb-device-utils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/sot-core/default.nix
+++ b/distros/melodic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-melodic-sot-core";
-  version = "4.11.6-r1";
+  version = "4.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/melodic/sot-core/4.11.6-1.tar.gz";
-    name = "4.11.6-1.tar.gz";
-    sha256 = "83bae069452c9010919d4cc4395bdd999fbc7aa34a186dcc49b057828a5e9f41";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/melodic/sot-core/4.11.8-1.tar.gz";
+    name = "4.11.8-1.tar.gz";
+    sha256 = "72bcd76b77f5ddb4dba9aabf97967f637e0055b9f9e73e3dfe586727ecc53383";
   };
 
   buildType = "cmake";

--- a/distros/melodic/sot-dynamic-pinocchio/default.nix
+++ b/distros/melodic/sot-dynamic-pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, gtest, liblapack, openblas, pinocchio, sot-core, sot-tools }:
 buildRosPackage {
   pname = "ros-melodic-sot-dynamic-pinocchio";
-  version = "3.6.3-r1";
+  version = "3.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release/archive/release/melodic/sot-dynamic-pinocchio/3.6.3-1.tar.gz";
-    name = "3.6.3-1.tar.gz";
-    sha256 = "bcc7594f6cdd521f12b898a2a8f29b11cb75f76f429e8723ceae767005db238a";
+    url = "https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release/archive/release/melodic/sot-dynamic-pinocchio/3.6.5-1.tar.gz";
+    name = "3.6.5-1.tar.gz";
+    sha256 = "70feb89ab90ebda7d34a1505aaabe1118a988a9e46619736046125bb904988c2";
   };
 
   buildType = "cmake";

--- a/distros/melodic/sot-tools/default.nix
+++ b/distros/melodic/sot-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, sot-core }:
 buildRosPackage {
   pname = "ros-melodic-sot-tools";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/melodic/sot-tools/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "972af1477b8121140c5b5a19b0baec03fd4b66de6f1bc92a2e6c100deb891617";
+    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/melodic/sot-tools/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "fb18de16f9d6de4ac41e43509b1058c5f78553a1bcd5e13b2e35d6ca672b6880";
   };
 
   buildType = "cmake";

--- a/distros/melodic/swri-cli-tools/default.nix
+++ b/distros/melodic/swri-cli-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, marti-introspection-msgs, rosgraph, rospy, rostopic }:
+buildRosPackage {
+  pname = "ros-melodic-swri-cli-tools";
+  version = "2.15.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_cli_tools/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "2ee4fd3897dceda29bb436710511d29e8ab2e72290b45efb62b209d29fe427ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ marti-introspection-msgs rosgraph rospy rostopic ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rosman contains the rosman tool for introspecting ROS nodes'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/swri-console-util/default.nix
+++ b/distros/melodic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
 buildRosPackage {
   pname = "ros-melodic-swri-console-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_console_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "433ec56e17dbb56b281ce4829c434c9e34e52bfea9830ddcccace64e112e4dff";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_console_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "e2892f1a73322c575fcc2f54bbfa875c94859f9b052e20e56c9c6bac6800bf13";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-dbw-interface/default.nix
+++ b/distros/melodic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-swri-dbw-interface";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_dbw_interface/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "e61b31c25ae10faaf18f42ae18461b5aa2987b74e6d4417c918a9848b2652583";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_dbw_interface/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "89ee023cd77c3844485b98c05ee7b7f7bafd64737de6c84e12e776077100e776";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-geometry-util/default.nix
+++ b/distros/melodic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-melodic-swri-geometry-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_geometry_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "66263fec32470ab146fe1ea50aa92fb10c6cb0aefeaaf5058e28021cd9db7157";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_geometry_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "597ad7151017fe1361d37eb5db999d87e77870f864708cc1fa698c9afe944871";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-image-util/default.nix
+++ b/distros/melodic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-swri-image-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_image_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "06089bd72e38de3c6490d0760537face450d4985e3f0c3118a04a123c6948dde";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_image_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "c06fa346ff49d1d38af68c3bed8ff0a38cb4a96798c68985c69016f8a4df6d3a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-math-util/default.nix
+++ b/distros/melodic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-swri-math-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_math_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "2236a1d247c02a57022d21aafdedc4e0e95cb8ece845f9a75812f93ef970dc4a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_math_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "ea43a9d90e91fa64205a78903c4e40d0ccd8b2a356caa7c3013a1a0a95ac2534";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-nodelet/default.nix
+++ b/distros/melodic/swri-nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-swri-nodelet";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_nodelet/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "c475d18d684240283b72456d39b059af1c3862d5a04da0daadd671546384c43d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_nodelet/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "78927d5e6057dc60de10bdff45f4d454a026528ab9ced40af2c6e20687930aad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-opencv-util/default.nix
+++ b/distros/melodic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-melodic-swri-opencv-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_opencv_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "bfe31c3c7313c2da2746e7357fd422e0957e755423c634effc3cadc37943797c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_opencv_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "b7da72b8e33fead7ca82dc04db4145a7b8351d9a8e49660cd5b7f10235165e56";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-prefix-tools/default.nix
+++ b/distros/melodic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-swri-prefix-tools";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_prefix_tools/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "f642ac0679c8c34680f80e14b693dadaa281116afe09752a082fb5e85f86cb57";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_prefix_tools/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "0c8ad3a2b2bc72de71aab602d56fdbeebfd31e960c2e02692a4ee4ff75123d26";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-roscpp/default.nix
+++ b/distros/melodic/swri-roscpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, marti-introspection-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-swri-roscpp";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_roscpp/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "ab67225b33d3f614606ddbbdca4f900891b0da27887e1f49acceb14dd2c33dd7";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_roscpp/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "8cd64485b1da019c1600856af0caa8831decd98cc2f8eeca2ae8c55a2ec76566";
   };
 
   buildType = "catkin";
   checkInputs = [ gtest message-generation message-runtime rostest rosunit ];
-  propagatedBuildInputs = [ boost diagnostic-updater dynamic-reconfigure libyamlcpp marti-common-msgs nav-msgs roscpp std-msgs std-srvs ];
+  propagatedBuildInputs = [ boost diagnostic-updater dynamic-reconfigure libyamlcpp marti-common-msgs marti-introspection-msgs nav-msgs roscpp std-msgs std-srvs ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/melodic/swri-rospy/default.nix
+++ b/distros/melodic/swri-rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-swri-rospy";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_rospy/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "46d86109dd3bbb2b2c8e79bc4a872377840c48666ac42a4717f33bbc945aea77";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_rospy/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "10011f7fd4f01422051fb0ccc2479f08e7298bdddb5f6477104c4b92aed3df4f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-route-util/default.nix
+++ b/distros/melodic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-swri-route-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_route_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "bfa0ab7ccec7918e9afc5e98f5633d6e40b80d1b948a977eb4408ddf8c64cca6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_route_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "2e8c0d95a5170682c60c68bb1d1e266df680a01f42d88a0e53b2d9661a083543";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-serial-util/default.nix
+++ b/distros/melodic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-melodic-swri-serial-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_serial_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "ba2381f31d41b2983a81a120a501fef6fd8ad633e06107bd74cb5b0e37826a0c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_serial_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "3827339995c14e34990f4e550fc978d0323e9a0996fa3294dd981b3725d7b352";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-string-util/default.nix
+++ b/distros/melodic/swri-string-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rostest }:
 buildRosPackage {
   pname = "ros-melodic-swri-string-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_string_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "1aabb188d6b38614399533297388e31fea036e0e72450f4b97e942dd1e826960";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_string_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "ea34be12aa11141705af1896728a59decfc1f4886b76b38af405f9c9c7d13345";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-system-util/default.nix
+++ b/distros/melodic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-swri-system-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_system_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "3609b6434039f2585e58ed08775f58509f72c1fbb8a46a58a2916a09a47fafc9";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_system_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "7ff8cdc3bf6831e6ed4988ca42b12e0578661504f53f4a49f4b4df3fb875879a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-transform-util/default.nix
+++ b/distros/melodic/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, genpy, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, pythonPackages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-swri-transform-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_transform_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "864f2928ed86f68a37eabe4e4992b1192b89dba2a47a2e32c3e3c93aaa9680fb";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_transform_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "724cd554abb5f178cfdd32914eef4453c163aa01229a83b43e61e2c174cda006";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-yaml-util/default.nix
+++ b/distros/melodic/swri-yaml-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-swri-yaml-util";
-  version = "2.14.2-r1";
+  version = "2.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_yaml_util/2.14.2-1.tar.gz";
-    name = "2.14.2-1.tar.gz";
-    sha256 = "c02cc9dfd8c1b4ffdaeb906b9803adcf889ad4242f76b15d5c165a9b8b2e386b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_yaml_util/2.15.2-1.tar.gz";
+    name = "2.15.2-1.tar.gz";
+    sha256 = "3c959e8d2d3fbab727fe55b10e3aa174a2ebffc79bce7e60e4df92dfa5460e8b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ boost libyamlcpp ];
+  propagatedBuildInputs = [ boost libyamlcpp roscpp ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/noetic/aruco-opencv-msgs/default.nix
+++ b/distros/noetic/aruco-opencv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-aruco-opencv-msgs";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "af7f10cf9574096846e43acb5716e80b259c3ca1fa608fb89a969fa4e98b76b7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Message definitions for aruco_opencv package.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/aruco-opencv/default.nix
+++ b/distros/noetic/aruco-opencv/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, aruco-opencv-msgs, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-aruco-opencv";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "11d15b4f656ba5b83f80f7c629e0aefba94fa7a32f5142abdc9496d2ed860f02";
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "173ba86a5ab4ea37c1fd173609664cc459946fb22d54542d8fe0009eb49351aa";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs image-transport message-runtime nodelet roscpp std-msgs tf2-geometry-msgs tf2-ros ];
+  buildInputs = [ aruco-opencv-msgs ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport nodelet roscpp tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "adbad742a323f3939a4c759142e9570a23d939821522c71a805333bddd4a7fcf";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "8f074e3d6d13ef356be42a772650e883ed64792d05775d353c41badd74779dec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cv-bridge/default.nix
+++ b/distros/noetic/cv-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, opencv, python3, python3Packages, rosconsole, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cv-bridge";
-  version = "1.16.0-r1";
+  version = "1.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/cv_bridge/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "e6a11ec534e810c25eea0b8a28ad0a7f48afe616ba27d489c82800f4e8d19e28";
+    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/cv_bridge/1.16.1-1.tar.gz";
+    name = "1.16.1-1.tar.gz";
+    sha256 = "7a38d268df7fefac92560c1eb1781a89bf7cc0ca2eede8bb8475ad6d19049ad5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.17.0-r1";
+  version = "2.17.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.17.0-1.tar.gz";
-    name = "2.17.0-1.tar.gz";
-    sha256 = "0a8689e29b8f036540f2b10fdd45c840d119cbac80c99cc29d71677ef90700f7";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.17.3-2.tar.gz";
+    name = "2.17.3-2.tar.gz";
+    sha256 = "abc55619ae8daed9c52fb41fd410beab97b3168238a8c8ebdb575a7d6e83512f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph-python/default.nix
+++ b/distros/noetic/dynamic-graph-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-python";
-  version = "4.0.4-r1";
+  version = "4.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.4-1.tar.gz";
-    name = "4.0.4-1.tar.gz";
-    sha256 = "3847b2fff930a9a3779617b11002f9793445d40d2b0f540a781bbfda0dddab9a";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.9-1.tar.gz";
+    name = "4.0.9-1.tar.gz";
+    sha256 = "cc53de43ac9dea8a20c816669af4fc1cdec3d46ca22738086ebc1508bfbdfdf8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph-tutorial/default.nix
+++ b/distros/noetic/dynamic-graph-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-tutorial";
-  version = "1.3.2-r1";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/noetic/dynamic-graph-tutorial/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "a5499ce3759b782a0ce47408c2dcc025ccef46c53dd64e3080968beee6a08a60";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/noetic/dynamic-graph-tutorial/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "69b286815c79975a7e57a5780a1dc3aff8dad3c59cfc794291344a70d2dbbb64";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph/default.nix
+++ b/distros/noetic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph";
-  version = "4.4.0-r1";
+  version = "4.4.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "0d32c5689296c82f14583c1014aad47e40968fb846aeb5ba790473c85cbc12cd";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.4.3-2.tar.gz";
+    name = "4.4.3-2.tar.gz";
+    sha256 = "ad0e881198a573563b54cfa2c496ab022e3e67e9e14ba6da08cbf156c29f5715";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.7.12-r1";
+  version = "2.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.12-1.tar.gz";
-    name = "2.7.12-1.tar.gz";
-    sha256 = "d4093ef0ee0376288e167dbf4e0e3d5b49b7a746cf9d4d4a7a174ceae6399664";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.7.13-1.tar.gz";
+    name = "2.7.13-1.tar.gz";
+    sha256 = "33d0299df472302f5e8e71451060d3c302fa8973fac4f65bdf8b926c2e26641e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eiquadprog/default.nix
+++ b/distros/noetic/eiquadprog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-eiquadprog";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/noetic/eiquadprog/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "6bc4987dbf43030bd604ca64ef425b65195083702d79ee32fa6d909b2bdc7bce";
+    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/noetic/eiquadprog/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "fc608b62a4c3e86830aa0861fd835a6ff5818f387b896d14664243dbea6c5d89";
   };
 
   buildType = "cmake";

--- a/distros/noetic/franka-control/default.nix
+++ b/distros/noetic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, joint-trajectory-controller, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-control";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "409e777e65b8003578ee54df9fe57b6422ce4d710aa6cc93624b92df74bca6cb";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "f3847ae023f58e2c58e32763b2f20950072fa5a5ee9ababf1ecf28434c565a28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-description/default.nix
+++ b/distros/noetic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-description";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "c704110dcc354c33fdab5e26198fad37b5ba4fb41f6a19c95dca53ed493c97ea";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "e4f25cfa94dd91fecbe01db3becf547144e2fa04448dae9284e2be03cf1be411";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-example-controllers/default.nix
+++ b/distros/noetic/franka-example-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, joint-limits-interface, libfranka, message-generation, message-runtime, moveit-commander, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, joint-limits-interface, libfranka, message-generation, message-runtime, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-example-controllers";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "e80e71f07aa6629d36399556753e968c928a4a52616ae0607a59e959d9b83dbf";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "1426e5d1d07f8927638ae4e2ae82271f5e65746de4a53ab0d94b748ba041836b";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen message-generation ];
-  propagatedBuildInputs = [ controller-interface dynamic-reconfigure eigen-conversions franka-control franka-description franka-gripper franka-hw geometry-msgs hardware-interface joint-limits-interface libfranka message-runtime moveit-commander panda-moveit-config pluginlib realtime-tools roscpp rospy tf tf-conversions urdf visualization-msgs ];
+  propagatedBuildInputs = [ controller-interface dynamic-reconfigure eigen-conversions franka-control franka-description franka-gripper franka-hw geometry-msgs hardware-interface joint-limits-interface libfranka message-runtime pluginlib realtime-tools roscpp rospy tf tf-conversions urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-gazebo/default.nix
+++ b/distros/noetic/franka-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost-sml, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, geometry-msgs, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-gazebo";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "209133fd36e20fc9b689f92edb7ccb6f819164b8ec4b91fcd9b6ca71b50207ea";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "79966d67f8e95ab6639ccf840bef6ca798adf6a14aaade57ece54c4617aad660";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-gripper/default.nix
+++ b/distros/noetic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-franka-gripper";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "4c56232bb3a3070c01023fe478c03dbaaf2d4ce877e50a57a8743a299b264690";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "a1bb6da85f91ec199a9f8826ff6b1e895acd3cee858e42ee01d6e93c55f6050a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-hw/default.nix
+++ b/distros/noetic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-hw";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "5cbbc021cc60a020412910083ff3c5f719916b2118c59a3864b29ca6788cb309";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "9f563d74195891dfae573c315329027e393eb315bff3b60af6d2af404e90e676";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-msgs/default.nix
+++ b/distros/noetic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-msgs";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "d59821cbe6934dc85d2720446f7bd9570a69de11e5544b245fa818b0524be498";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "a59af87cdd2614bfac7bb7d22237a0f6567900799c3b1bc762d5f0af2b06032d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-ros/default.nix
+++ b/distros/noetic/franka-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
+{ lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gazebo, franka-gripper, franka-hw, franka-msgs, franka-visualization }:
 buildRosPackage {
   pname = "ros-noetic-franka-ros";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "3302b0a6b292356f1dec1873affe90cf1fc9641f57b067f23e25a33191963cc4";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "d57778c575e9e673786e560666da93756f5ac51bfee69edccc20f4dea65c14b3";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ franka-control franka-description franka-example-controllers franka-gazebo franka-gripper franka-hw franka-msgs franka-visualization panda-moveit-config ];
+  propagatedBuildInputs = [ franka-control franka-description franka-example-controllers franka-gazebo franka-gripper franka-hw franka-msgs franka-visualization ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-visualization/default.nix
+++ b/distros/noetic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-visualization";
-  version = "0.9.1-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "c97af62d4fab69a917f496433489f7fe4250e6dd1eefd9be0e056273cfe19c12";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "bc41d3d3fb560cc97e745e57c41e926155b3517f9b78e84e413f9766aad2fa30";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -60,6 +60,8 @@ self: super: {
 
  aruco-opencv = self.callPackage ./aruco-opencv {};
 
+ aruco-opencv-msgs = self.callPackage ./aruco-opencv-msgs {};
+
  aruco-ros = self.callPackage ./aruco-ros {};
 
  assimp-devel = self.callPackage ./assimp-devel {};
@@ -1968,6 +1970,10 @@ self: super: {
 
  multisense-ros = self.callPackage ./multisense-ros {};
 
+ nao-meshes = self.callPackage ./nao-meshes {};
+
+ naoqi-bridge-msgs = self.callPackage ./naoqi-bridge-msgs {};
+
  nav2d = self.callPackage ./nav2d {};
 
  nav2d-exploration = self.callPackage ./nav2d-exploration {};
@@ -2163,6 +2169,8 @@ self: super: {
  people-msgs = self.callPackage ./people-msgs {};
 
  people-velocity-tracker = self.callPackage ./people-velocity-tracker {};
+
+ pepper-meshes = self.callPackage ./pepper-meshes {};
 
  perception = self.callPackage ./perception {};
 

--- a/distros/noetic/image-geometry/default.nix
+++ b/distros/noetic/image-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, opencv, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-geometry";
-  version = "1.16.0-r1";
+  version = "1.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/image_geometry/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "c1876437e6591c63987f60a88b94be33e615636475258dd843eb139d3258dc62";
+    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/image_geometry/1.16.1-1.tar.gz";
+    name = "1.16.1-1.tar.gz";
+    sha256 = "36c3f0c717a2648c81f8916c7f84565ce319e4c0c9161f14b6c01c9df9b32fa9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/iris-lama/default.nix
+++ b/distros/noetic/iris-lama/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-noetic-iris-lama";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/noetic/iris_lama/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "52cf3a1c63f9c978519569624a45504d703b683b2ce52f11ec1fb42f2562b4be";
+    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/noetic/iris_lama/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "470baf458114fc416eb0ac0462b223845394c2557408dcd75aa82105625da860";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mocap-nokov/default.nix
+++ b/distros/noetic/mocap-nokov/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-mocap-nokov";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/noetic/mocap_nokov/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "63a3a439a048a0d9a09bad81fb283cb4697e552709be63b13b1b4dd3e6f0c6ab";
+    url = "https://github.com/NOKOV-MOCAP/mocap_nokov_release/archive/release/noetic/mocap_nokov/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "c2067f07c2ef399b0c813c022d6884f6ee87d7f681403056e99005d447c6aeee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nao-meshes/default.nix
+++ b/distros/noetic/nao-meshes/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, openjdk }:
+buildRosPackage {
+  pname = "ros-noetic-nao-meshes";
+  version = "0.1.13";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/nao_meshes-release/archive/release/noetic/nao_meshes/0.1.13-0.tar.gz";
+    name = "0.1.13-0.tar.gz";
+    sha256 = "45bbadfb32df9bb25b48560aa4fbe709082a8077ab6ef5a2dc0f239aad5b1c15";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ openjdk ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''meshes for the Aldebaran Robotics NAO'';
+    license = with lib.licenses; [ "CC-BY-NC-ND-4.0" ];
+  };
+}

--- a/distros/noetic/naoqi-bridge-msgs/default.nix
+++ b/distros/noetic/naoqi-bridge-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-naoqi-bridge-msgs";
+  version = "0.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/naoqi_bridge_msgs-release/archive/release/noetic/naoqi_bridge_msgs/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "b93b08f2909efdadd7848fe7507a384f6c69954b0f20d9d0d97a84033494f377";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs genmsg geometry-msgs message-runtime nav-msgs sensor-msgs std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The naoqi_bridge_msgs package provides custom messages for running Aldebaran's robot such as NAO and Pepper. See the packages nao_robot and pepper_robot for details.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pepper-meshes/default.nix
+++ b/distros/noetic/pepper-meshes/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, openjdk }:
+buildRosPackage {
+  pname = "ros-noetic-pepper-meshes";
+  version = "0.2.5";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/pepper_meshes-release/archive/release/noetic/pepper_meshes/0.2.5-0.tar.gz";
+    name = "0.2.5-0.tar.gz";
+    sha256 = "08a86a6b1f3ef1378c9a02ac74fe74013cd897b1288cabc4dbfd914974290b6c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ openjdk ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''meshes for the Aldebaran Robotics Pepper'';
+    license = with lib.licenses; [ "CC-BY-NC-ND-4.0" ];
+  };
+}

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-pose-cov-ops";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "8c9cb108156d3ba5c46ef86f43d42991d395256c10b0cd06fcf04a7d42b777eb";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "d29d619df4e434f38ca90e53882d01a1035d13ceadcfd13916dcad89ba7e45af";
   };
 
   buildType = "catkin";
   buildInputs = [ ros-environment ];
   checkInputs = [ gtest rosunit ];
-  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp ];
+  propagatedBuildInputs = [ geometry-msgs mrpt2 roscpp tf2 ];
   nativeBuildInputs = [ catkin cmake ];
 
   meta = {

--- a/distros/noetic/pr2-common/default.nix
+++ b/distros/noetic/pr2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-dashboard-aggregator, pr2-description, pr2-machine, pr2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pr2-common";
-  version = "1.13.0-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_common/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "86d04f9900f7c459771ece80c73e2441f264f0533d19b2693690359291e4cf62";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_common/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "ad3cbd422f8f70acabc1253e26746689b616021507cee1f9c713600fb1ac5cf7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-dashboard-aggregator/default.nix
+++ b/distros/noetic/pr2-dashboard-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2-msgs, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pr2-dashboard-aggregator";
-  version = "1.13.0-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_dashboard_aggregator/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "ea1f2d0927c5831bc32f9c39bc68e1fb3b6aa8806bdfcdb5b49e9d65a4b684de";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_dashboard_aggregator/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "cffbc94a2f17facbf3596353782a182d7304eac3b43d26af9f00fbad24a3347d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-description/default.nix
+++ b/distros/noetic/pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, convex-decomposition, gtest, ivcon, rosbash, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-noetic-pr2-description";
-  version = "1.13.0-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_description/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "b6f1dc6a4f7e027ba1a6625e6faa720a8e12a55ff18348f122a6e19eff51c463";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_description/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "a330ee0985183df4ddbf72569f1ec2d4025ae5414bce874176ad68750344be76";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-machine/default.nix
+++ b/distros/noetic/pr2-machine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-pr2-machine";
-  version = "1.13.0-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_machine/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "98517069d84d60a45902a9452feb77c1814b4440063232696cc31b248ff58607";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_machine/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "1586780480d4ec1a797838f87265ef2c273be2455777f94b6742d1195a9481b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-msgs/default.nix
+++ b/distros/noetic/pr2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pr2-msgs";
-  version = "1.13.0-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_msgs/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "de042a096672c07223b8a4e82c71292d771e3badb90b014fc1c34c6dc7a436e7";
+    url = "https://github.com/pr2-gbp/pr2_common-release/archive/release/noetic/pr2_msgs/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "175c98cd5c4ce84e88c8c64a1d0496b4bb4d367b366ec8aaf0efc4d8b69655e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-bringup/default.nix
+++ b/distros/noetic/qb-device-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-bringup";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_bringup/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "c7b025dccb947e1e87b222bec3801cc629f13e0cafdee21b3ea6308f12b66452";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_bringup/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "db41bec0a226ffa8bb21c6c980940a0f80aa10992c37aee0e05fd573ce6629fe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-control/default.nix
+++ b/distros/noetic/qb-device-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, combined-robot-hw, control-msgs, controller-manager, qb-device-hardware-interface, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-control";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_control/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "db1480fc86a8b672458722985bc6ddcc88d562978b0d9a24e45a85fa64c830dd";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_control/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "691a12d32828349408e9be4a980b0b53b8af72a6d6f72c0ad92a583fc3fa046b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-description/default.nix
+++ b/distros/noetic/qb-device-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-description";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_description/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "34b74fe037976491c8508e88e9a9c02dacd8b4b10a48684181f9da8504da8414";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_description/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "a68151a68cfc86d4f1e306273fb96dfafdbedde57f1ba35af6902e90736d09fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-driver/default.nix
+++ b/distros/noetic/qb-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-srvs, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-driver";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_driver/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "41e7f2059c6e63c28ff45d24bc0c14ef505ec2d13ab15db4e5016f59f97b5589";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "b8890294f705082ae2de41ea0516e5e44d3edb55ea3a7b9f88c93011cdeb0fe3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-gazebo/default.nix
+++ b/distros/noetic/qb-device-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-gazebo";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_gazebo/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "b73b101337d4d7159ce6a7698643636210c02f1f7657ed2e5b390c622df6edb9";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_gazebo/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "a0a34f61a3958874231aca62adb0b9194bd580a4c1ec1e4f4d46f4e392c811de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-hardware-interface/default.nix
+++ b/distros/noetic/qb-device-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-hardware-interface";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_hardware_interface/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "e0ec7545af3ee737acd780356691359f428febc2884d9cd4ffd04a9a3f740b38";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_hardware_interface/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "74fae292de09d5a32635c8204274dc6385b392da37d1dffb3c1eabe20cef015b";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ hardware-interface joint-limits-interface qb-device-msgs qb-device-srvs roscpp transmission-interface urdf ];
+  propagatedBuildInputs = [ control-msgs hardware-interface joint-limits-interface qb-device-msgs qb-device-srvs roscpp transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/qb-device-msgs/default.nix
+++ b/distros/noetic/qb-device-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-msgs";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_msgs/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "717e04af776a6e48e1b262cfdeae20ef138c7b3ee475f3040bfe2fb6931b488c";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_msgs/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d70728e4aa968557dfeaf830ac8fc7772388600368e5b78dbc46c386f1a7c5ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-srvs/default.nix
+++ b/distros/noetic/qb-device-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-device-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-srvs";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_srvs/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "8f2882e27eb15b82e19f1f63a19b572f1d32fefc4efb834af7529561b5241dd4";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_srvs/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "0592f89dce9385bfaa55a6158511183660ef5d9dda77299de4054449d5917087";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-utils/default.nix
+++ b/distros/noetic/qb-device-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-utils";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_utils/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "c63437817b78213f7fb62da84b7d55f6b968aadd93474307eedb6d37f3d6839b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_utils/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "11f280e71adc3d63d289896eb50f3f6f6674e7a9b1c4f7e87d1de5fb48afa64d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device/default.nix
+++ b/distros/noetic/qb-device/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-gazebo, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs, qb-device-utils }:
 buildRosPackage {
   pname = "ros-noetic-qb-device";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "176dc010e29639854f3cd135923ad5c3e27d333dd5c2c97e6628ac6f02b917c1";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "518d6f733ea9878424eaff30225ae04a6a48d65dd16d721d16d7ad0dc86be9ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, imu-complementary-filter, imu-filter-madgwick, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.13-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "acd6500480193a21f7f726a694c2d8fbb77634c9b219a07e3448984b0512637d";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "e336ecf26b5ee997849217f27680fd0787359ebf1d7c67110ca0513864632019";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, rm-dbus, rm-description, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.13-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "32b4894122ec106292b595ec710c372a95b96c509eaf2915de63e49a7a7dd543";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "74ca0b37276db8be681fb4201d5f08afccacfd3f2816b2d9f876796645704283";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-dbus";
-  version = "0.1.13-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "3970f914fefb1865e1ba6805dc546e104106366fb818c438820c6ac75cb2f96d";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "6a2b0380e64504e654f4cd0cbf028adc9a02f8f88d74d4d8924b5a9ae3e8dfc1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.13-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "fadc636dbb602f42d78a0ef14b86d3eaebf1b375dedd3ffc98896fb2071e8ec0";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "e03de15c8cafe40eb076e07720da1c7c041d6f830af60ca26a033c623de212a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-rm-hw";
-  version = "0.1.13-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "6db581b3793c26a2add3cbbb9b291716fd403667249b658e1ed4a785503bbb7d";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "16717af03af980d47f5e6be6b72ba1344f5f02784bb6036612b78c597ce6c46d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.13-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "84d51eba57e6ba8fc9cf7ba6488def3ccbc1e5b82f2227440f8495ca749dead4";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "7d7cbbe87911ad07336c5787b5ee11e37e796ea05cf4b55a627469eb4c5757b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sot-core/default.nix
+++ b/distros/noetic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-noetic-sot-core";
-  version = "4.11.6-r1";
+  version = "4.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.6-1.tar.gz";
-    name = "4.11.6-1.tar.gz";
-    sha256 = "4b462e9c1a17017e791dc38799c91049ca30373bfd36cf49e202e13a0a43eb59";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.8-1.tar.gz";
+    name = "4.11.8-1.tar.gz";
+    sha256 = "ce9aa3de0f1aa4def5740d8776480f1ff1b844fc087f95523cf55fef2a1ccceb";
   };
 
   buildType = "cmake";

--- a/distros/noetic/sot-dynamic-pinocchio/default.nix
+++ b/distros/noetic/sot-dynamic-pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, gtest, liblapack, openblas, pinocchio, sot-core, sot-tools }:
 buildRosPackage {
   pname = "ros-noetic-sot-dynamic-pinocchio";
-  version = "3.6.3-r1";
+  version = "3.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release/archive/release/noetic/sot-dynamic-pinocchio/3.6.3-1.tar.gz";
-    name = "3.6.3-1.tar.gz";
-    sha256 = "50447cd2030f4dda6a737ffb9ecc4ab297b2803ff311c81718fac790a957679f";
+    url = "https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release/archive/release/noetic/sot-dynamic-pinocchio/3.6.5-1.tar.gz";
+    name = "3.6.5-1.tar.gz";
+    sha256 = "05a4c7c1768fbb3674a8eed9f75c2770ef2e65cc68a065835d79f2a2826b1581";
   };
 
   buildType = "cmake";

--- a/distros/noetic/sot-tools/default.nix
+++ b/distros/noetic/sot-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, sot-core }:
 buildRosPackage {
   pname = "ros-noetic-sot-tools";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/noetic/sot-tools/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "d54e689070390d5ffe5606f2131f31848e71c83e3d1100435ed7fdceae8ef117";
+    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/noetic/sot-tools/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "8a0424691bdf6c5700eb43384c78e2bc869d888a0a0bc525c8ec88c8829a710c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/vision-opencv/default.nix
+++ b/distros/noetic/vision-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry }:
 buildRosPackage {
   pname = "ros-noetic-vision-opencv";
-  version = "1.16.0-r1";
+  version = "1.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/vision_opencv/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "d981b709aa5f94a2464ffc0f1c2974ac064380ebd62d2a29a8a61d81958b1032";
+    url = "https://github.com/ros-gbp/vision_opencv-release/archive/release/noetic/vision_opencv/1.16.1-1.tar.gz";
+    name = "1.16.1-1.tar.gz";
+    sha256 = "ac2d8c16461688079c1b59608e917d65743477f1e0810ad18350b5998427b403";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'humble', 'melodic', 'noetic'] from nix-ros-overlay commit 7559a8cf6ef1ee4324d9b0857b24c89475786ab5.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *bosch-locator-bridge 2.0.7-r1 --> 2.0.8-r1*
* *depthai 2.17.0-r1 --> 2.17.3-r1*
* *dynamic-graph 4.2.2-r1 --> 4.4.3-r2*
* *eigenpy 2.7.12-r1 --> 2.7.13-r1*
* *geometry-tutorials 0.3.4-r1 --> 0.3.5-r1*
* *leo 1.0.3-r1 --> 1.1.0-r1*
* *leo-description 1.0.3-r1 --> 1.1.0-r1*
* *leo-msgs 1.0.3-r1 --> 1.1.0-r1*
* *leo-teleop 1.0.3-r1 --> 1.1.0-r1*
* *librealsense2 2.50.0-r2 --> 2.51.1-r1*
* *naoqi-libqi 2.9.7-r1*
* *pal-statistics 2.0.1-r1 --> 2.0.2-r1*
* *pal-statistics-msgs 2.0.1-r1 --> 2.0.2-r1*
* *pose-cov-ops 0.3.6-r1 --> 0.3.8-r1*
* *turtle-tf2-cpp 0.3.4-r1 --> 0.3.5-r1*
* *turtle-tf2-py 0.3.4-r1 --> 0.3.5-r1*
* *v4l2-camera 0.4.0-r1 --> 0.5.0-r1*

Galactic Changes:
-----------------
* *depthai 2.17.0-r1 --> 2.17.3-r1*
* *eigenpy 2.7.12-r1 --> 2.7.13-r1*
* *geometry-tutorials 0.3.4-r1 --> 0.3.5-r1*
* *pal-statistics 2.1.1-r1 --> 2.1.2-r1*
* *pal-statistics-msgs 2.1.1-r1 --> 2.1.2-r1*
* *pose-cov-ops 0.3.6-r1 --> 0.3.8-r1*
* *rplidar-ros 2.0.3-r1 --> 2.1.0-r1*
* *turtle-tf2-cpp 0.3.4-r1 --> 0.3.5-r1*
* *turtle-tf2-py 0.3.4-r1 --> 0.3.5-r1*

Humble Changes:
---------------
* *depthai 2.17.0-r1 --> 2.17.3-r1*
* *pal-statistics 2.1.3-r1*
* *pal-statistics-msgs 2.1.3-r1*
* *pose-cov-ops 0.3.6-r1 --> 0.3.8-r1*
* *rcl 5.3.1-r1 --> 5.3.2-r1*
* *rcl-action 5.3.1-r1 --> 5.3.2-r1*
* *rcl-lifecycle 5.3.1-r1 --> 5.3.2-r1*
* *rcl-yaml-param-parser 5.3.1-r1 --> 5.3.2-r1*
* *v4l2-camera 0.4.0-r1 --> 0.6.0-r1*

Melodic Changes:
----------------
* *dynamic-graph 4.4.0-r1 --> 4.4.3-r2*
* *dynamic-graph-python 4.0.4-r1 --> 4.0.9-r1*
* *dynamic-graph-tutorial 1.2.2-r1 --> 1.3.5-r1*
* *eigenpy 2.7.5-r1 --> 2.7.13-r1*
* *eiquadprog 1.2.3-r1 --> 1.2.4-r1*
* *franka-control 0.9.0-r1 --> 0.10.0-r1*
* *franka-description 0.9.0-r1 --> 0.10.0-r1*
* *franka-example-controllers 0.9.0-r1 --> 0.10.0-r1*
* *franka-gazebo 0.9.0-r1 --> 0.10.0-r1*
* *franka-gripper 0.9.0-r1 --> 0.10.0-r1*
* *franka-hw 0.9.0-r1 --> 0.10.0-r1*
* *franka-msgs 0.9.0-r1 --> 0.10.0-r1*
* *franka-ros 0.9.0-r1 --> 0.10.0-r1*
* *franka-visualization 0.9.0-r1 --> 0.10.0-r1*
* *marti-data-structures 2.14.2-r1 --> 2.15.2-r1*
* *mocap-nokov 0.0.2-r2 --> 0.0.3-r1*
* *naoqi-driver 0.5.11 --> 0.5.12-r1*
* *pose-cov-ops 0.3.7-r1 --> 0.3.8-r1*
* *pr2-common 1.12.4-r1 --> 1.13.1-r1*
* *pr2-dashboard-aggregator 1.12.4-r1 --> 1.13.1-r1*
* *pr2-description 1.12.4-r1 --> 1.13.1-r1*
* *pr2-machine 1.12.4-r1 --> 1.13.1-r1*
* *pr2-msgs 1.12.4-r1 --> 1.13.1-r1*
* *qb-device 2.0.1 --> 3.0.5-r1*
* *qb-device-bringup 2.0.1 --> 3.0.5-r1*
* *qb-device-control 2.0.1 --> 3.0.5-r1*
* *qb-device-description 2.0.1 --> 3.0.5-r1*
* *qb-device-driver 2.0.1 --> 3.0.5-r1*
* *qb-device-gazebo 3.0.4-r3 --> 3.0.5-r1*
* *qb-device-hardware-interface 2.0.1 --> 3.0.5-r1*
* *qb-device-msgs 2.0.1 --> 3.0.5-r1*
* *qb-device-srvs 2.0.1 --> 3.0.5-r1*
* *qb-device-utils 2.0.1 --> 3.0.5-r1*
* *sot-core 4.11.6-r1 --> 4.11.8-r1*
* *sot-dynamic-pinocchio 3.6.3-r1 --> 3.6.5-r1*
* *sot-tools 2.3.4-r1 --> 2.3.5-r1*
* *swri-cli-tools 2.15.2-r1*
* *swri-console-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-dbw-interface 2.14.2-r1 --> 2.15.2-r1*
* *swri-geometry-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-image-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-math-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-nodelet 2.14.2-r1 --> 2.15.2-r1*
* *swri-opencv-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-prefix-tools 2.14.2-r1 --> 2.15.2-r1*
* *swri-roscpp 2.14.2-r1 --> 2.15.2-r1*
* *swri-rospy 2.14.2-r1 --> 2.15.2-r1*
* *swri-route-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-serial-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-string-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-system-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-transform-util 2.14.2-r1 --> 2.15.2-r1*
* *swri-yaml-util 2.14.2-r1 --> 2.15.2-r1*

Noetic Changes:
---------------
* *aruco-opencv 0.1.0-r1 --> 0.2.0-r1*
* *aruco-opencv-msgs 0.2.0-r1*
* *bosch-locator-bridge 1.0.6-r1 --> 1.0.7-r1*
* *cv-bridge 1.16.0-r1 --> 1.16.1-r1*
* *depthai 2.17.0-r1 --> 2.17.3-r2*
* *dynamic-graph 4.4.0-r1 --> 4.4.3-r2*
* *dynamic-graph-python 4.0.4-r1 --> 4.0.9-r1*
* *dynamic-graph-tutorial 1.3.2-r1 --> 1.3.5-r1*
* *eigenpy 2.7.12-r1 --> 2.7.13-r1*
* *eiquadprog 1.2.3-r1 --> 1.2.4-r1*
* *franka-control 0.9.1-r1 --> 0.10.0-r1*
* *franka-description 0.9.1-r1 --> 0.10.0-r1*
* *franka-example-controllers 0.9.1-r1 --> 0.10.0-r1*
* *franka-gazebo 0.9.1-r1 --> 0.10.0-r1*
* *franka-gripper 0.9.1-r1 --> 0.10.0-r1*
* *franka-hw 0.9.1-r1 --> 0.10.0-r1*
* *franka-msgs 0.9.1-r1 --> 0.10.0-r1*
* *franka-ros 0.9.1-r1 --> 0.10.0-r1*
* *franka-visualization 0.9.1-r1 --> 0.10.0-r1*
* *image-geometry 1.16.0-r1 --> 1.16.1-r1*
* *iris-lama 1.3.0-r1 --> 1.3.1-r1*
* *mocap-nokov 0.0.2-r1 --> 0.0.3-r1*
* *nao-meshes 0.1.13*
* *naoqi-bridge-msgs 0.0.9-r1*
* *pepper-meshes 0.2.5*
* *pose-cov-ops 0.3.7-r1 --> 0.3.8-r1*
* *pr2-common 1.13.0-r1 --> 1.13.1-r1*
* *pr2-dashboard-aggregator 1.13.0-r1 --> 1.13.1-r1*
* *pr2-description 1.13.0-r1 --> 1.13.1-r1*
* *pr2-machine 1.13.0-r1 --> 1.13.1-r1*
* *pr2-msgs 1.13.0-r1 --> 1.13.1-r1*
* *qb-device 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-bringup 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-control 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-description 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-driver 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-gazebo 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-hardware-interface 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-msgs 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-srvs 3.0.4-r1 --> 3.0.5-r1*
* *qb-device-utils 3.0.4-r1 --> 3.0.5-r1*
* *rm-common 0.1.13-r1 --> 0.1.15-r1*
* *rm-control 0.1.13-r1 --> 0.1.15-r1*
* *rm-dbus 0.1.13-r1 --> 0.1.15-r1*
* *rm-gazebo 0.1.13-r1 --> 0.1.15-r1*
* *rm-hw 0.1.13-r1 --> 0.1.15-r1*
* *rm-msgs 0.1.13-r1 --> 0.1.15-r1*
* *sot-core 4.11.6-r1 --> 4.11.8-r1*
* *sot-dynamic-pinocchio 3.6.3-r1 --> 3.6.5-r1*
* *sot-tools 2.3.4-r1 --> 2.3.5-r1*
* *vision-opencv 1.16.0-r1 --> 1.16.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] flite
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] libzmqpp-dev
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-xdot
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pysnmp
 * [ ] python3-rosdep
 * [ ] python3-rtree
 * [ ] python3-scp
 * [ ] python3-typeguard
 * [ ] python3-websocket
 * [ ] python3-xdot
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

