### PR TITLE
fix: add zeromqt to behaviortree-cpp-v3

### DIFF
--- a/distros/ros1-overlay.nix
+++ b/distros/ros1-overlay.nix
@@ -1,6 +1,11 @@
 self:
 rosSelf: rosSuper: with rosSelf.lib; {
 
+  behaviortree-cpp-v3 = rosSuper.behaviortree-cpp-v3.overrideAttrs
+    ({ propagatedBuildInputs ? [ ], ... }: {
+      propagatedBuildInputs = propagatedBuildInputs ++ [ pkgs.zeromq ];
+    });
+
   catkin = rosSuper.catkin.overrideAttrs ({
     propagatedBuildInputs ? [],
     patches ? [],

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -12,6 +12,11 @@ rosSelf: rosSuper: with rosSelf.lib; {
     outputs = [ "out" "dev" ];
   });
 
+  behaviortree-cpp-v3 = rosSuper.behaviortree-cpp-v3.overrideAttrs
+    ({ propagatedBuildInputs ? [ ], ... }: {
+      propagatedBuildInputs = propagatedBuildInputs ++ [ pkgs.zeromq ];
+    });
+
   cyclonedds = rosSuper.cyclonedds.overrideAttrs ({
     cmakeFlags ? [], ...
   }: {


### PR DESCRIPTION
When I try to link against behaviortree-cpp-v3 I get undefined reference errors otherwise even if zeromqt is present in my env