### PR TITLE
distros/ros1-overlay: fix rviz build

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -178,8 +178,7 @@ let
     pr2-tilt-laser-interface = patchBoostSignals rosSuper.pr2-tilt-laser-interface;
 
     python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
-      propagatedNativeBuildInputs ? [],
-      postPatch ? "", ...
+      propagatedNativeBuildInputs ? [], ...
     }: {
       propagatedNativeBuildInputs = propagatedNativeBuildInputs ++ (with rosSelf.pythonPackages; [
         shiboken2

--- a/distros/ros1-overlay.nix
+++ b/distros/ros1-overlay.nix
@@ -51,5 +51,35 @@ rosSelf: rosSuper: with rosSelf.lib; {
     nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
   });
 
+  rviz = rosSuper.rviz.override {
+    python-qt-binding = (rosSuper.python-qt-binding.override {
+      python3Packages = rosSelf.python3Packages.override {
+        overrides = pySelf: pySuper: {
+          pyqt5 = rosSelf.python3Packages.pyqt5.overrideAttrs ({
+            patches ? [], ...
+          }: {
+            patches = patches ++ [ (self.fetchpatch {
+              url = "https://aur.archlinux.org/cgit/aur.git/plain/restore-sip4-support.patch?h=python-pyqt5-sip4&id=6e712e6c588d550a1a6f83c1b37c2c9135aae6ba";
+              sha256 = "sha256-NfMe/EK1Uj88S82xZSm+A6js3PK9mlgsaci/kinlsy8=";
+            }) ];
+          });
+        };
+      };
+    }).overrideAttrs({
+      propagatedNativeBuildInputs ? [],
+      postPatch ? "", ...
+    }: {
+      # rviz1 does not support shiboken/pyside2
+      propagatedNativeBuildInputs = (rosSelf.lib.subtractLists
+        (with rosSelf.pythonPackages; [ shiboken2 pyside2 ])
+        propagatedNativeBuildInputs)  ++ [ rosSelf.pythonPackages.sip_4 ];
+      postPatch = ''
+        sed -e "1 i\\import PyQt5" \
+            -e "s#sipconfig\._pkg_config\['default_mod_dir'\], 'PyQt5'#PyQt5.__path__[0]#" \
+            -i cmake/sip_configure.py
+      '' + postPatch;
+    });
+  };
+
   roscpp = patchBoostSignals rosSuper.roscpp;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668192777,
-        "narHash": "sha256-C/koqhRmkV2hRCENfDUAK6HP7HTDwLAmhyP5QOy1jtI=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "lopsided98",
         "repo": "nixpkgs",
-        "rev": "cb892295b6674f6d942ce78df3a27f2f219972e0",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
By making sip-4 compatible with pyqt5 which is required by python-qt-binding, a dependency of rviz, using this patch:

https://aur.archlinux.org/cgit/aur.git/plain/restore-sip4-support.patch?h=python-pyqt5-sip4&id=6e712e6c588d550a1a6f83c1b37c2c9135aae6ba

Should fix https://github.com/lopsided98/nix-ros-overlay/issues/227

Signed-off-by: Amneesh Singh <natto@weirdnatto.in>