### PR TITLE
flake: Configure the binary cache and add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ roslaunch turtlebot3_gazebo turtlebot3_world.launch
 roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
 ```
 
+With [Flakes enabled][flake], the equivalent of the above is:
+```
+nix develop github:lopsided98/nix-ros-overlay#example-turtlebot3-gazebo
+# Then use roslaunch comamnds as above
+```
+
+[flake]: https://nixos.wiki/wiki/Flakes#Enable_flakes
+
 ## Current status
 
 What works:

--- a/examples/ros2-basic.nix
+++ b/examples/ros2-basic.nix
@@ -1,6 +1,7 @@
 # Environment containing basic ROS2 tools
 
-with import ../. {};
+{ pkgs ? import ../. {} }:
+with pkgs;
 with rosPackages.humble;
 
 mkShell {

--- a/examples/turtlebot3-gazebo.nix
+++ b/examples/turtlebot3-gazebo.nix
@@ -2,7 +2,8 @@
 # roslaunch turtlebot3_gazebo turtlebot3_world.launch
 # roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
 
-with import ../. {};
+{ pkgs ? import ../. {} }:
+with pkgs;
 with rosPackages.noetic;
 with pythonPackages;
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,11 @@
       };
     in {
       legacyPackages = pkgs.rosPackages;
+
+      devShells = {
+        example-turtlebot3-gazebo = import ./examples/turtlebot3-gazebo.nix { inherit pkgs; };
+        example-ros2-basic = import ./examples/ros2-basic.nix { inherit pkgs; };
+      };
     }) // {
       overlays.default = import ./overlay.nix;
       nixosModules.default = import ./modules;

--- a/flake.nix
+++ b/flake.nix
@@ -27,4 +27,10 @@
         "'nix-ros-overlay.nixosModule' is deprecated, use 'nix-ros-overlay.nixosModules.default' instead"
         self.nixosModules.default;
     };
+
+  nixConfig = {
+    extra-substituters = [ "https://ros.cachix.org" ];
+    extra-trusted-public-keys = [ "ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=" ];
+  };
+
 }


### PR DESCRIPTION
This add the examples to the flake and automatically enable the binary cache. With this, one can simply run the example as:
```sh
nix develop github:wentasah/nix-ros-overlay/configure-cache-in-flake#example-turtlebot3-gazebo
```