### PR TITLE
rosdistro sync, Fri Feb 10 13:32:23 2023

### DIFF
--- a/distros/foxy/depthai/default.nix
+++ b/distros/foxy/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-depthai";
-  version = "2.19.1-r1";
+  version = "2.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.19.1-1.tar.gz";
-    name = "2.19.1-1.tar.gz";
-    sha256 = "eb803428dab9d961ae454a3ef4721da6488260c79eb5b83dbd21cefd5da243c6";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/foxy/depthai/2.20.2-1.tar.gz";
+    name = "2.20.2-1.tar.gz";
+    sha256 = "0be52d40cab357d0a5fc2a8c4e861b1df0351954f116a8eaa67da348940b510a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-aggregator/default.nix
+++ b/distros/foxy/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-aggregator";
-  version = "2.0.8-r2";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "7d666fe6d9592908b132b560e02fbc213f9808c628cd0e06cc101a1f1d48e47b";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "f4c2d2af57b3fe8e22d6eee193b78986e7e598f948821eb36d9d8648d1ddb3f0";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''diagnostic_aggregator'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/foxy/diagnostic-common-diagnostics/default.nix
+++ b/distros/foxy/diagnostic-common-diagnostics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, ntp, rclpy }:
+buildRosPackage {
+  pname = "ros-foxy-diagnostic-common-diagnostics";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_common_diagnostics/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "d7c62bb4ddbeb0b26f48bbb8f7510d92339dc79085f05edb66ba7c0afacf92ab";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater ntp rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''diagnostic_common_diagnostics'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/diagnostic-updater/default.nix
+++ b/distros/foxy/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-updater";
-  version = "2.0.8-r2";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "08abc22cf49ec9740af6ee857e2491213aeb78ffac9f589e14ab1faaa9b0c3ee";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "16893d3b9eedee351280cae40e72ec7a8f714c66553758a6cff97a78b9bcddd3";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/foxy/diagnostics/default.nix
+++ b/distros/foxy/diagnostics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+buildRosPackage {
+  pname = "ros-foxy-diagnostics";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostics/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "062fdd7e68ab16ba10f7c8ad5a109ef5c7c77635881e910e4deda63e1672bbb8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''diagnostics'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/foxy/eigenpy/default.nix
+++ b/distros/foxy/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-eigenpy";
-  version = "2.9.0-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "2535089ce6adfedeaecff201d5fdb496bf3aaff0668a6565219670450f8a7f24";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/foxy/eigenpy/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "54973a60d65ec89bec195f86eb872d71ea53ee0913a7b74c196c12767ee1215c";
   };
 
   buildType = "cmake";

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.1.2-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "16b983d6018e778aa240cc2430f17561c5415b7466cf067faea850065b5a716f";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "0f329b8b2fc87f34500a4b25c56aea61075914323fa8a4b3b9ecf7183a362077";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -352,9 +352,13 @@ self: super: {
 
  diagnostic-aggregator = self.callPackage ./diagnostic-aggregator {};
 
+ diagnostic-common-diagnostics = self.callPackage ./diagnostic-common-diagnostics {};
+
  diagnostic-msgs = self.callPackage ./diagnostic-msgs {};
 
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
+
+ diagnostics = self.callPackage ./diagnostics {};
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
@@ -713,6 +717,8 @@ self: super: {
  joy-linux = self.callPackage ./joy-linux {};
 
  joy-teleop = self.callPackage ./joy-teleop {};
+
+ joy-tester = self.callPackage ./joy-tester {};
 
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
 

--- a/distros/foxy/jackal-control/default.nix
+++ b/distros/foxy/jackal-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, interactive-marker-twist-server, jackal-description, joint-state-broadcaster, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, jackal-description, joint-state-broadcaster, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-foxy-jackal-control";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_control/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "97eeb525177c0695441b562ef3773e83b019d1aeecd91d91030444490616f646";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_control/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "ef3ce67ba7edcdbacde0cf6687a075491e55e5a0e5d8bd3b2bb58e8227bd88d2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager diff-drive-controller interactive-marker-twist-server jackal-description joint-state-broadcaster joint-trajectory-controller joy robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller imu-filter-madgwick interactive-marker-twist-server jackal-description joint-state-broadcaster joint-trajectory-controller joy robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/jackal-description/default.nix
+++ b/distros/foxy/jackal-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-foxy-jackal-description";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_description/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "800ded481161714cba87cb0c7b95275647c314743db4ce9bca6670bd600cf2de";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_description/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d1281aeb206b39161998f4e03e510e208be598488a72830e24ba96e72615959c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  propagatedBuildInputs = [ robot-state-publisher urdf velodyne-description xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/jackal-msgs/default.nix
+++ b/distros/foxy/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-jackal-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ea4f510daae2761aa419fb8742dda67946f52dc87b02cda9d7048a1691144d18";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "8f3d563c3a0de7a58fd17a60fac196b165b5fcec437e12f54991633ee9980ad9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/jackal-navigation/default.nix
+++ b/distros/foxy/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav2-bringup, slam-toolbox }:
 buildRosPackage {
   pname = "ros-foxy-jackal-navigation";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_navigation/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "a7dfe807131fa2ea3129b75ead05e14a1071eede76b1a38280097f96c364f792";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/foxy/jackal_navigation/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "193cbac1fb85df49a57da294aacc4c917fe2a54141054c1c1bbc5a88f9c8d2c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joy-tester/default.nix
+++ b/distros/foxy/joy-tester/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-joy-tester";
+  version = "0.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joy_tester-release/archive/release/foxy/joy_tester/0.0.2-2.tar.gz";
+    name = "0.0.2-2.tar.gz";
+    sha256 = "47af266b93b3ba2971f9b64368367a669cfc49ae5393f547e269abf47d7248fe";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.tkinter rclpy sensor-msgs ];
+
+  meta = {
+    description = ''Simple GUI tool for testing joysticks/gamepads'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/maliput/default.nix
+++ b/distros/foxy/maliput/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-gtest, fmt, gflags, libyamlcpp }:
 buildRosPackage {
   pname = "ros-foxy-maliput";
-  version = "1.0.9-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0f3a17fe9dd947deb4aaadd5ca38b36957502f7e8ec79ea6ef3ef0d7a98b5379";
+    url = "https://github.com/ros2-gbp/maliput-release/archive/release/foxy/maliput/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "60155e117fc30398fb885c5c436d7c680317b09e014b46074fe8cf8b5a5042cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mvsim/default.nix
+++ b/distros/foxy/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, box2d, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-foxy-mvsim";
-  version = "0.5.0-r1";
+  version = "0.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/foxy/mvsim/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "e44d3ae2e9c10a52ec9dce8b8f949dae8cba4e703aee2f5068fc82feb4bfc080";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/foxy/mvsim/0.5.1-2.tar.gz";
+    name = "0.5.1-2.tar.gz";
+    sha256 = "0efc35cba6f5b3ce4b1ec14be3f3fe2b83cea7e2e71ee64da2dd499a2c7a8ea1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pinocchio/default.nix
+++ b/distros/foxy/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-pinocchio";
-  version = "2.6.14-r1";
+  version = "2.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/foxy/pinocchio/2.6.14-1.tar.gz";
-    name = "2.6.14-1.tar.gz";
-    sha256 = "28027c7a5ca190bac5a9a74b8414377a531f73e1c0651e22e5f2816c3b50f1b5";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/foxy/pinocchio/2.6.16-1.tar.gz";
+    name = "2.6.16-1.tar.gz";
+    sha256 = "a5547d5ca86f81dcf8a567e63d61aeddfce42afba23b881e352cab061a498001";
   };
 
   buildType = "cmake";

--- a/distros/foxy/self-test/default.nix
+++ b/distros/foxy/self-test/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-self-test";
-  version = "2.0.8-r2";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "7a59d918b7b2ce03ad3496b1b8bcc79ac6eecbb35fed93a450fb7f5a6c56bcde";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "8d8ec86b9d1cfb25ef0a2795581a723b95559bfe7508fffef9c3524a81ff0871";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''self_test'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-control";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "449b07820274f65c7c7c5e10db1b1b9bd491fa1bfa631b5af17fb69a2800f91e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_control/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "95cf8e4e9349251fd0f6fe744cdf26f088c160151254ce2879f7daef0104036d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-driver";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "17bd28627d1ad0a4e0eebad2c5bf32e81f17dacc71b7f1a193ba2214062d21ed";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_driver/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "b025e55261f2faa356c103da72c5e6f643769d6c4b910b118b6393bd7e1a1880";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "e640771a214f49cf61f6e8cfd3daedca8e01c67ec5d29aacebc929a9d0a91784";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "777d6b70c2b7168d2a8e089354e810cb8ed694c00ed6982b7403c686875197c8";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster nav-msgs rclpy robot-state-publisher rviz2 sensor-msgs std-msgs tf2-ros webots-ros2-control webots-ros2-driver webots-ros2-msgs ];
 
   meta = {

--- a/distros/foxy/webots-ros2-importer/default.nix
+++ b/distros/foxy/webots-ros2-importer/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-importer";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "e924b570509c1f07f28feb5fdfd6a7498b4b05cf1e6c59bd5c259abaae0c7d97";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_importer/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "911ab0cba29dfa7abf8201f19b5b71d9342219396058f610df6143bf290f07b4";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.numpy python3Packages.pillow python3Packages.pycodestyle pythonPackages.pytest ];
+  checkInputs = [ ament-copyright python3Packages.numpy python3Packages.pillow python3Packages.pycodestyle pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces python3Packages.lark python3Packages.pycollada xacro ];
 
   meta = {

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-mavic";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "3549337790d4717a741203f04e448d4dd143f44c6d91c8aff2a0ac2a08b00d08";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "89f46552c748957cb906d013d2c0e5367de16c966b8f98e2621060721cb37005";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces rclpy webots-ros2-driver ];
 
   meta = {

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "c567b85e871660d513a25d08a1585d81a1fd52b55f88f8e77555e28f1e82dcc5";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "667ad2e0d9d375736da25302b4c8cf8ff0f8916c8ebd26f828dbad18dd6e93c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "11010a68c0d75923797a9e975e2b9c6b0a27c9a864583214fbbf14055062ff9e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "deb034f8b572bccd585ce2a0ea4ac744d1c2134e65924690591cbfd981de1f65";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-driver ];
 
   meta = {

--- a/distros/foxy/webots-ros2-tests/default.nix
+++ b/distros/foxy/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tests";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "eba8f4c721ae3f73c089a239f70b599f4d50df094c3440535ad69580be3a879b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tests/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "bb36d97b40b65f8a4bbdb14547a9f079d62e267925298672aaf6e13361fcdf94";
   };
 
   buildType = "ament_python";
   buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = ''System tests for `webots_ros2` packages.'';

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "f9bfd887c5d67a46c509ee8d3059e45e1e36cce9d7e5fe499bb1e3c87a176b7f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "ab19c8dd04bb429ce7020dabd9ef1a4551b457e6d545af4bad731dcf91162dc3";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster rclpy robot-state-publisher rviz2 tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "b25f39d1eabca7a89dbdbc8ad179f2d3c8611c200522dcc84eca06d03cb1070c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "e19838645807f76ad2f8e73268b36bdf8d3b1f74e68e67c5394762e60d5a7f8b";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller joint-state-broadcaster rclpy robot-state-publisher rviz2 tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "2f977716f2da66b3dab916c76be1e03e354c18ae97c8d75a9ff7821c1e3383ea";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "8ee7cea768a8c534b62231b0a021a1df70bb023f79aa8b185de992b7e3a9e9d1";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver xacro ];
 
   meta = {

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "d269d3edf9e5fc22589ff15f165221c511028cce1dde7e63adc2824dd439b765";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/foxy/webots_ros2/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "6be3b5a2d2b6fae7185a98ed7023fdce5500faab6dad76b495e7caaff5ee2cd5";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest webots-ros2-tests ];
+  checkInputs = [ ament-copyright pythonPackages.pytest webots-ros2-tests ];
   propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "ee541720cc76bf8a70c5ab343b182145c937d4899b6b76a943e81d64b179595a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "ab1fb0f6e59480151f37626c9b5b04f630edc5ddcdfbc875e15dea25162ee42e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock control-msgs controller-manager hardware-interface kinematics-interface-kdl ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/apriltag-msgs/default.nix
+++ b/distros/humble/apriltag-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-apriltag-msgs";
+  version = "2.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_msgs-release/archive/release/humble/apriltag_msgs/2.0.1-2.tar.gz";
+    name = "2.0.1-2.tar.gz";
+    sha256 = "151d641264106c2e4fd9d243ffff53489afc9c2c01140222da51142144e01bc0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''AprilTag message definitions'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/apriltag-ros/default.nix
+++ b/distros/humble/apriltag-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, apriltag, apriltag-msgs, cv-bridge, eigen, image-transport, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-apriltag-ros";
+  version = "3.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/humble/apriltag_ros/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "d7370dfa343f39b37b681abaef92c243656c98b7e18e7a2347a2e960177aa8e9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-lint-auto ];
+  propagatedBuildInputs = [ apriltag apriltag-msgs cv-bridge image-transport rclcpp rclcpp-components sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''AprilTag detection node'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/aruco-msgs/default.nix
+++ b/distros/humble/aruco-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-aruco-msgs";
+  version = "5.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_msgs/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "71b615a09b28bc3ac55c7c2203dea9455bd37bcad7e9e164a2c702cf829af226";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The aruco_msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/aruco-ros/default.nix
+++ b/distros/humble/aruco-ros/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, aruco, aruco-msgs, cv-bridge, geometry-msgs, image-transport, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-aruco-ros";
+  version = "5.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_ros/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "82efd2943b491cc0d620dcee270649528fa7e5c765ebbbcd27cd42b8e47f7ff2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ aruco aruco-msgs cv-bridge geometry-msgs image-transport rclcpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/aruco/default.nix
+++ b/distros/humble/aruco/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen }:
+buildRosPackage {
+  pname = "ros-humble-aruco";
+  version = "5.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "6d964a16ebd216b99eda6720bac0a01cf0661d947805ec66ed56da2790bca1b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cv-bridge eigen ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The ARUCO Library has been developed by the Ava group of the Univeristy of Cordoba(Spain).
+    It provides real-time marker based 3D pose estimation using AR markers.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/cascade-lifecycle-msgs/default.nix
+++ b/distros/humble/cascade-lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-cascade-lifecycle-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/humble/cascade_lifecycle_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0cdf0631d890e4532fbe613b0d61018ebf841a3f8fac225f43775e899e98ad0e";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/humble/cascade_lifecycle_msgs/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "f657ab4af09517b16809c4faf1e3f6b9bb056aa169d8171e8994d922b1d7df9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "76062d79fbc6a727f585d7a2c1fc524566ec5aad8b8e84a0634104d7f40b7274";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "b5b37a0c5403c606bc6e7d1ce0b93c4193735c86d673497413fc7e5c84a6fc71";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "84e4a4444f4f2d155a2c1ba57e7e38e8956316e48fa9daa8ac31b33715b094e0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "c942c3a9f8fe7e599046e5852c7ac40a158d42d98d218151bf946a0621ffd0af";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "71617d8f0825760514478820c7896ecdaedc5f7b9f19ba6c07173c8f30ba07ca";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "bd98a96252d202746467f0f15c8c5b6ff08304347e4191a057d1148635865cf7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/humble/dataspeed-dbw-common/default.nix
+++ b/distros/humble/dataspeed-dbw-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, rclcpp, ros2-socketcan }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-dbw-common";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6f2b51f5ee9e6ed31940325b9f5e9b50e7b52768f1f49579ce547cf79f7faaed";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_common/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ae6dad10446fc098c02088c625dd2d786b82a84b3313837a33cf271700f55a36";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-dbw-gateway/default.nix
+++ b/distros/humble/dataspeed-dbw-gateway/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, dataspeed-dbw-common, dataspeed-dbw-msgs, dbw-fca-msgs, dbw-ford-msgs, dbw-polaris-msgs, diagnostic-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, dataspeed-dbw-common, dataspeed-dbw-msgs, dbw-fca-msgs, dbw-ford-msgs, dbw-polaris-msgs, diagnostic-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-dbw-gateway";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_gateway/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e3ba55b2f45417cea4a2f26ce7d7b8b616b190249faf4970f0bac17698792d05";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_gateway/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "bb6fa62d393825fbc90387f2dee97ec750e46565cc8c8fde06b34182caad0403";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ dataspeed-dbw-common dataspeed-dbw-msgs dbw-fca-msgs dbw-ford-msgs dbw-polaris-msgs diagnostic-msgs rclcpp rclcpp-components rosidl-default-runtime sensor-msgs ];
+  propagatedBuildInputs = [ dataspeed-dbw-common dataspeed-dbw-msgs dbw-fca-msgs dbw-ford-msgs dbw-polaris-msgs diagnostic-msgs rclcpp rclcpp-components ros-environment rosidl-default-runtime sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/humble/dataspeed-dbw-msgs/default.nix
+++ b/distros/humble/dataspeed-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-dbw-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e2bcf7dcbd702723a46158414cc845d97de7b9d5d1f9599bf92bee9e9244d6d7";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e90290e1f3f731933040dd4b32054767adc259df2d43d1650892cd55647b1a1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc-can/default.nix
+++ b/distros/humble/dataspeed-ulc-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-dbw-common, dataspeed-ulc-msgs, geometry-msgs, rclcpp, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc-can";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_can/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e71fda64b95b74c8fc9f38875ada6203f1fe1e9d954218bfa69cb9389498bd4a";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_can/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e91ea32c708f283029ee723c667b7ba4b1054c293f0ac64492558b3776a469b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc-msgs/default.nix
+++ b/distros/humble/dataspeed-ulc-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d33067c5cda6849443256db93da86949f96ea9899dfe591c3efe5bd7bf2de838";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d6463b600e0123d46e4cd994cc10dd68368637b09d6e22829bbd667266a3dba3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc/default.nix
+++ b/distros/humble/dataspeed-ulc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-ulc-can, dataspeed-ulc-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "f4999de01e59802740826963a4dcbbf40260e83a67ef997ca99b25ae9433ed54";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "14eb7e0d0054222f4efc820b73eafd0182bbe943934e4ed7fa207650cde5cb47";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-can/default.nix
+++ b/distros/humble/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-can";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_can/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "de662693e811d8f18c6b98b775b733db380e5fd58c50b9c97ead112786b779b7";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_can/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "6eca01a7af4c8de36e79f533c5289082af2135145c20ca0d039542f8a5b43905";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-description/default.nix
+++ b/distros/humble/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-description";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "29b11e585dfb21ba9a05cc832744fe68979e51c39cf03ea608d270ec53071029";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_description/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "04bc168ad69f14482530926af9f76815a836c00218452b92cef76ba0438ffd29";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-joystick-demo/default.nix
+++ b/distros/humble/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-fca-can, dbw-fca-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-joystick-demo";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_joystick_demo/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8a626393754b22073e53ae5695b103c24add8dc1ffb16655546fb4c12f5813db";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_joystick_demo/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "4ee22bba8a68075fbb962bd5aa6d0330c4ec9f629ed7e3732b6a39b060d7a9bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-msgs/default.nix
+++ b/distros/humble/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d5057da6ca23403e0ac0a93d783715ae5b15ffbc95c210e96f25ed6ace28ea2d";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "c2822680773dab951ac1c96f0f515a75601bb4750ae37bb9a12f515e47b78ab0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca/default.nix
+++ b/distros/humble/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d212cb5d9c20577aabcbe401794f1e5cdf1caee9b75ec3ce500d2f20d8bf18d7";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "4d4d7ee487c8fa57a856a11c63a5171738143c919f1323d19f21c78565f45185";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-can/default.nix
+++ b/distros/humble/dbw-ford-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-ford-description, dbw-ford-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-can";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_can/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e1fb590eab2225e3125bdf586914c991b2294918b536e5d632edc4edb33cb06b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_can/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "662d843d1e553401d0304f9ae4bfe1825a12fe73e21d5b42b37644907270081b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-description/default.nix
+++ b/distros/humble/dbw-ford-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-description";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7bbf59bd586b2aad4df61086b8ec6cc6982954d9f6053cdd065003ec682ac08b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_description/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "32daa3b66ffbc26682cf4f3ee729249f1096c8e924e6fd465d1f0ae1c03a2ebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-joystick-demo/default.nix
+++ b/distros/humble/dbw-ford-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-ford-can, dbw-ford-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-joystick-demo";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_joystick_demo/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d087cad6398ef9abdc553973c020ea1de901e6bf08e95aaa2562782dfcb91636";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_joystick_demo/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3fe4e461c3bd9ab7052cf9c68a27300d3576f5aa6ee863cedd887ca04ad84c63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-msgs/default.nix
+++ b/distros/humble/dbw-ford-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "45596095dcf098c1908930ce0c9acf9d4e285b7d24796963fb4d14bc73dfb713";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a00d8a8528b8850eb7e71838825b8125e7567bc6501bdeab5767aaebf2b60c2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford/default.nix
+++ b/distros/humble/dbw-ford/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-ford-can, dbw-ford-description, dbw-ford-joystick-demo, dbw-ford-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "bf6ad1f55a924173c15a56d8a3b559a3a0280c2c28acee148e2bc16fc2b67eb5";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "144ee7d55b8fdf62b5400361550bfc59a49f7204b312750e3940509117b07f01";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-can/default.nix
+++ b/distros/humble/dbw-polaris-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-can";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_can/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e130577ce932683562ce81b3866768bf9f465dd9388f2d8358a62d2be26085a3";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_can/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a0d9d8f2de9f2de0c313a1f442fcfdeb99f86800d8b969d7fd9d4af995fdf999";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-description/default.nix
+++ b/distros/humble/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-description";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ce07bc24d948a5164e445affd87eae8d39fed6ab3a8bec834ce61bd6a4b2d941";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_description/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "79c187e96b509fefa1787a9f25ddc756cfafc90de881d0cb533238086de911b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-joystick-demo/default.nix
+++ b/distros/humble/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-polaris-can, dbw-polaris-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-joystick-demo";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_joystick_demo/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "3587f96390161860532e7df792c1428532c92f875c98a62ccad00ff3f2ffcc85";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_joystick_demo/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "872301d1189de912ff60b840d299ecc041945bf6cbc0cfea305aef9573feef57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-msgs/default.nix
+++ b/distros/humble/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "9c44956a92dc2822cc80c31bb8f18931ae58c02a1703875877b227af66f79f01";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ef019802cf637829f53f3f328390440fe94bb2ba5899d80413f28e9c54e6c64d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris/default.nix
+++ b/distros/humble/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8764a03ace3b965632223fa58803f628fa3b759c207a797816087bbbe5f030e6";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d9200b64339338ad9a8e83a33e5f77d8dcfcab53d9f2a2964b4df3b6afe41e8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.5.3-r1";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "370db157b07fae810ea63f80e1afa92dafc86a4f2c640b02dd97b1c6f177fb6c";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "66844bb22eac5db144709d3abf930d3ae13e161a9bfd3a14107208e3c65316e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.5.3-r1";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "d915d980dee87c69c97523dc9e7a539bf7f5246cfb89c729e37d8503df9d2d41";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "d027597d74c46bade902ffa50623bde0ce6b681c8e10ec0cf43f7053a2a07007";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ camera-info-manager cv-bridge depth-image-proc depthai depthai-bridge depthai-ros-msgs foxglove-msgs image-transport opencv rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs vision-msgs xacro ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depth-image-proc depthai depthai-bridge depthai-ros-msgs foxglove-msgs image-transport opencv rclcpp robot-state-publisher ros-environment rviz-imu-plugin sensor-msgs std-msgs stereo-msgs vision-msgs xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, depthai, depthai-bridge, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+buildRosPackage {
+  pname = "ros-humble-depthai-ros-driver";
+  version = "2.6.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "dcdea5987242afc63b57f0778a088cf4b8b8e68dc61733ab0c5452a22cbe22e1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-auto cv-bridge depthai depthai-bridge diagnostic-msgs image-pipeline image-transport image-transport-plugins rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Depthai ROS Monolithic node.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.5.3-r1";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "34ac0f32360dd9d1e135c77bca00e6f4925dad9debf71dc474968eb371df3803";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "6c00619908e8f834e74b3e53d2302602b8143b33c4726f564917cc93956531d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-examples, depthai-ros-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.5.3-r1";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "440f463ca84077a479762b389444b9e9d51620ec392fe894c62b9752ba1966de";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "e1375ae970185094bd6646adeb185865fe6131e8ddb1a78027a1b7eb6395ba5a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ depthai depthai-bridge depthai-examples depthai-ros-msgs ];
+  propagatedBuildInputs = [ depthai depthai-bridge depthai-examples depthai-ros-driver depthai-ros-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.19.1-r1";
+  version = "2.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.19.1-1.tar.gz";
-    name = "2.19.1-1.tar.gz";
-    sha256 = "fa76fab7cfc432b13de859ec597a9abf28a3b3be4b766f1493122166648d9ea0";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.20.2-1.tar.gz";
+    name = "2.20.2-1.tar.gz";
+    sha256 = "e6482e95f05da95a03898a83394c37df38cf34010d872f300d6ff544942b1444";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-aggregator/default.nix
+++ b/distros/humble/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-aggregator";
-  version = "3.0.0-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2fecf33067be564781b0efb26e815457a51523c52eeb680725b4e3d77026952d";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "037ce1fb3f7f2a6dd2e0d0a5bba456f9ae09e5252cbeac319b114159580ef8d2";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''diagnostic_aggregator'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/diagnostic-common-diagnostics/default.nix
+++ b/distros/humble/diagnostic-common-diagnostics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, ntp, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-diagnostic-common-diagnostics";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_common_diagnostics/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "8e444af59a9386405ab4ae8acd4d65665bcd2e403c40762d1858e16c6c520dad";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater ntp rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''diagnostic_common_diagnostics'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/diagnostic-updater/default.nix
+++ b/distros/humble/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-updater";
-  version = "3.0.0-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5d2f40a7d3119f3f4b645e8f51e3c499d3931dafdb5bac3dd19db43f69d7bacf";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "7f994e50365991eacbe59fe2c608ae8fa3e901499403457d3d50bd455bca3c0d";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/diagnostics/default.nix
+++ b/distros/humble/diagnostics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+buildRosPackage {
+  pname = "ros-humble-diagnostics";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostics/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "d70c6be758d83a3abdb67f5bf7ef786192a466137e0451551c5525b439423f79";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''diagnostics'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "a36d4a5f3a1a731d42c4312edcf4f00bee5d6b3c7630b73d2eb3c263bc7d56e3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "c4f2a450273ba27f6f432369e9df56f15d453900712c4b07e121084aeae06940";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library pluginlib ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle rcpputils realtime-tools tf2 tf2-msgs ];
+  propagatedBuildInputs = [ backward-ros controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle rcpputils realtime-tools tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "a7603dc0f608c6d96735ffc61022c769aa5b185a0aae69502d415431d3573cdf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "dc3b6991255fe92c9d1958716e6590b092a1ca6b93c9b2bb2ee6382bcaabcce3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pluginlib ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ forward-command-controller rclcpp ];
+  propagatedBuildInputs = [ backward-ros forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-eigenpy";
-  version = "2.8.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "2c103c8c2cfe8e6b4686fe892cdab90041659c2efd22bd14d4f34c1230f5df7c";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "373191edfcbbe5f151b1fdd09e067167e71893e6b873002598821f0659b73f36";
   };
 
   buildType = "cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "be8b20bb400b500f3e4d0d0ff8d8fd2d334e9c329e8a3d528288d4d965748f46";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "5bd267e9eef5c1c64a59c6effc702f7aab8cf87db337c1eee23857c4e5a230da";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
-  propagatedBuildInputs = [ controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
+  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "a64e8f1bec33f22945ca2a65e438389c694b194fca782fcd5e4a21150f44b611";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "18708e6694225def66a60cca4bf0aabfc231233e97f04225e8a12241ff0bd023";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pluginlib ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ controller-interface generate-parameter-library hardware-interface rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
+  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/gazebo-ros2-control-demos/default.nix
+++ b/distros/humble/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control-demos";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "ee4189b08b3bbf24b09afd12260d7c66ca02967d81f4d7fd53aa40e1a73e8bad";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "3d76faeca3d63b65f3ffa17c102af1f4a2548365227155083acd20c08e0800a3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control ros2-controllers std-msgs velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control ros2-controllers std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/gazebo-ros2-control/default.nix
+++ b/distros/humble/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "b549f9311a704006adf5ce23688fa1cf13850284ed19ea87f8a143af57ac8858";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "d4d419345e2087c67fbf651c64c6f317c901db3090a8fdc6d6f1500d6b4510cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -160,9 +160,19 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ apriltag-msgs = self.callPackage ./apriltag-msgs {};
+
+ apriltag-ros = self.callPackage ./apriltag-ros {};
+
+ aruco = self.callPackage ./aruco {};
+
+ aruco-msgs = self.callPackage ./aruco-msgs {};
+
  aruco-opencv = self.callPackage ./aruco-opencv {};
 
  aruco-opencv-msgs = self.callPackage ./aruco-opencv-msgs {};
+
+ aruco-ros = self.callPackage ./aruco-ros {};
 
  asio-cmake-module = self.callPackage ./asio-cmake-module {};
 
@@ -318,6 +328,8 @@ self: super: {
 
  depthai-examples = self.callPackage ./depthai-examples {};
 
+ depthai-ros-driver = self.callPackage ./depthai-ros-driver {};
+
  depthai-ros-msgs = self.callPackage ./depthai-ros-msgs {};
 
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
@@ -328,9 +340,13 @@ self: super: {
 
  diagnostic-aggregator = self.callPackage ./diagnostic-aggregator {};
 
+ diagnostic-common-diagnostics = self.callPackage ./diagnostic-common-diagnostics {};
+
  diagnostic-msgs = self.callPackage ./diagnostic-msgs {};
 
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
+
+ diagnostics = self.callPackage ./diagnostics {};
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
@@ -624,7 +640,29 @@ self: super: {
 
  io-context = self.callPackage ./io-context {};
 
+ irobot-create-common-bringup = self.callPackage ./irobot-create-common-bringup {};
+
+ irobot-create-control = self.callPackage ./irobot-create-control {};
+
+ irobot-create-description = self.callPackage ./irobot-create-description {};
+
+ irobot-create-gazebo-bringup = self.callPackage ./irobot-create-gazebo-bringup {};
+
+ irobot-create-gazebo-plugins = self.callPackage ./irobot-create-gazebo-plugins {};
+
+ irobot-create-gazebo-sim = self.callPackage ./irobot-create-gazebo-sim {};
+
+ irobot-create-ignition-bringup = self.callPackage ./irobot-create-ignition-bringup {};
+
+ irobot-create-ignition-sim = self.callPackage ./irobot-create-ignition-sim {};
+
+ irobot-create-ignition-toolbox = self.callPackage ./irobot-create-ignition-toolbox {};
+
  irobot-create-msgs = self.callPackage ./irobot-create-msgs {};
+
+ irobot-create-nodes = self.callPackage ./irobot-create-nodes {};
+
+ irobot-create-toolbox = self.callPackage ./irobot-create-toolbox {};
 
  joint-limits = self.callPackage ./joint-limits {};
 
@@ -641,6 +679,8 @@ self: super: {
  joy-linux = self.callPackage ./joy-linux {};
 
  joy-teleop = self.callPackage ./joy-teleop {};
+
+ joy-tester = self.callPackage ./joy-tester {};
 
  kdl-parser = self.callPackage ./kdl-parser {};
 
@@ -759,6 +799,12 @@ self: super: {
  magic-enum = self.callPackage ./magic-enum {};
 
  map-msgs = self.callPackage ./map-msgs {};
+
+ mapviz = self.callPackage ./mapviz {};
+
+ mapviz-interfaces = self.callPackage ./mapviz-interfaces {};
+
+ mapviz-plugins = self.callPackage ./mapviz-plugins {};
 
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
@@ -905,6 +951,8 @@ self: super: {
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
+ multires-image = self.callPackage ./multires-image {};
 
  mvsim = self.callPackage ./mvsim {};
 
@@ -1164,6 +1212,12 @@ self: super: {
 
  position-controllers = self.callPackage ./position-controllers {};
 
+ py-trees = self.callPackage ./py-trees {};
+
+ py-trees-ros = self.callPackage ./py-trees-ros {};
+
+ py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
+
  pybind11-json-vendor = self.callPackage ./pybind11-json-vendor {};
 
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
@@ -1199,6 +1253,12 @@ self: super: {
  radar-msgs = self.callPackage ./radar-msgs {};
 
  random-numbers = self.callPackage ./random-numbers {};
+
+ raspimouse = self.callPackage ./raspimouse {};
+
+ raspimouse-description = self.callPackage ./raspimouse-description {};
+
+ raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -1401,6 +1461,8 @@ self: super: {
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
  robot-upstart = self.callPackage ./robot-upstart {};
+
+ robotraconteur = self.callPackage ./robotraconteur {};
 
  ros2-control = self.callPackage ./ros2-control {};
 
@@ -1648,6 +1710,8 @@ self: super: {
 
  rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
 
+ rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
+
  rtabmap-ros = self.callPackage ./rtabmap-ros {};
 
  rtcm-msgs = self.callPackage ./rtcm-msgs {};
@@ -1870,6 +1934,8 @@ self: super: {
 
  tiago-simulation = self.callPackage ./tiago-simulation {};
 
+ tile-map = self.callPackage ./tile-map {};
+
  tinyxml2-vendor = self.callPackage ./tinyxml2-vendor {};
 
  tinyxml-vendor = self.callPackage ./tinyxml-vendor {};
@@ -2039,6 +2105,8 @@ self: super: {
  visualization-msgs = self.callPackage ./visualization-msgs {};
 
  vrpn = self.callPackage ./vrpn {};
+
+ wall-follower-ros2 = self.callPackage ./wall-follower-ros2 {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
 

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "79f7158a10ba2c33a7c3d100aad366e091417d9b41a91ddbefd35c907bbbc825";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "0f1c50fde419b9134b1379285caa9a00e9454ad38aebb8502353c800ec6910e6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pluginlib ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface rclcpp rclcpp-action realtime-tools ];
+  propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface rclcpp rclcpp-action realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "978e1185cffca2ed1c1b0f9eafee700f284fdabef2b81b941eee9a88b0297f68";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "4a908d00155763d8087210f7b20f831f16fda4bf65f5f7dab745691a9c3e655f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "ba4edd8aa4be7b2a1cc4b96ca8e9b038741f9c034e13217145392e92d240ef3a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "b0e68500151a80b60868fceccc6c0d2eebaeff46812b056c4981183f35d09166";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ros2-control-test-assets ];
-  propagatedBuildInputs = [ controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
+  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/irobot-create-common-bringup/default.nix
+++ b/distros/humble/irobot-create-common-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, irobot-create-control, irobot-create-description, irobot-create-nodes, joint-state-publisher, robot-state-publisher, ros2launch, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-common-bringup";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_common_bringup/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "7fff5e54c825eace136a6f89abd6173193d69c7aedfc08b96ebba82923a40040";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ irobot-create-control irobot-create-description irobot-create-nodes joint-state-publisher robot-state-publisher ros2launch rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides common launch and configuration scripts for a simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-control/default.nix
+++ b/distros/humble/irobot-create-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, joint-state-broadcaster, ros2-controllers, ros2launch, rsl }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-control";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_control/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "61bf120bab4110e7d0b8e1b3ceb1771d10595da276aea32e75d6af81a01e4666";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ joint-state-broadcaster ros2-controllers ros2launch rsl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides the diff-drive controller for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-description/default.nix
+++ b/distros/humble/irobot-create-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-lint-auto, urdf }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "efc97b6997893600772882f3cd6e88c13680a4ac1db1a4715841ab6e4b7cef92";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-lint-auto ];
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides the model description for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-gazebo-bringup/default.nix
+++ b/distros/humble/irobot-create-gazebo-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-plugins, gazebo-ros, gazebo-ros2-control, irobot-create-common-bringup, irobot-create-description, irobot-create-gazebo-plugins, ros2launch }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-gazebo-bringup";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_gazebo_bringup/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "ef85e982ecce4b7aa4f02fa6b6c690843356cf6e2af5b7a2f1f983a222ad90c8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control irobot-create-common-bringup irobot-create-description irobot-create-gazebo-plugins ros2launch ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides launch and configuration scripts for a Gazebo simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-gazebo-plugins/default.nix
+++ b/distros/humble/irobot-create-gazebo-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gazebo-dev, gazebo-ros, geometry-msgs, irobot-create-msgs, irobot-create-toolbox, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-gazebo-plugins";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_gazebo_plugins/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "182e483d873b259788805fc61d5479bb2b078ea2d72e4640a1f844fcec6fe50a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ gazebo-dev gazebo-ros geometry-msgs irobot-create-msgs irobot-create-toolbox rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides the Gazebo plugins for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-gazebo-sim/default.nix
+++ b/distros/humble/irobot-create-gazebo-sim/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-gazebo-bringup, irobot-create-gazebo-plugins }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-gazebo-sim";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_gazebo_sim/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d3e0a73b63c911e7200efa44a0b81c4be0a26cdc3a9a9152d2c72b89480f9bd7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ irobot-create-gazebo-bringup irobot-create-gazebo-plugins ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for the iRobot(R) Create(R) 3 robot Gazebo simulator<a href="http://gazebosim.org/">Gazebo</a> simulation stack.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-ignition-bringup/default.nix
+++ b/distros/humble/irobot-create-ignition-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-plugins, irobot-create-ignition-toolbox, irobot-create-msgs, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-ignition-bringup";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_ignition_bringup/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "f15ec81a9914aae70f7131216ba44a163069780e279c426917be07a727ee28fb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-ignition-plugins irobot-create-ignition-toolbox irobot-create-msgs ros-ign-bridge ros-ign-gazebo ros-ign-interfaces std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides launch and configuration scripts for a Ignition simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-ignition-sim/default.nix
+++ b/distros/humble/irobot-create-ignition-sim/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, irobot-create-ignition-bringup, irobot-create-ignition-plugins, irobot-create-ignition-toolbox }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-ignition-sim";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_ignition_sim/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bb1253fd1e649bda23e3d4b8a64b215269686d6284d272de19e3bce0e78fe3ac";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ irobot-create-ignition-bringup irobot-create-ignition-plugins irobot-create-ignition-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for the iRobot(R) Create(R) 3 robot Ignition simulator'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-ignition-toolbox/default.nix
+++ b/distros/humble/irobot-create-ignition-toolbox/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, control-msgs, irobot-create-msgs, irobot-create-toolbox, nav-msgs, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-ignition-toolbox";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_ignition_toolbox/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8e7746fc0c28603d5cdce006a5a5b2e98810cdbcd0a5fc9b6981436b59762d2b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ control-msgs irobot-create-msgs irobot-create-toolbox nav-msgs rclcpp rclcpp-action rcutils ros-ign-interfaces sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Nodes and tools for simulating in Ignition iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-nodes/default.nix
+++ b/distros/humble/irobot-create-nodes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, angles, boost, control-msgs, geometry-msgs, irobot-create-msgs, irobot-create-toolbox, nav-msgs, rclcpp, rclcpp-action, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-nodes";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_nodes/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "3682a96746d82158c19926625e7a564cb994c57bc7d06dd9e1dc393a9b7aaf71";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ angles boost control-msgs geometry-msgs irobot-create-msgs irobot-create-toolbox nav-msgs rclcpp rclcpp-action rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 Nodes for the simulated iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/irobot-create-toolbox/default.nix
+++ b/distros/humble/irobot-create-toolbox/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, ignition, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-irobot-create-toolbox";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/create3_sim-release/archive/release/humble/irobot_create_toolbox/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "90e9bceab4c14054f931172a3a90270ef1fd73bd56a8f1e09f62f27b74246026";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ignition.math6 rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Components and helpers for the iRobot(R) Create(R) 3 Educational Robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "4b87aca96eb01cd54e12303eb03ce376a3309943a765ba057d1c24caee3b620e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "c4a6db46e4110f4edee74f8444ed170c86b6a1d8bd3142aa130a02dd3884bcfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "43a1142b94ab9b79814f2bb46ceae4bdc5aaebd44718f7dfc24009231c53c7ac";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "883a4157d7f3bf79d36ca2e7ff2a517e73ffef794218cf6470fd8a5b1dbf0d8b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager rclcpp ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs controller-interface generate-parameter-library hardware-interface pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs ];
+  propagatedBuildInputs = [ backward-ros control-msgs controller-interface generate-parameter-library hardware-interface pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "f5f6f32b27b12999c5a6c42ff28f60ca20fbc2f84be0ed5eb8f6f86a390b2ab2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "b2b49d94aea700d50be849b5dc16ca162d7b8b65c5a6e852375238ec172b975f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools trajectory-msgs ];
+  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/joy-tester/default.nix
+++ b/distros/humble/joy-tester/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-joy-tester";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joy_tester-release/archive/release/humble/joy_tester/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "0e663654e883e6f52e014662f3dac7b14bed2acf78cc4b1358a34b85321c348d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.tkinter rclpy sensor-msgs ];
+
+  meta = {
+    description = ''Simple GUI tool for testing joysticks/gamepads'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/kinematics-interface-kdl/default.nix
+++ b/distros/humble/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-humble-kinematics-interface-kdl";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface_kdl/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "ddda66a26f596a21a5e69eb291eef52b95df950ff0cd9f5572dcb3880a4c9804";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface_kdl/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "02adf21b0fb7aa08e6a09f571deb396d4d92d7d3ff63e247586871e838fe6b4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinematics-interface/default.nix
+++ b/distros/humble/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-kinematics-interface";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "deed39ef1f407630336ace5f361a6ccdea49de31986c0852b28a93da3f556f14";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "9c3f84203b95080835019976c5d17a2dcdb9c78f6ac6b8a51594e8eebfdc3269";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz-interfaces/default.nix
+++ b/distros/humble/mapviz-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-mapviz-interfaces";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "fbe5e5b2e7dc49e0112755d56b38cce998568bd56d82eabf17aa6bcd55357fe4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ builtin-interfaces marti-common-msgs rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS interfaces used by Mapviz'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mapviz-plugins/default.nix
+++ b/distros/humble/mapviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, pluginlib, qt5, rclcpp, rclcpp-action, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-mapviz-plugins";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "1ad60aea7b1615cf8176032d112460bfe5412864c1fb6d93d0900320e29c7576";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-index-cpp cv-bridge gps-msgs image-transport map-msgs mapviz marti-common-msgs marti-nav-msgs marti-sensor-msgs marti-visualization-msgs nav-msgs pluginlib qt5.qtbase rclcpp rclcpp-action sensor-msgs std-msgs stereo-msgs swri-image-util swri-math-util swri-route-util swri-transform-util tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''Common plugins for the Mapviz visualization tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mapviz/default.nix
+++ b/distros/humble/mapviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, launch-xml, libyamlcpp, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg }:
+buildRosPackage {
+  pname = "ros-humble-mapviz";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "16896d2920ace6474671ed34a01fe5a2284e4cbdfc016727073e77853b9aebe2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ];
+  propagatedBuildInputs = [ cv-bridge freeglut geometry-msgs glew image-transport launch-xml libyamlcpp mapviz-interfaces marti-common-msgs pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros xorg.libXi xorg.libXmu ];
+  nativeBuildInputs = [ ament-cmake pkg-config qt5.qtbase ];
+
+  meta = {
+    description = ''mapviz'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/multires-image/default.nix
+++ b/distros/humble/multires-image/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, gps-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
+buildRosPackage {
+  pname = "ros-humble-multires-image";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "636309bee36de8ac3c3a597db252c0c3b7d5b1d27d37dfc254a7e5875c482f61";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs gps-msgs mapviz pluginlib qt5.qtbase rclcpp rclpy swri-math-util swri-transform-util tf2 ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''multires_image'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, box2d, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.5.0-r1";
+  version = "0.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "d34639b9a423d1ea137a58f6892a9d9bb041cc6ce9104a59f40235df35a53320";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.5.1-2.tar.gz";
+    name = "0.5.1-2.tar.gz";
+    sha256 = "43ae6084a104e16d5bca25c723dff2640d5fa6977aac327bba9452875c512c3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-gripper-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, position-controllers }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-controller-configuration";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "6145d044628ea3f1f3139f7b2b4a5dc9030669ef1ed5d8d945985ef149d55ddd";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "cfa354b462d596f42ff7ad718231d44790ff4d71ad943bfd3e6dbf83847d6074";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-description/default.nix
+++ b/distros/humble/pal-gripper-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-description";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "49fdd60b0383874024f24f56219cab4f2b6966c33c3dc5609f22d335495f72b4";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "6d6f58fe27df6772d428ee901ac54f9bc611ca06c8ebbecdf1f10c764d00ed2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper/default.nix
+++ b/distros/humble/pal-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-gripper-controller-configuration, pal-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "d10ed88b621cc35211d5ff899de08e9678930ba82fb4f5c5a8b92a3f0be245d5";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4a9d0423c569fc6773b8f63265efb7434c0246cbbd193bb51a4b97e7d6f919eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pinocchio/default.nix
+++ b/distros/humble/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-humble-pinocchio";
-  version = "2.6.14-r1";
+  version = "2.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/2.6.14-1.tar.gz";
-    name = "2.6.14-1.tar.gz";
-    sha256 = "ba81a7fcf74d2cbc466ffc1cb321187542c6c0d7e382d4b21f2814d720b5e416";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/2.6.16-1.tar.gz";
+    name = "2.6.16-1.tar.gz";
+    sha256 = "95df71c7318079224eea85648df9bef9dd7bdf7a04540d6c5cbf1f75768624bc";
   };
 
   buildType = "cmake";

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-pmb2-bringup";
-  version = "4.0.5-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "0dab720e96e8df92fa588b989eed6630cfad035333108392d58138c39ad2d152";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "4c431138f3880339d41214854d0f4553742b9c2af6c75371e0d7cbb440474b8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, joint-state-broadcaster }:
 buildRosPackage {
   pname = "ros-humble-pmb2-controller-configuration";
-  version = "4.0.5-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "401859c2d2111bc79cdcb1d971b0320896d36fd5ef183f265f742246dcffa51e";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "ddd6e3e62386499550990c48d57ea869c128e950a5fdbdb3d5be4a0dceb42783";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pmb2-controller-configuration, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pmb2-description";
-  version = "4.0.5-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "c1cb5bdeed8f9802c748191934a15db4cb1f5f76c7ac288d84a57e2ca0d52ec9";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "749709f5982f752db35d3eb971527c0edf6ed1827d3829d3baaec421cf47003c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-gazebo/default.nix
+++ b/distros/humble/pmb2-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-ros, gazebo-ros2-control, launch-pal, pal-gazebo-worlds, pmb2-2dnav, pmb2-bringup, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-gazebo";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "2290312e81004e766d6e5ea6f077529573487e3ddcdbb7e13d70d888561ff16a";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "37f644abf9f93d84420c9347fee946013910d15f4bf1b0e5c09da5d5ce92a3f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-robot";
-  version = "4.0.5-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/4.0.5-1.tar.gz";
-    name = "4.0.5-1.tar.gz";
-    sha256 = "bb9558926a34cacddc03c6258a9e852959294bfb4251c35138e8eeaaffdcf2e2";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "d2739de232876ff392c83f0dfdea82d87864e4f0c1c550cc75166fd6c8aabe21";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-simulation/default.nix
+++ b/distros/humble/pmb2-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-humble-pmb2-simulation";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "24325125b77e410e23f8a7c0f2c9d85c4fe10cbdfa42bf57b05996e37e5165fa";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "4b73ba85ac35f57669bf39457f8255a50f21e3ab796cf6e8232edcab68437335";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "3624b66794bd247a74d1f5ae37b41811caed76ff617d8cd9ea096baa28331813";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "981777e9d4dc2ec9446a51b6cfe2be25fe23e788bb8fccc9bf0e80ae8dfdd2be";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pluginlib ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ forward-command-controller rclcpp ];
+  propagatedBuildInputs = [ backward-ros forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/py-trees-ros-interfaces/default.nix
+++ b/distros/humble/py-trees-ros-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-humble-py-trees-ros-interfaces";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/humble/py_trees_ros_interfaces/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "db94fc8dfe11f0b3e7278ff905c5aad38c4c3e27cd291d2facbabd2f9f743667";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs diagnostic-msgs geometry-msgs rosidl-default-runtime unique-identifier-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces used by py_trees_ros and py_trees_ros_tutorials.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/py-trees-ros/default.nix
+++ b/distros/humble/py-trees-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-humble-py-trees-ros";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_ros-release/archive/release/humble/py_trees_ros/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "aeec328390cd3d790e79f8597fddeed3d2ea25b219547d9a30513f1e1b865836";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools ];
+  checkInputs = [ pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs tf2-ros unique-identifier-msgs ];
+
+  meta = {
+    description = ''ROS2 extensions and behaviours for py_trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/py-trees/default.nix
+++ b/distros/humble/py-trees/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-py-trees";
+  version = "2.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/humble/py_trees/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "a88f59a69b53c29904f4f41250cf56eec29fdfc92d712cdec1bf41799671ad5f";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools ];
+  propagatedBuildInputs = [ python3Packages.pydot ];
+
+  meta = {
+    description = ''Pythonic implementation of behaviour trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/raspimouse-description/default.nix
+++ b/distros/humble/raspimouse-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-humble-raspimouse-description";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/humble/raspimouse_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "268227e0f3f6c8de12e561198830ff870384d74901e3e65de669a6fc1a924d28";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The raspimouse_description package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/raspimouse-msgs/default.nix
+++ b/distros/humble/raspimouse-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-raspimouse-msgs";
+  version = "1.1.1-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/humble/raspimouse_msgs/1.1.1-7.tar.gz";
+    name = "1.1.1-7.tar.gz";
+    sha256 = "7bfb427eabf36be186aac43ce3eb3e6f00ce77b452856caf8fbfe59e6f2579ab";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''RaspiMouse messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/raspimouse/default.nix
+++ b/distros/humble/raspimouse/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav-msgs, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-raspimouse";
+  version = "1.1.1-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/humble/raspimouse/1.1.1-7.tar.gz";
+    name = "1.1.1-7.tar.gz";
+    sha256 = "0748abc5af4ccf3244d9868b444c654d0a9425c7022790f55d03f6983d7392ce";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs lifecycle-msgs nav-msgs raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RaspiMouse ROS 2 node'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/humble/rclcpp-cascade-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-cascade-lifecycle";
-  version = "1.0.2-r1";
+  version = "1.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/humble/rclcpp_cascade_lifecycle/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0cd86beddba6347d00b0c08dd3bb551bb3d381d645fb8b00c31b9a51df7b425d";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/humble/rclcpp_cascade_lifecycle/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "9287fedee0fe72d54ec5ec6f4aab3e5fb8d0ef9d377cb15c1f88cc0548c31451";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realtime-tools/default.nix
+++ b/distros/humble/realtime-tools/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-action, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, rclcpp, rclcpp-action, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-realtime-tools";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "99c99240f1ef6acfbeda4158b6f3e0f162f71463cbdc49fddaf2e110661f3b25";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "cc3b7aabeffe94904d77c6c3900158fd6e7e8f437584edcbe99bd32f602feeb7";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ rclcpp-action test-msgs ];
+  checkInputs = [ ament-cmake-gmock test-msgs ];
   propagatedBuildInputs = [ ament-cmake rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/robotraconteur/default.nix
+++ b/distros/humble/robotraconteur/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, swig, zlib }:
+buildRosPackage {
+  pname = "ros-humble-robotraconteur";
+  version = "0.16.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/0.16.0-4.tar.gz";
+    name = "0.16.0-4.tar.gz";
+    sha256 = "588df38a171f3cefd97f2ab935b6d80c1a6310c506946d23d6a58b5e9c38937d";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake swig ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ bluez boost dbus libusb1 openssl python3 python3Packages.numpy python3Packages.setuptools zlib ];
+  nativeBuildInputs = [ cmake swig ];
+
+  meta = {
+    description = ''Robot Raconteur ROS Package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "cdb63b40042e48114dd61cf98dcbebaf4d7645fd667305154fe900d2d96c2945";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "d47fde5b8496658933dbf02977be20965029fc94057b0fa07921bb9a101169f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "e9a8efa0c0df3d25512459d6f6fd341095b5f793b72fdc98a82b37c0f074c246";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "681a1646bffeaf43cb4c0f73a2f109920f4a1298f70ec2c9cc9905a35af04139";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "5e7aee9f4fb75533ed72b77b7c49559fc4b1d04bb9be8f04d78168784125e878";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "de221c927e4944f3f51e4765d83599b3b1f65329e0ab30d3f66a6f846966eb61";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, admittance-controller, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, tricycle-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "6efd6998095c4b097726dccfd456d6d2721fa2292a50f0537d128f1ed7c0c17d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "dd6f6324f3f68ae3cb0e470e34c045ed56254ea640e4513cb62e813fa7b5264a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "cc5deeda73b6d277e6aa8ec21f1e3f30748c8223fe1000a2312102a2e264ed72";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "b236fd34a4ae37f3c9bb488e8e902fb56756c9d8a44760c188f36c6439268deb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "ef01b5b0635a423842ea1f97134cb7229ee34c83d041436480e322980fb50441";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "d4d2c8d1a1221b415f20a1021d77f27550863b6225710f996aea7f7ef4776ca5";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "47aa1824859f38411e4dc793d6668d59b587374e650a65a71ebbaf26e6715201";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "e6e7c9c72d3c75626c48fc79f7ca2d998d41154e559997339430626f98bbe9e2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rt-usb-9axisimu-driver/default.nix
+++ b/distros/humble/rt-usb-9axisimu-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-rt-usb-9axisimu-driver";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release/archive/release/humble/rt_usb_9axisimu_driver/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "701f230c86513b2797cfabaf43d6ee4fcf105c7b5240f4af639087bf519cda3b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The rt_usb_9axisimu_driver package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/self-test/default.nix
+++ b/distros/humble/self-test/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-self-test";
-  version = "3.0.0-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8acb8d00b7710ecd2f1a5e0242c132953f85934edde4f7c41ca39774fbfda3dd";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "8adedd6b557dcf8593bae87b029a733cb85f25eba0449fcf732dafecd360328e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''self_test'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/tiago-bringup/default.nix
+++ b/distros/humble/tiago-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy-teleop, launch-pal, robot-state-publisher, tiago-controller-configuration, tiago-description, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-tiago-bringup";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "75481da17bcd49b6cec9c4574ddc3e04b415de5230889be65803dd02c2ccddf4";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "24805fe3551c1d9264e2626a80463f5a26be7aaad6b60b0b583afb69b3a84166";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-controller-configuration/default.nix
+++ b/distros/humble/tiago-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, joint-state-broadcaster, joint-trajectory-controller, pal-gripper-controller-configuration }:
 buildRosPackage {
   pname = "ros-humble-tiago-controller-configuration";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "b03dccd2268a99bc75b899a171c1d3e661e3757114cd76211cef831b8cbda68d";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "517d9b2ee5e9e9bfec33eb5ddb2318b55acd88b5543a47e9a33788ee3c8e02b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-description/default.nix
+++ b/distros/humble/tiago-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, hey5-description, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-gripper-description, pmb2-description, tiago-controller-configuration, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-description";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "6b34f0467a25c466df3502f50dcf9141ddfc171eea6e68cfe7848f7ac324270f";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "cdd35c9282d4369542974118c79b015c2f1b98e23bf28d610616d2eea4d8d719";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-gazebo/default.nix
+++ b/distros/humble/tiago-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch, launch-pal, launch-ros, pal-gazebo-worlds, tiago-2dnav, tiago-bringup, tiago-description, tiago-moveit-config }:
 buildRosPackage {
   pname = "ros-humble-tiago-gazebo";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "dc24fd9202946c91d8733cc60727a2bbc0445f272923417ac40c7f44d23e2ee5";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "02c62ba6b9d38bb24528e002e24863561b03e8b5de14d9f61c29e5b94159e278";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-moveit-config/default.nix
+++ b/distros/humble/tiago-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-visualization, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-moveit-config";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "c7835ca1c9b0cb1cec9eb8169c352e7f36bb8892fcbf20a3fb38bc4dde87d20e";
+    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "9d9d0b4ab314daf1424294327e166fe1947fe55312f03ab69aa2890191520cac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-robot/default.nix
+++ b/distros/humble/tiago-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-bringup, tiago-controller-configuration, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-robot";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "66e6fda09df3afc1e804d6b80bd6534b1b34c798b00a9be3590ca2a321cefdd2";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "ea5c1d94b0f8d4ca134a56f5bce7ee3ce1ba0a58261d5b085838bcd827cefa7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-simulation/default.nix
+++ b/distros/humble/tiago-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-gazebo }:
 buildRosPackage {
   pname = "ros-humble-tiago-simulation";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "e7aa5db9bc41a3394ad2ee514b60af9d6ab6f8ed9cc2d25de217031283762c9b";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "87af41770a47fb140e87a8efaf4b011c94bfeca6cc5d6885d4fc54805ff621e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tile-map/default.nix
+++ b/distros/humble/tile-map/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, libyamlcpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2 }:
+buildRosPackage {
+  pname = "ros-humble-tile-map";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "cfb7c13de406d62d8115891044592854b9a78dcb67eecf4d4b92d46700d50bd2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ glew jsoncpp libyamlcpp mapviz pluginlib qt5.qtbase rclcpp swri-math-util swri-transform-util tf2 ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''Tile map provides a slippy map style interface for visualizing 
+     OpenStreetMap and GoogleMap tiles.  A mapviz visualization plug-in is also
+     implemented'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.20.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.20.0-1.tar.gz";
-    name = "2.20.0-1.tar.gz";
-    sha256 = "0d5d89a02f936c570b068c595581dea9ea71eec3aacb7841f60e09b2161e52c3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "b6784f40b93acaacde38abff00af9774c7e0c80a176c75ddf71ba76f6c238777";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "c8d7a4c7a63b7fa55a5f2c0b374dd5b0b2bfe9dba10ff5213a03370cd43c3d3a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "a1a3873ce2af82dde5d1e9328a74d2fed9b30f58ff3814472e129ae5d33e2e81";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pluginlib ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ ackermann-msgs controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-msgs ];
+  propagatedBuildInputs = [ ackermann-msgs backward-ros controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.15.0-r1";
+  version = "2.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.15.0-1.tar.gz";
-    name = "2.15.0-1.tar.gz";
-    sha256 = "bd38190600bf47ec1ce03373fb343bb50444b3e90ddddbc5b4776821caf4be95";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.16.1-1.tar.gz";
+    name = "2.16.1-1.tar.gz";
+    sha256 = "a5a8c950b5ce2ad49e04d0819d69c76391567e10230e5afd011ce9b4f18ff750";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pluginlib ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
-  propagatedBuildInputs = [ forward-command-controller rclcpp ];
+  propagatedBuildInputs = [ backward-ros forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/wall-follower-ros2/default.nix
+++ b/distros/humble/wall-follower-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-wall-follower-ros2";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/wall_follower_ros2-release/archive/release/humble/wall_follower_ros2/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "7b88f39913cbca9f5ce5364fb7a9fe2ce9b6c4f870c1f0edd3672a7b06074c65";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''wall_follower_ros2 package'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/webots-ros2-control/default.nix
+++ b/distros/humble/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-control";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "6f155527ac879d11a2835ceae8df4033c590b952380d5ba6c07ac09430494ff6";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "283f5129cb544eaf95e29a816993c24595717bd24ef1290e93b6853a2c3b4205";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "169ebddf0e351a109469cd959a2d69824c31a91168d19329aedc01e694cb68ff";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "bce8caff9a984702fb16f2a7ed408c839e01e2af99c52cd1929c0f63615982b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-epuck/default.nix
+++ b/distros/humble/webots-ros2-epuck/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-epuck";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "21ab2cf44ef469656c15996182974c79b9dfbbb6032ea21e390df494e2897222";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "013d56b8c2f21b5a11443962899a08638e204252f35ea08b7cf63a62e496e99e";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster nav-msgs rclpy robot-state-publisher rviz2 sensor-msgs std-msgs tf2-ros webots-ros2-control webots-ros2-driver webots-ros2-msgs ];
 
   meta = {

--- a/distros/humble/webots-ros2-importer/default.nix
+++ b/distros/humble/webots-ros2-importer/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-importer";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "e00c5b67ba6f83fb30d843f52ae50c4d1f44e26c482a29798231d17066a9e30f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "2f65aa61bfaa01f50a673e4e6c032a3d5190b69f40b464f7f47700cf5f69b141";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.numpy python3Packages.pillow python3Packages.pycodestyle pythonPackages.pytest ];
+  checkInputs = [ ament-copyright python3Packages.numpy python3Packages.pillow python3Packages.pycodestyle pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces python3Packages.lark python3Packages.pycollada xacro ];
 
   meta = {

--- a/distros/humble/webots-ros2-mavic/default.nix
+++ b/distros/humble/webots-ros2-mavic/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-mavic";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "8e34e3506d88eb2aa7d4f91b60fdd1f5d14f5b8b0c54cb21d900cc70cbc9b9f1";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "80cb4d62fdcc246c8576bd9e64db7e0184cefe6c0cab896b71a371032da65a27";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces rclpy webots-ros2-driver ];
 
   meta = {

--- a/distros/humble/webots-ros2-msgs/default.nix
+++ b/distros/humble/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-msgs";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "869dbf3f7dcfee1ea06a760352403841c4e9235ccf986cb04181070e278e239e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "622a72d2d8bc1b55b3f47def31995c53a292d0801edc9d2e1f0b501bef8d6403";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tesla";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "bfc5a7411438ba591eec1a82cc7f9c0c001415bb15dd4d448127f685ac9216f6";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "5d60ebdc527649d62932c586f4a43d92626af7b8c8fd36b358898458d73bd8e0";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-driver ];
 
   meta = {

--- a/distros/humble/webots-ros2-tests/default.nix
+++ b/distros/humble/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tests";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "a2b23929177d0f5213202575179f361aea3a3a374be37b741e7e83b769bc28fe";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "289b46ce00c10185b97e6f1cca9125befc8eb3fbb412d983fd2fdd646607825f";
   };
 
   buildType = "ament_python";
   buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = ''System tests for `webots_ros2` packages.'';

--- a/distros/humble/webots-ros2-tiago/default.nix
+++ b/distros/humble/webots-ros2-tiago/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tiago";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "d07d115364aaa80bc9c6b4dfe52ccb1079a9d9601694659b5d4d89ace658464a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "68c80515e5e86e184dcfe7231eba3c0e134d1fbb202154785228312014a7acb7";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster rclpy robot-state-publisher rviz2 tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {

--- a/distros/humble/webots-ros2-turtlebot/default.nix
+++ b/distros/humble/webots-ros2-turtlebot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-turtlebot";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "3663a33a99ae6b44920f662c7e1857e51af397fc07bea676ca19222f7de08fcd";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "70ee66b0c3ab1d4f72c0bd860e16dac7c539acd5a9b4867a311144fbed175be6";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller joint-state-broadcaster rclpy robot-state-publisher rviz2 tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {

--- a/distros/humble/webots-ros2-universal-robot/default.nix
+++ b/distros/humble/webots-ros2-universal-robot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-universal-robot";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "73c3d9d9e673598bc40d37d4d76b7032fe5ac2b3ca8319ef46c453f0018a8a6d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "8234e3bda9dc8c9b9b72c97327d3c77a7af313e80d1d3d748296b1c149dcfab3";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver xacro ];
 
   meta = {

--- a/distros/humble/webots-ros2/default.nix
+++ b/distros/humble/webots-ros2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "e269b39842a45ea391b1887afea8f9585bbc598b544706de178939c24ce03deb";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "757cfd2e97ca82fdab110576dfd7a7a0aae7e82e20b5efbdf7f3d206f747e0d2";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest webots-ros2-tests ];
+  checkInputs = [ ament-copyright pythonPackages.pytest webots-ros2-tests ];
   propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {

--- a/distros/melodic/ackermann-steering-controller/default.nix
+++ b/distros/melodic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, rosunit, std-msgs, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ackermann-steering-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "ef28b520da2cd4076e270ecf5d77c4d6672ad6fea02314fdf818134b24313c68";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "2938ffff8636854ae1ee988b336c2cedfc11fd8bb0f02e7bb1fda9558186a4e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/compressed-depth-image-transport/default.nix
+++ b/distros/melodic/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport }:
 buildRosPackage {
   pname = "ros-melodic-compressed-depth-image-transport";
-  version = "1.9.5";
+  version = "1.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/melodic/compressed_depth_image_transport/1.9.5-0.tar.gz";
-    name = "1.9.5-0.tar.gz";
-    sha256 = "344ba8616aae571668169db0759f432c049e9f2c272dbcbb2a82371ff285c212";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/melodic/compressed_depth_image_transport/1.9.6-1.tar.gz";
+    name = "1.9.6-1.tar.gz";
+    sha256 = "8ec936100e0c8dcfaf91ff57acc993981520e99ae7a9d052c26ce68c615ef1cf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/compressed-image-transport/default.nix
+++ b/distros/melodic/compressed-image-transport/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport, libjpeg_turbo }:
 buildRosPackage {
   pname = "ros-melodic-compressed-image-transport";
-  version = "1.9.5";
+  version = "1.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/melodic/compressed_image_transport/1.9.5-0.tar.gz";
-    name = "1.9.5-0.tar.gz";
-    sha256 = "b3f07ada5ec4f1e8335c95ded17dc75ba399b98d21c1a043fde96c3f974ba64d";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/melodic/compressed_image_transport/1.9.6-1.tar.gz";
+    name = "1.9.6-1.tar.gz";
+    sha256 = "fe3ff17c99e2a26500d70767d69fe555da00b8cd03e3800624c0ad1137d49284";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport libjpeg_turbo ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/costmap-cspace-msgs/default.nix
+++ b/distros/melodic/costmap-cspace-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/costmap_cspace_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "da79ed874b003e9f707cfa3973fe724b22fb2e11e893e96ae4c73bbc99278c40";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/costmap_cspace_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "bc1f4119b7074ebe45e5a7e9163aa40ab1c75745ad0a168bdb0bfd073e898a64";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "ed9ab1e9318aede548580144e7c0eb7d12dc124283730425fa8bd0ed585d7a00";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "482e879279bdd7f1cb256cdbbf61b598a3aceef952103281b8693afab10c088d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/diff-drive-controller/default.nix
+++ b/distros/melodic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-diff-drive-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/diff_drive_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "ffc17987a71bd6bee3e0224ff9f04d6fdffd5909cdf6e9cf4510902768929710";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/diff_drive_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "d6d3b34385ffda6d79c9cfe35fd4472dafcc9434bb6293244f39f64bb5fd57ff";
   };
 
   buildType = "catkin";

--- a/distros/melodic/effort-controllers/default.nix
+++ b/distros/melodic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, pluginlib, realtime-tools, robot-state-publisher, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-effort-controllers";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/effort_controllers/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "87ac8f3079b57ca3c35361d3005d85c09170b21cf0b01fc2ac078fddf05c4ec1";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/effort_controllers/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "a0a6b0295b3191d8c0f737cad8253a462bd6457011381d557a6f260e8e5b44d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.9.0-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "ecb7a83764b63a4faf0e57d295300e98adbf56dc71680c00d70dddc9c475c2e7";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/melodic/eigenpy/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "bbe6d7a79f7f3c5e3f2025cc9b820ca878e0931f604227f8b84c61bdf27bb353";
   };
 
   buildType = "cmake";

--- a/distros/melodic/force-torque-sensor-controller/default.nix
+++ b/distros/melodic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-force-torque-sensor-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/force_torque_sensor_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "9c66710f29ce9b5f15b89d26d2945071f891e947157c9ee6bc62305a061301d3";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/force_torque_sensor_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "36ae7ed1871c2f14d0dc03bba28da0532072f8ddf96a4f441020b43d427d3446";
   };
 
   buildType = "catkin";

--- a/distros/melodic/forward-command-controller/default.nix
+++ b/distros/melodic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-forward-command-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/forward_command_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "5f1e8cb2ea9ed8bb0d670f9780213bd09f87d12641ea59dae671d2787b3c79a9";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/forward_command_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "07e53744b75ecb941adf3741371e89d9eadf284dbdef9ac7bad99af6849daa38";
   };
 
   buildType = "catkin";

--- a/distros/melodic/four-wheel-steering-controller/default.nix
+++ b/distros/melodic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf-geometry-parser }:
 buildRosPackage {
   pname = "ros-melodic-four-wheel-steering-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/four_wheel_steering_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "fc0688411a344b201c2f046fcbfc3519022d0d6b31ed6b00ef2c6a2550ff2807";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/four_wheel_steering_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "f6e234a342e628d441c21375f5077143a18f16626435cf3e961600f06afc55c3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1538,6 +1538,8 @@ self: super: {
 
  image-transport = self.callPackage ./image-transport {};
 
+ image-transport-codecs = self.callPackage ./image-transport-codecs {};
+
  image-transport-plugins = self.callPackage ./image-transport-plugins {};
 
  image-view = self.callPackage ./image-view {};

--- a/distros/melodic/gripper-action-controller/default.nix
+++ b/distros/melodic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-gripper-action-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/gripper_action_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "d2809f80fe662d21b1e654c7f3cdc1b4b99e60336b37ae7d7fc138e5e56a606c";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/gripper_action_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "044e3c43ac62bb943dc8f110231515d7eac609ab1fca0a4537d34b393436620a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-transport-codecs/default.nix
+++ b/distros/melodic/image-transport-codecs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, pythonPackages, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
+buildRosPackage {
+  pname = "ros-melodic-image-transport-codecs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/melodic/image_transport_codecs/2.1.0-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "17942113552a82f30af0db0ee45f1b7e3347e0479ca1a8d607d60a021c9cb3eb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ rosbag roslint ];
+  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport cras-cpp-common cras-topic-tools dynamic-reconfigure image-transport libjpeg_turbo pluginlib pythonPackages.enum34 sensor-msgs theora-image-transport topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Image transport plugins available as C, C++ and Python libraries'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/image-transport-plugins/default.nix
+++ b/distros/melodic/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-melodic-image-transport-plugins";
-  version = "1.9.5";
+  version = "1.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/melodic/image_transport_plugins/1.9.5-0.tar.gz";
-    name = "1.9.5-0.tar.gz";
-    sha256 = "1838bdad50e903b572a00fcb66935326e81c5e706af3356a64c0322927361ecd";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/melodic/image_transport_plugins/1.9.6-1.tar.gz";
+    name = "1.9.6-1.tar.gz";
+    sha256 = "d66eacafc8f1895620d6980b268e97f6ede7a21cccb5a60308daec4dd2ab4295";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-sensor-controller/default.nix
+++ b/distros/melodic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-imu-sensor-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/imu_sensor_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "e08eb7d66b078379ee01e910381311ae5d956f1479890874f1e8a9ae096f5f91";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/imu_sensor_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "cc7634585b412cf892400427daeebcf6ddd2f6335acadc59b6db02f3c0c98c4f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-state-controller/default.nix
+++ b/distros/melodic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joint-state-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_state_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "eff367735f79b32aa52aba89499345d6b4389bb3cd2883d58f57c04b7ec89dd4";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_state_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "35648c8ae981f344b4c3977be8c87d428caf635b9acc208b80d18fcfec787c77";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-trajectory-controller/default.nix
+++ b/distros/melodic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-joint-trajectory-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_trajectory_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "4c8b612ce523760bd97ef16961d516adbe64ee44f9c035da71277466c05586d2";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_trajectory_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "0ab87d3745b840add650c2d25dca07c57c04ecff4d8e87b2bbe2b2933dc3cbf3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "7ec6df67c67cc7bcc0543000e3a59ff038c42bc934d7340f6a3ab717203ccee9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "b000e4b23f498b3d6c4db6395f7d616376aa9b1cca03e2d13c534d932f32924a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer-msgs/default.nix
+++ b/distros/melodic/map-organizer-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/map_organizer_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "5b1c9308d03d5c7eb1e0e7dcc9d6c9db253a36d2da8493fe01e6df74f27ec452";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/map_organizer_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "227088f427e2855398fadcfdb9b7dd63f06bb116614c6dfb10f1ae6e40499d2e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "6599738c32d6b026d12bd2e495c0b5335cb77ab8cca4b4426d0f7fd925a1b738";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "cf5786bc380b377d150d259d23ee38a98d4b0bdd27110fd0de6fd2c48a54ebfa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "4970be1307315807f6e48e07f5db4775eb8971502989a23f087ce83b93bf76ef";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "5054266ae80e3432bd5b00a4a491ceb56e2e5ebf164ad545a26637d0c6fab927";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "fe51a74a8a1eb112c4eb3c3e8d61468fe47b02012933e88ead0ad2ad59cba8f2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "e22a9843e76d0fb146513c852e19af40d800ac4818be2070895925745299065e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-msgs/default.nix
+++ b/distros/melodic/neonavigation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, map-organizer-msgs, planner-cspace-msgs, safety-limiter-msgs, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/neonavigation_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "45623c8fec17c42f7de1820ac84dc5a142216652e18744091d6b2920d878ae8c";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/neonavigation_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "cf4699b03338bf7e1d42542d6132332dfa5f244cd4b7a5771b1855cd43e3e5f9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "927d2a66e0671136b9a3e3a70ee71643e85b959b015b00638ff0ca798b136fd3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "169d0804115073dbeb21cfc3c6319a3d21c297d5b700e49564c870503713cdbf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "238ce698e4379d802a279ed1a456710d817558cd66d168c006f28eda816a4d4b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "e4514c10461b381922b85c1e400921110c15a762b2106f979ea0994b9de6f16f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.6.14-r1";
+  version = "2.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.14-1.tar.gz";
-    name = "2.6.14-1.tar.gz";
-    sha256 = "69b3e44c5b7f30d69e60e871c09ebac1cf2cffb57a4351bf02ed092575b64ab0";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/melodic/pinocchio/2.6.16-1.tar.gz";
+    name = "2.6.16-1.tar.gz";
+    sha256 = "f58ab18d9cea7356ef49678e385022c6be24b57fad076a50114dbdb1098a58b7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/planner-cspace-msgs/default.nix
+++ b/distros/melodic/planner-cspace-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/planner_cspace_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "8dd9bd2422d97b8701cf6b417e2a204548d3430c26a156654c5b220fd53bfedd";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/planner_cspace_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "e3ba350cae6f66ec6bb0566f57d2981058c3ac4b76fc567997216298faf8aee1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "5dc22bf2a84842ea114ea5e59db74a7b93f4892fbb69b22390e0e6e56a5fb586";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "3537b0e1e0ce94840480273df09c3771567965a7fff7d33e490f60f8d3df845e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/position-controllers/default.nix
+++ b/distros/melodic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-position-controllers";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/position_controllers/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "ff766d80dd25382f0cb374a6d861fe529df1e78616bff2f7c67055b54278e6d5";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/position_controllers/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "f3b9db8f9a79b2f4b25ccc2a7ec72f50fa99866e528396678db11e9a1a10e357";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-controllers/default.nix
+++ b/distros/melodic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-melodic-ros-controllers";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ros_controllers/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "a7b4e753197be0734e0703db5b7254c6fed1661d1df9653bb3083d6e378e0069";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ros_controllers/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "355e0f544e6a79bead15c8e2ad7434819726335ab592f6c2f153f0f7b9cd1b29";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/melodic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-joint-trajectory-controller";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/rqt_joint_trajectory_controller/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "68cbcd1d5be02ae72c77a890debca340b587a338e72afe4a26f966605724d2bc";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/rqt_joint_trajectory_controller/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "e8580f11b3502c986a28a16e3b000109aa1f6b7d6fefc9047f539953d028df12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter-msgs/default.nix
+++ b/distros/melodic/safety-limiter-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/safety_limiter_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "2766e5617f0e92762fc7f259b384ee3145499157e836804e26a8c2a952958afe";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/safety_limiter_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "19c9672df9a419da01b62224f3cee708b11fe90a2b74fb238e6c0262833720d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "736ad5a3331b38b82b55876c3ca7a9568a8340b8818f7fe8d5191dcb16942e8a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "23172b8b980ff984fc409f6687273d7904a0e8cddd205ce5b82df2d0fdc267b0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/theora-image-transport/default.nix
+++ b/distros/melodic/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport, libogg, libtheora, message-generation, message-runtime, pluginlib, rosbag, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-theora-image-transport";
-  version = "1.9.5";
+  version = "1.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/melodic/theora_image_transport/1.9.5-0.tar.gz";
-    name = "1.9.5-0.tar.gz";
-    sha256 = "03701fa45f64b4642eb8b7720662363bb10c4f20e32da2783c595258fc3eaced";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/melodic/theora_image_transport/1.9.6-1.tar.gz";
+    name = "1.9.6-1.tar.gz";
+    sha256 = "76033c052a1319137834fc4b7a3a0961b94de7447852d56cfe644577cf437d1f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "77d72bdb55cf94816b7fccf61cf1121fcac5aeed19a2d0f37e0b671857be297f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "ce1ce3226cb7545b335fd5744ea3610c77bc63f519b55a8bca70ebfc3812efb1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker-msgs/default.nix
+++ b/distros/melodic/trajectory-tracker-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/trajectory_tracker_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "2086e554a50e2b029b0c610edfdbd0d88ce9cb00fb283309acfc501e60b02ac5";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/trajectory_tracker_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "ae82797adaa22473bfaa99dc8d648c9dc85f36c045e7234d82f1995decc18a64";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "50a33ab91b36b87515be6c5e6ebaaac9ef09696109d25b37b776da712e22bc38";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "3708b1a834e70e8500b41ffff3c2a16fe85e3838d9ae286b84988a9565f1fe46";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velocity-controllers/default.nix
+++ b/distros/melodic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, pluginlib, realtime-tools, urdf }:
 buildRosPackage {
   pname = "ros-melodic-velocity-controllers";
-  version = "0.17.2-r1";
+  version = "0.17.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/velocity_controllers/0.17.2-1.tar.gz";
-    name = "0.17.2-1.tar.gz";
-    sha256 = "08a54e78a180a7e56154d1860450a7c3c3f36158944b60cd584cfed0baf463f7";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/velocity_controllers/0.17.3-1.tar.gz";
+    name = "0.17.3-1.tar.gz";
+    sha256 = "279f930a09daff1581d120a5535709cc117f25ccfa0805b3e58da2a3463a00bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ackermann-steering-controller/default.nix
+++ b/distros/noetic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, controller-manager-msgs, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, std-msgs, std-srvs, tf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ackermann-steering-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "f48ecda6c297da3a8a25179219ddb619790598d50a89871804fca0610f56c2fd";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "9ec642f1a8508bf41ea70f7ca39e559962aafe350383af60b179f4365fdfcf92";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "8f074e3d6d13ef356be42a772650e883ed64792d05775d353c41badd74779dec";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "50b11444e5a90f8815362a29b06d981b4f5ee05df1c368c2cc4b35fc281887d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/compressed-depth-image-transport/default.nix
+++ b/distros/noetic/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport }:
 buildRosPackage {
   pname = "ros-noetic-compressed-depth-image-transport";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/noetic/compressed_depth_image_transport/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "e1d9148c00c4ca8e7a71faea92217cb02ed97a74e7b065eae76b70f021f5ba25";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/noetic/compressed_depth_image_transport/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "10dcb5522b1bfb2a308e76a676c64dd46622fcc1e223d86bbc8faf0a5c7953ac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/compressed-image-transport/default.nix
+++ b/distros/noetic/compressed-image-transport/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport, libjpeg_turbo, rostest }:
 buildRosPackage {
   pname = "ros-noetic-compressed-image-transport";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/noetic/compressed_image_transport/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "e6e3ada1e7da3d37a2b3d73c9bad5c9c6acc1535ba0f24916f8de15fad7d85d1";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/noetic/compressed_image_transport/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "f2ca94a705d508273d49daf18aad8d84f81f17af8b6006221b2c9c843ae24b6f";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport libjpeg_turbo ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/costmap-cspace-msgs/default.nix
+++ b/distros/noetic/costmap-cspace-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/costmap_cspace_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "3554cbf6c004d7b8a1d237cd8dd0156695fb8d0d45c08e36667e175a67f6bff7";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/costmap_cspace_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "58b5235e88eb8142c12c079768f2f402634e5e8fd4fa2f195b3d76741379e5c8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "5f9815d86c7e4ea6a7b43f7e4a5dfeb22730fc099ca780c1efcc6e1e6c524e56";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "52e456b44a91a7b91115b42ade78faa39e1b7b0ebad181e0a84393fe323b9afc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.5.3-r1";
+  version = "2.6.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "48385dce4792e5e91638822c6f89bed063f60de83940a5bd7d39a2b2680ca134";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "3a991482ea739af84895998b90bc761227a7b00833d1d5b07cdd48f168fb2082";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.5.3-r1";
+  version = "2.6.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "edf6207f6f31210aace57db787018c6d9018f5bd980edb4bc3befb73209ce304";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "5e9a13548e4dc54b04e365f57d669774dae67dc07b4027d5d1c2f9d2e4f24038";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, diagnostic-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-depthai-ros-driver";
+  version = "2.6.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "5f3257fbf082d42976b606430208190b89337efc8baf70675cb95ea29d7e2f98";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depthai depthai-bridge diagnostic-msgs dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet roscpp rospy sensor-msgs std-msgs std-srvs vision-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Depthai ROS Monolithic node.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.5.3-r1";
+  version = "2.6.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "4d78472bab64daf71294237e094ee6e8d8af86f0fa8b4894aef1ff0dd6d779d3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "197f4203cb13cdc836e58c8e017c1786b109d767d0b579649d43209f1138dbed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-examples, depthai-ros-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.5.3-r1";
+  version = "2.6.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.5.3-1.tar.gz";
-    name = "2.5.3-1.tar.gz";
-    sha256 = "178efffc5af6e70fbe9387e1fc664ab280c6ec8e4318677b94042e32a39021b5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "a4970edb501654b2d5edd10de9bb6d6cd8427a66c8c0b04ce4931c0364f45c4a";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ depthai depthai-bridge depthai-examples depthai-ros-msgs ];
+  propagatedBuildInputs = [ depthai depthai-bridge depthai-examples depthai-ros-driver depthai-ros-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.19.1-r1";
+  version = "2.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.19.1-1.tar.gz";
-    name = "2.19.1-1.tar.gz";
-    sha256 = "5f817f4e7aee3fd7ed03f98efa135fd8ad6ca75154bd3dab4ee5415a62b5eb0b";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.20.2-1.tar.gz";
+    name = "2.20.2-1.tar.gz";
+    sha256 = "bb565978a29a525387915fa4bd75001b28e556ef052716035040d6eff050161d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/diff-drive-controller/default.nix
+++ b/distros/noetic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, rostopic, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-diff-drive-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "40464044b17732a609ab6fec86b178c5dbddb662c69425f148c70fddd6688e1e";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "e75b021feca32420a2538d746a16418e94e4d50ef788d1955a63231f59786b48";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-control/default.nix
+++ b/distros/noetic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-dingo-control";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_control/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "b3539f28b55abbe1e333a6c7fa90ec112638f2a7627fcdc527a3d4e9f132f671";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_control/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "10f14345b123c015cb1c7eb6807d91d2bbd3295ae219667d5c67c2cb5a9d3819";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-description/default.nix
+++ b/distros/noetic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fath-pivot-mount-description, flir-camera-description, lms1xx, realsense2-description, robot-state-publisher, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dingo-description";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_description/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "eb30f6ea53cd495b9f71a10b01b546c84020a7354be2fc667f767979a3310051";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "5eb3f06f70c0c36101989d3a7d82a5993a636231b7f1bf67a245e31a1915921b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-msgs/default.nix
+++ b/distros/noetic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dingo-msgs";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "df3705e9517d92870644ff2acfc87c04d82d87f592f710916adebd95d68e7a80";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "0f4c194764043c6756b042c1c023ec56a02cbc4018b9b04adb6757ceaee6a331";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-navigation/default.nix
+++ b/distros/noetic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-dingo-navigation";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_navigation/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "d5f5fa1a4c0e80e5945812a144fea859417545878af2e2dc6b3f35751fafc692";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/noetic/dingo_navigation/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "cc64308e97be52c047759499a8493d5a6b218e557ed6707a79f62df66ec955d9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/effort-controllers/default.nix
+++ b/distros/noetic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, joint-state-controller, pluginlib, realtime-tools, robot-state-publisher, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-effort-controllers";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "d8a504ae0f9a64d8143dc1752b24571f59df7ecda9465439e0e29b76e903883d";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "a9a66d95cbf9f411432c02a64c2ec3b926e6d364cfad6af8e9a273a3a23fd871";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.8.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "cbb7dfd91f3547c084258489d96f85520b8c6dd89fd71a3c5ec9376ac93fc486";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "97f080c09f6bd8bd89245fe09e6e64627b4f780a7e443063f9c89e98e55e59a6";
   };
 
   buildType = "cmake";

--- a/distros/noetic/flatland-msgs/default.nix
+++ b/distros/noetic/flatland-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-flatland-msgs";
+  version = "1.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/avidbots/flatland-release/archive/release/noetic/flatland_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "ee81482a4671679d2d09242f1c3906131aa05db641ea9c308723d3e8f7f3145e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin cmake-modules message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The flatland_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/flatland-plugins/default.nix
+++ b/distros/noetic/flatland-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, flatland-msgs, flatland-server, libyamlcpp, nav-msgs, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-flatland-plugins";
+  version = "1.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/avidbots/flatland-release/archive/release/noetic/flatland_plugins/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "81efee9b1753084eb2df133d31e2e5ab5e8ab65ecf2d875e1849e834403f89b1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cmake-modules flatland-msgs flatland-server libyamlcpp nav-msgs pluginlib roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Default plugins for flatland'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/flatland-server/default.nix
+++ b/distros/noetic/flatland-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, flatland-msgs, geometry-msgs, interactive-markers, libyamlcpp, lua, opencv, pluginlib, roscpp, std-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-flatland-server";
+  version = "1.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/avidbots/flatland-release/archive/release/noetic/flatland_server/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "a287943a19195f43545aa4555aabb714a905ca4326d45b42ba47a8cf89741615";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin cmake-modules ];
+  propagatedBuildInputs = [ flatland-msgs geometry-msgs interactive-markers libyamlcpp lua opencv pluginlib roscpp std-msgs tf2 tf2-geometry-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The flatland_server package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/flatland-viz/default.nix
+++ b/distros/noetic/flatland-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, flatland-msgs, flatland-server, ogre1_9, qt5, roscpp, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-flatland-viz";
+  version = "1.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/avidbots/flatland-release/archive/release/noetic/flatland_viz/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "2f705b2466ce163f42016b5f5aadaf2e15e7c849994b0e1a592b44cf6f0775b7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin cmake-modules ];
+  propagatedBuildInputs = [ flatland-msgs flatland-server ogre1_9 qt5.qtbase roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The flatland gui and visualization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/flatland/default.nix
+++ b/distros/noetic/flatland/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, flatland-msgs, flatland-plugins, flatland-server, flatland-viz }:
+buildRosPackage {
+  pname = "ros-noetic-flatland";
+  version = "1.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/avidbots/flatland-release/archive/release/noetic/flatland/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "784ee615a40de0de7527e0d037447b3fce595206a49d1e4ab0b78bf677d64cd1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ flatland-msgs flatland-plugins flatland-server flatland-viz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This is the metapackage for flatland.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/force-torque-sensor-controller/default.nix
+++ b/distros/noetic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-force-torque-sensor-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "32b266e7c3060f15c4c905f845dc61e3001a1088ffe0a0d74d3f5e8a0332dcd8";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "072db63595fd7cb0c8df7a8ba28e94cfd09c6950dbf21d2160b22c33ec0c3200";
   };
 
   buildType = "catkin";

--- a/distros/noetic/forward-command-controller/default.nix
+++ b/distros/noetic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-forward-command-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "316d39e6cd77b1339a38c0f434903f991a6c08c5a56ba757785518de041605a6";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "5e0da91dd971bc9cf09c4251e076355dd3ffcec02d0a90c61d5558cd7f4d55a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/four-wheel-steering-controller/default.nix
+++ b/distros/noetic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rosgraph-msgs, rostest, std-msgs, std-srvs, tf, urdf-geometry-parser, xacro }:
 buildRosPackage {
   pname = "ros-noetic-four-wheel-steering-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "381358d31a514ee95b0aca60a51ec7f9a4bd0cf6900281448aa29895846bf4b4";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "707059f1318b760df190f02b0ef8473cd27dbe1025043d14620ef054d8563e15";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -592,6 +592,8 @@ self: super: {
 
  depthai-examples = self.callPackage ./depthai-examples {};
 
+ depthai-ros-driver = self.callPackage ./depthai-ros-driver {};
+
  depthai-ros-msgs = self.callPackage ./depthai-ros-msgs {};
 
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
@@ -954,6 +956,16 @@ self: super: {
 
  fkie-potree-rviz-plugin = self.callPackage ./fkie-potree-rviz-plugin {};
 
+ flatland = self.callPackage ./flatland {};
+
+ flatland-msgs = self.callPackage ./flatland-msgs {};
+
+ flatland-plugins = self.callPackage ./flatland-plugins {};
+
+ flatland-server = self.callPackage ./flatland-server {};
+
+ flatland-viz = self.callPackage ./flatland-viz {};
+
  flexbe-behavior-engine = self.callPackage ./flexbe-behavior-engine {};
 
  flexbe-core = self.callPackage ./flexbe-core {};
@@ -1284,6 +1296,8 @@ self: super: {
 
  image-transport = self.callPackage ./image-transport {};
 
+ image-transport-codecs = self.callPackage ./image-transport-codecs {};
+
  image-transport-plugins = self.callPackage ./image-transport-plugins {};
 
  image-view = self.callPackage ./image-view {};
@@ -1539,6 +1553,8 @@ self: super: {
  lanelet2-io = self.callPackage ./lanelet2-io {};
 
  lanelet2-maps = self.callPackage ./lanelet2-maps {};
+
+ lanelet2-matching = self.callPackage ./lanelet2-matching {};
 
  lanelet2-projection = self.callPackage ./lanelet2-projection {};
 
@@ -1935,6 +1951,16 @@ self: super: {
  moveit-sim-controller = self.callPackage ./moveit-sim-controller {};
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
+
+ moveit-task-constructor-capabilities = self.callPackage ./moveit-task-constructor-capabilities {};
+
+ moveit-task-constructor-core = self.callPackage ./moveit-task-constructor-core {};
+
+ moveit-task-constructor-demo = self.callPackage ./moveit-task-constructor-demo {};
+
+ moveit-task-constructor-msgs = self.callPackage ./moveit-task-constructor-msgs {};
+
+ moveit-task-constructor-visualization = self.callPackage ./moveit-task-constructor-visualization {};
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
@@ -3062,11 +3088,17 @@ self: super: {
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
 
+ rviz-marker-tools = self.callPackage ./rviz-marker-tools {};
+
  rviz-plugin-tutorials = self.callPackage ./rviz-plugin-tutorials {};
 
  rviz-python-tutorial = self.callPackage ./rviz-python-tutorial {};
 
  rviz-satellite = self.callPackage ./rviz-satellite {};
+
+ rviz-tool-cursor = self.callPackage ./rviz-tool-cursor {};
+
+ rviz-tool-path-display = self.callPackage ./rviz-tool-path-display {};
 
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 

--- a/distros/noetic/gripper-action-controller/default.nix
+++ b/distros/noetic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gripper-action-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "873785fdc6e4508817f5c0714825e0be2a10d09d76fb0c3f49e39dcc78978f8d";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "7fa4dfa383f738067f6b9b04b5092bb6ed2ffcad9e03461fd71f75332c2cc6eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-image-transport-codecs";
+  version = "2.1.1-r2";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.1.1-2/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "60b1012df7a6d08a411b77588a742f1eab4b3705b0122562ea929f3a8dd7e69e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ rosbag roslint ];
+  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport cras-cpp-common cras-topic-tools dynamic-reconfigure image-transport libjpeg_turbo pluginlib sensor-msgs theora-image-transport topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Image transport plugins available as C, C++ and Python libraries'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/image-transport-plugins/default.nix
+++ b/distros/noetic/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-plugins";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/noetic/image_transport_plugins/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "ee12b60b2c6244a1af9754990a3e6ac315f8c28afdfdd186df47f0927ae36719";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/noetic/image_transport_plugins/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "22c7cca0ba5aa490318456a28c2f475a2806acbdfe92fc4aa18c49db6a91f627";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-sensor-controller/default.nix
+++ b/distros/noetic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-imu-sensor-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "21d541fed9acd9edff448e77232612f5f0e961f8bb0290fbb7c88517f863223b";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "55b76a3936dcb4386e2eb67e8f92974c262b5bfa92ea5d2f57c3bbce0d9310c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-controller/default.nix
+++ b/distros/noetic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "481caa3fa4796a9094a2c572b686bf9ebfd2e349e0681cac3d33b447f22b2ff7";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "f4273452c44dd20301ffe24c82913ae05a0db0c9063d89196808726d51b5a6f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-trajectory-controller/default.nix
+++ b/distros/noetic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, boost, catkin, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, std-msgs, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-joint-trajectory-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "6c04c77fba8f34d3347a1fb997c2436c3c03cc5a92fbaf729389d355298550da";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "333d133c70c87427c9039f55cab66ea03ce09c003a3a807ffda15f81ec5dfcf9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "e7ee13d1e28cfa1795d440e3c873ef8bb723a5c29a55fed5e184b11dd85a9a23";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "1218357ada48069e15a4303eeb88fa19096072c385df39e9b8b482e0aea57720";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-core/default.nix
+++ b/distros/noetic/lanelet2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, eigen, gtest, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-core";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_core/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "ddfea83676a4f5c5e963b8d2862b482ebdd7a59b67df52cfdb23f4bd43bfa7d1";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_core/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "e3b5c96e09004e05b427cd6e8fc737803f79e0b2b8537e324cad5dec0d0bfd03";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-examples/default.nix
+++ b/distros/noetic/lanelet2-examples/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules, rosbash }:
+{ lib, buildRosPackage, fetchurl, catkin, gtest, lanelet2-core, lanelet2-io, lanelet2-matching, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules, rosbash }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-examples";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_examples/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "57602b504adc7f742ff2a6cd04f679e515e0ad4e88bd3d698130eb47f205b524";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_examples/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "4502cb3ee1b63a33000997abb4cf1fc1d96e0694b09a2e0598813e6e26c9971d";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ lanelet2-core lanelet2-io lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules rosbash ];
+  propagatedBuildInputs = [ lanelet2-core lanelet2-io lanelet2-matching lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules rosbash ];
   nativeBuildInputs = [ catkin mrt-cmake-modules ];
 
   meta = {

--- a/distros/noetic/lanelet2-io/default.nix
+++ b/distros/noetic/lanelet2-io/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, gtest, lanelet2-core, mrt-cmake-modules, pugixml }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-io";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_io/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "c17faa85a5a1fad9b956597b60963cb78e7f497e2b45356c67b24aea8c1efc4b";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_io/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "dec750c61a59d8bb8fc19d950a28ae51bfab244cdf0c57e4c25dd7c41b967621";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-maps/default.nix
+++ b/distros/noetic/lanelet2-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lanelet2-core, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-maps";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_maps/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "606cfe35ab43bfeca8abb7213e030056dc3a4eb920f49c59f5add39ab04aa7ec";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_maps/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "9ac2f7295c5b958987b1a48a68884a8870b79de61fb889c49f9cdaca5ea1683b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-matching/default.nix
+++ b/distros/noetic/lanelet2-matching/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-traffic-rules, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-noetic-lanelet2-matching";
+  version = "1.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_matching/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "4b06f673bbb0c2daa71c136bbf64300e16cee3a9da8b8ab01f3f13de882afadd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ gtest lanelet2-io lanelet2-maps lanelet2-projection ];
+  propagatedBuildInputs = [ lanelet2-core lanelet2-traffic-rules mrt-cmake-modules ];
+  nativeBuildInputs = [ catkin mrt-cmake-modules ];
+
+  meta = {
+    description = ''Library to match objects to lanelets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/lanelet2-projection/default.nix
+++ b/distros/noetic/lanelet2-projection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographiclib, gtest, lanelet2-io, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-projection";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_projection/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "722991b38fdaf300d51b46ae7706017a934c2190ff5d6e84e9f5137e2d1dbcd1";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_projection/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "0c3addfe614636a1ec9f366c9cd15f92ed61320ea4b6cc9cb8e20370d1b32a2f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-python/default.nix
+++ b/distros/noetic/lanelet2-python/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, gtest, lanelet2-core, lanelet2-io, lanelet2-matching, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-python";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_python/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "12f04c8e937e1ac5f922d3f8afe4ef6f847d5a06a29bbbcfa1724379800841f9";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_python/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "8eba1e57bba5b61af36b28dd20e200d6fa9052034b8634b12a5d9b7807c53c1f";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ boost lanelet2-core lanelet2-io lanelet2-projection lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ];
+  propagatedBuildInputs = [ boost lanelet2-core lanelet2-io lanelet2-matching lanelet2-projection lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ];
   nativeBuildInputs = [ catkin mrt-cmake-modules ];
 
   meta = {

--- a/distros/noetic/lanelet2-routing/default.nix
+++ b/distros/noetic/lanelet2-routing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, gtest, lanelet2-core, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-routing";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_routing/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "929df4e7c8aee6ec92fb03a8dd0b0bbe41bd57e3c99ebb3f355674d08c502e02";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_routing/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "67382d066431a60e58792d9e712e4e17efe55e21fb10b1aaf921c64bebedb9a8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-traffic-rules/default.nix
+++ b/distros/noetic/lanelet2-traffic-rules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, lanelet2-core, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-traffic-rules";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_traffic_rules/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "85f85ce06f1e71e26bd5c8bea1fa08cbc32300547fa4d417cccec8b8231e970a";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_traffic_rules/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "e3b668ffb054dd6f86ba12d1b57994b5e97ad25f704784e6b3155a832f685164";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-validation/default.nix
+++ b/distros/noetic/lanelet2-validation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2-validation";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_validation/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "7e790e68136a204efbbbd3b6df8f7faa2dca79cf7c2b37bfa143f6313af6e9a9";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_validation/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "42ece07fe3f13902de85315279469f7bcdde0432e3fc2b48134395c97916cb5a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2/default.nix
+++ b/distros/noetic/lanelet2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lanelet2-core, lanelet2-examples, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, ros-environment }:
+{ lib, buildRosPackage, fetchurl, catkin, lanelet2-core, lanelet2-examples, lanelet2-io, lanelet2-maps, lanelet2-matching, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-lanelet2";
-  version = "1.1.1-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "c34c9b5f14881562d39c80145644750c465f28146f5bf5a3679903728d2be40c";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "6febb7cf4e7df0b5d6cbbb3259dbc1e04d149413cabb897e887e8a952948430f";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ros-environment ];
-  propagatedBuildInputs = [ lanelet2-core lanelet2-examples lanelet2-io lanelet2-maps lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules lanelet2-validation ];
+  propagatedBuildInputs = [ lanelet2-core lanelet2-examples lanelet2-io lanelet2-maps lanelet2-matching lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules lanelet2-validation ];
   nativeBuildInputs = [ catkin ros-environment ];
 
   meta = {

--- a/distros/noetic/map-organizer-msgs/default.nix
+++ b/distros/noetic/map-organizer-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/map_organizer_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "1434e36726307ee6ed9b2a58934b286802700a685e8382c35af4b4aa200060ef";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/map_organizer_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "ffe0ca6b9f2dfb1921ba6c8fe3c5ec63be83ea437b4c53d6ca3d6cf6f3903976";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "e307ca8f3f49ae73d8291551bff54cd85709c9be173ad01f1792a7308fc16f70";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "67cd3aa0d869aa1b0114750a600bab085e61cd26365350f903fdcbea12988f01";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-task-constructor-capabilities/default.nix
+++ b/distros/noetic/moveit-task-constructor-capabilities/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-ros-move-group, moveit-task-constructor-core, moveit-task-constructor-msgs, pluginlib, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-task-constructor-capabilities";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit_task_constructor-release/archive/release/noetic/moveit_task_constructor_capabilities/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "838abdf038d54c59dad6fc0924965d1ddd94278c63905c0170ec8a154eec917d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ actionlib moveit-core moveit-ros-move-group moveit-task-constructor-core moveit-task-constructor-msgs pluginlib std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''MoveGroupCapabilites to interact with MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-task-constructor-core/default.nix
+++ b/distros/noetic/moveit-task-constructor-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, moveit-core, moveit-planners, moveit-resources-fanuc-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-task-constructor-msgs, python3Packages, roscpp, roslint, rostest, rosunit, rviz-marker-tools, tf2-eigen, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-task-constructor-core";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit_task_constructor-release/archive/release/noetic/moveit_task_constructor_core/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "113df3b217b389a0fe5e5ea75b926fb19b38dcc45809aaa36bdcd10a41216ea2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin python3Packages.setuptools roslint ];
+  checkInputs = [ moveit-planners moveit-resources-fanuc-moveit-config rostest rosunit ];
+  propagatedBuildInputs = [ geometry-msgs moveit-core moveit-ros-planning moveit-ros-planning-interface moveit-task-constructor-msgs roscpp rviz-marker-tools tf2-eigen visualization-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''MoveIt Task Pipeline'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-task-constructor-demo/default.nix
+++ b/distros/noetic/moveit-task-constructor-demo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, moveit-task-constructor-capabilities, moveit-task-constructor-core, roscpp, rosparam-shortcuts, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-task-constructor-demo";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit_task_constructor-release/archive/release/noetic/moveit_task_constructor_demo/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "b790f9cfb87e30b9daabe935b2337f5d47965aed106d69114021d3076efe127c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ moveit-core moveit-resources-panda-moveit-config moveit-ros-planning-interface moveit-task-constructor-capabilities moveit-task-constructor-core roscpp rosparam-shortcuts ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''demo tasks illustrating various capabilities of MTC.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-task-constructor-msgs/default.nix
+++ b/distros/noetic/moveit-task-constructor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-task-constructor-msgs";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit_task_constructor-release/archive/release/noetic/moveit_task_constructor_msgs/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "80fba3c2a652ac9e7c71251a3da269331108aa13f8d688cf033fff1ed11b1d92";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ message-generation message-runtime moveit-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for MoveIt Task Pipeline'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-task-constructor-visualization/default.nix
+++ b/distros/noetic/moveit-task-constructor-visualization/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-resources-fanuc-moveit-config, moveit-ros-visualization, moveit-task-constructor-core, moveit-task-constructor-msgs, qt5, roscpp, rostest, rosunit, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-task-constructor-visualization";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit_task_constructor-release/archive/release/noetic/moveit_task_constructor_visualization/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "b1ff5e97a5fff72a1c8b1033162f0a5a124e318148d069a2bbcab76032e020ae";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin qt5.qtbase ];
+  checkInputs = [ moveit-resources-fanuc-moveit-config rostest rosunit ];
+  propagatedBuildInputs = [ moveit-core moveit-ros-visualization moveit-task-constructor-core moveit-task-constructor-msgs roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Visualization tools for MoveIt Task Pipeline'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, box2d, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "b77a72c415155763ff7bd0a3d5347ab121847007b954a8de89e2a9e084edf61a";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "0e202234ed5de817db4d530a2ea98920e8fce809498087cdbf121502c0e22211";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "4088361bc74f98def74831770d59bd52beddd491e0578b24d240eee0f4dd7a18";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "d82c0b510042786549f5e6544cb9e447710f115272ef15251ee09683e9d719ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "0a15d0fe248291ba0a4e9022f2545f7e556094cc4f95a60b9a6bbd1f80f40d13";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "0c36d6382e432a8b7f9b904fba97f69a3a51b8830bae9112697b5bf1283cc9b4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-msgs/default.nix
+++ b/distros/noetic/neonavigation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, map-organizer-msgs, planner-cspace-msgs, safety-limiter-msgs, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/neonavigation_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "22b11f09239459dfa5972250c5fb0d15d0df4ef5c97bd8c418a9eb2eb542627c";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/neonavigation_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "8956d12a43d9ba0dbfe6c9dd1ef582bfc19b619deba6fab8ae9c6837cf4f50e6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "3b4849335328e956b53f18971c80e9111469a5a6b5e1f81546fcccb49106a445";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "49ea16b6bf971640a78a430d3bd01b7e2dd3f96e956f7a1b32728fd18bee7940";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "1b95004724669b5512bd53ed7e8dee3146b75a84cd2f8383ac03299ce50bc559";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "d372d1fb8c533a627785dd93e7c599253e45bb7ad6a0582cf0676cfdd7a735fc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.14-r1";
+  version = "2.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.14-1.tar.gz";
-    name = "2.6.14-1.tar.gz";
-    sha256 = "1e1159636d3134c1d790c196bd600d5f49a21e08ec1c05db8cac7431a71d7a54";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.16-1.tar.gz";
+    name = "2.6.16-1.tar.gz";
+    sha256 = "68dbeb81cf279d8fc721b57c9b021de6fe72b143a6f97c070ea82ae29b8345f1";
   };
 
   buildType = "cmake";

--- a/distros/noetic/planner-cspace-msgs/default.nix
+++ b/distros/noetic/planner-cspace-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/planner_cspace_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "1dcaa56a3324805c727d96ec0769155b9921b96fe183a7e359928514be125718";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/planner_cspace_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "d47e6ca73d1dc9fd18cd6f6f30ffc98310aff6428da03bdefd2bf80e8cc0b4b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "b237c579afd93ace3f667351dbe480a119c32f5bcc9a2aaacddb2edd1067d232";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "d4b4b05c89916e000280e237f0dc43f2c766f53f11822964f8846086db6fbe18";
   };
 
   buildType = "catkin";

--- a/distros/noetic/position-controllers/default.nix
+++ b/distros/noetic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-position-controllers";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "062678a7125a118858ed423f1ea21f2a66f70a7452f8ce76bdd58681a55f769c";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "c500dd7552be7a2cc00d187813d1d36247e7cebbd4c732a393a747fb7c7ae091";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robotraconteur/default.nix
+++ b/distros/noetic/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, catkin, dbus, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-noetic-robotraconteur";
-  version = "0.15.5-r1";
+  version = "0.16.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros-release/archive/release/noetic/robotraconteur/0.15.5-1.tar.gz";
-    name = "0.15.5-1.tar.gz";
-    sha256 = "db9915e61c7d083039943fbab37e24d53709b8237ac97f026b55b3e4ce84a30d";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros-release/archive/release/noetic/robotraconteur/0.16.0-2.tar.gz";
+    name = "0.16.0-2.tar.gz";
+    sha256 = "b00b4e3e01787cad0d1263f45714043c7dcace192d4a51137ba416fba0f554ea";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ros-controllers/default.nix
+++ b/distros/noetic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "a16b7d6c323fb7ba9df1bee367d0d7c827fdc80d767dadcf0087368cf9f97f87";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "3786fd145afe12f1822e42878a3f87bbcc5d854d9d6577cc4ef5bcd1daadf7c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/noetic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-joint-trajectory-controller";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "65cb9aa90ba30ef7f1503bb92679652a08936e4b448f2dd4507a6f2f38c23970";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "a05b3a672cd5e090031c165489f0ec0dfe8e86d52b89df3ed4b3dc6732f74a04";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz-marker-tools/default.nix
+++ b/distros/noetic/rviz-marker-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, rviz, tf2-eigen, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rviz-marker-tools";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit_task_constructor-release/archive/release/noetic/rviz_marker_tools/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "3ece254dce1783a6ddb5c2932201746cfca2f4b2814c4ecf6f79f72e91b0ae46";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs roscpp rviz tf2-eigen visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for marker creation / handling'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rviz-tool-cursor/default.nix
+++ b/distros/noetic/rviz-tool-cursor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, pluginlib, qt5, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-rviz-tool-cursor";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/rviz_tool_cursor/archive/release/noetic/rviz_tool_cursor/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d49f247e02bfbec7d2dfaa8b39d423b918917709d4b27070c460ef79fa73b9b0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin eigen ];
+  propagatedBuildInputs = [ pluginlib qt5.qtbase rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rviz_tool_cursor package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rviz-tool-path-display/default.nix
+++ b/distros/noetic/rviz-tool-path-display/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-rviz-tool-path-display";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/rviz_tool_path_display-release/archive/release/noetic/rviz_tool_path_display/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "2fe0988163c991188af9981fc516d622931be45504a7029770d579e7efec7aab";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ pluginlib qt5.qtbase rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rviz_tool_path_display package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/safety-limiter-msgs/default.nix
+++ b/distros/noetic/safety-limiter-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/safety_limiter_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "c2d48a00e5386a9f6f6f867c8346fe87d1f738b9190e750c0eb85b2ab7160718";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/safety_limiter_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "e6bb0b7fc523be880b311cd46f858714f82b23c7320e5f71cea717b9d5b9be9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "468e22d1642e239e0c46ddd3f3c707be9369eec6444b9f378a1703bf4c71f3d8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "fb1c069352f70b9e15a73ee103d9568b44990b018cef64eb1216a2edc1ce1a2c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/theora-image-transport/default.nix
+++ b/distros/noetic/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-transport, libogg, libtheora, message-generation, message-runtime, pluginlib, rosbag, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-theora-image-transport";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_transport_plugins-release/archive/release/noetic/theora_image_transport/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "0118b37d2c05543c66294cb79f2065613fc1b6f869f3284de12420b701bd1b08";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/noetic/theora_image_transport/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "902a465ccdd3284b2e72cf275540b73d2d28953ce7d8e00a95ef28e3f5630ade";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "0a3d12d35b11ca2aa54684d94eb7fdabb81565aeb5ac51c3d659099b663b0981";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "960f06a22490d941da933695a1f1ad276f34e2e2844f2c703c202b1180e1908d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker-msgs/default.nix
+++ b/distros/noetic/trajectory-tracker-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker-msgs";
-  version = "0.8.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/trajectory_tracker_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "4bd4fe7f2414137d70ce6abcc7217a92b96e27bb1a2c0a3415d8b81190175d7d";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/noetic/trajectory_tracker_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "af1dfa3abee3b579ef71e2094ff455358addce0e19506e9e7ce671c34ce7a49c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.11.8-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "a5672fbf3046ecb0052c5869fee74d96774df4c9f227e6b9e0a8d5c1fc95192c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "c0f1b96238355ac2153dbc739eebf39ccbe6e6d7df44f3d51d83c2a5eeefa16c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velocity-controllers/default.nix
+++ b/distros/noetic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, roscpp, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-velocity-controllers";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "5b88737c78dae005d51d4cd2fd9260d4cf8518bc8ee34d5169e1b139d1063be5";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "6bd0772935ba2de9d7015e174c45b94942f89a29899ec0bfc2828eaea941f2a6";
   };
 
   buildType = "catkin";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2deadcef69dfec1b8d15e7fd0a3bd5ba0d7b55e4960808c4119c4c033f14c427";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0d19d642a83407d62dce409c0c1d781e69aaf707a149775b22aa8d2990fc2276";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cascade-lifecycle-msgs/default.nix
+++ b/distros/rolling/cascade-lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-cascade-lifecycle-msgs";
-  version = "1.0.3-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/rolling/cascade_lifecycle_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "d160f54cd90181784ad831c308f48af57ea989f21c9a67cb35ee75565133bc0f";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/rolling/cascade_lifecycle_msgs/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "9c8c123dbc8f52ba674db23b5c6ab88d5556e4cf34124f2a847f613d1c029a4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diagnostic-aggregator/default.nix
+++ b/distros/rolling/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-aggregator";
-  version = "3.0.0-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_aggregator/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6e17a7568e48888274575514761bba5daf5e6b91acc52cad415189665c61a4ee";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_aggregator/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "207e5646dc6c86ffa192035fcd19fbd606dd5c67e89d2ef5126c2d25714bb14c";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''diagnostic_aggregator'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/diagnostic-common-diagnostics/default.nix
+++ b/distros/rolling/diagnostic-common-diagnostics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, ntp, rclpy }:
+buildRosPackage {
+  pname = "ros-rolling-diagnostic-common-diagnostics";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_common_diagnostics/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "27022010e8da7b28c0929f57c56a1efff26a536b9ab774c1079724f82c3e4b4e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ diagnostic-updater ntp rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''diagnostic_common_diagnostics'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/diagnostic-updater/default.nix
+++ b/distros/rolling/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-updater";
-  version = "3.0.0-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_updater/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "69910ba4759b5604a441df600dcd599b53e965c5ed9cbb01c36b755231da8e45";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_updater/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "d79a8990f08cf2f45051516a03742e83433a3c0b27b14d49df6965b5605cbf96";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = ''diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/diagnostics/default.nix
+++ b/distros/rolling/diagnostics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
+buildRosPackage {
+  pname = "ros-rolling-diagnostics";
+  version = "3.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostics/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "16002ae1836463c67d4424b6b4aef8eb668f5f69ed467d731307914296177ff0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-common-diagnostics diagnostic-updater self-test ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''diagnostics'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "706ee9efed669775badd86036f4c6164a904ced45df0b8c6e10c1229af8f3c62";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7e28cc1ce4103f3418d4b03e6c21d089d91561bc27658a1eca983992a7fc3126";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "bfb84a3030f96f17a75d5f40f036d9864381a20754257968f0a5ec79a6cf89f7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7135e9c64e7e879d9fc2a8faccceea522b071907fbe91d41442d442710d69149";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/eigenpy/default.nix
+++ b/distros/rolling/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-eigenpy";
-  version = "2.8.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/rolling/eigenpy/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "e7923018e187d1cd43c8bdabe9af308c435dc43af36ffa46cebb7f4acf74fe76";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/rolling/eigenpy/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "f647b3c2c8804a7ad15d7a474335f1ededb9b4d349d68c81071d6aeec2874e6d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "a7b32df165f1d5166907d40c1f5bdb2f9a71cd9e492a524231169e80742ea600";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "db7e7af887c17fbb5fa5a48083e43ad523e4a673945c9d211b71b862987f1c3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6978f5de37204c6e3a081c21afcfbf3a1f44a614eecfbb784d9c0ff552a15241";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a188b29466bbda21c4c9f8b49e90a6a66035557f629cbb20b45189be093e35bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -266,9 +266,13 @@ self: super: {
 
  diagnostic-aggregator = self.callPackage ./diagnostic-aggregator {};
 
+ diagnostic-common-diagnostics = self.callPackage ./diagnostic-common-diagnostics {};
+
  diagnostic-msgs = self.callPackage ./diagnostic-msgs {};
 
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
+
+ diagnostics = self.callPackage ./diagnostics {};
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
@@ -593,6 +597,8 @@ self: super: {
  joy-linux = self.callPackage ./joy-linux {};
 
  joy-teleop = self.callPackage ./joy-teleop {};
+
+ joy-tester = self.callPackage ./joy-tester {};
 
  kdl-parser = self.callPackage ./kdl-parser {};
 
@@ -963,6 +969,8 @@ self: super: {
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
  position-controllers = self.callPackage ./position-controllers {};
+
+ py-trees = self.callPackage ./py-trees {};
 
  py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
 

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d59239302030a0b74894798992f7c850f3ac1fcefb0145373b6fa20d1769d671";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ca491cbc6ed0e1a9ee5ba6dd3bed5fa24ecdc2ba9c7e68064bf9f2fa946c6028";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ign-ros2-control-demos/default.nix
+++ b/distros/rolling/ign-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-ign-gazebo, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ign-ros2-control-demos";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/ign_ros2_control_demos/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "23cb863a33e5cb0b54f893af1db5bd30b2c9ac78d4b21843cccc179d486b68bc";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/ign_ros2_control_demos/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "af3c1a81abd7fa4fe93a3ef11e3ce801c6b2bce41b18ae73bebac0bede3907fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9f6fc3ef07905f328dc9e615fb515463bfb02b851644cc76263f27213a35854d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8fe23b0db0c21108b5a742ed2ed2ab24541ff22ebe854707e0ae04612d260f8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "bfa696bb183d770dd20c26d65989a2914fbf1aa214ed2daccdf1e965c23fd535";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7f8081acf4abe203294d89f1a5048013bfc6b58f40b3733f12651e3e0ecc0ccf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0bb028c0437d3ceb6e4968deddc333d86d38ebe45343c5f393ff0087b22581d5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1bf88204d52b17ff49e73a3b0bea97cedb34b86870b616a2d15ee189a8b46f91";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joy-tester/default.nix
+++ b/distros/rolling/joy-tester/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-joy-tester";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joy_tester-release/archive/release/rolling/joy_tester/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "107a3de56449518b764f5cb4841358fc3861542dc59f209db4de1639c2f40a19";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.tkinter rclpy sensor-msgs ];
+
+  meta = {
+    description = ''Simple GUI tool for testing joysticks/gamepads'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/kinematics-interface-kdl/default.nix
+++ b/distros/rolling/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface-kdl";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "1c3621219ee1cb0253e90fa15fce3f3819b3c633b9916ca0eccd5568cf4f701c";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "229b0a9a9358d23b339551f3393141de26b4351201a2f4614dff517f6713d567";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinematics-interface/default.nix
+++ b/distros/rolling/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "1b9444290bfd0d3a1371d3aa7a26546b6309eab643b4555a18b809d7f791a336";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "05785d486012efd58333fc10a4c22f9755b4a09505c048a8809eb1ea0c4015ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, box2d, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.5.0-r1";
+  version = "0.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "52eccd0d081a7a22923bb51af1b2bec2cc9ddd6adc2ace683800cc5b95ebb11e";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.5.1-2.tar.gz";
+    name = "0.5.1-2.tar.gz";
+    sha256 = "b3cc14b6ecaa4c9a002907cbe69be4c163a7fb9db20d590175de7ecdd0510114";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pinocchio/default.nix
+++ b/distros/rolling/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-pinocchio";
-  version = "2.6.14-r1";
+  version = "2.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/2.6.14-1.tar.gz";
-    name = "2.6.14-1.tar.gz";
-    sha256 = "b81701710743b4b7bade11d9e0be973aa04716e2caa59a21768120220bff9484";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/2.6.16-1.tar.gz";
+    name = "2.6.16-1.tar.gz";
+    sha256 = "82fdee2ca383c0aad318b675b7adec20e99cb797e5ede981b4cd757e709894bf";
   };
 
   buildType = "cmake";

--- a/distros/rolling/plotjuggler-ros/default.nix
+++ b/distros/rolling/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler-ros";
-  version = "1.7.3-r3";
+  version = "1.7.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/rolling/plotjuggler_ros/1.7.3-3.tar.gz";
-    name = "1.7.3-3.tar.gz";
-    sha256 = "9cec6e4f7dccc9b9ce7a3c5f099f1867e1f405d1eae663a2bcc5d14fd837dd40";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/rolling/plotjuggler_ros/1.7.3-4.tar.gz";
+    name = "1.7.3-4.tar.gz";
+    sha256 = "9561916e988f54d656fb969490cf604ab162e3a5c7a70927f87efa106027dd9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d8e7f9257e1516d97ec8b215359666a1c696881b59a0f91459e70f1b05907607";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b2cb6855f82cd98614f0c2e6a6b71414e3db817bfbb9d7647e76f4204bf71116";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/py-trees-ros-interfaces/default.nix
+++ b/distros/rolling/py-trees-ros-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-py-trees-ros-interfaces";
-  version = "2.0.3-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros_interfaces-release/archive/release/rolling/py_trees_ros_interfaces/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "8e9685733ba7885de72beb4abf6f4978e2f30cfd1d8b3e0a16a34e4107dbbb80";
+    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/rolling/py_trees_ros_interfaces/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "a9c5cf6aa609bd14b43784b3b43b5d49e0bed837935cd2c15248730ac6483eaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/py-trees/default.nix
+++ b/distros/rolling/py-trees/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-py-trees";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/rolling/py_trees/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "0579dbccace6dd5ff26ef699dfcde7f6f31a3ebff517da1abc25cfcc544159ba";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools ];
+  propagatedBuildInputs = [ python3Packages.pydot ];
+
+  meta = {
+    description = ''Pythonic implementation of behaviour trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "18.0.0-r1";
+  version = "19.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/18.0.0-1.tar.gz";
-    name = "18.0.0-1.tar.gz";
-    sha256 = "ee3c8692a366334ca025a3845f90ee296adf3c0469e4feb9960acd066a3517c3";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/19.0.0-1.tar.gz";
+    name = "19.0.0-1.tar.gz";
+    sha256 = "40022b808ece856dd0380049bbe4ab17c75a6b2c56d05980f77632c1393abc5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-cascade-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-cascade-lifecycle";
-  version = "1.0.3-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/rolling/rclcpp_cascade_lifecycle/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "97eff7bf149616dd9d0f0563a1e265b381ff990cf683001d7203aef420fb7e48";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/rolling/rclcpp_cascade_lifecycle/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "28731034fa247f8f76d854d4711dde18e9560b7a8fe30d1057d5fe2a6cdd1351";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "18.0.0-r1";
+  version = "19.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/18.0.0-1.tar.gz";
-    name = "18.0.0-1.tar.gz";
-    sha256 = "f95f068ddd71c25523db404db717ead253fe39941938d749f0092c97748e8477";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/19.0.0-1.tar.gz";
+    name = "19.0.0-1.tar.gz";
+    sha256 = "345981666bb8a7747561a763eee317f0df8ec0f3c377d373d2433a11a31bc248";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "18.0.0-r1";
+  version = "19.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/18.0.0-1.tar.gz";
-    name = "18.0.0-1.tar.gz";
-    sha256 = "0ba7955fef1252b364d198c3a4b41d4072d98eca60143ed17b867455e1f77f58";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/19.0.0-1.tar.gz";
+    name = "19.0.0-1.tar.gz";
+    sha256 = "47b1869b1902aba5fb5ce0b9979259d4724eb879ce50d28cb67dffb30445a63e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "18.0.0-r1";
+  version = "19.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/18.0.0-1.tar.gz";
-    name = "18.0.0-1.tar.gz";
-    sha256 = "b188e26a7cef94e4a49bd6ee189f6f37ccc074c01ccec1938193d18902990f3d";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/19.0.0-1.tar.gz";
+    name = "19.0.0-1.tar.gz";
+    sha256 = "a9d6a284531177b8bc4c7c87697ec75ae1b337e961b65e7df04a47eab3cf0b74";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/realtime-tools/default.nix
+++ b/distros/rolling/realtime-tools/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-action, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, rclcpp, rclcpp-action, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-realtime-tools";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "3cbfcf620ba7bb222a9289f097b172bb105c56c2078af6a8522416dfefb8f828";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "aea0f3317586e8a20c1ea2dd76691fc46d1d40425bc8b100ee2bb2611482bcbd";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ rclcpp-action test-msgs ];
+  checkInputs = [ ament-cmake-gmock test-msgs ];
   propagatedBuildInputs = [ ament-cmake rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "367d67fc2c1dfb0f5bf566280831569fe6b73777562515da44803782f63e94f7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c6060099013fd3df905f99e3896e7d185a93da86bf6b42c7f79a9ce59d0b27e7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, admittance-controller, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, tricycle-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "52ed77acd91c55838bdc9412ec47b701ded2684a1713b410ce6d20858b8b9734";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "f9c019bad9f2d903200dfcb9fa5335280bd3241aa5f908506dab46db9f41567e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0f4ea33d575f725e3d1ef17ba45bcd6aba464eda39b14d91a2b899bc45604d07";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "4bd9ced26571e6bdf5753b62465e7bf63cfabe8435a1a9ae6b63a6955615e0b3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/self-test/default.nix
+++ b/distros/rolling/self-test/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-self-test";
-  version = "3.0.0-r1";
+  version = "3.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/self_test/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6771598989986442c5eca165a5b09ca8286ee44447fe99489d828f43f41f6713";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/self_test/3.1.0-2.tar.gz";
+    name = "3.1.0-2.tar.gz";
+    sha256 = "f3fea4fbf95dbacab108a706a6278d31954356b46a81b19af1b7977731db5c4b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''self_test'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "31f17114c6c0f03d2d014bc2898773bb8034baf5831f98e89774aa043a4427b0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ad22f8ace607921e846ecc43ce014337cd00120ea138da1053fed0c22313c7e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0dc3895f62392f07e90538591e36a10ebfaf418c2aba34aa4252a3b08b694955";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e3072bbd90d6473a295ff25a65fd0e0864d1fb957e3e75408ac6429c1870c1d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-control/default.nix
+++ b/distros/rolling/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-control";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "0903018b487b9222fe6e0558b3fada95a84807ef5a18b0b71c070a2466890b2d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "b19b8c7fb5f2afc47fe715825448145ca05b8312437a49bc54ea7b3b997e9f63";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "93c3f38fe38d54c68cedb835dd21f002df0915408c137bbf610fba18a0be63a8";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "177d1e9762401d8b412be331a2e057d552b7ce4100a18c009ea60bbdae966e0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-epuck/default.nix
+++ b/distros/rolling/webots-ros2-epuck/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-epuck";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "075fb159c4e89725c1fc51db8afc6a33624a8554425a4ef701e501bc532bb66a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "77c494f44578525d0e69f54c51573df76f570495356d52343fdb092603ae97bc";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster nav-msgs rclpy robot-state-publisher rviz2 sensor-msgs std-msgs tf2-ros webots-ros2-control webots-ros2-driver webots-ros2-msgs ];
 
   meta = {

--- a/distros/rolling/webots-ros2-importer/default.nix
+++ b/distros/rolling/webots-ros2-importer/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-importer";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "c6facaae14ec0b2eabea338bddadc0b5143cd358a9a6ea1f68ce7a365d55324d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "9a1db55318c20dc1ce4b5e1308eb0b197ed1cce0e07797ea09eb7986522c6cd1";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.numpy python3Packages.pillow python3Packages.pycodestyle pythonPackages.pytest ];
+  checkInputs = [ ament-copyright python3Packages.numpy python3Packages.pillow python3Packages.pycodestyle pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces python3Packages.lark python3Packages.pycollada xacro ];
 
   meta = {

--- a/distros/rolling/webots-ros2-mavic/default.nix
+++ b/distros/rolling/webots-ros2-mavic/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-mavic";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "16ff15b6911183dad92f512becd93dcba72567882f95fb0574492a740295f1c0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "67ac1882f2799cdaa1c62f3bb972b102e56505aea19a379480f2d75c3fe731a7";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces rclpy webots-ros2-driver ];
 
   meta = {

--- a/distros/rolling/webots-ros2-msgs/default.nix
+++ b/distros/rolling/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-msgs";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "2c89eba9802b617e934ad1ece42cc4254e2ddf0f00c98beb127b30beec5ea51f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "e9f48f7cb6c3c193b97869f66e365a82c136b64df3cc238e90d4635018f29f49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tesla";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "915623a32381ad3f3456824a344a9c54b4aed108815186eff62488cfba1824ca";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "5ea664b7e537e7e5c16623b615075a86b0a98aef38ca6c002393c26ce710d776";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-driver ];
 
   meta = {

--- a/distros/rolling/webots-ros2-tests/default.nix
+++ b/distros/rolling/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tests";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "ded7c552175848163e34b850939ff58244c21d67f044b2d9b929e33e571dd199";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "c0adc4e2639f6679be21ea1bbafac90b2d759b71c08776ba3a3f99067f10f3d7";
   };
 
   buildType = "ament_python";
   buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = ''System tests for `webots_ros2` packages.'';

--- a/distros/rolling/webots-ros2-tiago/default.nix
+++ b/distros/rolling/webots-ros2-tiago/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tiago";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "33ec6b04e3a46ae61620739bfc99990ae4a81532162a854813040e08d2a4e838";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "0163796e4215e89536e050482975e8c14d91a6b2b3e2bc01049a8378c8ecf479";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller geometry-msgs joint-state-broadcaster rclpy robot-state-publisher rviz2 tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {

--- a/distros/rolling/webots-ros2-turtlebot/default.nix
+++ b/distros/rolling/webots-ros2-turtlebot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-turtlebot";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "73cdefe6b710771e0bdcea3abd6eccf25856225ddc188fce727383a5b61faedf";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "1fbc0d0b038d65ac44264c5efdb73ff2ced3cf6953964f3acd7801d059fd5c04";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces controller-manager diff-drive-controller joint-state-broadcaster rclpy robot-state-publisher rviz2 tf2-ros webots-ros2-control webots-ros2-driver ];
 
   meta = {

--- a/distros/rolling/webots-ros2-universal-robot/default.nix
+++ b/distros/rolling/webots-ros2-universal-robot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-universal-robot";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "243d6590e30ba79eba4a50ac8399ecc83005fb87c592e975585268a19dc80730";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "336fffb58694a8f06dda9a77e2df0d757fd0d52f2e9e0925012774a29c5b9689";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ builtin-interfaces control-msgs controller-manager joint-state-broadcaster joint-trajectory-controller rclpy robot-state-publisher rviz2 trajectory-msgs webots-ros2-control webots-ros2-driver xacro ];
 
   meta = {

--- a/distros/rolling/webots-ros2/default.nix
+++ b/distros/rolling/webots-ros2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2";
-  version = "2023.0.1-r1";
+  version = "2023.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.0.1-1.tar.gz";
-    name = "2023.0.1-1.tar.gz";
-    sha256 = "245e9a9ef37e93008f3b5d7b46b13d391c628221bc8aea02adb3df22a9b35f66";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.0.2-1.tar.gz";
+    name = "2023.0.2-1.tar.gz";
+    sha256 = "4ca23a2c40a3a98ca040531e0567a8af4c933c5195723ae985cfa181a9bfe71e";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest webots-ros2-tests ];
+  checkInputs = [ ament-copyright pythonPackages.pytest webots-ros2-tests ];
   propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'humble', 'melodic', 'noetic', 'rolling'] from nix-ros-overlay commit 9100a4701418d6a89880a9e112e7e056bab5ca7c.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *depthai 2.19.1-r1 --> 2.20.2-r1*
* *diagnostic-aggregator 2.0.8-r2 --> 3.1.0-r2*
* *diagnostic-common-diagnostics 3.1.0-r2*
* *diagnostic-updater 2.0.8-r2 --> 3.1.0-r2*
* *diagnostics 3.1.0-r2*
* *eigenpy 2.9.0-r1 --> 2.9.2-r1*
* *fastrtps 2.1.2-r1 --> 2.1.3-r1*
* *jackal-control 1.0.1-r1 --> 1.0.3-r1*
* *jackal-description 1.0.1-r1 --> 1.0.3-r1*
* *jackal-msgs 1.0.1-r1 --> 1.0.3-r1*
* *jackal-navigation 1.0.1-r1 --> 1.0.3-r1*
* *joy-tester 0.0.2-r2*
* *maliput 1.0.9-r1 --> 1.1.0-r1*
* *mvsim 0.5.0-r1 --> 0.5.1-r2*
* *pinocchio 2.6.14-r1 --> 2.6.16-r1*
* *self-test 2.0.8-r2 --> 3.1.0-r2*
* *webots-ros2 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-control 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-driver 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-epuck 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-importer 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-mavic 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-msgs 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tesla 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tests 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tiago 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-turtlebot 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-universal-robot 2023.0.1-r1 --> 2023.0.2-r1*

Humble Changes:
---------------
* *admittance-controller 2.15.0-r1 --> 2.16.1-r1*
* *apriltag-msgs 2.0.1-r2*
* *apriltag-ros 3.1.1-r1*
* *aruco 5.0.0-r1*
* *aruco-msgs 5.0.0-r1*
* *aruco-ros 5.0.0-r1*
* *cascade-lifecycle-msgs 1.0.2-r1 --> 1.0.2-r2*
* *controller-interface 2.20.0-r1 --> 2.22.0-r1*
* *controller-manager 2.20.0-r1 --> 2.22.0-r1*
* *controller-manager-msgs 2.20.0-r1 --> 2.22.0-r1*
* *dataspeed-dbw-common 2.1.0-r1 --> 2.1.1-r1*
* *dataspeed-dbw-gateway 2.1.0-r1 --> 2.1.1-r1*
* *dataspeed-dbw-msgs 2.1.0-r1 --> 2.1.1-r1*
* *dataspeed-ulc 2.1.0-r1 --> 2.1.1-r1*
* *dataspeed-ulc-can 2.1.0-r1 --> 2.1.1-r1*
* *dataspeed-ulc-msgs 2.1.0-r1 --> 2.1.1-r1*
* *dbw-fca 2.1.0-r1 --> 2.1.1-r1*
* *dbw-fca-can 2.1.0-r1 --> 2.1.1-r1*
* *dbw-fca-description 2.1.0-r1 --> 2.1.1-r1*
* *dbw-fca-joystick-demo 2.1.0-r1 --> 2.1.1-r1*
* *dbw-fca-msgs 2.1.0-r1 --> 2.1.1-r1*
* *dbw-ford 2.1.0-r1 --> 2.1.1-r1*
* *dbw-ford-can 2.1.0-r1 --> 2.1.1-r1*
* *dbw-ford-description 2.1.0-r1 --> 2.1.1-r1*
* *dbw-ford-joystick-demo 2.1.0-r1 --> 2.1.1-r1*
* *dbw-ford-msgs 2.1.0-r1 --> 2.1.1-r1*
* *dbw-polaris 2.1.0-r1 --> 2.1.1-r1*
* *dbw-polaris-can 2.1.0-r1 --> 2.1.1-r1*
* *dbw-polaris-description 2.1.0-r1 --> 2.1.1-r1*
* *dbw-polaris-joystick-demo 2.1.0-r1 --> 2.1.1-r1*
* *dbw-polaris-msgs 2.1.0-r1 --> 2.1.1-r1*
* *depthai 2.19.1-r1 --> 2.20.2-r1*
* *depthai-bridge 2.5.3-r1 --> 2.6.2-r1*
* *depthai-examples 2.5.3-r1 --> 2.6.2-r1*
* *depthai-ros 2.5.3-r1 --> 2.6.2-r1*
* *depthai-ros-driver 2.6.2-r1*
* *depthai-ros-msgs 2.5.3-r1 --> 2.6.2-r1*
* *diagnostic-aggregator 3.0.0-r1 --> 3.1.0-r2*
* *diagnostic-common-diagnostics 3.1.0-r2*
* *diagnostic-updater 3.0.0-r1 --> 3.1.0-r2*
* *diagnostics 3.1.0-r2*
* *diff-drive-controller 2.15.0-r1 --> 2.16.1-r1*
* *effort-controllers 2.15.0-r1 --> 2.16.1-r1*
* *eigenpy 2.8.1-r1 --> 2.9.2-r1*
* *force-torque-sensor-broadcaster 2.15.0-r1 --> 2.16.1-r1*
* *forward-command-controller 2.15.0-r1 --> 2.16.1-r1*
* *gazebo-ros2-control 0.4.0-r1 --> 0.4.1-r1*
* *gazebo-ros2-control-demos 0.4.0-r1 --> 0.4.1-r1*
* *gripper-controllers 2.15.0-r1 --> 2.16.1-r1*
* *hardware-interface 2.20.0-r1 --> 2.22.0-r1*
* *imu-sensor-broadcaster 2.15.0-r1 --> 2.16.1-r1*
* *irobot-create-common-bringup 2.0.0-r1*
* *irobot-create-control 2.0.0-r1*
* *irobot-create-description 2.0.0-r1*
* *irobot-create-gazebo-bringup 2.0.0-r1*
* *irobot-create-gazebo-plugins 2.0.0-r1*
* *irobot-create-gazebo-sim 2.0.0-r1*
* *irobot-create-ignition-bringup 2.0.0-r1*
* *irobot-create-ignition-sim 2.0.0-r1*
* *irobot-create-ignition-toolbox 2.0.0-r1*
* *irobot-create-nodes 2.0.0-r1*
* *irobot-create-toolbox 2.0.0-r1*
* *joint-limits 2.20.0-r1 --> 2.22.0-r1*
* *joint-state-broadcaster 2.15.0-r1 --> 2.16.1-r1*
* *joint-trajectory-controller 2.15.0-r1 --> 2.16.1-r1*
* *joy-tester 0.0.2-r1*
* *kinematics-interface 0.0.2-r1 --> 0.1.0-r1*
* *kinematics-interface-kdl 0.0.2-r1 --> 0.1.0-r1*
* *mapviz 2.2.0-r1*
* *mapviz-interfaces 2.2.0-r1*
* *mapviz-plugins 2.2.0-r1*
* *multires-image 2.2.0-r1*
* *mvsim 0.5.0-r1 --> 0.5.1-r2*
* *pal-gripper 3.0.1-r1 --> 3.0.2-r1*
* *pal-gripper-controller-configuration 3.0.1-r1 --> 3.0.2-r1*
* *pal-gripper-description 3.0.1-r1 --> 3.0.2-r1*
* *pinocchio 2.6.14-r1 --> 2.6.16-r1*
* *pmb2-bringup 4.0.5-r1 --> 5.0.0-r1*
* *pmb2-controller-configuration 4.0.5-r1 --> 5.0.0-r1*
* *pmb2-description 4.0.5-r1 --> 5.0.0-r1*
* *pmb2-gazebo 4.0.1-r1 --> 4.0.2-r1*
* *pmb2-robot 4.0.5-r1 --> 5.0.0-r1*
* *pmb2-simulation 4.0.1-r1 --> 4.0.2-r1*
* *position-controllers 2.15.0-r1 --> 2.16.1-r1*
* *py-trees 2.2.3-r1*
* *py-trees-ros 2.2.1-r1*
* *py-trees-ros-interfaces 2.1.0-r1*
* *raspimouse 1.1.1-r7*
* *raspimouse-description 1.0.1-r1*
* *raspimouse-msgs 1.1.1-r7*
* *rclcpp-cascade-lifecycle 1.0.2-r1 --> 1.0.2-r2*
* *realtime-tools 2.4.0-r1 --> 2.5.0-r1*
* *robotraconteur 0.16.0-r4*
* *ros2-control 2.20.0-r1 --> 2.22.0-r1*
* *ros2-control-test-assets 2.20.0-r1 --> 2.22.0-r1*
* *ros2-controllers 2.15.0-r1 --> 2.16.1-r1*
* *ros2-controllers-test-nodes 2.15.0-r1 --> 2.16.1-r1*
* *ros2controlcli 2.20.0-r1 --> 2.22.0-r1*
* *rqt-controller-manager 2.20.0-r1 --> 2.22.0-r1*
* *rqt-joint-trajectory-controller 2.15.0-r1 --> 2.16.1-r1*
* *rt-usb-9axisimu-driver 2.0.2-r1*
* *self-test 3.0.0-r1 --> 3.1.0-r2*
* *tiago-bringup 4.0.1-r1 --> 4.0.2-r1*
* *tiago-controller-configuration 4.0.1-r1 --> 4.0.2-r1*
* *tiago-description 4.0.1-r1 --> 4.0.2-r1*
* *tiago-gazebo 4.0.0-r1 --> 4.0.1-r1*
* *tiago-moveit-config 3.0.0-r1 --> 3.0.1-r1*
* *tiago-robot 4.0.1-r1 --> 4.0.2-r1*
* *tiago-simulation 4.0.0-r1 --> 4.0.1-r1*
* *tile-map 2.2.0-r1*
* *transmission-interface 2.20.0-r1 --> 2.22.0-r1*
* *tricycle-controller 2.15.0-r1 --> 2.16.1-r1*
* *velocity-controllers 2.15.0-r1 --> 2.16.1-r1*
* *wall-follower-ros2 0.0.1-r1*
* *webots-ros2 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-control 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-driver 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-epuck 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-importer 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-mavic 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-msgs 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tesla 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tests 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tiago 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-turtlebot 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-universal-robot 2023.0.1-r1 --> 2023.0.2-r1*

Melodic Changes:
----------------
* *ackermann-steering-controller 0.17.2-r1 --> 0.17.3-r1*
* *compressed-depth-image-transport 1.9.5 --> 1.9.6-r1*
* *compressed-image-transport 1.9.5 --> 1.9.6-r1*
* *costmap-cspace 0.11.8-r1 --> 0.12.0-r1*
* *costmap-cspace-msgs 0.8.0-r1 --> 0.12.0-r1*
* *diff-drive-controller 0.17.2-r1 --> 0.17.3-r1*
* *effort-controllers 0.17.2-r1 --> 0.17.3-r1*
* *eigenpy 2.9.0-r1 --> 2.9.2-r1*
* *force-torque-sensor-controller 0.17.2-r1 --> 0.17.3-r1*
* *forward-command-controller 0.17.2-r1 --> 0.17.3-r1*
* *four-wheel-steering-controller 0.17.2-r1 --> 0.17.3-r1*
* *gripper-action-controller 0.17.2-r1 --> 0.17.3-r1*
* *image-transport-codecs 2.1.0-r1*
* *image-transport-plugins 1.9.5 --> 1.9.6-r1*
* *imu-sensor-controller 0.17.2-r1 --> 0.17.3-r1*
* *joint-state-controller 0.17.2-r1 --> 0.17.3-r1*
* *joint-trajectory-controller 0.17.2-r1 --> 0.17.3-r1*
* *joystick-interrupt 0.11.8-r1 --> 0.12.0-r1*
* *map-organizer 0.11.8-r1 --> 0.12.0-r1*
* *map-organizer-msgs 0.8.0-r1 --> 0.12.0-r1*
* *neonavigation 0.11.8-r1 --> 0.12.0-r1*
* *neonavigation-common 0.11.8-r1 --> 0.12.0-r1*
* *neonavigation-launch 0.11.8-r1 --> 0.12.0-r1*
* *neonavigation-msgs 0.8.0-r1 --> 0.12.0-r1*
* *obj-to-pointcloud 0.11.8-r1 --> 0.12.0-r1*
* *pinocchio 2.6.14-r1 --> 2.6.16-r1*
* *planner-cspace 0.11.8-r1 --> 0.12.0-r1*
* *planner-cspace-msgs 0.8.0-r1 --> 0.12.0-r1*
* *position-controllers 0.17.2-r1 --> 0.17.3-r1*
* *ros-controllers 0.17.2-r1 --> 0.17.3-r1*
* *rqt-joint-trajectory-controller 0.17.2-r1 --> 0.17.3-r1*
* *safety-limiter 0.11.8-r1 --> 0.12.0-r1*
* *safety-limiter-msgs 0.8.0-r1 --> 0.12.0-r1*
* *theora-image-transport 1.9.5 --> 1.9.6-r1*
* *track-odometry 0.11.8-r1 --> 0.12.0-r1*
* *trajectory-tracker 0.11.8-r1 --> 0.12.0-r1*
* *trajectory-tracker-msgs 0.8.0-r1 --> 0.12.0-r1*
* *velocity-controllers 0.17.2-r1 --> 0.17.3-r1*

Noetic Changes:
---------------
* *ackermann-steering-controller 0.21.0-r1 --> 0.21.1-r1*
* *bosch-locator-bridge 1.0.7-r1 --> 1.0.8-r1*
* *compressed-depth-image-transport 1.14.0-r1 --> 1.15.0-r1*
* *compressed-image-transport 1.14.0-r1 --> 1.15.0-r1*
* *costmap-cspace 0.11.8-r1 --> 0.12.0-r1*
* *costmap-cspace-msgs 0.8.0-r1 --> 0.12.0-r1*
* *depthai 2.19.1-r1 --> 2.20.2-r1*
* *depthai-bridge 2.5.3-r1 --> 2.6.1-r2*
* *depthai-examples 2.5.3-r1 --> 2.6.1-r2*
* *depthai-ros 2.5.3-r1 --> 2.6.1-r2*
* *depthai-ros-driver 2.6.1-r2*
* *depthai-ros-msgs 2.5.3-r1 --> 2.6.1-r2*
* *diff-drive-controller 0.21.0-r1 --> 0.21.1-r1*
* *dingo-control 0.2.0-r1 --> 0.3.0-r1*
* *dingo-description 0.2.0-r1 --> 0.3.0-r1*
* *dingo-msgs 0.2.0-r1 --> 0.3.0-r1*
* *dingo-navigation 0.2.0-r1 --> 0.3.0-r1*
* *effort-controllers 0.21.0-r1 --> 0.21.1-r1*
* *eigenpy 2.8.1-r1 --> 2.9.2-r1*
* *flatland 1.3.2-r1*
* *flatland-msgs 1.3.2-r1*
* *flatland-plugins 1.3.2-r1*
* *flatland-server 1.3.2-r1*
* *flatland-viz 1.3.2-r1*
* *force-torque-sensor-controller 0.21.0-r1 --> 0.21.1-r1*
* *forward-command-controller 0.21.0-r1 --> 0.21.1-r1*
* *four-wheel-steering-controller 0.21.0-r1 --> 0.21.1-r1*
* *gripper-action-controller 0.21.0-r1 --> 0.21.1-r1*
* *image-transport-codecs 2.1.1-r2*
* *image-transport-plugins 1.14.0-r1 --> 1.15.0-r1*
* *imu-sensor-controller 0.21.0-r1 --> 0.21.1-r1*
* *joint-state-controller 0.21.0-r1 --> 0.21.1-r1*
* *joint-trajectory-controller 0.21.0-r1 --> 0.21.1-r1*
* *joystick-interrupt 0.11.8-r1 --> 0.12.0-r1*
* *lanelet2 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-core 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-examples 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-io 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-maps 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-matching 1.2.0-r2*
* *lanelet2-projection 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-python 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-routing 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-traffic-rules 1.1.1-r1 --> 1.2.0-r2*
* *lanelet2-validation 1.1.1-r1 --> 1.2.0-r2*
* *map-organizer 0.11.8-r1 --> 0.12.0-r1*
* *map-organizer-msgs 0.8.0-r1 --> 0.12.0-r1*
* *moveit-task-constructor-capabilities 0.1.0-r2*
* *moveit-task-constructor-core 0.1.0-r2*
* *moveit-task-constructor-demo 0.1.0-r2*
* *moveit-task-constructor-msgs 0.1.0-r2*
* *moveit-task-constructor-visualization 0.1.0-r2*
* *mvsim 0.5.1-r1 --> 0.5.2-r1*
* *neonavigation 0.11.8-r1 --> 0.12.0-r1*
* *neonavigation-common 0.11.8-r1 --> 0.12.0-r1*
* *neonavigation-launch 0.11.8-r1 --> 0.12.0-r1*
* *neonavigation-msgs 0.8.0-r1 --> 0.12.0-r1*
* *obj-to-pointcloud 0.11.8-r1 --> 0.12.0-r1*
* *pinocchio 2.6.14-r1 --> 2.6.16-r1*
* *planner-cspace 0.11.8-r1 --> 0.12.0-r1*
* *planner-cspace-msgs 0.8.0-r1 --> 0.12.0-r1*
* *position-controllers 0.21.0-r1 --> 0.21.1-r1*
* *robotraconteur 0.15.5-r1 --> 0.16.0-r2*
* *ros-controllers 0.21.0-r1 --> 0.21.1-r1*
* *rqt-joint-trajectory-controller 0.21.0-r1 --> 0.21.1-r1*
* *rviz-marker-tools 0.1.0-r2*
* *rviz-tool-cursor 1.0.1-r1*
* *rviz-tool-path-display 0.1.1-r1*
* *safety-limiter 0.11.8-r1 --> 0.12.0-r1*
* *safety-limiter-msgs 0.8.0-r1 --> 0.12.0-r1*
* *theora-image-transport 1.14.0-r1 --> 1.15.0-r1*
* *track-odometry 0.11.8-r1 --> 0.12.0-r1*
* *trajectory-tracker 0.11.8-r1 --> 0.12.0-r1*
* *trajectory-tracker-msgs 0.8.0-r1 --> 0.12.0-r1*
* *velocity-controllers 0.21.0-r1 --> 0.21.1-r1*

Rolling Changes:
----------------
* *admittance-controller 3.0.0-r1 --> 3.1.0-r1*
* *cascade-lifecycle-msgs 1.0.3-r1 --> 1.0.3-r2*
* *diagnostic-aggregator 3.0.0-r1 --> 3.1.0-r2*
* *diagnostic-common-diagnostics 3.1.0-r2*
* *diagnostic-updater 3.0.0-r1 --> 3.1.0-r2*
* *diagnostics 3.1.0-r2*
* *diff-drive-controller 3.0.0-r1 --> 3.1.0-r1*
* *effort-controllers 3.0.0-r1 --> 3.1.0-r1*
* *eigenpy 2.8.1-r1 --> 2.9.2-r1*
* *force-torque-sensor-broadcaster 3.0.0-r1 --> 3.1.0-r1*
* *forward-command-controller 3.0.0-r1 --> 3.1.0-r1*
* *gripper-controllers 3.0.0-r1 --> 3.1.0-r1*
* *ign-ros2-control-demos 0.6.0-r1 --> 0.6.1-r1*
* *imu-sensor-broadcaster 3.0.0-r1 --> 3.1.0-r1*
* *joint-state-broadcaster 3.0.0-r1 --> 3.1.0-r1*
* *joint-trajectory-controller 3.0.0-r1 --> 3.1.0-r1*
* *joy-tester 0.0.2-r1*
* *kinematics-interface 0.0.2-r1 --> 0.1.0-r1*
* *kinematics-interface-kdl 0.0.2-r1 --> 0.1.0-r1*
* *mvsim 0.5.0-r1 --> 0.5.1-r2*
* *pinocchio 2.6.14-r1 --> 2.6.16-r1*
* *plotjuggler-ros 1.7.3-r3 --> 1.7.3-r4*
* *position-controllers 3.0.0-r1 --> 3.1.0-r1*
* *py-trees 2.2.1-r1*
* *py-trees-ros-interfaces 2.0.3-r3 --> 2.1.0-r1*
* *rclcpp 18.0.0-r1 --> 19.0.0-r1*
* *rclcpp-action 18.0.0-r1 --> 19.0.0-r1*
* *rclcpp-cascade-lifecycle 1.0.3-r1 --> 1.0.3-r2*
* *rclcpp-components 18.0.0-r1 --> 19.0.0-r1*
* *rclcpp-lifecycle 18.0.0-r1 --> 19.0.0-r1*
* *realtime-tools 2.4.0-r1 --> 2.5.0-r1*
* *ros2-controllers 3.0.0-r1 --> 3.1.0-r1*
* *ros2-controllers-test-nodes 3.0.0-r1 --> 3.1.0-r1*
* *rqt-joint-trajectory-controller 3.0.0-r1 --> 3.1.0-r1*
* *self-test 3.0.0-r1 --> 3.1.0-r2*
* *tricycle-controller 3.0.0-r1 --> 3.1.0-r1*
* *velocity-controllers 3.0.0-r1 --> 3.1.0-r1*
* *webots-ros2 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-control 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-driver 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-epuck 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-importer 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-mavic 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-msgs 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tesla 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tests 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-tiago 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-turtlebot 2023.0.1-r1 --> 2023.0.2-r1*
* *webots-ros2-universal-robot 2023.0.1-r1 --> 2023.0.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5-plugins
 * [ ] ignition-gazebo6
 * [ ] ignition-gui3
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-sphinx
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-mistune
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-colcon-common-extensions
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-rosdep
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] texlive-fonts-recommended
 * [ ] wiimote

