### PR TITLE
rosdistro sync, Fri Dec 23 13:53:59 2022

### DIFF
--- a/distros/foxy/aruco-opencv-msgs/default.nix
+++ b/distros/foxy/aruco-opencv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-aruco-opencv-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/foxy/aruco_opencv_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a2fff398ce13fb4cda9164896779dc49981baa1b2226ac1d60d80170667e1433";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message definitions for aruco_opencv package.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/aruco-opencv/default.nix
+++ b/distros/foxy/aruco-opencv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, aruco-opencv-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-aruco-opencv";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/foxy/aruco_opencv/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "45cddb72580326049122896e65ebd9e16c82ee351413acc80a76cb6bf5a0f9cc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ArUco marker detection using aruco module from OpenCV libraries.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/find-object-2d/default.nix
+++ b/distros/foxy/find-object-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, cv-bridge, geometry-msgs, image-transport, message-filters, qt5, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-find-object-2d";
+  version = "0.7.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/foxy/find_object_2d/0.7.0-3.tar.gz";
+    name = "0.7.0-3.tar.gz";
+    sha256 = "4d0ccbadb0b7d4240396631c5ba7c808d3f0f7e5b08a6c05ad5bb1a5e811f973";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge geometry-msgs image-transport message-filters qt5.qtbase rclcpp rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The find_object_2d package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -144,6 +144,10 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ aruco-opencv = self.callPackage ./aruco-opencv {};
+
+ aruco-opencv-msgs = self.callPackage ./aruco-opencv-msgs {};
+
  asio-cmake-module = self.callPackage ./asio-cmake-module {};
 
  astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
@@ -536,6 +540,8 @@ self: super: {
 
  filters = self.callPackage ./filters {};
 
+ find-object-2d = self.callPackage ./find-object-2d {};
+
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
  fmi-adapter = self.callPackage ./fmi-adapter {};
@@ -807,6 +813,8 @@ self: super: {
  lifecycle-msgs = self.callPackage ./lifecycle-msgs {};
 
  logging-demo = self.callPackage ./logging-demo {};
+
+ lsc-ros2-driver = self.callPackage ./lsc-ros2-driver {};
 
  lua-vendor = self.callPackage ./lua-vendor {};
 
@@ -1987,6 +1995,8 @@ self: super: {
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
  ur-bringup = self.callPackage ./ur-bringup {};
+
+ ur-calibration = self.callPackage ./ur-calibration {};
 
  ur-client-library = self.callPackage ./ur-client-library {};
 

--- a/distros/foxy/hpp-fcl/default.nix
+++ b/distros/foxy/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/foxy/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "71cb9ea7481453088cb4c805be8fac78599b6ea96a606845b83c7c9b6c4d87d1";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/foxy/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b4296473da19156f008e0de41bee793a9f140b146752b1ea3167e2e822842d09";
   };
 
   buildType = "cmake";

--- a/distros/foxy/leo-viz/default.nix
+++ b/distros/foxy/leo-viz/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/foxy/leo_viz/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
-    sha256 = "f1fe34a25448ceb368f97f35618d6f91c61ac2acb43238151bb63cf6d73c47aa";
+    sha256 = "043b980487e2e2da5b3b3b9e630b9ae36384d6c9a8425202c2d5548cf84ec087";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/lsc-ros2-driver/default.nix
+++ b/distros/foxy/lsc-ros2-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-updater, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-lsc-ros2-driver";
+  version = "1.0.0-r10";
+
+  src = fetchurl {
+    url = "https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release/archive/release/foxy/lsc_ros2_driver/1.0.0-10.tar.gz";
+    name = "1.0.0-10.tar.gz";
+    sha256 = "886f88cbea772cbf6b794b944b00676d2ef24c0a0e2cf76c022002c9628b9358";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-updater rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver package for Autonics LSC Series'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/maliput-dragway/default.nix
+++ b/distros/foxy/maliput-dragway/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-pytest, maliput, maliput-py, python3, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-maliput-dragway";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "7f525c51c1ec61da22b6b35010fec6c1daffc69f83b3c6201ff7cbd980512c4d";
+    url = "https://github.com/ros2-gbp/maliput_dragway-release/archive/release/foxy/maliput_dragway/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "cc347a1c58da21b7e55b1e9f10b68da0d7bce79628cbb1f8794bde2c0d2076a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-full/default.nix
+++ b/distros/foxy/maliput-full/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, maliput, maliput-dragway, maliput-drake, maliput-integration, maliput-malidrive, maliput-multilane, maliput-object, maliput-object-py, maliput-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, maliput, maliput-dragway, maliput-drake, maliput-integration, maliput-malidrive, maliput-multilane, maliput-object, maliput-object-py, maliput-osm, maliput-py, maliput-sparse, maliput-viz }:
 buildRosPackage {
   pname = "ros-foxy-maliput-full";
-  version = "0.1.0-r2";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_infrastructure-release/archive/release/foxy/maliput_full/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "3d6e191e7efa5169c258c109d0f67b3d2859d36d7e4bc65407d2271f95363016";
+    url = "https://github.com/ros2-gbp/maliput_infrastructure-release/archive/release/foxy/maliput_full/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "004c3eed0fc6ca317254087ea8215baacea3843d551e68dd39a23163c38eb2e2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ maliput maliput-dragway maliput-drake maliput-integration maliput-malidrive maliput-multilane maliput-object maliput-object-py maliput-py ];
+  propagatedBuildInputs = [ maliput maliput-dragway maliput-drake maliput-integration maliput-malidrive maliput-multilane maliput-object maliput-object-py maliput-osm maliput-py maliput-sparse maliput-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/maliput-integration/default.nix
+++ b/distros/foxy/maliput-integration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-pytest, gflags, libyamlcpp, maliput, maliput-dragway, maliput-malidrive, maliput-multilane, maliput-object, maliput-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-pytest, gflags, libyamlcpp, maliput, maliput-dragway, maliput-malidrive, maliput-multilane, maliput-object, maliput-osm, maliput-py, maliput-sparse }:
 buildRosPackage {
   pname = "ros-foxy-maliput-integration";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "ed3c28adc54486b0d7b55cca3b9608f28a5a4f8b2df4cd8eb5d7104625648b2c";
+    url = "https://github.com/ros2-gbp/maliput_integration-release/archive/release/foxy/maliput_integration/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "c5bc9aab2aaa380b1002189e22b2890a15a9ea06116fbf0ef7b40cbcc59086c6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-flake8 ament-cmake-gtest ament-cmake-pytest ];
-  propagatedBuildInputs = [ gflags libyamlcpp maliput maliput-dragway maliput-malidrive maliput-multilane maliput-object maliput-py ];
+  propagatedBuildInputs = [ gflags libyamlcpp maliput maliput-dragway maliput-malidrive maliput-multilane maliput-object maliput-osm maliput-py maliput-sparse ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/maliput-malidrive/default.nix
+++ b/distros/foxy/maliput-malidrive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, fmt, maliput, maliput-drake, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-maliput-malidrive";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "f41692153765780d42d64711bb2a9ad67f4cc0b630bea1d253f3dad5bd90c8f8";
+    url = "https://github.com/ros2-gbp/maliput_malidrive-release/archive/release/foxy/maliput_malidrive/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "7db77cbb7a3ca75c56ebfd8eee378a7460e95f2cc215964fe23f2ad5908d2f9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-multilane/default.nix
+++ b/distros/foxy/maliput-multilane/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, libyamlcpp, maliput, maliput-drake }:
 buildRosPackage {
   pname = "ros-foxy-maliput-multilane";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "f4baa1a87ada1ddea559cbc8702297cad292b0c1ec293b57f1dca77f568f95f8";
+    url = "https://github.com/ros2-gbp/maliput_multilane-release/archive/release/foxy/maliput_multilane/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "3424358c4da51208c068e5e67155ca33cd2f7ffdad75ba973d7b9ad8dd1b3934";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/maliput-osm/default.nix
+++ b/distros/foxy/maliput-osm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, lanelet2-io, maliput, maliput-sparse }:
 buildRosPackage {
   pname = "ros-foxy-maliput-osm";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_osm-release/archive/release/foxy/maliput_osm/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "0dc54efc50f858aa408a59f477db642225cdb630067df2c6191b77c87dc6ec94";
+    url = "https://github.com/ros2-gbp/maliput_osm-release/archive/release/foxy/maliput_osm/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "1d4efc868d03997316e661e78c48942dc6e17f0f8288e7a626d05edecb515afd";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''Maliput backend for loading lanelet2-based osm maps.'';
-    license = with lib.licenses; [ "BSD-Clause-3" ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/foxy/maliput-sparse/default.nix
+++ b/distros/foxy/maliput-sparse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, maliput }:
 buildRosPackage {
   pname = "ros-foxy-maliput-sparse";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput_sparse-release/archive/release/foxy/maliput_sparse/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "5bdf9754568dd8b22690b9ca45da393f8cc8da944096610a222e5e4a654ce361";
+    url = "https://github.com/ros2-gbp/maliput_sparse-release/archive/release/foxy/maliput_sparse/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "dc5726126f02af283be9ac58cfe10a4810a2b9cf9a30de783a20ef4bf75cac5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/robot-localization/default.nix
+++ b/distros/foxy/robot-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geometry-msgs, launch-ros, launch-testing-ament-cmake, libyamlcpp, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geographiclib, geometry-msgs, launch-ros, launch-testing-ament-cmake, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-robot-localization";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/foxy/robot_localization/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "5d4ee836e941dd006a6d799d64ef4fc6edb48fe09dfc769daf6b63a027ef73b5";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/foxy/robot_localization/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "495d5a7059f0edb14fdb145b723590360f4236d1f2fb8d59d7170735761cc91b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake builtin-interfaces rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater eigen geographic-msgs geometry-msgs libyamlcpp nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater eigen geographic-msgs geographiclib geometry-msgs nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake builtin-interfaces rosidl-default-generators ];
 
   meta = {

--- a/distros/foxy/rtabmap-ros/default.nix
+++ b/distros/foxy/rtabmap-ros/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, ros-environment, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rtabmap-ros";
-  version = "0.20.20-r1";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/foxy/rtabmap_ros/0.20.20-1.tar.gz";
-    name = "0.20.20-1.tar.gz";
-    sha256 = "fdbc66f0c1e5bf6236f6b1b3ff75acf73250488618657fa207bdc1c6bbb60a9c";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/foxy/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "2d10f8270356d9768f39d97a3e48438bd79e83a86f93aa4f78ebf4a336e816f2";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pcl rosidl-default-generators ];
+  buildInputs = [ ament-cmake ament-cmake-python pcl ros-environment rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces class-loader compressed-depth-image-transport compressed-image-transport cv-bridge geometry-msgs image-geometry image-transport laser-geometry message-filters nav-msgs nav2-common nav2-msgs octomap octomap-msgs pcl-conversions pluginlib rclcpp rclcpp-components rclpy rosgraph-msgs rosidl-default-runtime rtabmap rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs std-srvs stereo-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros visualization-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''RTAB-Map's ros-pkg. RTAB-Map is a RGB-D SLAM approach with real-time constraints.'';

--- a/distros/foxy/ur-bringup/default.nix
+++ b/distros/foxy/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, controller-manager, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, moveit-ros-move-group, moveit-simple-controller-manager, robot-state-publisher, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-bringup";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_bringup/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "abb4c199aa880f10d34ac99a798c60bc0e3c232f1dc775bbc2df75a8798e08be";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_bringup/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "7dafb1e9059c5e11be824334c7011c00d3552204ac5a3f502ea5d6591a9a1d46";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-calibration/default.nix
+++ b/distros/foxy/ur-calibration/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
+buildRosPackage {
+  pname = "ros-foxy-ur-calibration";
+  version = "2.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_calibration/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "45d2918cd9139d2b3271fc07c31529a6f84ae2d82bf84c05436615f6dc5ca538";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen libyamlcpp rclcpp ur-client-library ur-robot-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for extracting the factory calibration from a UR robot and change it such that it can be used by ur_description to gain a correct URDF'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/ur-controllers/default.nix
+++ b/distros/foxy/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ur-controllers";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_controllers/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "504e4388ae67a2b0c2e973b8612cd06c6c0e9d63b80234ca93133f9829414ac1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_controllers/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "af2d3866838b85de7c16d8399f090535f7789199cfd5a110bb7870fd4a866b01";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-dashboard-msgs/default.nix
+++ b/distros/foxy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-ur-dashboard-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_dashboard_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "26d405770c4d0dc9c24a19672b8eb4be60c5432e309dd5eb425e1311f7ccfab5";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_dashboard_msgs/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "249d0c38e3912e89cf472fc47c98318c28d0fe547d94d8a7c79fddef6b98a370";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-description/default.nix
+++ b/distros/foxy/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, launch, launch-ros, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-description";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_description/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "164e84cc2c3bf21047765f0b08c9482f779e7e9d92dc4b18263798edd4f78528";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_description/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "01f4db0ef0116f3f60d0c41ded738da68b3625cbb8859628b581442497c2d0c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-moveit-config/default.nix
+++ b/distros/foxy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-kinematics, moveit-planners-ompl, moveit-ros-visualization, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-foxy-ur-moveit-config";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_moveit_config/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "657a1bb747f891bb180aeb4fb01b87b642d859f19aeb517ec9f70ef1710eb29d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_moveit_config/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "8ab9b671f0e3eebc811e21f8924417313dfab467bbf60861d6eab6a293c14eb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-robot-driver/default.nix
+++ b/distros/foxy/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, rclpy, std-msgs, std-srvs, ur-bringup, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ur-robot-driver";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_robot_driver/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "41eaa6477f3c1c3e709b144f5f4febe3cc5a5c5c669d91fb55109b6ebfbe37f3";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/foxy/ur_robot_driver/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "aabafe12862568360b9af51e65084913c773119b362393f1a7172f0e4e878d1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-control";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "9f1251c97e47dfd2f88167a00357ea178ec8a9558be3fbd8f2f4a17fd834cbaf";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "04337f7173cbfac439b75a26d87844951179b7099d6caca2263467d2a7296d53";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-driver";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "82b6599c7dcea80ac19a21b3d8c0659f92bb631c2fc4fc1f9838263f75cb3c81";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "56dbe46e039e5619bb3f2da2cf77f6f3588697af66ea62bfc0407d69122b3537";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "4164bca9824d80bf8d0674782bea83759d6fa86224eae039476f2c4568930d27";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "46bd5cfb5732bf8ec91aa1c9df8a667d32f073b5f6938c30cd294b81f4091f18";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-importer/default.nix
+++ b/distros/foxy/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-importer";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "3eaa84c421cb59827f7c77d2b7636e3cef8def1fdc7be17032950040f13cc55e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "22f4c3fbc800babaea5dd1a60f4d30b0b85e107ec8092c5238f23b80945a6f37";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-mavic";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "9db6a0543959c72d50fc89dc5ac4cc138d646a2c75010b495137f0bb048e593f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "78f1480655776321e47e1dc5f3256ce642f03cfc058c29585d0285b58a87108e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "561a1ad1ac38908120463a910bdf01d8e41671f78381d7b87544068dee8e5e4e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "62c6f2186a03cc4f54540bda5a52e835fba7632f8b0d56c73c01f507ebfa91cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "62c39b9822457eededdbbf5f141eb6b35466bcccfcb7585e9b5c6b4f067e0c7f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "326f18a802f40101cf5a002c88a6495bfa439484a5f675ecbb113e9a833aca19";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tests/default.nix
+++ b/distros/foxy/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tests";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "2985d1ed39dc3577cb161f3208af25fcd7933efdf1557d599099ec7f2666f8a8";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "8d29bf605a41940ca1acd5b5e4fb97ec265eef6b9dff882ca6bc8065f6f19257";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "267076c72b41f65daa4462a7b5c4d7a8ed772cc1906ec3be181d1e846e61f903";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "c4a2fbffa8b5073db06adf0aa470464899efece0e02e6049e05ad99ad923baec";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "30c298168f8343911801a04e50347b4324ede83241d2f14cbe53d620f0e439d9";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "a170074caa9c3cb8459cbff3c4ce6a97e64aee23f06bbfa9c3cee7cd27a44e30";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "553ee3aae1562b93c8d3013ba9ccc85eb4ed6febc585658a63b01425b683854e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "c27e530815b12354279f7512a8ce3118eb5db0780532cbefe102b22a578dc482";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "7cefa21cf71f9ef8d0610b35f8bd2bf185a7db61a3d93550ae0a5f47ec0a75b8";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "d32612a128e91085ce922771a7e7f1f7324eeb31c789deb0922b9f98d7e37f23";
   };
 
   buildType = "ament_python";

--- a/distros/humble/aruco-opencv-msgs/default.nix
+++ b/distros/humble/aruco-opencv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-aruco-opencv-msgs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/humble/aruco_opencv_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4af7440e8153fbfec3e72ac947c4b36a881050ff73290515eecef76815cd0905";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message definitions for aruco_opencv package.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/aruco-opencv/default.nix
+++ b/distros/humble/aruco-opencv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, aruco-opencv-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-aruco-opencv";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/humble/aruco_opencv/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "3852511a4ea6852d279a54a2e4c164ead0e28a3a034f6b7ab7bda09a4e970683";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ArUco marker detection using aruco module from OpenCV libraries.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "42ca2b3091951bde6bd5c1f6645427902fdddf06c78e243ad2213ded9da61f99";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "ddd242e4836c9d50829ccd25d307e76c5251f2614137412e44157ae394385e1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a11f3cf6c8b749cfe331fb540acf8a5ee833e91bbad1a4b55e5b2e5c648364a9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "aadb6e10934226347bf82566d6987f1c81adb42c524269e00919e6bd754aa253";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9aec60908d729bdf73478ccc992354ab27e8e69a982d4d5b820301ed91235f91";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "adaa9dc10f96ae8c2491182b20264ec8883badfb89b3e0631802c5b683d46083";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "bb7fcd749fd3b12dbc44f4b5ddffba7c681cac7f51c95e56ec1b1c7cfa159791";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c58fce2f917af0c2c94557a737bf37316a05b771bc18f6dc519fdb49b1aabec2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "3a8a35d680c70740ef2f6684de941b02f33d17b912ffc9915126c70a8f686d6e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "1a12b601a31d4bb3d56559b88ed68d8a7b222dab3ddcdb24e1bef23186aad1a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/find-object-2d/default.nix
+++ b/distros/humble/find-object-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, cv-bridge, geometry-msgs, image-transport, message-filters, qt5, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-find-object-2d";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/humble/find_object_2d/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "01e262c4209580ebb7b339b6b2f9333e592eb8dd1b00fb0881eae099eda14bc8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge geometry-msgs image-transport message-filters qt5.qtbase rclcpp rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The find_object_2d package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "7fb7206bd77168bb7db1469e0583208abb1856670c9fc1984a7cf4143b4102f2";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "f24594342f96c3d9cb39c9b3b672c6ef3e41e29169ac9303dd2ee7f071a94e2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -160,6 +160,10 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ aruco-opencv = self.callPackage ./aruco-opencv {};
+
+ aruco-opencv-msgs = self.callPackage ./aruco-opencv-msgs {};
+
  asio-cmake-module = self.callPackage ./asio-cmake-module {};
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
@@ -437,6 +441,8 @@ self: super: {
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
  filters = self.callPackage ./filters {};
+
+ find-object-2d = self.callPackage ./find-object-2d {};
 
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
@@ -745,6 +751,8 @@ self: super: {
  lifecycle-py = self.callPackage ./lifecycle-py {};
 
  logging-demo = self.callPackage ./logging-demo {};
+
+ lsc-ros2-driver = self.callPackage ./lsc-ros2-driver {};
 
  lusb = self.callPackage ./lusb {};
 
@@ -1895,6 +1903,8 @@ self: super: {
  transmission-interface = self.callPackage ./transmission-interface {};
 
  tricycle-controller = self.callPackage ./tricycle-controller {};
+
+ turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/humble/hpp-fcl/default.nix
+++ b/distros/humble/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "da835d11bed0eaeb08dcf667bc6bc6e73a3cc4d388c769c2eb440b797ff12016";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "4bb0dba653f59122623445b11a2c09cc6e96b63d21a570f6767be7ea665ae3d3";
   };
 
   buildType = "cmake";

--- a/distros/humble/lsc-ros2-driver/default.nix
+++ b/distros/humble/lsc-ros2-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-updater, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-lsc-ros2-driver";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release/archive/release/humble/lsc_ros2_driver/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "1c59950825906d29f11e58275fabd6bd399d22dc2d609a46381143864d4ac872";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-updater rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver package for Autonics LSC Series'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/magic-enum/default.nix
+++ b/distros/humble/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-humble-magic-enum";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "da533032dd091e7c8414799d79cfb5b6d913b819e2629d22dc308952fbbb7ad4";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "1a9b5fdd097bba70f0c5ecebcaba35227e41f4066b51bca197f41ad9e974e45c";
   };
 
   buildType = "cmake";

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b368ed056d6faabb3b0346e12ea1e937022cee6832538f1ec7b82ef944b0bafa";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "15b7780859e96069906fa93d40b7a2ff62e4d8ab1319d0cbdba5144353e6bcd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "5d353c27721e6b5d77055601267501221e19b5006deef10b7f4308610d29da2c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "ed7d17632c4f6273f579950fb8cdc3888784861a8d10fcb78d9f54e3fd477761";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "7d7ded16a55f6efa999caef22b8555b40c4e12c2def8bfaba9f315800525caec";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "7dab7a73dd284ead80a5494a962be87df0e1fb426cd227802a19792f6cb11539";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "728bb8457aa37e8c13da8b0d10f44c92d09833c0773578516de8deba34da152c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "dcb219962ff4ddf37e7164226c9653947374781c5ec28c17ac8563b52f22ba73";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake nav2-common ];
+  buildInputs = [ ament-cmake behaviortree-cpp-v3 nav2-common ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common test-msgs ];
-  propagatedBuildInputs = [ behaviortree-cpp-v3 builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "21bb0a7a791e4b2a61a3b2ab05a51e8279cf458ceec507c4f3303d12d861d158";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "1d2f57a70d2521077366907abdec5e35b5b243c089d20d5ac61f70ee436416f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "03ded9ef219db9db55686a66efde48397f734ce4e9c64e403f19908d7077262a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "12c4fbf0743efb8ae3700edc676ae091c3fc7b6c6631d87e1c7bff6f67477466";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "3aeac565b1e041d9b13e979f9c0b191167171313c2cd1ba74e7721bd4e8a3a0b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "a690d20fe647e873be5b8a5ae582efa54dd0e8d78b0b5f1a8e0b7cb0a7e73b9e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake nav2-common std-srvs ];
+  buildInputs = [ ament-cmake behaviortree-cpp-v3 nav2-common std-srvs ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ behaviortree-cpp-v3 geometry-msgs nav-msgs nav2-behavior-tree nav2-core nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle std-msgs tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs nav2-behavior-tree nav2-core nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle std-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "d7184314492d9484b08cf88b5eb95c8e0c083a066556335d8365ffd5881df9a6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "44a34cbeb900fd25926cbaae1f88f1e190d7910843ec1feb32a3f992baaba04b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "bf454eb3be86bc47d677e722e9eff52dc585aaa937146f3b28eed465b19929d7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c2d659c4e4f0fc0d68ff223fd6bffcd95a4dc1a8b7c05ec97e7ec44242f9c5d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "88d29fc0d2f100cf275004f1523da79b89613dbf61ac4beca1035d4bb8893b0e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "6989cbe11505e72a13037000e135c82b9fcbda9715d9466bd990c08ec3ec161b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "3e9c4cdda7e9095370317ade171ac75e9c36e31f0cb85807a0267305749adf6a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "2330d166274919d26b10c2c7ba1e336a8a34591d6c83daa849c534b1072d0321";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "4e1efd9268c84f5cfea0764a45b21acfc1c9b2b9091553b8f028946ec7aaa232";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "2029c85aae39bdd9798812ea2cd42b2df6bd5b24583c8baa9370c625b11879ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "370b7e3d91365dc554684ce182877c530b7f958fa512a314ec7a5a55c615fc7c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "8b8a72b5113584ec2ac499ef8ea65e3924b43624460dfc4d92c0a0ab8ee845f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c16ea5a0e6bc85aa6b9ee66cf306da338b5e6fee213654f4664ba48db0ae7f10";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "383f26fe6ade59f9cf92ce03b4876436a0dac810bcf1191f9ba9b2d9a3da1da2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "d7d76229d53151ec6bdaf0238593fad7d17435c1e618e1c9a81d6144b9eb0fc4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "63d48e8d6feac03262a5f68623e5f09712f4a5ff4876a850a0bf2e306a6006f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "0eda627d7d4d1e9223ab215db594777f9f7bb439bee22b2e1085cebda2780746";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "b54b8dae2d7ccaa670698b1727ef455497e15e46499f2cbaebfaa48ad420fd34";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "40fc050d212e7f121b597ff0ade43a74708352051e5091eff97a901625f75015";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "287b1ecd02f7fec7e9a7f06e379ca16d53a18990f19f8d8a3259cb9f55700974";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9ccb80b8b75a8f8db9ef5a1582d3e5b9bae7e19c89cf84f9774dc21fdf00e609";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "ccf53438ab4522511e5bde45df400693f2d91e3808db65e5a976a24e4ceca3cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "42cb168bd610039a41c7dd5fa8643643e2fe99aaae07ee81bd2748f58ee93e6b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "733ad1d8d8fdefef898a3f55fc7914252d0451c621a743ab4a493bb5442acbb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b97082de7168c1f75025bd2a952142943f5121d3ea773695e98baa03efc0bc1d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "495800d971a33b5ce8851885308809ad5e030d14842d61fea760163496d5078d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "aab6d9d4a3ed823eabe6286cb639f59876d7e908844d0e1d7ff27cbfacfe1012";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "2e45ef836e4bb86d080cbe929141e8fea232e7eb5c7cccca63d0f405a7527f88";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "32f70242a4c64215b8fa8a7ccf364340fa35db955c115bfa463fef2bd64ed627";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "74a4e1f70be173fa7728f801700b83d95b912332c6b1dc16e8f393395401e81e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "8ec5854481ecd5ef77d8332b957e817c04875329dfdd42bb1c1c60200a295569";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "dbba50ec6336faf8eb13d77023e61d802e428955ec56203eb5fc835e91619301";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "3fc11f5136f0f9f65f05d7cb5394fc39886e61591c37568c64ba80240b1417fa";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "55e0a15f4e7da4bd340becd6a7ebfa814d10dd15bc9e46b765db4d86316cd45c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9cbc9a90daa77ecc29dbcaa709c5060e2b6aa87ca979d7deaad2004b55149494";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "8d658ae905d5006452cce4f8773d6caf0da1120b5cd2c6a3a635daea602310f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "bca5d52b824b1943fe02631f5985dabcfaac062d099567bdbe27ecf23bf84bd9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "397c84bec776d872edf8adfd65892083ef79ce91868e6c314da598e188891d46";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "596aa00a31be4d3d03d9e07efc0cd4cd586b79d7de492948fce88e2975de967e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "f0e1a4cc9f971d82bee6addb82b3c649aa09c45fe087572bf9c2b4070faf55d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9b157711c23031bd4ee1beb8b43c64666160b9c40530f592285924284689c853";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "d0ad0a12d517cffa91d28bf0c5a907079dee8b3850dba1987fbcb53454cf4792";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ebafd82a740450d774c4742d488614b65e5026eecfab22f2264fd9de06bb0a34";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "292e4ea74bfa1914e0fb86a0aa87ce82cf8daa1d194c8a6db72c5b8946d26d38";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b5cdea2260ab274f9b3f90bd410dbdc57fdc7b620751c72c2d49cfbc7be4b6ef";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "2434116fff4b37d97e5edbc494b97f5ff01ea0e560d1f6c2e16286c123df6567";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "2caf7e58c2f00e31c7945ac33db07593206b61d9d6d34b1108423b94822ff7ca";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "9d183117e5c297e83f71b5251d78636f13a5f7bb3c47c79cb0a5b878a44fe265";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c80d6b1a142cf7a6ca97b1df8df3859e6c7db4436c20f0c1e51f61f4f84a3899";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "dbed2b3019a15e148b1830617b691c8da6380a8dace57a568350a8114fa0f3a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-gripper-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, position-controllers }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-controller-configuration";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "e092a9f85c3279d267912151e15179cbf3ddae54fdd5dd0ea1f198d29ce654a5";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "6145d044628ea3f1f3139f7b2b4a5dc9030669ef1ed5d8d945985ef149d55ddd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-description/default.nix
+++ b/distros/humble/pal-gripper-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-description";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5c44cedb08db7f9898c7dde696d3737dbcc68faf371e4a4fa0ef5d5b4a586d18";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "49fdd60b0383874024f24f56219cab4f2b6966c33c3dc5609f22d335495f72b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper/default.nix
+++ b/distros/humble/pal-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-gripper-controller-configuration, pal-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "7277c38c80ec941d7b42252bd6ddda68bfabbce8869d6d2c0d401454ad41069c";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d10ed88b621cc35211d5ff899de08e9678930ba82fb4f5c5a8b92a3f0be245d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, nav2-bringup, pmb2-maps, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-pmb2-2dnav";
-  version = "3.0.2-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "8bbdd435735ccfbd1324ef9c62ef65cda66d097a6b16e152d781e9f3e51f2eea";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "f6d8beefed00991c12a63493632a060ac1e5f201f4eb4ea3f6ac9cf21407518d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-maps/default.nix
+++ b/distros/humble/pmb2-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto }:
 buildRosPackage {
   pname = "ros-humble-pmb2-maps";
-  version = "3.0.2-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_maps/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "8ed9b8bf2ee08c78c83f067e3f54b5ba6dab499384bea0899228be863b0b720a";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_maps/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "5283001e4b86d5c4301c5605284b8456dbdea6e8b6bee5ebbe1e5be76e112b0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-maps }:
 buildRosPackage {
   pname = "ros-humble-pmb2-navigation";
-  version = "3.0.2-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "4ba6c59610b51f5e3345c5d2160705fd8e37a6756e020db927a43772520be509";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "2b1b5c4af40c39cda2be525406bf2d481df3cc4b72d03a1a9206db042970d478";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-ros/default.nix
+++ b/distros/humble/rtabmap-ros/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, ros-environment, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, builtin-interfaces, class-loader, compressed-depth-image-transport, compressed-image-transport, cv-bridge, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, nav-msgs, nav2-common, nav2-msgs, octomap, octomap-msgs, pcl, pcl-conversions, pluginlib, rclcpp, rclcpp-components, rclpy, ros-environment, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rtabmap, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-ros";
-  version = "0.20.20-r2";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.20.20-2.tar.gz";
-    name = "0.20.20-2.tar.gz";
-    sha256 = "cb56154449de5964d15556f390054bed69a801a41d4e028af8d0d9b840062787";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "862a4619a3f25e8d7abd8b817a9172ea1fd8384dd042db0d59f0198d6a17ba9b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pcl ros-environment rosidl-default-generators ];
+  buildInputs = [ ament-cmake ament-cmake-python pcl ros-environment rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces class-loader compressed-depth-image-transport compressed-image-transport cv-bridge geometry-msgs image-geometry image-transport laser-geometry message-filters nav-msgs nav2-common nav2-msgs octomap octomap-msgs pcl-conversions pluginlib rclcpp rclcpp-components rclpy rosgraph-msgs rosidl-default-runtime rtabmap rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs std-srvs stereo-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros visualization-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''RTAB-Map's ros-pkg. RTAB-Map is a RGB-D SLAM approach with real-time constraints.'';

--- a/distros/humble/simple-term-menu-vendor/default.nix
+++ b/distros/humble/simple-term-menu-vendor/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-simple-term-menu-vendor";
-  version = "1.5.4-r1";
+  version = "1.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/simple_term_menu_vendor-release/archive/release/humble/simple_term_menu_vendor/1.5.4-1.tar.gz";
-    name = "1.5.4-1.tar.gz";
-    sha256 = "5bb5f723b52aa72ebde2a06c4f13ab65bac8ec49395d7b791d2263351eeb6074";
+    url = "https://github.com/clearpath-gbp/simple_term_menu_vendor-release/archive/release/humble/simple_term_menu_vendor/1.5.7-1.tar.gz";
+    name = "1.5.7-1.tar.gz";
+    sha256 = "f4e8e4a75bbe5e87372fa093968765b32034e4e2e7729381c6d291ec51344e6a";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''A Python package which creates simple interactive menus on the command line.'';

--- a/distros/humble/slam-toolbox/default.nix
+++ b/distros/humble/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-slam-toolbox";
-  version = "2.6.3-r1";
+  version = "2.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.3-1.tar.gz";
-    name = "2.6.3-1.tar.gz";
-    sha256 = "014605650dc6c4db35af5775c7f064ff9a673ed6a4b54f8da0455d16528ebe26";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.4-1.tar.gz";
+    name = "2.6.4-1.tar.gz";
+    sha256 = "347a14b83e8e5c073f244ba0daf4b3d0d9927e2d964310e49040da53a1213df9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-2dnav/default.nix
+++ b/distros/humble/tiago-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, pmb2-2dnav }:
 buildRosPackage {
   pname = "ros-humble-tiago-2dnav";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "fa12dcc1924799b98ed1ed990a905e24e0fe9bbe112fd1e57942bb1b2fba81cd";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "55a10605194143d22212f4c7447125392d3a6187800474758423bd95a677e4fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-navigation/default.nix
+++ b/distros/humble/tiago-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, tiago-2dnav }:
 buildRosPackage {
   pname = "ros-humble-tiago-navigation";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "410405d5ff7911eea1642fcf1ecac5b033c8bdc579e7aa9ca535517403b3ecc5";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "fcd59cbb3c58ea337123bcf32c029179f05d16ce44e9c598bec3cc31f54582d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turbojpeg-compressed-image-transport/default.nix
+++ b/distros/humble/turbojpeg-compressed-image-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libjpeg_turbo }:
+buildRosPackage {
+  pname = "ros-humble-turbojpeg-compressed-image-transport";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release/archive/release/humble/turbojpeg_compressed_image_transport/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "556f7afedd8d86dd7d21bba16a7bb2b2c8ba2b6623a7fab87c44cd09ae5ab881";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-transport libjpeg_turbo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Compressed_image_transport provides a plugin to image_transport for transparently sending images
+    encoded as JPEG by turbojpeg.'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}

--- a/distros/humble/webots-ros2-control/default.nix
+++ b/distros/humble/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-control";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "4042df4139de6fa684e825f9e903fa42b4dacc06def328786ba4eaf55a9074b1";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "97d4ca5aa463e11841c38406d55907f9314ec136d0c0f2a8d53abedba0490eb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "ac852dbb09306ec1093175327a887ffc0b3ec53c02ce0cb4955df0094212781e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "f1d2b5cff817cbc99c57038eff0ebc92b73bb8ca824312857545d09d13bc764b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-epuck/default.nix
+++ b/distros/humble/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-epuck";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "e3c70542a7052cc8975ea41db80f32eb67bc5140265abf59a58a1b6b665d39ed";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "6b141e6e54e846e75e38d72096e52952f730c01f3bfdc3127c18ca53818dd674";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-importer/default.nix
+++ b/distros/humble/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-importer";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "65c5a3b68b2f650605f9199f1e5a3bb4c2da6a6bd784605c7658adf233a80f67";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "0e008de3ec4844766c0716757ad8d8caea0130dd64d40622a14517a49b6f2225";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-mavic/default.nix
+++ b/distros/humble/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-mavic";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "735b52ac3a5714cb77c9a569d007f0996ab3d919acc1872058fa3176d206bdab";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "673c0bd2edf8c6a3e8c0a8568cb66493d8883e40a6b31b8ceea628146369da9a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-msgs/default.nix
+++ b/distros/humble/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-msgs";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "b186c3bfb0094a83cbf4cfc67c18afa429184237be11351bb33e9a08e7831fd0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "abbd85289cd7661095dd1d7939ffc55f45a46ab0bba22a53741f72bfa0a14209";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tesla";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "dd28d9d9eb6d9d35051338011e6e4970a9f16c62b0cc4fa4043ec15c8c5e2819";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "b33b4cc816d15588914f4eca83325a3f3384f478f7bc5aa6fc3e9b5135681ddb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tests/default.nix
+++ b/distros/humble/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tests";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "52d88de8719d4e34cec66d3ea309c81b6910ef2a11bb329a4affd341ca1feaaf";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "fb7f70bf34fc860bfc5d72d0ff9ec774e97492b6906999541af4f19d09f7170d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tiago/default.nix
+++ b/distros/humble/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tiago";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "3b278cc0361e962e4643cc6dabcab6e505824fe206d268960a61d884bf923bd9";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "326f700d38ecca0faac5beddfddca0551dcfc68dd2916a8f737713df9365815e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-turtlebot/default.nix
+++ b/distros/humble/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-turtlebot";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "a58bb78ed0100eb57a29905367fd68fe698211efb30f87f19c4a1bd16e1c5f4b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "4017c86d8fffa4062e273e3e86f679da19c1a09352781f956aaf241e89f116dd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-universal-robot/default.nix
+++ b/distros/humble/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-universal-robot";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "9db0d6e09a684861acaf5c7d9b76088ba47df19a4067de3bf5818f6cfcd0cd4c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "fc3ea2401134bfbf4c185f087d89ab8364e7f8ca9f9fa0492180de6da780862a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2/default.nix
+++ b/distros/humble/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "92584f74152cdeb49a2a6cbd2abaa845b473ec78212c4900d3825e6af5ddd34f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "8ca2e94d739f0980e2f059ff0cb26c8d8b006b63e59d6a73b09471e7370a18f7";
   };
 
   buildType = "ament_python";

--- a/distros/melodic/find-object-2d/default.nix
+++ b/distros/melodic/find-object-2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-find-object-2d";
-  version = "0.6.4-r2";
+  version = "0.7.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/find_object_2d-release/archive/release/melodic/find_object_2d/0.6.4-2.tar.gz";
-    name = "0.6.4-2.tar.gz";
-    sha256 = "bb19a36951a2bd531bd45af05d8b1a98084eb5eb3042f700f9bc7e77260d9648";
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/melodic/find_object_2d/0.7.0-2.tar.gz";
+    name = "0.7.0-2.tar.gz";
+    sha256 = "bd49b707c52b9c3bbc257f082562beb25139a89572bb87f531f795b6b8edacb9";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ cv-bridge image-transport message-filters message-runtime qt5.qtbase roscpp rospy sensor-msgs std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-transport message-filters message-runtime qt5.qtbase roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/foxglove-bridge/default.nix
+++ b/distros/melodic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-melodic-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "f9b234563a407c0e4205f968d5c2ab49ccb435a59c6f04ad9d9ba89b306ae1ce";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "bff9c1a2651cacd73e4020a5412bf4cb7dd6043d0c3b2de84862a6c635f15028";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hpp-fcl/default.nix
+++ b/distros/melodic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "e3721312c1b3ae8bd2598a6a395fbe851c071c2a6e06dd2e39a7eb65c6d673c4";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/melodic/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6bcc4bea9886c332a57db218d8767e49524a8984bb8623d13bee3184e5ae672b";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mapviz-plugins/default.nix
+++ b/distros/melodic/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt5, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mapviz-plugins";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz_plugins/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "8b6e1b1021f5ec7a2cfd911371375422a4824bdc632885e76f8233e36d28a93c";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz_plugins/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "2afe3c84ce13234d9940c410214ba6f6ca4e260d422141c9f476d94c3b64025a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mapviz/default.nix
+++ b/distros/melodic/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, freeglut, glew, image-transport, marti-common-msgs, message-generation, message-runtime, pkg-config, pluginlib, qt5, rosapi, roscpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-transform-util, swri-yaml-util, tf, xorg }:
 buildRosPackage {
   pname = "ros-melodic-mapviz";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "ca4b2e993f0e850ce5af70045fc0372bc65d3bce7b286d4a1f2ab6a5aec8c49d";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/mapviz/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "3bb76b8171a87c65566aa6e2f6ae5140c6f2b20553d66189d11b0e2c6fd085c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/multires-image/default.nix
+++ b/distros/melodic/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gps-common, mapviz, pluginlib, qt5, roscpp, rospy, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-melodic-multires-image";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/multires_image/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "566978f405d258ba5c807dbf25edcd2a438061545c51b54cad478140a7fb6b13";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/multires_image/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "f915a51c4f1ecf3ef912fd59b1391248f355405e0a77c7694801bc61befccb44";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rtabmap-ros/default.nix
+++ b/distros/melodic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rtabmap-ros";
-  version = "0.20.20-r1";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.20-1.tar.gz";
-    name = "0.20.20-1.tar.gz";
-    sha256 = "10e72afaf27e3685fdbeec4880a72285acf2c80df12185f3a657ce7855d3b99d";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "7b38d0cf63f57c6e08c12dc01439f1f2e28a95564c67cec9419bcb5fe2bc9f15";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tile-map/default.nix
+++ b/distros/melodic/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, glew, jsoncpp, mapviz, pluginlib, qt5, roscpp, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-melodic-tile-map";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/tile_map/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "308fd95d57644bbffe9aead80823c17cc1d58ac8a8a3e9092addc3292d464d2a";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/melodic/tile_map/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "b8dff88df9fe3838b14c477a6d9ac3ae00085e8deb0b7d58ddd37130e32582f4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/vector-map-msgs/default.nix
+++ b/distros/melodic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/melodic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "121a81bc986a40e9e83e28737b74241bdf9332c0f95e1ea42c3deb03aeb4a8b7";
+    sha256 = "116c8842e3f610f9c6c59fe5db04d2f6cf998a11fb1f85bcb8748cfe247490ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/boost-plugin-loader/default.nix
+++ b/distros/noetic/boost-plugin-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtest, ros-industrial-cmake-boilerplate }:
 buildRosPackage {
   pname = "ros-noetic-boost-plugin-loader";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tesseract-robotics-release/boost_plugin_loader-release/archive/release/noetic/boost_plugin_loader/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "304122a4b9423b6512662cadb878f0ad355a5574b77b81715302f4349a59018c";
+    url = "https://github.com/tesseract-robotics-release/boost_plugin_loader-release/archive/release/noetic/boost_plugin_loader/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "5b25d104c423656c625823667d299ab922c345f0aacdd9de0f1c4e16381e3951";
   };
 
   buildType = "cmake";

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "088def569359166b86d71b06bb68e8ef1b36bebe229d4d97c8cebbfd7b82f08c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "85dd9768021a63512b2411ae6a4bbd23dc171091a50499d7a1bd92839f1fdd7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/find-object-2d/default.nix
+++ b/distros/noetic/find-object-2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-find-object-2d";
-  version = "0.6.3-r5";
+  version = "0.7.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/find_object_2d-release/archive/release/noetic/find_object_2d/0.6.3-5.tar.gz";
-    name = "0.6.3-5.tar.gz";
-    sha256 = "a8e5130cd08ff78be8b6837bf44e8474bd5637e58af118ff9b4f7f193119d25c";
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/noetic/find_object_2d/0.7.0-2.tar.gz";
+    name = "0.7.0-2.tar.gz";
+    sha256 = "704099801e897cec9bb812ca9e1ec89ab4d586ee8adb8427a07caa4a318be6b4";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ cv-bridge image-transport message-filters message-runtime qt5.qtbase roscpp rospy sensor-msgs std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-transport message-filters message-runtime qt5.qtbase roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "540a6a8e96dbe6c8477d769ff23d5ea766c4ac74df0b6063f4d60a66ec4f2e57";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "abf7487e53c5a0e4d2c07b0bb38bfdd641c02fc87fb69e0123eca0e4939d2733";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hpp-fcl/default.nix
+++ b/distros/noetic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "db5942833a159bd2e01ca70be38173d41f3f2f1dda2994db75008456c312b242";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "66aaa2fb542f7619cfa86943f41c932deb3bd479d956ef877313411c4a71b1c8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/magic-enum/default.nix
+++ b/distros/noetic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-magic-enum";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c8535eb03907e53c67e80e5252c64d1a832b39be5f655464da9fe5f7f5ff8711";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "61de1b8f2efbce9574758aaaa3fb54128a78f93caa2d0c06f6d2e7815756811d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mapviz-plugins/default.nix
+++ b/distros/noetic/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt5, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mapviz-plugins";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz_plugins/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "9725c95f637969dbcba301a892b89133500331980fd639e08efba8478d423bed";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz_plugins/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "4c2972160dc7a5fd7858760b98b68f0a87c185d6c1926be7983162d83d447129";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mapviz/default.nix
+++ b/distros/noetic/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, freeglut, glew, image-transport, marti-common-msgs, message-generation, message-runtime, pkg-config, pluginlib, qt5, rosapi, roscpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-transform-util, swri-yaml-util, tf, xorg }:
 buildRosPackage {
   pname = "ros-noetic-mapviz";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "9117c574ec2db3bdec3a33e14ea06b04113e8bd3a6e0c9d7b7b3a454c256567b";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "46114381cfdbe6e838810c21ed5994d4a91669c6a7d038b72de21522a8ce2787";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "530fc31c405e52cfc6a4bc28ecb5f9dbd0272d11845c586a10dd1d2b7e28dcf3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "e0d9989e14a21150f9261e1f75827ea74f86e7341a70cfa5da6f7da8e257b038";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-catkin, python3, random-numbers, rosconsole, roslib, rostest, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-catkin, python3, random-numbers, rosconsole, roslib, rostest, rostime, rosunit, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "d54a92f5194fe6aaff11a86330a61583e64767f55f10369353be3430ba2a2132";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "e439e607979521397192558d3b56cae72a5a109aa8a5830c898e3146c0a7d1bd";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin pkg-config ];
   checkInputs = [ angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl rostest rosunit tf2-kdl ];
-  propagatedBuildInputs = [ assimp boost bullet console-bridge eigen eigen-stl-containers fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-catkin python3 random-numbers rosconsole roslib rostime sensor-msgs shape-msgs srdfdom std-msgs tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ assimp boost bullet console-bridge eigen eigen-stl-containers fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-catkin python3 random-numbers rosconsole roslib rostime ruckig sensor-msgs shape-msgs srdfdom std-msgs tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "a056f10f4e9e64ed601c2880d49a9bfbd46818fdadb4021295d7c4c6569e1ea3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "9688d622e8127589c25610b60828375e49dca28f84f2ebe7ef180d4df26e151d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "a26672cda1471b2829c76254176f20c68954ab3bba3b6e5ea67935c0143901c0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "420326e567e66e956e7b05f6851cad2c3c21baab6ff699676cd5882d528ad7b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "6f4de7f92fce6c815eddc9c3cf49d39efc8e3703ded7dc83fe00b54d47c1e171";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "b3bf0b98e9da1cfa7352742ef0afeaf9cd0bd44be36a99610544ac09b9d4b97d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "b3129b25cf35c0688169528619dd427e108e50f0454e95e92e7cca7a5e45dbf1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "cf7d28dc918dc4f4605093822171b90c90aa43841868077b1c97b4b020a9ba71";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "899f9f38ba3d2b5cf09ed7b449110bf2aa06c09b4c4972879710a4b21a861416";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "7bc3708371aa72dbc2eb071d0c9863d68ecbf2871b62532597e530a1c5c4f6a8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "cd885e4ac1ba0ce7e07c71a2f292a7558bc04b5c27c5ca049081272957142a5d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "45cd855778073e02f5560af0b9113d69efda56a8e81ce215b1a630bc508791e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "ab8fbbba3d596d91a318db2b85eaf5a7e020843b43390d6004a5bb0468863357";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "9f9e7a7f3931fc1d3e36410e0589770edb04c8f60ae5bb219749436fbf0401b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "1ca5a0d72d8246414ccc3dbbdfd9b6347b579af8e79e6a7a04d026126685e935";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "6ada34db9b0c6d9309be152a1094aaa08c7872e097ec97cef41888f688d2f894";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "1929807bcb010e84fb755cbcca197a4de91755d4685cea36da4f77dd9a97da9e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "a536fc18f29a077c737f97e8d7e051c7ae70e2af713f1d54fbd520e74725296a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "af85513249b7e0b23f1e4c8be7136b28b8c0648934032d4cb505bae43a4d838f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "b1b929b7e81c9660a6be980271886d8be135d656b0dec3c1906d42becdecbc0e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "fd9580df3358ea6f70ce09daf7efc4e7bfb74466fad2d31d12c9535d609877f9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "3482659693e76c45665125ac3a81f88cfb025a300a6b0fd120cc07cefd367f85";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-perception/default.nix
+++ b/distros/noetic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, nodelet, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-perception";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "582395b1556c7e1d7790873850472803fb09eadb7d8abd01dc21bc160350b769";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "3c47387e40dfe90de39484ded54873179351a099ec4a870b6e9f00258c6a7c65";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "469d24e901f03498c3db022b4540e1c24f800f048dbdb2abe0c0c0c77247fea4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "bd4ce4aee536f550697114c9317d0dec1bbef996eddbdea7988eeb3fe278973c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "ff665188a7b246b4cd913d9a7b142e99df08c8ee4c656315dcdd1b6eae4b4e1d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "2add2fdda1af08d9400c16cd27d5182de36a4dbdeacb754093c3747ab581c65b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "644c586e966454ce569459c66e8abcf16a2c12f4de2dba0fbd7816083a8e8d4c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "97d125f94e0f144be421f13edb125f89b3c1a7442fe34dd12ccbaaa472cd43f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "8a09bc70a67daea05f9f068b80c914b56fe181093bd4f821dc22c6e593de3fd6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "b79088f0c19e546d2fa1f658d64a2071f96344b2630e63930066f6bba88e6d07";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "3cd42347f3f4c04b6b249c14035507b2f213abcb33e957db59eef180e561910d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "0cc161324d2f1e41f1ef9f111ad3ffc4b8f4acc0bfdcad5f09c495a8ed27783e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "6f33b9d36a14e3f532649c8f9a3793d7ff9fa8719788e55778c711f6df247acd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "a887cb182404c1a009395173c7387f78600efb6f09d8925665142e04cda2eee2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "8f7ed101747465bca618566f73a42063a0cc030038c00c59407f4db26b3fa470";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "29eaf5bc9876ed12faa738b66786391ddb6718b41adc1dfd280c76b1a6146efa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "013279fbde762bc01b6fdbc9eec3b2a255d6ce1e5d937d9c59a25f73210c4548";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "a1d59373afb603c7132d3975a072378fd4616dcc891822bcb336a97d919ff526";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "f123d0630956ee59052b928f423778c6b862b879c5c4351de4b4523a70205ef4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "094f75f1559fcdf81d2ae5f4a6bb833f488345b5fbe4538fc557278b621be89a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "a69727ddd847767239cc85d7d7c478fc63f0d3d6b808520956da6aecfd613102";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "70beeca47ddae60922a1d4b706e38201ebfcefcfb2da1311d2692ab08740260e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "79b94adb647fde63b1bdf4db73c3db25c6c772bdc6f29c69f5c61fc2f52a3fe1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "504073ca1c20a5b4c63a5288c1dd5dcd9f797aa551c9918a282d4c50e5148f8a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/multires-image/default.nix
+++ b/distros/noetic/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gps-common, mapviz, pluginlib, qt5, roscpp, rospy, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-noetic-multires-image";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/multires_image/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "cb7ef6ab42f6ad715cf1e2e7ffc02862c4b4d599ba8ed38133a02fa0c7e1116a";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/multires_image/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "99f107b5e3dd220a36b74628fc7a29f16bd979dc94d28e4ad823a38f280768ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "14d4f3cfd982952165fde4a9c90060799a445f7dabc560f327e261818b5ec4a0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "de499881a05cdaa6f4f8bbf7ca232dec7f349931474c5cbd8928533a638d6ef7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "b7d8df578168ad518b5d55764edbdb6f84df9aeaa87a9c8c293714f4c72fa6a7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "a800e9525b218e9f50ab8b6fa323d4a86f8e67cae8d1f72f98531fca66df9997";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-human-radar/default.nix
+++ b/distros/noetic/rqt-human-radar/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rqt-gui, rqt-gui-cpp }:
+{ lib, buildRosPackage, fetchurl, catkin, hri, qt5, roscpp, rqt-gui, rqt-gui-cpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-rqt-human-radar";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/rqt_human_radar-release/archive/release/noetic/rqt_human_radar/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "778fad637e30634d4c5412aac8dc4e7a97866870d663c6f89902fb1fe8afeaa0";
+    url = "https://github.com/ros4hri/rqt_human_radar-release/archive/release/noetic/rqt_human_radar/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "6a0e5059377c856f35ce5eeb0fb1338ea03e1b31c1ff47fbbaffe843f0df913a";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
-  propagatedBuildInputs = [ rqt-gui rqt-gui-cpp ];
+  buildInputs = [ catkin roscpp ];
+  propagatedBuildInputs = [ hri qt5.qtbase qt5.qtsvg rqt-gui rqt-gui-cpp tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rtabmap-ros/default.nix
+++ b/distros/noetic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-ros";
-  version = "0.20.20-r1";
+  version = "0.20.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.20-1.tar.gz";
-    name = "0.20.20-1.tar.gz";
-    sha256 = "5b1ea636c14d342e8d41968021a2c0530158dc7337b541f0d7411d40b56a4ede";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.22-1.tar.gz";
+    name = "0.20.22-1.tar.gz";
+    sha256 = "1922d8de7460bdcb8a073595f28c50e3be3fae773e41061d5e03a706996751b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slam-toolbox-msgs/default.nix
+++ b/distros/noetic/slam-toolbox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox-msgs";
-  version = "1.5.6-r1";
+  version = "1.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_msgs/1.5.6-1.tar.gz";
-    name = "1.5.6-1.tar.gz";
-    sha256 = "e68433efbd4d95cbb033c59522b2405cbe8055da14859df2ee983f25618714d4";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_msgs/1.5.7-1.tar.gz";
+    name = "1.5.7-1.tar.gz";
+    sha256 = "b4cbb8c199c530efb3a49c31ef1c350902a5eb6fb4441f81ec0e858a33633aca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slam-toolbox-rviz/default.nix
+++ b/distros/noetic/slam-toolbox-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, rviz, slam-toolbox-msgs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox-rviz";
-  version = "1.5.6-r1";
+  version = "1.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_rviz/1.5.6-1.tar.gz";
-    name = "1.5.6-1.tar.gz";
-    sha256 = "f3073d278d5cbf2fc2bbb00ecbfa28495ebcb88b2b1c847fe57273016f4278b2";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_rviz/1.5.7-1.tar.gz";
+    name = "1.5.7-1.tar.gz";
+    sha256 = "6e386f21987e672b991209e1be7a2e87e9c7c129abc9266f9d9b051f2bfaa723";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slam-toolbox/default.nix
+++ b/distros/noetic/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, gtest, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb, tf, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox";
-  version = "1.5.6-r1";
+  version = "1.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox/1.5.6-1.tar.gz";
-    name = "1.5.6-1.tar.gz";
-    sha256 = "8cc607ced61f8d2d6f167ba6e802cf055e9b702bf897dfd5310e85fb2b6172a7";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox/1.5.7-1.tar.gz";
+    name = "1.5.7-1.tar.gz";
+    sha256 = "fcfc8ef223c1b4af185e100df124b08fdd1d6493ab72c3d1f26efbc041c11246";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tile-map/default.nix
+++ b/distros/noetic/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, glew, jsoncpp, mapviz, pluginlib, qt5, roscpp, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-noetic-tile-map";
-  version = "1.4.1-r2";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/tile_map/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "50c04b7b4f00b808c329d3d161ba2ada5155278071db1bafda5edec95e4559d4";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/tile_map/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "2c4ecc0cd98353b953027598473433fa7e37f5516fc4cab995098980ca4e18af";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vector-map-msgs/default.nix
+++ b/distros/noetic/vector-map-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/vector_map_msgs/1.14.0-1.tar.gz";
     name = "1.14.0-1.tar.gz";
-    sha256 = "4132fc88a828774dc43bac8d108aed130622159af96ab717a8a0c8464929a65f";
+    sha256 = "870df6369942aa12d4c13eca898c481571bb2464d0333c56258e2f2498c8eded";
   };
 
   buildType = "catkin";

--- a/distros/rolling/aruco-opencv-msgs/default.nix
+++ b/distros/rolling/aruco-opencv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-aruco-opencv-msgs";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv_msgs/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "8c0c68f242ed89c595abbb0180dd32febcf9ac61675a4bac4d87c23dac75996f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message definitions for aruco_opencv package.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/aruco-opencv/default.nix
+++ b/distros/rolling/aruco-opencv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, aruco-opencv-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-aruco-opencv";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "91a2d2635c9d22069b85a6c14220d8124ee94eb1e94701ed81828407425b19bc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ArUco marker detection using aruco module from OpenCV libraries.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/find-object-2d/default.nix
+++ b/distros/rolling/find-object-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, cv-bridge, geometry-msgs, image-transport, message-filters, qt5, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-find-object-2d";
+  version = "0.7.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/rolling/find_object_2d/0.7.0-2.tar.gz";
+    name = "0.7.0-2.tar.gz";
+    sha256 = "17a2b3050d92508fd8cd0b4b67c54de682180ebb11a2c80be7d14b276a31b474";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge geometry-msgs image-transport message-filters qt5.qtbase rclcpp rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The find_object_2d package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "1fb1f5719608cc9880697de13e622632b42f4e8d1699b99dd591ff55eabb86af";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "6725f9692a22c0789e44acfa22df5227ff65a4e86542f578dcd938dcbedf8560";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -154,6 +154,10 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ aruco-opencv = self.callPackage ./aruco-opencv {};
+
+ aruco-opencv-msgs = self.callPackage ./aruco-opencv-msgs {};
+
  asio-cmake-module = self.callPackage ./asio-cmake-module {};
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
@@ -429,6 +433,8 @@ self: super: {
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
  filters = self.callPackage ./filters {};
+
+ find-object-2d = self.callPackage ./find-object-2d {};
 
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
@@ -1653,6 +1659,8 @@ self: super: {
  transmission-interface = self.callPackage ./transmission-interface {};
 
  tricycle-controller = self.callPackage ./tricycle-controller {};
+
+ turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/rolling/hpp-fcl/default.nix
+++ b/distros/rolling/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-hpp-fcl";
-  version = "2.1.3-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "012f15eb4e5bdb70d724bad0f7c122c4bda9b126117f3911f49ba5680a2f5f7c";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5816642c80a414c2c9aede70f50438c137b8d8ff156bfc24d8710d517fb07445";
   };
 
   buildType = "cmake";

--- a/distros/rolling/robot-localization/default.nix
+++ b/distros/rolling/robot-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2022 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geographiclib, geometry-msgs, launch-ros, launch-testing-ament-cmake, message-filters, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geographiclib, geometry-msgs, launch-ros, launch-testing-ament-cmake, message-filters, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-robot-localization";
-  version = "3.3.1-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "27484234ab1967d0f205e0adbc9764e9364164556042ae47efa6c279266453b6";
+    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "da700e625dc433d51ce964ff61e05d8cc25af701481ae3731270467adf3b877e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake builtin-interfaces rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater eigen geographic-msgs geographiclib geometry-msgs message-filters nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
+  propagatedBuildInputs = [ angles boost diagnostic-msgs diagnostic-updater eigen geographic-msgs geographiclib geometry-msgs message-filters nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake builtin-interfaces rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/turbojpeg-compressed-image-transport/default.nix
+++ b/distros/rolling/turbojpeg-compressed-image-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2022 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libjpeg_turbo }:
+buildRosPackage {
+  pname = "ros-rolling-turbojpeg-compressed-image-transport";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release/archive/release/rolling/turbojpeg_compressed_image_transport/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "9a7b57d259cdc07818c669af5de471b764d7f3f2828b84f0669cd05ce3c0f065";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-transport libjpeg_turbo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Compressed_image_transport provides a plugin to image_transport for transparently sending images
+    encoded as JPEG by turbojpeg.'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}

--- a/distros/rolling/webots-ros2-control/default.nix
+++ b/distros/rolling/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-control";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "282e1ca4a2162fc59c1052a6fc42fa01c1f483f55bcf445c19565900f2cdc349";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "bc18ae3d0d826124b9e6a3b4e6c849de8fa955be7d0aa91064acc2d04e9c86ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "d734727f522b6bfb32be508a0c8a6fdb31ee3fa31954ba1e94bf776ec6633451";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "25fe4b869386510403e91c91590ba7ba6adda04b921575612d4dc139de893e0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-epuck/default.nix
+++ b/distros/rolling/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-epuck";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "975d6ebc2e2f6e1ccc2fbd0350067e18e62d4634240fb26854a733bdefcc5eb7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "65951e8295b1ec95fd196455fce15d31e33ac67a4f220ea3a4a13c6653b778ce";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-importer/default.nix
+++ b/distros/rolling/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-importer";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "839149c3bfcad894795d445f061dd914cccc05d8a062eed23427053bf0add1b4";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "c8ccc7189af00979b05ace9879ca070ba94022b481fbad73cfede970cf293758";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-mavic/default.nix
+++ b/distros/rolling/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-mavic";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "89cddff502072c2ba76b8c9a9af8c30ee990d825fe5680246e110314f4608193";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "8c0fea99310490c57bd88dd26b3cfc1606a504e5c4c8e6f1b533f7e61c23c6cb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-msgs/default.nix
+++ b/distros/rolling/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-msgs";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "af3d705f3e4789d6f65783138ca2c7fccbcd2a6348d05dee69c5afb814d44321";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "6831ae5b5922d921bda9cad059f7dccc0e91f105d1f4bad04c80d74d9ccd4e07";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tesla";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "bf9e8296c32979acf1401bd0f9c50227c91fa70118e7371061f42098888ddbde";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "36e1c2061d78bbd0c9a5f811847d8f004cb912cb0c98d8488cb90a45ae52e235";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tests/default.nix
+++ b/distros/rolling/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tests";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "e7c3de56eb3648797471c01298d0db25f56eede428ccb02c117bd75a62a9c555";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "c4288d056de8331a6dbb84a3ab8aa0f621607c9e06dbba4415e4dec1581996ec";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tiago/default.nix
+++ b/distros/rolling/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tiago";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "ff336116a15546248c84cb6e124442ac09985782f13d7a33a443d47f10b11da3";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "e17e362c77aeb7ed64e6671a05db0bc9c1070e63adac51ececc6867f040043d7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-turtlebot/default.nix
+++ b/distros/rolling/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-turtlebot";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "55524b0824500c2e01318deaa0cac850a3447feb52484465495ae12fdfeb11a7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "170c28a0ade6ad80b1e5b54c2791cafd54c7f19096d84e953ab93c7f852816d2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-universal-robot/default.nix
+++ b/distros/rolling/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-universal-robot";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "8e39fbff8d3be97705365a1c348bd234cb0753259c7dc74df9efefc8233ba9b3";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "c2786bcccc7618d9f61d8e92e73c4faff9d028a18e54c4afa50fe79456c27037";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2/default.nix
+++ b/distros/rolling/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2";
-  version = "2023.0.0-r1";
+  version = "2023.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "5d1a95155534bad87eb1353b3e50363d6d2def1dd2ab5a07d068f09a86769935";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.0.0-2.tar.gz";
+    name = "2023.0.0-2.tar.gz";
+    sha256 = "688e77ad4322458a84f43c5702fb87640f267d56917f674fe748d37848698cbb";
   };
 
   buildType = "ament_python";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'humble', 'melodic', 'noetic', 'rolling'] from nix-ros-overlay commit 795e67fe0e19118cef94209e4470edc64f13df93.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *aruco-opencv 1.0.1-r1*
* *aruco-opencv-msgs 1.0.1-r1*
* *find-object-2d 0.7.0-r3*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *lsc-ros2-driver 1.0.0-r10*
* *maliput-dragway 0.1.3-r1 --> 0.1.4-r1*
* *maliput-full 0.1.0-r2 --> 0.2.0-r1*
* *maliput-integration 0.1.3-r1 --> 0.1.4-r1*
* *maliput-malidrive 0.1.3-r1 --> 0.1.4-r1*
* *maliput-multilane 0.1.3-r1 --> 0.1.4-r1*
* *maliput-osm 0.1.0-r1 --> 0.2.0-r1*
* *maliput-sparse 0.1.0-r1 --> 0.2.0-r1*
* *robot-localization 3.1.1-r1 --> 3.1.2-r1*
* *rtabmap-ros 0.20.20-r1 --> 0.20.22-r1*
* *ur-bringup 2.0.1-r1 --> 2.0.2-r2*
* *ur-calibration 2.0.2-r2*
* *ur-controllers 2.0.1-r1 --> 2.0.2-r2*
* *ur-dashboard-msgs 2.0.1-r1 --> 2.0.2-r2*
* *ur-description 2.0.1-r1 --> 2.0.2-r2*
* *ur-moveit-config 2.0.1-r1 --> 2.0.2-r2*
* *ur-robot-driver 2.0.1-r1 --> 2.0.2-r2*
* *webots-ros2 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-control 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-driver 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-epuck 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-importer 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-mavic 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-msgs 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tesla 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tests 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tiago 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-turtlebot 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-universal-robot 2023.0.0-r1 --> 2023.0.0-r2*

Humble Changes:
---------------
* *aruco-opencv 2.0.1-r1*
* *aruco-opencv-msgs 2.0.1-r1*
* *costmap-queue 1.1.3-r1 --> 1.1.4-r1*
* *dwb-core 1.1.3-r1 --> 1.1.4-r1*
* *dwb-critics 1.1.3-r1 --> 1.1.4-r1*
* *dwb-msgs 1.1.3-r1 --> 1.1.4-r1*
* *dwb-plugins 1.1.3-r1 --> 1.1.4-r1*
* *find-object-2d 0.7.0-r1*
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *lsc-ros2-driver 1.0.0-r2*
* *magic-enum 0.8.1-r1 --> 0.8.2-r1*
* *nav-2d-msgs 1.1.3-r1 --> 1.1.4-r1*
* *nav-2d-utils 1.1.3-r1 --> 1.1.4-r1*
* *nav2-amcl 1.1.3-r1 --> 1.1.4-r1*
* *nav2-behavior-tree 1.1.3-r1 --> 1.1.4-r1*
* *nav2-behaviors 1.1.3-r1 --> 1.1.4-r1*
* *nav2-bringup 1.1.3-r1 --> 1.1.4-r1*
* *nav2-bt-navigator 1.1.3-r1 --> 1.1.4-r1*
* *nav2-collision-monitor 1.1.3-r1 --> 1.1.4-r1*
* *nav2-common 1.1.3-r1 --> 1.1.4-r1*
* *nav2-constrained-smoother 1.1.3-r1 --> 1.1.4-r1*
* *nav2-controller 1.1.3-r1 --> 1.1.4-r1*
* *nav2-core 1.1.3-r1 --> 1.1.4-r1*
* *nav2-costmap-2d 1.1.3-r1 --> 1.1.4-r1*
* *nav2-dwb-controller 1.1.3-r1 --> 1.1.4-r1*
* *nav2-lifecycle-manager 1.1.3-r1 --> 1.1.4-r1*
* *nav2-map-server 1.1.3-r1 --> 1.1.4-r1*
* *nav2-msgs 1.1.3-r1 --> 1.1.4-r1*
* *nav2-navfn-planner 1.1.3-r1 --> 1.1.4-r1*
* *nav2-planner 1.1.3-r1 --> 1.1.4-r1*
* *nav2-regulated-pure-pursuit-controller 1.1.3-r1 --> 1.1.4-r1*
* *nav2-rotation-shim-controller 1.1.3-r1 --> 1.1.4-r1*
* *nav2-rviz-plugins 1.1.3-r1 --> 1.1.4-r1*
* *nav2-simple-commander 1.1.3-r1 --> 1.1.4-r1*
* *nav2-smac-planner 1.1.3-r1 --> 1.1.4-r1*
* *nav2-smoother 1.1.3-r1 --> 1.1.4-r1*
* *nav2-system-tests 1.1.3-r1 --> 1.1.4-r1*
* *nav2-theta-star-planner 1.1.3-r1 --> 1.1.4-r1*
* *nav2-util 1.1.3-r1 --> 1.1.4-r1*
* *nav2-velocity-smoother 1.1.3-r1 --> 1.1.4-r1*
* *nav2-voxel-grid 1.1.3-r1 --> 1.1.4-r1*
* *nav2-waypoint-follower 1.1.3-r1 --> 1.1.4-r1*
* *navigation2 1.1.3-r1 --> 1.1.4-r1*
* *pal-gripper 3.0.0-r1 --> 3.0.1-r1*
* *pal-gripper-controller-configuration 3.0.0-r1 --> 3.0.1-r1*
* *pal-gripper-description 3.0.0-r1 --> 3.0.1-r1*
* *pmb2-2dnav 3.0.2-r1 --> 4.0.0-r1*
* *pmb2-maps 3.0.2-r1 --> 4.0.0-r1*
* *pmb2-navigation 3.0.2-r1 --> 4.0.0-r1*
* *rtabmap-ros 0.20.20-r2 --> 0.20.22-r1*
* *simple-term-menu-vendor 1.5.4-r1 --> 1.5.7-r1*
* *slam-toolbox 2.6.3-r1 --> 2.6.4-r1*
* *tiago-2dnav 4.0.1-r1 --> 4.0.2-r1*
* *tiago-navigation 4.0.1-r1 --> 4.0.2-r1*
* *turbojpeg-compressed-image-transport 0.1.3-r1*
* *webots-ros2 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-control 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-driver 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-epuck 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-importer 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-mavic 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-msgs 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tesla 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tests 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tiago 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-turtlebot 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-universal-robot 2023.0.0-r1 --> 2023.0.0-r2*

Melodic Changes:
----------------
* *find-object-2d 0.6.4-r2 --> 0.7.0-r2*
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *mapviz 1.4.1-r1 --> 1.4.2-r1*
* *mapviz-plugins 1.4.1-r1 --> 1.4.2-r1*
* *multires-image 1.4.1-r1 --> 1.4.2-r1*
* *rtabmap-ros 0.20.20-r1 --> 0.20.22-r1*
* *tile-map 1.4.1-r1 --> 1.4.2-r1*

Noetic Changes:
---------------
* *boost-plugin-loader 0.2.0-r1 --> 0.2.1-r1*
* *chomp-motion-planner 1.1.10-r1 --> 1.1.11-r1*
* *find-object-2d 0.6.3-r5 --> 0.7.0-r2*
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *magic-enum 0.8.1-r1 --> 0.8.2-r1*
* *mapviz 1.4.1-r2 --> 1.4.2-r1*
* *mapviz-plugins 1.4.1-r2 --> 1.4.2-r1*
* *moveit 1.1.10-r1 --> 1.1.11-r1*
* *moveit-chomp-optimizer-adapter 1.1.10-r1 --> 1.1.11-r1*
* *moveit-core 1.1.10-r1 --> 1.1.11-r1*
* *moveit-fake-controller-manager 1.1.10-r1 --> 1.1.11-r1*
* *moveit-kinematics 1.1.10-r1 --> 1.1.11-r1*
* *moveit-planners 1.1.10-r1 --> 1.1.11-r1*
* *moveit-planners-chomp 1.1.10-r1 --> 1.1.11-r1*
* *moveit-planners-ompl 1.1.10-r1 --> 1.1.11-r1*
* *moveit-plugins 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-benchmarks 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-control-interface 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-manipulation 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-move-group 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-occupancy-map-monitor 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-perception 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-planning 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-planning-interface 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-robot-interaction 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-visualization 1.1.10-r1 --> 1.1.11-r1*
* *moveit-ros-warehouse 1.1.10-r1 --> 1.1.11-r1*
* *moveit-runtime 1.1.10-r1 --> 1.1.11-r1*
* *moveit-servo 1.1.10-r1 --> 1.1.11-r1*
* *moveit-setup-assistant 1.1.10-r1 --> 1.1.11-r1*
* *moveit-simple-controller-manager 1.1.10-r1 --> 1.1.11-r1*
* *multires-image 1.4.1-r2 --> 1.4.2-r1*
* *pilz-industrial-motion-planner 1.1.10-r1 --> 1.1.11-r1*
* *pilz-industrial-motion-planner-testutils 1.1.10-r1 --> 1.1.11-r1*
* *rqt-human-radar 0.2.0-r1 --> 0.2.1-r1*
* *rtabmap-ros 0.20.20-r1 --> 0.20.22-r1*
* *slam-toolbox 1.5.6-r1 --> 1.5.7-r1*
* *slam-toolbox-msgs 1.5.6-r1 --> 1.5.7-r1*
* *slam-toolbox-rviz 1.5.6-r1 --> 1.5.7-r1*
* *tile-map 1.4.1-r2 --> 1.4.2-r1*

Rolling Changes:
----------------
* *aruco-opencv 4.0.1-r1*
* *aruco-opencv-msgs 4.0.1-r1*
* *find-object-2d 0.7.0-r2*
* *foxglove-bridge 0.2.1-r1 --> 0.2.2-r1*
* *hpp-fcl 2.1.3-r1 --> 2.2.0-r1*
* *robot-localization 3.3.1-r1 --> 3.5.0-r1*
* *turbojpeg-compressed-image-transport 0.2.1-r1*
* *webots-ros2 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-control 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-driver 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-epuck 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-importer 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-mavic 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-msgs 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tesla 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tests 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-tiago 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-turtlebot 2023.0.0-r1 --> 2023.0.0-r2*
* *webots-ros2-universal-robot 2023.0.0-r1 --> 2023.0.0-r2*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-edifice
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui3
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] wiimote

