### PR TITLE
ignition.transport: Fix underlinking

### DIFF
--- a/pkgs/ignition/transport/default.nix
+++ b/pkgs/ignition/transport/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, ignition, ignition-cmake ? ignition.cmake
 , ignition-math ? ignition.math, ignition-msgs ? ignition.msgs
-, ignition-utils ? ignition.utils, protobuf, libuuid, sqlite, cppzmq, zeromq
+, ignition-utils ? ignition.utils, protobuf, libuuid, sqlite, libsodium, cppzmq, zeromq
 , majorVersion ? "11"
 , version ? "11.1.0"
 , srcHash ? "sha256-bOsulr8O5sRJ3XAQOP9xWCgoXqEH6M+IEFa0Sx6vze0="
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   propagatedNativeBuildInputs = [ ignition-cmake ];
-  buildInputs = [ ignition-math sqlite ]
+  buildInputs = [ ignition-math sqlite libsodium ]
     ++ lib.optional (lib.versionAtLeast version "5") ignition-utils;
   propagatedBuildInputs = [ protobuf cppzmq zeromq libuuid ignition-msgs ];
 


### PR DESCRIPTION
Building a program depending on ignition-transport would fail with underlinking:

	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: warning: libsodium.so.23, needed by /nix/store/nfv1rmk3ah4dy81qnshylwibbn7dpxb6-ignition-transport8-8.3.0/lib/libignition-transport8.so.8, not found (try using -rpath or -rpath-link)
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box_open'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box_open_afternm'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box_afternm'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box_beforenm'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box_easy_afternm'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `randombytes'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_secretbox_open'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `sodium_allocarray'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_secretbox'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `sodium_free'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `sodium_init'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_scalarmult_base'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box_open_easy_afternm'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `randombytes_close'
	/nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/a51pkq1ikrd3blpq1h7gwzaf4nw8az88-zeromq-4.3.4/lib/libzmq.so.5: undefined reference to `crypto_box_keypair'
	collect2: error: ld returned 1 exit status
