### PR TITLE
ogre1_9: init at 1.9.1

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -111,6 +111,8 @@ in {
     utils = self.ignition.utils1;
   };
 
+  ogre1_9 = self.callPackage ./ogre/1.9.x.nix { };
+
   openni2 = self.callPackage ./openni2 { };
 
   opensplice_6_9 = self.callPackage ./opensplice { };

--- a/pkgs/ogre/1.9.x.nix
+++ b/pkgs/ogre/1.9.x.nix
@@ -1,0 +1,93 @@
+{ fetchFromGitHub
+, stdenv
+, lib
+, cmake
+, libGLU
+, libGL
+, freetype
+, freeimage
+, zziplib
+, xorgproto
+, libXrandr
+, libXaw
+, freeglut
+, libXt
+, libpng
+, boost
+, ois
+, libX11
+, libXmu
+, libSM
+, pkg-config
+, libXxf86vm
+, libICE
+, libXrender
+, withNvidiaCg ? false
+, nvidia_cg_toolkit
+, withSamples ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ogre";
+  version = "1.9.1";
+
+  src = fetchFromGitHub {
+    owner = "OGRECave";
+    repo = "ogre";
+    rev = "v${version}";
+    sha256 = "11lfgzqaps3728dswrq3cbwk7aicigyz08q4hfyy6ikc6m35r4wg";
+  };
+
+  # fix for ARM. sys/sysctl.h has moved in later glibcs, and
+  # https://github.com/OGRECave/ogre-next/issues/132 suggests it isn't
+  # needed anyway.
+  postPatch = ''
+    substituteInPlace OgreMain/src/OgrePlatformInformation.cpp \
+      --replace '#include <sys/sysctl.h>' ""
+  '';
+
+  cmakeFlags = [
+    "-DOGRE_BUILD_SAMPLES=${toString withSamples}"
+  ]
+  ++ map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
+    ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
+  ++ map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libGLU
+    libGL
+    freetype
+    freeimage
+    zziplib
+    xorgproto
+    libXrandr
+    libXaw
+    freeglut
+    libXt
+    libpng
+    boost
+    ois
+    libX11
+    libXmu
+    libSM
+    libXxf86vm
+    libICE
+    libXrender
+  ]
+  ++ lib.optionals withNvidiaCg [
+    nvidia_cg_toolkit
+  ];
+
+  meta = {
+    description = "A 3D engine";
+    homepage = "https://www.ogre3d.org/";
+    maintainers = [ lib.maintainers.raskin ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Introduce version of Ogre removed from Nixpkgs.
Required by https://github.com/lopsided98/nix-ros-overlay/issues/161
Taken from https://github.com/NixOS/nixpkgs/commit/40f52d9003c5cb4929a346529d2ff1357bd89d6c
