### PR TITLE
rosdistro sync, Fri Dec 16 13:23:45 2022

### DIFF
--- a/distros/foxy/aruco-opencv-msgs/default.nix
+++ b/distros/foxy/aruco-opencv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-aruco-opencv-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/foxy/aruco_opencv_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c9f73d39eb28e060278c88613caaaefb917492bb303e0c23506cc3258cc29c85";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Message definitions for aruco_opencv package.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/aruco-opencv/default.nix
+++ b/distros/foxy/aruco-opencv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, aruco-opencv-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-aruco-opencv";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/foxy/aruco_opencv/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "662d8bf61232491d19bc521f2d96aa07af6a5fe2330f5a0e5a97a852df9d2bb6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ArUco marker detection using aruco module from OpenCV libraries.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/find-object-2d/default.nix
+++ b/distros/foxy/find-object-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, cv-bridge, geometry-msgs, image-transport, message-filters, qt5, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-find-object-2d";
+  version = "0.7.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/foxy/find_object_2d/0.7.0-3.tar.gz";
+    name = "0.7.0-3.tar.gz";
+    sha256 = "4d0ccbadb0b7d4240396631c5ba7c808d3f0f7e5b08a6c05ad5bb1a5e811f973";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge geometry-msgs image-transport message-filters qt5.qtbase rclcpp rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The find_object_2d package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -144,6 +144,10 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ aruco-opencv = self.callPackage ./aruco-opencv {};
+
+ aruco-opencv-msgs = self.callPackage ./aruco-opencv-msgs {};
+
  asio-cmake-module = self.callPackage ./asio-cmake-module {};
 
  astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
@@ -535,6 +539,8 @@ self: super: {
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
  filters = self.callPackage ./filters {};
+
+ find-object-2d = self.callPackage ./find-object-2d {};
 
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
@@ -1987,6 +1993,8 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur-bringup = self.callPackage ./ur-bringup {};
+
+ ur-calibration = self.callPackage ./ur-calibration {};
 
  ur-client-library = self.callPackage ./ur-client-library {};
 

--- a/distros/foxy/hpp-fcl/default.nix
+++ b/distros/foxy/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/foxy/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "71cb9ea7481453088cb4c805be8fac78599b6ea96a606845b83c7c9b6c4d87d1";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/foxy/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b4296473da19156f008e0de41bee793a9f140b146752b1ea3167e2e822842d09";
   };
 
   buildType = "cmake";

--- a/distros/foxy/leo-viz/default.nix
+++ b/distros/foxy/leo-viz/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/foxy/leo_viz/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "f1fe34a25448ceb368f97f35618d6f91c61ac2acb43238151bb63cf6d73c47aa";
+    sha256 = "043b980487e2e2da5b3b3b9e630b9ae36384d6c9a8425202c2d5548cf84ec087";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-dragway/default.nix
+++ b/distros/foxy/maliput-dragway/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, python3, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-maliput-dragway";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "7f525c51c1ec61da22b6b35010fec6c1daffc69f83b3c6201ff7cbd980512c4d";
+    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "cc347a1c58da21b7e55b1e9f10b68da0d7bce79628cbb1f8794bde2c0d2076a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-integration/default.nix
+++ b/distros/foxy/maliput-integration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-pytest, gflags, libyamlcpp, maliput, maliput-dragway, maliput-malidrive, maliput-multilane, maliput-object, maliput-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-pytest, gflags, libyamlcpp, maliput, maliput-dragway, maliput-malidrive, maliput-multilane, maliput-object, maliput-osm, maliput-py, maliput-sparse }:
 buildRosPackage {
   pname = "ros-foxy-maliput-integration";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "ed3c28adc54486b0d7b55cca3b9608f28a5a4f8b2df4cd8eb5d7104625648b2c";
+    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "c5bc9aab2aaa380b1002189e22b2890a15a9ea06116fbf0ef7b40cbcc59086c6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ gflags libyamlcpp maliput maliput-dragway maliput-malidrive maliput-multilane maliput-object maliput-py ];
+  propagatedBuildInputs = [ gflags libyamlcpp maliput maliput-dragway maliput-malidrive maliput-multilane maliput-object maliput-osm maliput-py maliput-sparse ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/maliput-malidrive/default.nix
+++ b/distros/foxy/maliput-malidrive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, fmt, maliput, maliput-drake, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-maliput-malidrive";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "f41692153765780d42d64711bb2a9ad67f4cc0b630bea1d253f3dad5bd90c8f8";
+    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "7db77cbb7a3ca75c56ebfd8eee378a7460e95f2cc215964fe23f2ad5908d2f9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
 buildRosPackage {
   pname = "ros-foxy-maliput-multilane";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "f4baa1a87ada1ddea559cbc8702297cad292b0c1ec293b57f1dca77f568f95f8";
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "3424358c4da51208c068e5e67155ca33cd2f7ffdad75ba973d7b9ad8dd1b3934";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-osm/default.nix
+++ b/distros/foxy/maliput-osm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, lanelet2-io, maliput, maliput-sparse }:
 buildRosPackage {
   pname = "ros-foxy-maliput-osm";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_osm-release/archive/release/foxy/maliput_osm/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "0dc54efc50f858aa408a59f477db642225cdb630067df2c6191b77c87dc6ec94";
+    url = "https://github.com/ros2-gbp/maliput_osm-release/archive/release/foxy/maliput_osm/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "1d4efc868d03997316e661e78c48942dc6e17f0f8288e7a626d05edecb515afd";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''Maliput backend for loading lanelet2-based osm maps.'';
-    license = with lib.licenses; [ "BSD-Clause-3" ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/foxy/maliput-sparse/default.nix
+++ b/distros/foxy/maliput-sparse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, maliput }:
 buildRosPackage {
   pname = "ros-foxy-maliput-sparse";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_sparse-release/archive/release/foxy/maliput_sparse/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "5bdf9754568dd8b22690b9ca45da393f8cc8da944096610a222e5e4a654ce361";
+    url = "https://github.com/ros2-gbp/maliput_sparse-release/archive/release/foxy/maliput_sparse/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "dc5726126f02af283be9ac58cfe10a4810a2b9cf9a30de783a20ef4bf75cac5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rtabmap-ros/default.nix
+++ b/distros/foxy/rtabmap-ros/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, ros-environment, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rtabmap-ros";
-  version = "0.20.20-r1";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/foxy/rtabmap_ros/0.20.20-1.tar.gz";
-    name = "0.20.20-1.tar.gz";
-    sha256 = "fdbc66f0c1e5bf6236f6b1b3ff75acf73250488618657fa207bdc1c6bbb60a9c";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/foxy/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "2d10f8270356d9768f39d97a3e48438bd79e83a86f93aa4f78ebf4a336e816f2";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pcl rosidl-default-generators ];
+  buildInputs = [ ament-cmake ament-cmake-python pcl ros-environment rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces class-loader compressed-depth-image-transport compressed-image-transport cv-bridge geometry-msgs image-geometry image-transport laser-geometry message-filters nav-msgs nav2-common nav2-msgs octomap octomap-msgs pcl-conversions pluginlib rclcpp rclcpp-components rclpy rosgraph-msgs rosidl-default-runtime rtabmap rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs std-srvs stereo-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros visualization-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''RTAB-Map's ros-pkg. RTAB-Map is a RGB-D SLAM approach with real-time constraints.'';

--- a/distros/foxy/ur-bringup/default.nix
+++ b/distros/foxy/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, controller-manager, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, moveit-ros-move-group, moveit-simple-controller-manager, robot-state-publisher, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-bringup";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_bringup/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "abb4c199aa880f10d34ac99a798c60bc0e3c232f1dc775bbc2df75a8798e08be";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_bringup/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "7dafb1e9059c5e11be824334c7011c00d3552204ac5a3f502ea5d6591a9a1d46";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-calibration/default.nix
+++ b/distros/foxy/ur-calibration/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
+buildRosPackage {
+  pname = "ros-foxy-ur-calibration";
+  version = "2.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_calibration/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "45d2918cd9139d2b3271fc07c31529a6f84ae2d82bf84c05436615f6dc5ca538";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen libyamlcpp rclcpp ur-client-library ur-robot-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for extracting the factory calibration from a UR robot and change it such that it can be used by ur_description to gain a correct URDF'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/ur-controllers/default.nix
+++ b/distros/foxy/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ur-controllers";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_controllers/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "504e4388ae67a2b0c2e973b8612cd06c6c0e9d63b80234ca93133f9829414ac1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_controllers/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "af2d3866838b85de7c16d8399f090535f7789199cfd5a110bb7870fd4a866b01";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-dashboard-msgs/default.nix
+++ b/distros/foxy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-ur-dashboard-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_dashboard_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "26d405770c4d0dc9c24a19672b8eb4be60c5432e309dd5eb425e1311f7ccfab5";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_dashboard_msgs/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "249d0c38e3912e89cf472fc47c98318c28d0fe547d94d8a7c79fddef6b98a370";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-description/default.nix
+++ b/distros/foxy/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, launch, launch-ros, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-description";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_description/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "164e84cc2c3bf21047765f0b08c9482f779e7e9d92dc4b18263798edd4f78528";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_description/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "01f4db0ef0116f3f60d0c41ded738da68b3625cbb8859628b581442497c2d0c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-moveit-config/default.nix
+++ b/distros/foxy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-kinematics, moveit-planners-ompl, moveit-ros-visualization, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-moveit-config";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_moveit_config/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "657a1bb747f891bb180aeb4fb01b87b642d859f19aeb517ec9f70ef1710eb29d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_moveit_config/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "8ab9b671f0e3eebc811e21f8924417313dfab467bbf60861d6eab6a293c14eb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-robot-driver/default.nix
+++ b/distros/foxy/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, rclpy, std-msgs, std-srvs, ur-bringup, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ur-robot-driver";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_robot_driver/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "41eaa6477f3c1c3e709b144f5f4febe3cc5a5c5c669d91fb55109b6ebfbe37f3";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_robot_driver/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "aabafe12862568360b9af51e65084913c773119b362393f1a7172f0e4e878d1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "7fb7206bd77168bb7db1469e0583208abb1856670c9fc1984a7cf4143b4102f2";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "f24594342f96c3d9cb39c9b3b672c6ef3e41e29169ac9303dd2ee7f071a94e2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hpp-fcl/default.nix
+++ b/distros/humble/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "da835d11bed0eaeb08dcf667bc6bc6e73a3cc4d388c769c2eb440b797ff12016";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "4bb0dba653f59122623445b11a2c09cc6e96b63d21a570f6767be7ea665ae3d3";
   };
 
   buildType = "cmake";

--- a/distros/humble/magic-enum/default.nix
+++ b/distros/humble/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-humble-magic-enum";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "da533032dd091e7c8414799d79cfb5b6d913b819e2629d22dc308952fbbb7ad4";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "1a9b5fdd097bba70f0c5ecebcaba35227e41f4066b51bca197f41ad9e974e45c";
   };
 
   buildType = "cmake";

--- a/distros/humble/rtabmap-ros/default.nix
+++ b/distros/humble/rtabmap-ros/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, ros-environment, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, ros-environment, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-ros";
-  version = "0.20.20-r2";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.20.20-2.tar.gz";
-    name = "0.20.20-2.tar.gz";
-    sha256 = "cb56154449de5964d15556f390054bed69a801a41d4e028af8d0d9b840062787";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "862a4619a3f25e8d7abd8b817a9172ea1fd8384dd042db0d59f0198d6a17ba9b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pcl ros-environment rosidl-default-generators ];
+  buildInputs = [ ament-cmake ament-cmake-python pcl ros-environment rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces class-loader compressed-depth-image-transport compressed-image-transport cv-bridge geometry-msgs image-geometry image-transport laser-geometry message-filters nav-msgs nav2-common nav2-msgs octomap octomap-msgs pcl-conversions pluginlib rclcpp rclcpp-components rclpy rosgraph-msgs rosidl-default-runtime rtabmap rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs std-srvs stereo-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros visualization-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''RTAB-Map's ros-pkg. RTAB-Map is a RGB-D SLAM approach with real-time constraints.'';

--- a/distros/humble/simple-term-menu-vendor/default.nix
+++ b/distros/humble/simple-term-menu-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-simple-term-menu-vendor";
-  version = "1.5.4-r1";
+  version = "1.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/simple_term_menu_vendor-release/archive/release/humble/simple_term_menu_vendor/1.5.4-1.tar.gz";
-    name = "1.5.4-1.tar.gz";
-    sha256 = "5bb5f723b52aa72ebde2a06c4f13ab65bac8ec49395d7b791d2263351eeb6074";
+    url = "https://github.com/clearpath-gbp/simple_term_menu_vendor-release/archive/release/humble/simple_term_menu_vendor/1.5.5-1.tar.gz";
+    name = "1.5.5-1.tar.gz";
+    sha256 = "c6c3e381e8c43f5affa69e1820458ba56abbf142466ad5b375e2cc58b3846541";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''A Python package which creates simple interactive menus on the command line.'';

--- a/distros/melodic/find-object-2d/default.nix
+++ b/distros/melodic/find-object-2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-find-object-2d";
-  version = "0.6.4-r2";
+  version = "0.7.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/find_object_2d-release/archive/release/melodic/find_object_2d/0.6.4-2.tar.gz";
-    name = "0.6.4-2.tar.gz";
-    sha256 = "bb19a36951a2bd531bd45af05d8b1a98084eb5eb3042f700f9bc7e77260d9648";
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/melodic/find_object_2d/0.7.0-2.tar.gz";
+    name = "0.7.0-2.tar.gz";
+    sha256 = "bd49b707c52b9c3bbc257f082562beb25139a89572bb87f531f795b6b8edacb9";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ cv-bridge image-transport message-filters message-runtime qt5.qtbase roscpp rospy sensor-msgs std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-transport message-filters message-runtime qt5.qtbase roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/foxglove-bridge/default.nix
+++ b/distros/melodic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-melodic-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "f9b234563a407c0e4205f968d5c2ab49ccb435a59c6f04ad9d9ba89b306ae1ce";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "bff9c1a2651cacd73e4020a5412bf4cb7dd6043d0c3b2de84862a6c635f15028";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hpp-fcl/default.nix
+++ b/distros/melodic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "e3721312c1b3ae8bd2598a6a395fbe851c071c2a6e06dd2e39a7eb65c6d673c4";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6bcc4bea9886c332a57db218d8767e49524a8984bb8623d13bee3184e5ae672b";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mapviz-plugins/default.nix
+++ b/distros/melodic/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt5, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mapviz-plugins";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz_plugins/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "8b6e1b1021f5ec7a2cfd911371375422a4824bdc632885e76f8233e36d28a93c";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz_plugins/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "2afe3c84ce13234d9940c410214ba6f6ca4e260d422141c9f476d94c3b64025a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mapviz/default.nix
+++ b/distros/melodic/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, freeglut, glew, image-transport, marti-common-msgs, message-generation, message-runtime, pkg-config, pluginlib, qt5, rosapi, roscpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-transform-util, swri-yaml-util, tf, xorg }:
 buildRosPackage {
   pname = "ros-melodic-mapviz";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "ca4b2e993f0e850ce5af70045fc0372bc65d3bce7b286d4a1f2ab6a5aec8c49d";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "3bb76b8171a87c65566aa6e2f6ae5140c6f2b20553d66189d11b0e2c6fd085c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/multires-image/default.nix
+++ b/distros/melodic/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gps-common, mapviz, pluginlib, qt5, roscpp, rospy, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-melodic-multires-image";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/multires_image/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "566978f405d258ba5c807dbf25edcd2a438061545c51b54cad478140a7fb6b13";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/multires_image/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "f915a51c4f1ecf3ef912fd59b1391248f355405e0a77c7694801bc61befccb44";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rtabmap-ros/default.nix
+++ b/distros/melodic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rtabmap-ros";
-  version = "0.20.20-r1";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.20-1.tar.gz";
-    name = "0.20.20-1.tar.gz";
-    sha256 = "10e72afaf27e3685fdbeec4880a72285acf2c80df12185f3a657ce7855d3b99d";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "7b38d0cf63f57c6e08c12dc01439f1f2e28a95564c67cec9419bcb5fe2bc9f15";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tile-map/default.nix
+++ b/distros/melodic/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, glew, jsoncpp, mapviz, pluginlib, qt5, roscpp, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-melodic-tile-map";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/tile_map/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "308fd95d57644bbffe9aead80823c17cc1d58ac8a8a3e9092addc3292d464d2a";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/tile_map/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "b8dff88df9fe3838b14c477a6d9ac3ae00085e8deb0b7d58ddd37130e32582f4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/vector-map-msgs/default.nix
+++ b/distros/melodic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "121a81bc986a40e9e83e28737b74241bdf9332c0f95e1ea42c3deb03aeb4a8b7";
+    sha256 = "116c8842e3f610f9c6c59fe5db04d2f6cf998a11fb1f85bcb8748cfe247490ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/boost-plugin-loader/default.nix
+++ b/distros/noetic/boost-plugin-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtest, ros-industrial-cmake-boilerplate }:
 buildRosPackage {
   pname = "ros-noetic-boost-plugin-loader";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tesseract-robotics-release/boost_plugin_loader-release/archive/release/noetic/boost_plugin_loader/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "304122a4b9423b6512662cadb878f0ad355a5574b77b81715302f4349a59018c";
+    url = "https://github.com/tesseract-robotics-release/boost_plugin_loader-release/archive/release/noetic/boost_plugin_loader/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "5b25d104c423656c625823667d299ab922c345f0aacdd9de0f1c4e16381e3951";
   };
 
   buildType = "cmake";

--- a/distros/noetic/find-object-2d/default.nix
+++ b/distros/noetic/find-object-2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-find-object-2d";
-  version = "0.6.3-r5";
+  version = "0.7.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/find_object_2d-release/archive/release/noetic/find_object_2d/0.6.3-5.tar.gz";
-    name = "0.6.3-5.tar.gz";
-    sha256 = "a8e5130cd08ff78be8b6837bf44e8474bd5637e58af118ff9b4f7f193119d25c";
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/noetic/find_object_2d/0.7.0-2.tar.gz";
+    name = "0.7.0-2.tar.gz";
+    sha256 = "704099801e897cec9bb812ca9e1ec89ab4d586ee8adb8427a07caa4a318be6b4";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ cv-bridge image-transport message-filters message-runtime qt5.qtbase roscpp rospy sensor-msgs std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-transport message-filters message-runtime qt5.qtbase roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "540a6a8e96dbe6c8477d769ff23d5ea766c4ac74df0b6063f4d60a66ec4f2e57";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "abf7487e53c5a0e4d2c07b0bb38bfdd641c02fc87fb69e0123eca0e4939d2733";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hpp-fcl/default.nix
+++ b/distros/noetic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "db5942833a159bd2e01ca70be38173d41f3f2f1dda2994db75008456c312b242";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "66aaa2fb542f7619cfa86943f41c932deb3bd479d956ef877313411c4a71b1c8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/magic-enum/default.nix
+++ b/distros/noetic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-magic-enum";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c8535eb03907e53c67e80e5252c64d1a832b39be5f655464da9fe5f7f5ff8711";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "61de1b8f2efbce9574758aaaa3fb54128a78f93caa2d0c06f6d2e7815756811d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mapviz-plugins/default.nix
+++ b/distros/noetic/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt5, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mapviz-plugins";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz_plugins/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "9725c95f637969dbcba301a892b89133500331980fd639e08efba8478d423bed";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz_plugins/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "4c2972160dc7a5fd7858760b98b68f0a87c185d6c1926be7983162d83d447129";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mapviz/default.nix
+++ b/distros/noetic/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, freeglut, glew, image-transport, marti-common-msgs, message-generation, message-runtime, pkg-config, pluginlib, qt5, rosapi, roscpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-transform-util, swri-yaml-util, tf, xorg }:
 buildRosPackage {
   pname = "ros-noetic-mapviz";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "9117c574ec2db3bdec3a33e14ea06b04113e8bd3a6e0c9d7b7b3a454c256567b";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "46114381cfdbe6e838810c21ed5994d4a91669c6a7d038b72de21522a8ce2787";
   };
 
   buildType = "catkin";

--- a/distros/noetic/multires-image/default.nix
+++ b/distros/noetic/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gps-common, mapviz, pluginlib, qt5, roscpp, rospy, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-noetic-multires-image";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/multires_image/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "cb7ef6ab42f6ad715cf1e2e7ffc02862c4b4d599ba8ed38133a02fa0c7e1116a";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/multires_image/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "99f107b5e3dd220a36b74628fc7a29f16bd979dc94d28e4ad823a38f280768ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-human-radar/default.nix
+++ b/distros/noetic/rqt-human-radar/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rqt-gui, rqt-gui-cpp }:
+{ lib, buildRosPackage, fetchurl, catkin, hri, qt5, roscpp, rqt-gui, rqt-gui-cpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-rqt-human-radar";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/rqt_human_radar-release/archive/release/noetic/rqt_human_radar/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "778fad637e30634d4c5412aac8dc4e7a97866870d663c6f89902fb1fe8afeaa0";
+    url = "https://github.com/ros4hri/rqt_human_radar-release/archive/release/noetic/rqt_human_radar/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "6a0e5059377c856f35ce5eeb0fb1338ea03e1b31c1ff47fbbaffe843f0df913a";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
-  propagatedBuildInputs = [ rqt-gui rqt-gui-cpp ];
+  buildInputs = [ catkin roscpp ];
+  propagatedBuildInputs = [ hri qt5.qtbase qt5.qtsvg rqt-gui rqt-gui-cpp tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rtabmap-ros/default.nix
+++ b/distros/noetic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-ros";
-  version = "0.20.20-r1";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.20-1.tar.gz";
-    name = "0.20.20-1.tar.gz";
-    sha256 = "5b1ea636c14d342e8d41968021a2c0530158dc7337b541f0d7411d40b56a4ede";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "1922d8de7460bdcb8a073595f28c50e3be3fae773e41061d5e03a706996751b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tile-map/default.nix
+++ b/distros/noetic/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, glew, jsoncpp, mapviz, pluginlib, qt5, roscpp, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-noetic-tile-map";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/tile_map/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "50c04b7b4f00b808c329d3d161ba2ada5155278071db1bafda5edec95e4559d4";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/tile_map/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "2c4ecc0cd98353b953027598473433fa7e37f5516fc4cab995098980ca4e18af";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vector-map-msgs/default.nix
+++ b/distros/noetic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "4132fc88a828774dc43bac8d108aed130622159af96ab717a8a0c8464929a65f";
+    sha256 = "870df6369942aa12d4c13eca898c481571bb2464d0333c56258e2f2498c8eded";
   };
 
   buildType = "catkin";

--- a/distros/rolling/aruco-opencv-msgs/default.nix
+++ b/distros/rolling/aruco-opencv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-aruco-opencv-msgs";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv_msgs/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "8c0c68f242ed89c595abbb0180dd32febcf9ac61675a4bac4d87c23dac75996f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message definitions for aruco_opencv package.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/aruco-opencv/default.nix
+++ b/distros/rolling/aruco-opencv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, aruco-opencv-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-aruco-opencv";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "91a2d2635c9d22069b85a6c14220d8124ee94eb1e94701ed81828407425b19bc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ArUco marker detection using aruco module from OpenCV libraries.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "1fb1f5719608cc9880697de13e622632b42f4e8d1699b99dd591ff55eabb86af";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "6725f9692a22c0789e44acfa22df5227ff65a4e86542f578dcd938dcbedf8560";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -154,6 +154,10 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ aruco-opencv = self.callPackage ./aruco-opencv {};
+
+ aruco-opencv-msgs = self.callPackage ./aruco-opencv-msgs {};
+
  asio-cmake-module = self.callPackage ./asio-cmake-module {};
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
@@ -1653,6 +1657,8 @@ self: super: {
  transmission-interface = self.callPackage ./transmission-interface {};
 
  tricycle-controller = self.callPackage ./tricycle-controller {};
+
+ turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/rolling/hpp-fcl/default.nix
+++ b/distros/rolling/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "012f15eb4e5bdb70d724bad0f7c122c4bda9b126117f3911f49ba5680a2f5f7c";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5816642c80a414c2c9aede70f50438c137b8d8ff156bfc24d8710d517fb07445";
   };
 
   buildType = "cmake";

--- a/distros/rolling/turbojpeg-compressed-image-transport/default.nix
+++ b/distros/rolling/turbojpeg-compressed-image-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libjpeg_turbo }:
+buildRosPackage {
+  pname = "ros-rolling-turbojpeg-compressed-image-transport";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release/archive/release/rolling/turbojpeg_compressed_image_transport/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "9a7b57d259cdc07818c669af5de471b764d7f3f2828b84f0669cd05ce3c0f065";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-transport libjpeg_turbo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Compressed_image_transport provides a plugin to image_transport for transparently sending images
+    encoded as JPEG by turbojpeg.'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'humble', 'melodic', 'noetic', 'rolling'] from nix-ros-overlay commit 795e67fe0e19118cef94209e4470edc64f13df93.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *aruco-opencv 1.0.0-r1*
* *aruco-opencv-msgs 1.0.0-r1*
* *find-object-2d 0.7.0-r3*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *maliput-dragway 0.1.3-r1 --> 0.1.4-r1*
* *maliput-integration 0.1.3-r1 --> 0.1.4-r1*
* *maliput-malidrive 0.1.3-r1 --> 0.1.4-r1*
* *maliput-multilane 0.1.3-r1 --> 0.1.4-r1*
* *maliput-osm 0.1.0-r1 --> 0.2.0-r1*
* *maliput-sparse 0.1.0-r1 --> 0.2.0-r1*
* *rtabmap-ros 0.20.20-r1 --> 0.20.22-r1*
* *ur-bringup 2.0.1-r1 --> 2.0.2-r2*
* *ur-calibration 2.0.2-r2*
* *ur-controllers 2.0.1-r1 --> 2.0.2-r2*
* *ur-dashboard-msgs 2.0.1-r1 --> 2.0.2-r2*
* *ur-description 2.0.1-r1 --> 2.0.2-r2*
* *ur-moveit-config 2.0.1-r1 --> 2.0.2-r2*
* *ur-robot-driver 2.0.1-r1 --> 2.0.2-r2*

Humble Changes:
---------------
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *magic-enum 0.8.1-r1 --> 0.8.2-r1*
* *rtabmap-ros 0.20.20-r2 --> 0.20.22-r1*
* *simple-term-menu-vendor 1.5.4-r1 --> 1.5.5-r1*

Melodic Changes:
----------------
* *find-object-2d 0.6.4-r2 --> 0.7.0-r2*
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *mapviz 1.4.1-r1 --> 1.4.2-r1*
* *mapviz-plugins 1.4.1-r1 --> 1.4.2-r1*
* *multires-image 1.4.1-r1 --> 1.4.2-r1*
* *rtabmap-ros 0.20.20-r1 --> 0.20.22-r1*
* *tile-map 1.4.1-r1 --> 1.4.2-r1*

Noetic Changes:
---------------
* *boost-plugin-loader 0.2.0-r1 --> 0.2.1-r1*
* *find-object-2d 0.6.3-r5 --> 0.7.0-r2*
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *magic-enum 0.8.1-r1 --> 0.8.2-r1*
* *mapviz 1.4.1-r2 --> 1.4.2-r1*
* *mapviz-plugins 1.4.1-r2 --> 1.4.2-r1*
* *multires-image 1.4.1-r2 --> 1.4.2-r1*
* *rqt-human-radar 0.2.0-r1 --> 0.2.1-r1*
* *rtabmap-ros 0.20.20-r1 --> 0.20.22-r1*
* *tile-map 1.4.1-r2 --> 1.4.2-r1*

Rolling Changes:
----------------
* *aruco-opencv 4.0.1-r1*
* *aruco-opencv-msgs 4.0.1-r1*
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *turbojpeg-compressed-image-transport 0.2.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-edifice
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

