### PR TITLE
Update renamed Python dependencies

### DIFF
--- a/distros/foxy/tracetools-test/default.nix
+++ b/distros/foxy/tracetools-test/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config ];
-  checkInputs = [ ament-cmake-gtest ament-cmake-mypy ament-cmake-pytest ament-lint-auto ament-lint-common launch-ros python3Packages.pytestcov pythonPackages.pytest tracetools tracetools-launch tracetools-read ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-mypy ament-cmake-pytest ament-lint-auto ament-lint-common launch-ros python3Packages.pytest-cov pythonPackages.pytest tracetools tracetools-launch tracetools-read ];
   propagatedBuildInputs = [ rclcpp std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 

--- a/distros/galactic/tracetools-test/default.nix
+++ b/distros/galactic/tracetools-test/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config ];
-  checkInputs = [ ament-cmake-gtest ament-cmake-mypy ament-cmake-pytest ament-lint-auto ament-lint-common launch-ros python3Packages.pytestcov pythonPackages.pytest tracetools tracetools-launch tracetools-read ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-mypy ament-cmake-pytest ament-lint-auto ament-lint-common launch-ros python3Packages.pytest-cov pythonPackages.pytest tracetools tracetools-launch tracetools-read ];
   propagatedBuildInputs = [ lifecycle-msgs rclcpp rclcpp-lifecycle std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 

--- a/distros/melodic/pilz-store-positions/default.nix
+++ b/distros/melodic/pilz-store-positions/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin roslint std-msgs ];
-  checkInputs = [ code-coverage pythonPackages.mock pythonPackages.pytestcov ros-pytest rostest visualization-msgs ];
+  checkInputs = [ code-coverage pythonPackages.mock pythonPackages.pytest-cov ros-pytest rostest visualization-msgs ];
   propagatedBuildInputs = [ geometry-msgs libyaml rospy tf2-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/ros-pytest/default.nix
+++ b/distros/noetic/ros-pytest/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ python3Packages.pytestcov pythonPackages.pytest rospy ];
+  propagatedBuildInputs = [ python3Packages.pytest-cov pythonPackages.pytest rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/pkgs/colcon/core.nix
+++ b/pkgs/colcon/core.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonApplication, buildPythonPackage, makeWrapper, fetchPypi
 , isPy27, python, distlib, empy, pytest, pytest-cov, pytest-repeat
-, pytest-rerunfailures, pytestrunner }:
+, pytest-rerunfailures, pytest-runner }:
 
 let
   withExtensions = extensions: buildPythonApplication {
@@ -36,7 +36,7 @@ let
       pytest-cov
       pytest-repeat
       pytest-rerunfailures
-      pytestrunner
+      pytest-runner
     ];
 
     # Requires unpackaged dependencies

--- a/pkgs/colcon/core.nix
+++ b/pkgs/colcon/core.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonApplication, buildPythonPackage, makeWrapper, fetchPypi
-, isPy27, python, distlib, empy, pytest, pytestcov, pytest-repeat
+, isPy27, python, distlib, empy, pytest, pytest-cov, pytest-repeat
 , pytest-rerunfailures, pytestrunner }:
 
 let
@@ -33,7 +33,7 @@ let
       distlib
       empy
       pytest
-      pytestcov
+      pytest-cov
       pytest-repeat
       pytest-rerunfailures
       pytestrunner


### PR DESCRIPTION
Packages `pytestcov` and `pytestrunner` have been renamed in nixpkgs to `pytest-cov` and `pytest-runner`.
When using a package that depends on them, the following error output is displayed:
```
error: 'pytestrunner' has been renamed to/replaced by 'pytest-runner'
```
```
error: 'pytestrunner' has been renamed to/replaced by 'pytest-runner'
```
---
This PR renames all references (that I could find) to their updated name.

Thanks for all your work on this overlay, it really is amazing.