### PR TITLE
Add colcon-defaults extension

### DIFF
--- a/pkgs/colcon/core.nix
+++ b/pkgs/colcon/core.nix
@@ -29,11 +29,11 @@ let
 
   package = buildPythonPackage rec {
     pname = "colcon-core";
-    version = "0.10.0";
+    version = "0.12.1";
 
     src = fetchPypi {
       inherit pname version;
-      hash = "sha256-VOlHWEUdLYgdrF5ILDdE9dJzP71FmBwkwIQOuz56SqM=";
+      hash = "sha256-L7sK9sekF0bw8+N2bcuHb0Ur0xgzz7Tv3DPInp+gd/A=";
     };
 
     propagatedBuildInputs = [

--- a/pkgs/colcon/defaults.nix
+++ b/pkgs/colcon/defaults.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, colcon-core, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "colcon-defaults";
+  version = "0.2.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-BT6KGPuuBM8YKilo1/ftR0xRJb87MGuASSUFdPQJb6E=";
+  };
+
+  propagatedBuildInputs = [
+    colcon-core
+    pyyaml
+  ];
+
+  # Requires unpackaged dependencies
+  doCheck = false;
+
+  disabled = isPy27;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to provide custom default values for the command line arguments from a configuration file.";
+    homepage = "https://colcon.readthedocs.io/en/released/user/configuration.html#defaults-yaml";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,6 +14,8 @@ self: super: with self.lib; let
 
       colcon-core = pyFinal.callPackage ./colcon/core.nix { };
 
+      colcon-defaults = pyFinal.callPackage ./colcon/defaults.nix { };
+
       colcon-library-path = pyFinal.callPackage ./colcon/library-path.nix { };
 
       colcon-metadata = pyFinal.callPackage ./colcon/metadata.nix { };
@@ -57,6 +59,7 @@ in {
   colcon = with self.python3Packages; colcon-core.withExtensions [
     colcon-cmake
     colcon-core
+    colcon-defaults
     colcon-library-path
     colcon-metadata
     colcon-package-information


### PR DESCRIPTION
This extension allows one to configure colcon defaults in `~/.colcon/default.yaml`. It requires colcon-core ≥ 0.12 so I updated it as well. I tested the result by building my project and found no problems.

I left the maintainer field of the colcon-defaults expression set to @lopsided98 (the same as in other extensions). Let me know if you prefer having me there instead.