### PR TITLE
Update ros2-basic example to include ros-core and colcon

### DIFF
--- a/examples/ros2-basic.nix
+++ b/examples/ros2-basic.nix
@@ -8,9 +8,8 @@ mkShell {
   nativeBuildInputs = [
     (buildEnv {
       paths = [
-        ros-environment
-        ros2topic
-        ros2node
+        ros-core
+        colcon
         geometry-msgs
       ];
     })


### PR DESCRIPTION
Previously, ros-core was not included presumably due to its dependency on ros2doctor, which depended on ifcfg package unavailable in nixpkgs. As pointed in https://github.com/lopsided98/nix-ros-overlay/issues/75#issuecomment-1508021227, this is no longer true. Since ros2cli version 0.17.0 (2022-01-25) ifcfg is no longer necessary as it was replaced by psutils [1]. This means that we can use ros-core without problems instead of manually specifying its dependencies such ros-environment, ros2topic, etc.

In addition to ros-core, colcon is a basic tool for ROS 2. Include it in the example too.

[1]: https://github.com/ros2/ros2cli/commit/cc5d6b1f9b26ada1a8f366ef7fe9534077c859c2