### PR TITLE
Add colcon extensions

### DIFF
--- a/pkgs/colcon/argcomplete.nix
+++ b/pkgs/colcon/argcomplete.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core, python3Packages }:
+
+buildPythonPackage rec {
+  pname = "colcon-argcomplete";
+  version = "0.3.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PnCjK30WuBanxyGCvbIN+YX/wBZ47Jxn1EZZgUphmH0=";
+  };
+
+  propagatedBuildInputs = [ colcon-core python3Packages.argcomplete ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to provide command line completion using argcomplete.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/colcon/bash.nix
+++ b/pkgs/colcon/bash.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-bash";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-hpUMpiKTtlXvjWVdKZTREDIf/y/Gc5xGpk8AWgzuG90=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to provide Bash scripts.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/colcon/devtools.nix
+++ b/pkgs/colcon/devtools.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-devtools";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-OhQb2+RKzvdK0Shmc4VoRrwP6EDm4As7OKWi/pMk8qI=";
+  };
+
+  propagatedBuildInputs = [
+    colcon-core
+  ];
+
+  meta = with lib; {
+    description = "Extension for colcon to provide information about all extension points and extensions.";
+    homepage = "https://github.com/colcon/colcon-devtools";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/colcon/zsh.nix
+++ b/pkgs/colcon/zsh.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-zsh";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-VVwbFlP5qXwayxb7NQBCs8zl1pKhPbmmy8w7Tem5S+s=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to provide Z shell scripts.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -44,6 +44,8 @@ self: super: with self.lib; let
 
       colcon-test-result = pyFinal.callPackage ./colcon/test-result.nix { };
 
+      colcon-zsh = pyFinal.callPackage ./colcon/zsh.nix { };
+
       osrf-pycommon = pyFinal.callPackage ./osrf-pycommon {};
 
       rosdep = pyFinal.callPackage ./rosdep { };
@@ -71,6 +73,7 @@ in {
     colcon-recursive-crawl
     colcon-ros
     colcon-test-result
+    colcon-zsh
   ];
 
   gazebo_9 = self.libsForQt5.callPackage ./gazebo/9.nix { };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -8,6 +8,8 @@ self: super: with self.lib; let
 
       catkin-tools = pyFinal.callPackage ./catkin-tools { };
 
+      colcon-argcomplete = pyFinal.callPackage ./colcon/argcomplete.nix { };
+
       colcon-bash = pyFinal.callPackage ./colcon/bash.nix { };
 
       colcon-cargo = pyFinal.callPackage ./colcon/cargo.nix { };
@@ -63,6 +65,7 @@ in {
   cargo-ament-build = self.callPackage ./cargo-ament-build { };
 
   colcon = with self.python3Packages; colcon-core.withExtensions [
+    colcon-argcomplete
     colcon-bash
     colcon-cmake
     colcon-core

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18,6 +18,8 @@ self: super: with self.lib; let
 
       colcon-defaults = pyFinal.callPackage ./colcon/defaults.nix { };
 
+      colcon-devtools = pyFinal.callPackage ./colcon/devtools.nix { };
+
       colcon-library-path = pyFinal.callPackage ./colcon/library-path.nix { };
 
       colcon-metadata = pyFinal.callPackage ./colcon/metadata.nix { };
@@ -65,6 +67,7 @@ in {
     colcon-cmake
     colcon-core
     colcon-defaults
+    colcon-devtools
     colcon-library-path
     colcon-metadata
     colcon-package-information

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -8,6 +8,8 @@ self: super: with self.lib; let
 
       catkin-tools = pyFinal.callPackage ./catkin-tools { };
 
+      colcon-bash = pyFinal.callPackage ./colcon/bash.nix { };
+
       colcon-cargo = pyFinal.callPackage ./colcon/cargo.nix { };
 
       colcon-cmake = pyFinal.callPackage ./colcon/cmake.nix { };
@@ -57,6 +59,7 @@ in {
   cargo-ament-build = self.callPackage ./cargo-ament-build { };
 
   colcon = with self.python3Packages; colcon-core.withExtensions [
+    colcon-bash
     colcon-cmake
     colcon-core
     colcon-defaults

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -73,8 +73,11 @@ in {
     colcon-devtools
     colcon-library-path
     colcon-metadata
+    colcon-notification
+    colcon-output
     colcon-package-information
     colcon-package-selection
+    colcon-parallel-executor
     colcon-python-setup-py
     colcon-recursive-crawl
     colcon-ros


### PR DESCRIPTION
This adds a few missing colcon extensions and the last commit enables already present extensions, which are enabled in typical colcon installatins (i.e. official ROS docker images).

I can imagine that the last commit, which enables parallel builds and hides build logs, might be controversial, because it could make debugging build failures harder. If this is the reason for those extension not being currently enabled, I would propose to introduce `colcon-full` with those extensions enabled. Then, we would recommend `colcon-full` for interactive sessions and keep `colcon` for Nix package building.