### PR TITLE
rosdistro sync, Fri Jun 23 13:34:50 2023

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+buildRosPackage {
+  pname = "ros-humble-ackermann-steering-controller";
+  version = "2.22.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "c48017bf51d2f46d0a05fd6e841e988ecf14b3fcd39acb12001588db9043bd7a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Steering controller for Ackermann kinematics. Rear fixed wheels are powering the vehicle and front wheels are steering it.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "1837839bc7efbb0385b3137810747d0882466f5c4256b0a315e07ae1b2b72830";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "09019986d69f5c82166f2e085e50f530fcc82fcfb7d443d65fcba49aba7b4b8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-auto/default.nix
+++ b/distros/humble/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-auto";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "79252bcd997e9e874778c8fdf4616b6980a0ecff56ea07c6e063b34962f5b5de";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "eb6b95a6da39bc3fde90d2b3ab0ba6b5b71924189400b15b08b1941ef9ae8bc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-core/default.nix
+++ b/distros/humble/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-core";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "103b98f3b56dc5312d3958924cc02c998ae7fe9e087e7228a45f32268c230974";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "c05e3c0719f2fc087cd4af182ac2368a6597bbc1b98306f1367ddbbf04ee2971";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-definitions/default.nix
+++ b/distros/humble/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-definitions";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "41068c0a96bd1267d0568209ff70a7527fb5ecd72ac2eac700fd80c3fdf15934";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "3d2638baf82355590ce9483e1f738821994b0b15309dbcd9237c978db68d2e88";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-dependencies/default.nix
+++ b/distros/humble/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-dependencies";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "483c0e2a98ed75824cf8773f1e89a25c97ead11a1e9a74443abbb63c30d32cd9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "548cc12d07b68caa4d84c77f51678076209c3cb00e8a6a031d18547e05336f44";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-include-directories/default.nix
+++ b/distros/humble/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-include-directories";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4ff7eac5dd1da9092086274674e4f91af23e3ac6412838b20d4805c4a1e58859";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "77adb3adc71302cca4db53cfc3af9fdf77c29be016504ce760aeaa3f5a07d347";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-interfaces/default.nix
+++ b/distros/humble/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-interfaces";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "fc28d927623608d83fe0d15c94d755583f9d3b08658d606571e9113b3097e373";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "bd6a0ac3cb12aed2a7793c575cfc7c2249529c95fb2793af63a2df06cb351dc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-libraries/default.nix
+++ b/distros/humble/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-libraries";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4229e0a8ace5f8ce5bdec3d39340ac6ae28ce5543d2b24948e1f3f263300ee56";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "6484a53839239de785bb7b6bd006c0ca3a893ed4372b312cd2d871e75374e329";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-link-flags/default.nix
+++ b/distros/humble/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-link-flags";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "1eb67d2647f123ff42fdc552cad3484e35c1a14f6375d975230aa070f51c9350";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "fc6e90fec1562a8dc1a32bc8c01a80bcd611d7b2f41a4ffc00edef60c1db65b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-targets/default.nix
+++ b/distros/humble/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-targets";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "a0b015ffc727f3f40592652d4bdc8775c9307f384c8f67c4313c7166f0f7b848";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "de09468f1cefc323da78db6b471a8e37a917d97e4c363e6e08f0050a9c51e9c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gen-version-h/default.nix
+++ b/distros/humble/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gen-version-h";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4f23e60ac06c001613cd23f0126682f9dc41b4193196be9976ee1a2774527303";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "6cd5fd074e20543f7c664e1fb5c312155f62a4feab6414212508bb920c23972f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gmock/default.nix
+++ b/distros/humble/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gmock";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ecd7a9bf528a1ab8dff1f284582cb50028fc52cb5bfed0d8dac45cd272949554";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "3e1013d4e2a329caab9e95ec039a21892c7b3cc1864c99dde16fb44ef2c3ac94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-google-benchmark/default.nix
+++ b/distros/humble/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-google-benchmark";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "414b68dc1dd928fd607bff5a684802e45ff61d2939770a3cbdc3b4e0eadf5ade";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "61b5b8b77056d31d59cde313693e984f7a54e81f74ae14dc0fdd8752050aa991";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gtest/default.nix
+++ b/distros/humble/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gtest";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "b8ec12df57850dfa21dac8c499f8353d5b1e146f0aaed3e72efc352e2d12312d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "9af876628a98e92b7c99f395acb240569c7fcfb355a4d296de9b891deffd83da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-include-directories/default.nix
+++ b/distros/humble/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-include-directories";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "5c74caf585da70b6b1631cda5d428df1822bef1d72be2a9bd1a6915a45559535";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "2a8a02d0e87d592e82f57c1afa4b0db34cef61a3b1b445a6732ada760d7d695f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-libraries/default.nix
+++ b/distros/humble/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-libraries";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "0f178c27bfd3690970645d821ba5ec477f693af5745f4d463f0eb1b5cefa061a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "5ee16b3c66e2bb9f0a6595042107e909fdbc58333b459a65f93fabbeb9e5342a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-nose/default.nix
+++ b/distros/humble/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-nose";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4775449157340a6c8a409168a7616a5392b644c0f8e2591291a2b22ef558906b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "4eeb0f9a6f03ea11f13384ef23f24061ac9fd04700591c419f2b564208ece065";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pytest/default.nix
+++ b/distros/humble/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pytest";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ca1d4d92d658cfb9839c6722dc32377f3b252d8a57a8a43518cd2f2e5e6b2331";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "5b749179a6dadadea2b56e1948146b2205fddccad356b3dcfee4a6a77590244b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-python/default.nix
+++ b/distros/humble/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-python";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "6eb57f32300687dbd6f2275eecd1d73eb560a9ddd4ad9a2413835bd7ed5ec817";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "08c19d5e6f9e803c0edde9bf1104132f7b681ccd2ec3be0878bf5ef40495669e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-target-dependencies/default.nix
+++ b/distros/humble/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-target-dependencies";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "c9cb852059541447cf0236bb9b7eb67ea99c20e5d7ac6b4ff534ff8927e66fb8";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "3227dc0bc47d106909b1893449bf7f6116d6ebd1a789d2a165e1fb197bbb45c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-test/default.nix
+++ b/distros/humble/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-test";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ad92d734d45284816388c208c2026ad5f6da07b8cc1beb0356f199065cef0e9b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "691dec8726fdb028e5c9268c874c309fb8be74231ccd10728357cc77e6340a12";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-version/default.nix
+++ b/distros/humble/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-version";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ac17c1f2a0c4d19c8c9c49699b381c73ddac3e24362da359b860df259346a66c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "d22aa8e92bf5913635eab765dc471758a28be773455d71acf2f1a310fa885ccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake/default.nix
+++ b/distros/humble/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "1684718b9e10922fd46685c1125e8c9e0ed849f69146e21bdeb5f3f50c8fffe3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "074073fadbe10a41872a61b828621ce1dbdf1735352f24dff7f5d851c5f2bdea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.2.1-r2";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.2.1-2.tar.gz";
-    name = "4.2.1-2.tar.gz";
-    sha256 = "76c17254be3312c9ce9789fc8bccd96e81fe387607ccdc9551e9e01a23c760bf";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "da2dc9ff566c4d49324c061afbbbc298feae12ee5fac51041d78cd3b54de32ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+buildRosPackage {
+  pname = "ros-humble-bicycle-steering-controller";
+  version = "2.22.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "b64e58df8201bd8ab6f2e82d346e34932a8a017fbba3fffb3f8c3551ef0cc926";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Steering controller with bicycle kinematics. Rear fixed wheel is powering the vehicle and front wheel is steering.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-config";
+  version = "0.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.2-2.tar.gz";
+    name = "0.0.2-2.tar.gz";
+    sha256 = "0ffea88361b6ccd2aab37d7e96fbee16ef6f3c81fd1447713a26f53dc6ca8a0a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+
+  meta = {
+    description = ''Clearpath Configuration YAML Parser and Writer'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/clearpath-msgs/default.nix
+++ b/distros/humble/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-msgs";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "e988c3fdb73dd7c36ee762efdb7c41dbdf3d939f14360e648e6af5aa73901f0c";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "a55f459d96d9ea0214420798560f041d3290068d5b395a68ce605b5b02f286dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-msgs/default.nix
+++ b/distros/humble/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-msgs";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "b964f9e2cf355e7544501398db83a2677971f9f27ad5c32c773b1dbc51a8eb02";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "f337f2741b91d275ba709cfe3becb53c933b18ff17cd3c2e06e4e8345ae4b551";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "a7b0a33b2b96aae75d86e102f92284a47aead4317450577068c3224ef5da8e9a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "d3d31aceb0570af4578a8a5e4cb0510d1fbebe0fa1c595e572a3c6d9028de468";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "50c9c35a4ff17da33bb232ad998f0d57182f1e87ebed6764812c762b19cbe376";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "b27c985afa581a1613f46c4b9261779e111375fa4ac498db90598376d6db73e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "aa7d4cff53e6f2954b047bf020c983ca3c284ed40ee0e2efe4856b2344dc5f37";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "d50e34c762958f5f3c6356d1ea8a6b87c22b010b0cb9c2cfe61d12240576283f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "a4e0a015e38cc1e03281e098f4186bb910d9fa6700a6470a85e17771a14e0043";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "18283f67abbd248fdfb75fdb635280d733bfeeaee538290478e9941d74fe69fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "6294219501ddf69915a6d480866830ed43a71ae6f22e835d412b15dbacc5c5b7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "5f8e7ddc317bf0df36016d621f18ae0a61ece60a12531ad12c7c95346bd0c8f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "f2fb40e7c6f7b9291cb2de360d926ab6018cc153428644cfca03978de9afcef5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "016c3133084a11b9b517e57d4bf4d114497c3233c1133b1fcc5a0d72d96952c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "0073cb16e4e515322520320edbce8b6eec28cf1f45c7f2b426ed43cb9f0bf4c9";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "311ff89eab0b423f07acd765cc08103bf30862b5d000afb3576d1054604081e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "13e03b26407a0e4e324b0f0bb07fae759a148d7e4dcc8f847f494c6fdf3b4b76";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "d18120194c92c240fc0f084217ae7a00026c642589827606edb0ebd6a02af13a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "03ed66141519eed62e763d172365d5066eb1413dc654f42f2d731f5cb2786b24";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "81fe852b7b38b5f630d379fe46f968de95ce89c99778906f68e006b6e189b890";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs image-pipeline image-transport image-transport-plugins rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs image-pipeline image-transport image-transport-plugins pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "b69a10c464c1f72ee94744bd60a8eefeecba1eccde5d488c07b1c6f63af008b0";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "77e9439a2e2aafa07a95ec9e13aa70e1a839bb85be8b473ffda465a59468e683";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "5f2967bfbf32b98fa569711e289c6c793747d79611b52524d2d6182641c4f5e8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "267c416ffbfd85c1d7ecabe28bf27b4122bc1ef9222362c9211264956fc0536f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.21.2-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.21.2-1.tar.gz";
-    name = "2.21.2-1.tar.gz";
-    sha256 = "ce54a47f2c1368566c091aa3b57dc1f954f380b7b611eb6788245e7a5ca7a20a";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "d180d4256989f5dc06091b018383b9d211e504681946aadb76dd97a0128850c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "f6424a4838b5227d4b085f641b829c9d7379e8367e7d2bf48c0bc2e6aadcc616";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "8c9a9b32fcb635d9411aff572ed5b1dd79b8933f219f2ff725d7d191c114ee0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "1e68f6b74190a50779e61788fac5d21b2b5fee9316edcd1dc49b5a9f4d61e7b2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "bcead1d719abea2400bdc6e73f23899ea0320a8dcf9c7084cde8dfd0b7f5e95b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "966a6218e09ddc7535a560437dfac57fa5e11f6448b20e328b2788e7907e1681";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "a5bc665e5d3fcb1bceb1dc3bea69639f9abc11c26ed760040a12342ed9e2bb5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "63d50a6c2917fb6148717dc8eab05483346249cf33eb4f301043e30c01f03ce1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "7501261e764859262248f186a4697dc709f05156364037e7187391b9f5398fa2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "7f4d289b90260149a9a221d149de3ea8d0d7fbd06323d07ccb9533b656636b9a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f493f82a2d10765c5f55022215a796c051721cfd34bff4df427d6adae35e2aa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "bfaca4ef78ded6ab44dc4f4e4572c7db6a097ed0d046dc1b14cf07d267f1de35";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "3240391b99d1ee343e4114351d47a7ed2e8855e57528addc26d851dc3e3908a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fastrtps";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "e9309a16a3df6e187f88dd605eb37bd7095a911b35cb2ec2cf49289c25e3cbee";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "98990243a4732532b1f1b08d86b836c002c2c5ba6747560638d19c20fad97fed";
   };
 
   buildType = "cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "43a728652d845202b2c17b0eadeef024f3b24746fdfb89e330efdfb937a667f7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "931d7dbda817c0c629ad539a50cf18cae33ba1971fd5be176407443d27bc1d34";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "53d5fc98b2ea11444ca9853c188790eda4a39f4110c327b6041f454678bdbff3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "bfe7c15825b776efe83000bbd742aadf1a9eb089c86f507f33217454262737c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "5c17d5046c188b0e37c1c82ca374b48602c6071f56ae52ec29546c06e2d3dbd9";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "a0dfd6817965671ab9effe95e9447904c42a70db26621fa5301d1b2d97d10ca5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -8,6 +8,8 @@ self: super: {
 
  ackermann-msgs = self.callPackage ./ackermann-msgs {};
 
+ ackermann-steering-controller = self.callPackage ./ackermann-steering-controller {};
+
  action-msgs = self.callPackage ./action-msgs {};
 
  action-tutorials-cpp = self.callPackage ./action-tutorials-cpp {};
@@ -246,6 +248,8 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bicycle-steering-controller = self.callPackage ./bicycle-steering-controller {};
+
  bno055 = self.callPackage ./bno055 {};
 
  bond = self.callPackage ./bond {};
@@ -283,6 +287,8 @@ self: super: {
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
 
  class-loader = self.callPackage ./class-loader {};
+
+ clearpath-config = self.callPackage ./clearpath-config {};
 
  clearpath-msgs = self.callPackage ./clearpath-msgs {};
 
@@ -887,6 +893,8 @@ self: super: {
  lifecycle-msgs = self.callPackage ./lifecycle-msgs {};
 
  lifecycle-py = self.callPackage ./lifecycle-py {};
+
+ lms1xx = self.callPackage ./lms1xx {};
 
  logging-demo = self.callPackage ./logging-demo {};
 
@@ -2014,6 +2022,8 @@ self: super: {
 
  std-srvs = self.callPackage ./std-srvs {};
 
+ steering-controllers-library = self.callPackage ./steering-controllers-library {};
+
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
@@ -2167,6 +2177,8 @@ self: super: {
  transmission-interface = self.callPackage ./transmission-interface {};
 
  tricycle-controller = self.callPackage ./tricycle-controller {};
+
+ tricycle-steering-controller = self.callPackage ./tricycle-steering-controller {};
 
  turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
 

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "c5aa41428392872000b085e0c5a094617b5d42407a60f293dff8806143edea24";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "75adfe2705c4b1faa848579fccec33ce0ac13d6910d68be24bc06a6169359c6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "2bbea1df93fb7ac02c080d4260a627d4a1964554892acf31bd1fa88a99d75d30";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "6ce6e36a1a98cbd597fad56b3278a6d18b7e12c95f9134e06b547f4973d6e359";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ignition-cmake2-vendor/default.nix
+++ b/distros/humble/ignition-cmake2-vendor/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/ignition_cmake2_vendor-release/archive/release/humble/ignition_cmake2_vendor/0.0.2-2.tar.gz";
     name = "0.0.2-2.tar.gz";
-    sha256 = "dcb1ce243048b84ce324cd1eacd6af6fc767d53068f2fa2fe472eb8e08cdbb8f";
+    sha256 = "9fffa5d0f4bd7ea0eea709e603b2f6dd30511ec21b514d4950775a365ad61a4e";
   };
 
   buildType = "cmake";

--- a/distros/humble/ignition-math6-vendor/default.nix
+++ b/distros/humble/ignition-math6-vendor/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/ignition_math6_vendor-release/archive/release/humble/ignition_math6_vendor/0.0.2-2.tar.gz";
     name = "0.0.2-2.tar.gz";
-    sha256 = "fec674061b7a8feda3bdadf48c9ce762ba2170b39660f9cb763da882425167be";
+    sha256 = "829ad291e00604ebe981322945ce10f2666e3886dc53048af053d52ad79fc239";
   };
 
   buildType = "cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "7fce08330f8b876bd77976a9835e98e01fd6f2c888c2c0165f3f8ed65670567b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "baca2b259e2d085a0f9b56f043b823cee50f7491f67528b3721c559425602f7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "2d3072d68db37fad10c1075c5e8acde3a24d42a4928dd566c5d3b34e9e968282";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "d6cbb4c35a7b7fa4ecb80dcef81cad64d3b39c2d02d2dcba7b32509f40478e1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "47732499ec84406a8ce9a1e10c6de9608bbe6ffa37767c0776d0a11121b476b6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "f10a8dd7bfb666868d210e8717386d85df692e4dfb6236fa94dd06a3d8115604";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "362a6a43da462ea756fe7f4f7779084d66ba6565f696d58d7de03fc65bf39976";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "26cc99d69c9a0ba3177dc8d605073529bbf193ce03b71ff13abd3a37af657e80";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/librealsense2/default.nix
+++ b/distros/humble/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-humble-librealsense2";
-  version = "2.51.1-r2";
+  version = "2.54.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/humble/librealsense2/2.51.1-2.tar.gz";
-    name = "2.51.1-2.tar.gz";
-    sha256 = "32dc72f786c742dd110357cda1d3fb8b60841a53fe63b3aba4d9560f025494c2";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/humble/librealsense2/2.54.1-1.tar.gz";
+    name = "2.54.1-1.tar.gz";
+    sha256 = "4d24c5f3e178071855f666eae87966fb7f1faa29bbc48710c5e3ee478ea4c0bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/lms1xx/default.nix
+++ b/distros/humble/lms1xx/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, laser-geometry, rclcpp, sensor-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-lms1xx";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/LMS1xx-release/archive/release/humble/lms1xx/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7fffa4273c75cd2865f6d3a55b1aeb1b46d7a45a01e38cd60f5f772ab180be95";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs laser-geometry rclcpp sensor-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The lms1xx package contains a basic ROS 2 driver for the SICK LMS1xx line of LIDARs.'';
+    license = with lib.licenses; [ "LGPL" ];
+  };
+}

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "3ab16a904e12dbac4a196351d4e3f6adb8073a9b190e300fc89da58b17d9508e";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "4640af4d93f3432220ece29b4473027242c3ffaec47c0cbe6313c18349e37f00";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "584e41ccf6da7fe4bd961e4373936e1836a814a3f8c2c4347f87828d06069cd8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "58ff5c33f5fc87457324c215669b1f66f273ea026837ddbd582c4ea35b58ff99";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "c5bbe22e31c0d1a84032f337238f51f78670c1e719f253e4cd10021be2b85723";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "0bcb864d5acdd03191795c4e4dbd70c7d3ab26c36698d3fd99ed1db5d0a9b166";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "f94470a3223aed663bce1d297883808c7e6c40bafda0fdb1a1db17f67d488416";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "12edb43d3f4da9123864248d63654487e40c0ae07322c5a3110e29fa6c8614eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "97f5c712629324fe6c780b23db6bdf54ea97e752db6a96a717f43c6983163995";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f3cf93144b7295c6f89169199580f552bd2c9d6a38829e84f1744fa2ec3e6d18";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "a592b7f70723f90271dae9982b0e84773285468bdf3d419f4a219b40e1c13bc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "b22cec9f161b1ea76a1d66ea3d69e8ba13533ebef7b432f510a4cc72525d73e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "2c1d53fc686eb7b5badeeb26750a0e758de23764f1f277dbd528b3143f11fb4e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c4f3323259fed44144cb5db6798ee766685026a01cdbe8f1f225a2fb8a6699ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "7ed8eefe3e1957233c4ca6c6bd532c9117f566aabf4e3fd1bd5c316cd8eb121c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "142aea73e3fa5a3955c882c2958a1bd1b03dd553d8d453ddcfe3c970285e1ca6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "de3e2f4e660049aa0ac788353bc1de414579b23d48ac8dda061a8bd7ac8fbfed";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "81719f709a06bae22de7f95d7f3c7902a32d3118edd545f9375c2f3d308a0324";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "b23c5abdab85d51251dc2fcd1a8457e7d3dc7514c738e530922ec7e332e0e072";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "d631beb5937a9822a7d36299fdd1548fdb2c8240551f51434038e53dc5d6a5ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "fa245483fd066e85ea270c630902cad9c8e785b5c17b45869ebf773afb970624";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "1cf7e74f87e78c72b7825bee1073f837bcc7b3f91f78b9f238d758048f95bb97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "42b20b018a9eaabb6136cc33fcbd8ae97bc267fa8b21ad36d0495532f341d929";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "7f691c6fe45846d9fa41374c717398b17f67d356e0c987843af2873e078670f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "18daa328ce085d261b5d2d37a19b07705ac781395f386803407886cc88e94c96";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "a5c97c0117862acada5b2c39b719fe54a514ac760b63b6aca5cf4c8b800d305d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "928fc6d80667fef05e242f2644bae3ecb9b51e842edf49fbc67e717ab1e244bc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "359810688bb6f5502b5fde55267d39e7d2d3287be5d0f34ef6464a270bd96b77";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "9259772e70601d3caceebd949e543a5745bd94a48e404fb4984903c6cac96fb9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "de633bc517bcffac84cddc5f60eba7c81072632209061e26670467ea05fca30f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "88e23d598b174e73b056642c286207cf74098d815fc5cb6311290f8ec2e1fca7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "80caeae46edf6669ff2e6005a3cbe4d512fd8a08c5c958d28ed5a8da39f3e72d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "c0e0edea75a4d3f8a48b1a8bd88edde527087305a39f64b89eb83d36b6faeedb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "55596a49aa322347b2d595db566acabc119c3126583aa75caa5afcf3dfde7744";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "618ce9bcd28edc5491057a1b9023d0e2c6754ab2d2321c6b9565cbeb3b3fab04";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c6e5194c08dedc65c0028008b18defe750503f063ab4ca19e0622a7c1c63998e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "5181e72757e7ba4a29d485bd0cc436b251d03b81d2145b37166ee7f5e022c06f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "9fb4ac4d69c89e050ba15a0ea7b4e905ba4c8846532d16411b70f89021c7769c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "9680c7eaa2acf8416ead193463c07f3d4629d5a502c572ed5cca44fcccb1c037";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "d289b425ce5f7bc1e3ea1405031c881a739506dc4a6dc9d534587aa9cc1c7d65";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "de89428c521ce6f5dce048e1ddeda45987b890211667b5513824b4aa300794ff";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "fe66aabdc36346956210eca8be2edd5be13f7147394844a8ed8247ea8ee8b9d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "763ccca607ff9beccb0cd6eb5156a3c789eca52be394e5b12391c73f7781cf60";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f9e839d1aa3d98ae0a178b9ac3d2b45d7ee3d9b15006bfb8cd445a2bbd84af50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "fb1540bf2df1b8677ae96c1e67824ba78ba32438b811213d5011e312cdb2d6c7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "da48e98fc4d7b82c5388cf8ec85cfe8ab5674b2f2cf14804d15aa05f888eccef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "6c458cb7db6ff15cdd5b687286cb06e22dcd18981d2dbf3901b0c0a49fb7ad93";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "27bf09aab1ceb475bdaa5bff9465b49889e5def79464a6cb676891c3fee7477d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "7138508c54fdf3864f7e38aa07b2de7c8419f7b227ee9452edc1beb00885045d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "b9b5be3401d94d992d5fad6a30dd2fa0db46b37407233b315182566d44ca96a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "dcf142b4c6e53759aba78d91356857181c090d82342c1c954bcc740207e07359";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c2595417b9b8f86a28fb7c50654bde157f36ed383a3ef8edc565fa53ebbef197";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "554dfbfb50eb9fa90e9b29ad55697a0cae649a8d934df1895e473d8199c48466";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "ea54a42aaa2a302e287b98e21ba3b16ab6543ea3b0beec5116089798fcf1d423";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "1a50b281910d6a1495b5922e97c6258341acec494e5cf4b217370c7995a145f8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "1a099a226353b2c03febe1ab961f5ab5d0eab605f1096e7d8af559684322eba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "fc8ddc3504d298c6a7bb556a6494b6e3646c245c2046053d132f304dde52ad34";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "207055653a32f7a387e5ba2314b055cd8846f378681c448d26569bcb60135a82";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "324686c47fc96cc5c30a7bf7906d3026ae185bc6b2962d60fd884bd79b891409";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c638c153e1019d650fa5118cdb5a7d85634ecc6cf94bd73a30438e3ec5d2dde8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "e50d739397b0f7cafa169df4a93cfef927f76cc317ec7a707bce6c63b75ee467";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "35001662df8e6b42dba77f809aaa098a6bf6fdf3835a7a2ffcbb19b85a64912f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "42c80a8e88ce6a93efe227f0c536863dd4abd106965fae1aa8d96069451a9d31";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f807622da572d2f9d76851ade481137a32fd4a0083ebf8451c8c00aa3f334102";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "655b9d33649f8e3fccfc511928dac18192fa6aadec9d404e1ee58b0509320e13";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "9c7fed8b7567eca8f8aa8195897fd823b8dc3744a0f58bce8208a453e21f8668";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "d48f54e3626660e28168e1be8cf2c85391554ffd25733d04d583a8b2a7731135";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "019cb36e22d6d04fde154d5289cd62c9a2b128792272203468511e4d556624c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rc-reason-clients/default.nix
+++ b/distros/humble/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "25c88f019eacb627209b4e2acb8111b288f6f42f285b0abeb5330094e1befb9b";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "e97e9b874214e57645119ce0f6e83d78a281c21ea09a7d62cf06ec7b4c94963c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rc-reason-msgs/default.nix
+++ b/distros/humble/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "527d7ed3342ba3e54af4c763030e1683e31efc74b6b4205ef3a57e7e2d06db54";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "ae2db8d62dfec093c4d27b6ae935054694ba3c8be9d8b85346a2e93e245d9a3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "ab297c74ce0e29177ee83f933f157c0ac1841ee60d3a7c99d7e2682f4943e504";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "165f644b41ee73a94ba434699b4677962e793858679276ae600547ca26a26b00";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "6a9fc3db4fbc95648d184ce29dbc16612454166c27e9467622c574fbefd23c65";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "cc672d899e15b7c485096f32f9aa9dc50ce722f5d6d79ad4302c498f410fb5db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "657cdcf12d1f86a2b39e8ba8cbce8847445e069f1ed66b2208c9099af41ed304";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "f5c613631907ca70a2931bba83ca91a58f2dade1909afaaad77d989c2536a770";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, admittance-controller, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, tricycle-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "3ba2ac9d99eece88958c725e5d9a6314c38f3c2854483966cd98852d40464f26";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "e706c878524955135379d10e29b1642ef0852c124147444666849c3864283682";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ admittance-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers tricycle-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "fee5221ee2323ee58e52b58a0b98e27d410868fdecd2c14b29d7f4a2a383af8a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "e5f14751e273379234ad57e343c2371dc7aacfadb0adfe541b2d177653d125b1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "37b0b3303f75045d312f02404efc777482b1f55f1bc2a5b47266ca73f4b18cf9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "91694afa6431f86a92ea4793ff128d0a7bbe922747c369ee8510e6621bc9cfe3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "bdcf62b403caabdde6afab9c80fc4f1ceace04aef3c60ec25fbf4dea5e3671a3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "c6d7e903e9140c67c188b74645e9ecf8c89072f8221dddc3ed01b6a1fc58b4d0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-humble-steering-controllers-library";
+  version = "2.22.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "11ce0bef3f182fb69cb2f7e0f2dadea9d87e2f5ba55add92ee7b358e0e3808f1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for steering robot configurations including odometry and interfaces.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.26.0-r1";
+  version = "2.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "d9c60fb295278b1aec5f3f4b9afbc04457ea90400e52a19289c15263b655f4f6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.27.0-1.tar.gz";
+    name = "2.27.0-1.tar.gz";
+    sha256 = "b11976da6d3c52ff52909e92f1ed47146a70ea0c1a3f66a169ee90b7f49b0d98";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "4bbf26b3e7775f31226332bb5c0c2e0c8b343da59f95a3a426e86570666e7f82";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "8da0496a7d39e4b74e395155f82f38af37c44a39b9c0938611b33ff949b42ea5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+buildRosPackage {
+  pname = "ros-humble-tricycle-steering-controller";
+  version = "2.22.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "2401afd7594e3be56d5d5b71d75bf84f82709a31a09cfc5a12a4f82374b9c017";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Steering controller with tricycle kinematics. Rear fixed wheels are powering the vehicle and front wheel is steering.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlesim/default.nix
+++ b/distros/humble/turtlesim/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.4.2-1.tar.gz";
     name = "1.4.2-1.tar.gz";
-    sha256 = "e259c12d06533fe5943d8b5c5606cb215d2b2cfb309e0aaae263f51f5147d6f3";
+    sha256 = "4790460ab3745e6f64057c0a1fc334348d7b55ed9905cb36a4143a177e1ea73a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.21.0-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "7155adc3c9a50be800d07929339c54bfc282a60e8f53a0b012412035afceed16";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "4ff52cea08f46634075e9e2c244ed947e1022afbd896cf12075ef7e955afb01e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-auto/default.nix
+++ b/distros/iron/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-auto";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "24c1bae12124e08c64ba25e146dee3d194b7b79e524e6a070976bcfaf1159161";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f2412dd4cecdbe9d1a1f10bd11c4a0691faeac16d4fd70cdafeebce744c501b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-core/default.nix
+++ b/distros/iron/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-core";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "64f95de3cd815e18155000eea34a30b8d0ddd4dfeb9cc1713c7b5f94a24e201c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "7a9de8482aff77d0194a52364d7e97540af85edefac22e88bda5dbd3b1111bb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-definitions/default.nix
+++ b/distros/iron/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-definitions";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "ba4644adc79a1a6326a6d8fb1647274cad241e2892db9d5db119751c21da5aaf";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "282d5de031937b5282f4783042742fa6ba12d20da006736746c62fca3dbc359f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-dependencies/default.nix
+++ b/distros/iron/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-dependencies";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "1f235975badec9554027c37f27ba9ec36ef15734ffed5dff60f3837a771cd940";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2e81dfdd5df113ee47f3b2d127821b507ac006407999317d5fe338903c5e1269";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-include-directories/default.nix
+++ b/distros/iron/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-include-directories";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "0927eb469d0653bdab7d5660c0fbd04c9c0223daee19a13faac98eb293c92161";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a1db6ecae340f695e58641ec537cf673712c47965ea84b96acda3468d3c7a007";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-interfaces/default.nix
+++ b/distros/iron/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-interfaces";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "df37e085d38bc9ba219d58a4381a325ec786d0bb8c4a48f21da574599a7aee03";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "08a5c80213905983de9cf7d8325332837c36617d935d667c1d3fdc2b3e4125be";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-libraries/default.nix
+++ b/distros/iron/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-libraries";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "4c5c3043d26630dbbfd87cf052816f7e4097da5deb25da1e3a851a158b7cf388";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "b8a391cd7d8e9e4dd6f6b3b9c4348cd32543ce27997d4be0701182dfbb990446";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-link-flags/default.nix
+++ b/distros/iron/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-link-flags";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "b24f450af63160de6f9cd2be6a23dd953cf4f3069d7d4edce7b7f6b5725e92b6";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "baf68dcb21a84e3ed209b92f8674b4df3f36b4c33aefd3443b859bba6617638d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-targets/default.nix
+++ b/distros/iron/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-targets";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "c479aa7d0ee82398be4760f6ba0a08ad9f14d2d326efaeb6f12f9f324cbebaf0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "91710a34ca5865df1ce8151e4f46167b86081577d4ea2158399f0502ffada859";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gen-version-h/default.nix
+++ b/distros/iron/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gen-version-h";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "ea58b00c7d467436406c571449e75b369b3b704c091eca994ea151b0be68a553";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f947b05e180a613609d58702fad526c7d4e1d76b6c165cb61c80437472ba252e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gmock/default.nix
+++ b/distros/iron/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gmock";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "b260b7a7381ee10000ab9ed0134884bcee6735d9d3b59c406b72cb3bcce9ed15";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "4aa77161e81a4378eaaa73c203825d9fafda11cf13466657b7d967c160746d15";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-google-benchmark/default.nix
+++ b/distros/iron/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-google-benchmark";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "acaa4dc6692a5e0838071cf1abb9d2781b93b6bec765f989c34d8a6beea5d36f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "8ac453a1aa03cc3b095286d0f0d3ae3da8750c68f280a27fafccfbeebb50c0ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gtest/default.nix
+++ b/distros/iron/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gtest";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "d03d1fd2f2e9a0dc6a4f4a4eee8df2b3179255856b1caff5cb3a1677ad7a96d0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a713c488c550f795b972d357a574bf7470044d29f53d1b6b56f2efa7cc270771";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-include-directories/default.nix
+++ b/distros/iron/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-include-directories";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "3fd61da12f68459012ffca1fb6bb66f24005092a0875214e7dbe60ff6d36aaf3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "fc1844dd5cc25b47a8cf789578dace16fdf6d5e83c8b53315ff7739fc308d3cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-libraries/default.nix
+++ b/distros/iron/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-libraries";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "0dc30dbc9ebbdf412888e9dc190471ec2d7488f5c68ff46e7b6603680bbf604d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "08b9475583e805630930e7d46fa6d25ff79022b658bb75f48c94c1571f9af304";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pytest/default.nix
+++ b/distros/iron/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pytest";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "3bc71fc8b1340e6425d50b526516b2172c2e701199ed2ff4913e1ed1928883b9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "6d5c99756c9d212b62bb63bbfecb51a9b7b3025819a4b626d874063b11395d59";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-python/default.nix
+++ b/distros/iron/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-python";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "1c84ead3f131d363eaf95b76a2b548b8858c3025ca4d5301ff4e04a9ee84e88e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5e8d912a66e82b4f56a9b23995d98574f6c02ba4ca62a8e082ce9284cddc168d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-target-dependencies/default.nix
+++ b/distros/iron/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-target-dependencies";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "e89d106d6437e5219dad37dfccefb8cb0a834c1f3d237de121893b35d3818597";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f26815d7d79bd0e8d9999ec879b80f90115ec72b64ed73899afd213c2f27d572";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-test/default.nix
+++ b/distros/iron/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-test";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "c819c30ebbfc12a6cbf2b0bbdaf545febfc6c36132e1fb588a9eb3cf219afc15";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ee30a27078e3448e72be82f2d91d956277a0f1410212f7fafa8074c116b368a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-version/default.nix
+++ b/distros/iron/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-version";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "e1ef13a54fa80209049696f07227cabb1c82bee4323046e0435fef5ad955fc2c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "04fb4886abdd06619c2da88bfcc37b7790739f89181b062c4dae17211df09388";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake/default.nix
+++ b/distros/iron/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "d1231e41bdd97bee78bab5d6c1f86096aa667b35910aaf08b84e6599b1e2825d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ddae13dce739f826668ee72cf092c396211037d8e2cd22cda9e343bcb4006ccf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.2.1-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "9fef0b37e34517f052f2283c30c6813697dd35ef3d6451af4fe3eb44eab05a33";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "b43e6d852ca344290d1c333a6038d5fa5ac94911be219164562f03170a88d60c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "19f57a7a97b6a591736b102aa723ae7424732bf241e079f0a12dc148451b61bf";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "8a7452601e52d1412543d4f65650a48892b4c26bb092319352d780833e996980";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "326861295391f5002efc8944e8e6b7a0ce16e1d8a4268ad7c62d2e0c4dcaff82";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "0cff8050ab0ddf2b682a525dafdf52fc367aa245c1414aa1597d4c591cd6470c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "131b1c5f38d1a9b8fa89aa0614bcb48556947557f512134e27e4a9413dad12eb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "e8bb50a4deb1f51cf32db1d34d81ea3e54dcef6a3800cb34c89e91e030a13020";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/iron/depthai/default.nix
+++ b/distros/iron/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-depthai";
-  version = "2.21.2-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.21.2-1.tar.gz";
-    name = "2.21.2-1.tar.gz";
-    sha256 = "9c665686be6a7214434e186b337a7f3efefdf6e42b731e0231755f8d456a210b";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "ab355885dad8c0908d0735bd9f42c41d9b645408964792f3fe68b113414fa345";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/foxglove-bridge/default.nix
+++ b/distros/iron/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "b2d705766a7fef5cab173d3bdd962bb6236eea1783ed6c6f9314f314ac08d42d";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "f0d3eb2e22dfa76635bc2389357ec7f80b492035b600e744de7cf6b3c423aa1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -102,8 +102,6 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
- ament-cmake-vendor-package = self.callPackage ./ament-cmake-vendor-package {};
-
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "25d537ca8a0c965f90e782797a3f73036593b5291ff65f39029e0612dfc6746f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "9e0026f634e3152578b259e0307154fb4451dede0a5804cd9f9f1f4a549e807c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "4b74966369e0fd6d808edc46a2ec28821c653bff500fce4b54b971f856a1e234";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "22c395682b71caad0e36b3c5900a9761ab33462993f0d4988793462a49019ecb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "492d4a46e15c44a9f954d2c7a5175e82e4b98e61ea486c20b5f1703d9fe67f7f";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "8c1cf5ea034235fdf1e8ed900e87f41f64a9f5375cadaf0d44eb0fde2f96f28c";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/rc-reason-clients/default.nix
+++ b/distros/iron/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1c9bae15eaf94702c2ae23e4d32611d5028e4770d41051b5e5121782757fd72e";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6d4db486918945f395bd95cfdbbf655bfc33597f7610a31b1daa23d730876a02";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rc-reason-msgs/default.nix
+++ b/distros/iron/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "bc33f63c0c28ec03bc4c402f56388c2a73df87c128a2b097242710988dc67ecd";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "30d1720b6732b245d578ca35d16626262ddccba29362554aee42606c0863592e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc-examples/default.nix
+++ b/distros/iron/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc-examples";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_examples/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "b1fc6db030cae1d15084a570a94239bb8ca4c0b3bc9cb0a7cfb0aade0367270f";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_examples/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "5050ea3a6bb86bf1219b8b9ed1a50cc19014242bceac4215bb4a7704de894439";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc-lifecycle/default.nix
+++ b/distros/iron/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc-lifecycle";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_lifecycle/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "84bf07cb5d904d7920a72d283979eb493127621210e136e954501cee4050e692";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_lifecycle/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "0e29084b4dea7b7a00177466b5f7e74bcd938892ff1d9cada26876c3f9cf67cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc-parameter/default.nix
+++ b/distros/iron/rclc-parameter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc-parameter";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_parameter/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "5256b396bf6ad6aad508908a2eaae4d2b0b30d632cf35f4600421c17cdc80071";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_parameter/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "a381dabd2d9d9c51ced210b3453de03364a7d4413051338dc61cb01e65540f7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc/default.nix
+++ b/distros/iron/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcl-action, rclcpp, rclcpp-action, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "71f0a4e7882ec2fbf68724f96103e467d77db040a394c8e145948d65c1b263bb";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "a1fb3fda135580c3701685ba46180989cc20b99ec5a39f84eb84e7f0f14dea77";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "30b0f4f8a279c2cce514c11402f5bece91aadcc9d625d93c5f12e7af8792ad4e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "696b84c7d65112fc1ebc91d1f442ec695f12191c08648aa86565c60e81851aaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "935ec95b2f1f0df5e1c5d176afc67b5f40ac8c878fc19cae87040a3f19547240";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "f0d1ff040762bf7f96dd4bf1fce68998ad0fdfb95f64429bef71f16399102dea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "93a3c2f96989f6110c0698f71de2340c0d45ebb36eedc7ba96cc3ed3fce03499";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "1a2a8bda362144465230c4109e7d148f226ae50cdcf648bc8651c5d27945999b";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "28d1e604e0bd429034a8a7496cf9e16ec2bb38a89c1315084cf0cc69c7b0aa7c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "6f85e2e03c76bcd2d40af1570886e6d1632284a500622efdfa7506573109c384";
   };
 
   buildType = "ament_python";

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.12.1-r2";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "352bd2ae788f0ce90745b78c4ace947026519c3fd0d895190e8a89cbc57d57a4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "059f67af07f2d96e44da6f2892f4229e25138ab0f7754cededf141aeb1f3a0d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/costmap-cspace-rviz-plugins/default.nix
+++ b/distros/melodic/costmap-cspace-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, qt5, roscpp, roslint, rviz }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/costmap_cspace_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "bcd73822b9dd77d03b425ddad5918adea6d64ac3e9b7bbe8f4605ef9048af760";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/costmap_cspace_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "71d6175db707daf9106b869a957398f1da44c549dbaa6ac3a8d734c7b2332991";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cras-imu-tools/default.nix
+++ b/distros/melodic/cras-imu-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, geometry-msgs, nav-msgs, nodelet, sensor-msgs, std-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-melodic-cras-imu-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_imu_tools/-/archive/release/melodic/cras_imu_tools/1.0.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "9b817cebe3bb0d2d3b3a982edab8497eedb9a4f8f19c91120480c5fc2f510e0f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common geometry-msgs nav-msgs nodelet sensor-msgs std-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with IMU data'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/cras-laser-geometry/default.nix
+++ b/distros/melodic/cras-laser-geometry/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, laser-geometry, nodelet, roscpp, sensor-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-cras-laser-geometry";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry/-/archive/release/melodic/cras_laser_geometry/1.1.2-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "282c97c2aa1f7c560f53765196a35d02ec77fa7225101d3fa939480a54c5e5b6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common laser-geometry nodelet roscpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with laser scans.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/executive-smach/default.nix
+++ b/distros/melodic/executive-smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-executive-smach";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/executive_smach/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "5266563dc0f5888791fbf077127b3bb5539550c93496a103a4b0f3e1bafef697";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/executive_smach/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c6f4e3dca18e632c85fc175bb016e8c6998fcea02bd6000b3d41c00e29b13a74";
   };
 
   buildType = "catkin";

--- a/distros/melodic/foxglove-bridge/default.nix
+++ b/distros/melodic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-melodic-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "1a976d0d6a364bb4b51f7c9f71fa5aa0e96088949fda5c6cd91cc35907aabd4c";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "6ac0ef80b230832983e291973fe147328072cf658798d0eddf7441c75a88b0d7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -618,6 +618,10 @@ self: super: {
 
  cpu-temperature-diagnostics = self.callPackage ./cpu-temperature-diagnostics {};
 
+ cras-imu-tools = self.callPackage ./cras-imu-tools {};
+
+ cras-laser-geometry = self.callPackage ./cras-laser-geometry {};
+
  create-bringup = self.callPackage ./create-bringup {};
 
  create-description = self.callPackage ./create-description {};
@@ -2859,6 +2863,8 @@ self: super: {
  pluginlib = self.callPackage ./pluginlib {};
 
  pluginlib-tutorials = self.callPackage ./pluginlib-tutorials {};
+
+ point-cloud-color = self.callPackage ./point-cloud-color {};
 
  point-cloud-publisher-tutorial = self.callPackage ./point-cloud-publisher-tutorial {};
 

--- a/distros/melodic/gps-common/default.nix
+++ b/distros/melodic/gps-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, message-generation, message-runtime, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-gps-common";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_common/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "06528187c6d9c788cdae1cd1b7c92953d09e49337a1820f9898f7bb9e51e8935";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_common/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "581e8d2f049bbff34bc0d28c57531f6e660be5a0382b2c6ec21895052e9d1801";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gps-umd/default.nix
+++ b/distros/melodic/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd-client }:
 buildRosPackage {
   pname = "ros-melodic-gps-umd";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_umd/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "35dec4ec952f063ec3265e29eea27c8814c28a11899371c3816d4912c76741b7";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_umd/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "c5991c11b09136690bbe3841b841b5c75233c89c31510d70127cac10f4d920fd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gpsd-client/default.nix
+++ b/distros/melodic/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd, pkg-config, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-gpsd-client";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gpsd_client/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "adf1eb7857e1de99693e8b0826b037bc3562caf6f21e015d0023146e21d47ecd";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gpsd_client/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9638164d61ad7d708032f5068f873980b4090b70726cb3147fb50c4d73789a89";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-transport-codecs/default.nix
+++ b/distros/melodic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, pythonPackages, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-image-transport-codecs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/melodic/image_transport_codecs/2.2.2-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/melodic/image_transport_codecs/2.2.3-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "ac6e2a0cf6b5edd4cbb9a0a966fd84b123f6c60894272661fe8a88769635e7da";
+    sha256 = "bb4faa447143819d0bffe0abb1a8b0f18e5e1650f8366da239ae682a14a88227";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-rviz-plugins/default.nix
+++ b/distros/melodic/neonavigation-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, trajectory-tracker-rviz-plugins }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-rviz-plugins, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/neonavigation_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "79c1f10964f90287b135a6ffaf4b990828625d5f68ed97e4d8ec7773b2c8832e";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/neonavigation_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "023740620e951a376a54bced6fdd64b66e11c67e0078ef6e28cc44ea54fff2a0";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ trajectory-tracker-rviz-plugins ];
+  propagatedBuildInputs = [ costmap-cspace-rviz-plugins trajectory-tracker-rviz-plugins ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/point-cloud-color/default.nix
+++ b/distros/melodic/point-cloud-color/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, nodelet, point-cloud-transport, roscpp, sensor-msgs, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-point-cloud-color";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_color/-/archive/release/melodic/point_cloud_color/1.2.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "dec704b3ca07a05afd49c2a4c7df7d2fd1a03b390dd87576560338dfce49dd14";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cv-bridge image-transport nodelet point-cloud-transport roscpp sensor-msgs tf2-eigen tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package for coloring point clouds using calibrated cameras.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/point-cloud-transport-plugins/default.nix
+++ b/distros/melodic/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, draco-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-melodic-point-cloud-transport-plugins";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/melodic/point_cloud_transport_plugins/1.0.3-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/melodic/point_cloud_transport_plugins/1.0.5-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "45523d8fed826b961a2b185779b143f3b9742432e3fa3bca15753d55228b355f";
+    sha256 = "b7d1dd4ff02a511b6e42035a9d5d8ef0cc7047fb886b306de1c0a7f019daccd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-clients/default.nix
+++ b/distros/melodic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, pythonPackages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "5680aca20acb26716ada6a8fb89a11b099535eab0eea9976e07cb35e2379feb9";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "f6198732d4e87f351743c1ab26ec97f5bbb39388b5674a1deeaa8a8b21c6e71a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-msgs/default.nix
+++ b/distros/melodic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ed41aa1d94c1f1f73d7b36a780e835adebd9fb42dbcce24e1be957b952f6e684";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "13ca795687d15af9b4c2982c1f6a7102dd7042b842a2b626893b2bc905f13c2b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/septentrio-gnss-driver/default.nix
+++ b/distros/melodic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-septentrio-gnss-driver";
-  version = "1.2.3-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.2.3-2.tar.gz";
-    name = "1.2.3-2.tar.gz";
-    sha256 = "06bad4f5068960ec8c7adb2133dd0fc7eff960e6fdae3c2401c577d80f09b701";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7c8ead556a7d887fe2ac1c02d7569057ba8066a00e056f085e8c9655d2dc7e8d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/simple-grasping/default.nix
+++ b/distros/melodic/simple-grasping/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf, vtkWithQt5 }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-simple-grasping";
-  version = "0.3.1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/simple_grasping-release/archive/release/melodic/simple_grasping/0.3.1-0.tar.gz";
-    name = "0.3.1-0.tar.gz";
-    sha256 = "1dada4bbf81347bac9d7fee738e20246ec4f6f25a8983a7edda10894bd896a54";
+    url = "https://github.com/ros-gbp/simple_grasping-release/archive/release/melodic/simple_grasping/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5f4b636cc6d5e50fb1aabff62b7f43299aa56d4344fa82f74b17d0fa37990870";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules message-generation ];
-  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf vtkWithQt5 ];
+  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/smach-msgs/default.nix
+++ b/distros/melodic/smach-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-smach-msgs";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_msgs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "b42e7a31e5e9ee3fcec7388566ca1a78d2af773c2e0bc7428d4f2d62ed732bcf";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "476fe42075f0b02c261d9b468e585d988ec2f8afca42cb3caf4d0b465cee4b45";
   };
 
   buildType = "catkin";

--- a/distros/melodic/smach-ros/default.nix
+++ b/distros/melodic/smach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, rospy, rostest, rostopic, smach, smach-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-smach-ros";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_ros/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "2a6062c9bb60b5cea300784b67e7c977b1cd42bc7117c0d5bea7122eb04d37ed";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_ros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "04573f2454e319ed33b8d7e1038c13ddd7f2d85f88ed3a47c46e3f2e2c8f7c45";
   };
 
   buildType = "catkin";

--- a/distros/melodic/smach/default.nix
+++ b/distros/melodic/smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-smach";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "37de5727c98e7aa222670ad40229cfe239e2907f25ec0d7133b4ec2c29eb6c7c";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "432350b9408615075e0f13acdd5cbd80dd18b35deebdf8fdb45a04d8cb0f6994";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker-rviz-plugins/default.nix
+++ b/distros/melodic/trajectory-tracker-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rviz, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/trajectory_tracker_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "644e1c112888474dc2bee1a80c94dfa76798cfeca77fad982e691b88088d220d";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/trajectory_tracker_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "a4140671aeac1c451bf611ab0533b9d211216a3a27d687dd269da4dd321c75f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aques-talk/default.nix
+++ b/distros/noetic/aques-talk/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
+buildRosPackage {
+  pname = "ros-noetic-aques-talk";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/aques_talk/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "23a718587034dbc0eb16f95cc5c83c892925b5be0f55dffbbb238b4d96c150aa";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ kakasi nkf sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS interface aques_talk demo program'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/assimp-devel/default.nix
+++ b/distros/noetic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-noetic-assimp-devel";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/assimp_devel/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "6263583e257e9315af21c2303407fc683187673d6a618e294385b7498bb6f2e7";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/assimp_devel/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "e8e1d96cbd67690f2d08c69cc97bb158f37a5502d2db01d0b19d524ba57a89d3";
   };
 
   buildType = "catkin";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''assimp library'';
-    license = with lib.licenses; [ "LGPL" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/bayesian-belief-networks/default.nix
+++ b/distros/noetic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-noetic-bayesian-belief-networks";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/bayesian_belief_networks/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "d1d29e63bcd7143dda22e3de735cb375146b274c9c2e3c34859759f091665ed9";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/bayesian_belief_networks/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "2fe668ade379094723382cf451a6c2115ad22fea43586006cee1c0a9d3332f36";
   };
 
   buildType = "catkin";

--- a/distros/noetic/chaplus-ros/default.nix
+++ b/distros/noetic/chaplus-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-chaplus-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/chaplus_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "ae79ee80c96bbf0e602474b0cb400a1992e7f9507e101daa4545c24fb228d5ef";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ python3Packages.requests rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ROS package for chaplus service'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/costmap-cspace-rviz-plugins/default.nix
+++ b/distros/noetic/costmap-cspace-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, qt5, roscpp, roslint, rviz }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/costmap_cspace_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "6c2f6975ca322e23f1254669e5744fffdebe59cefbca478728e34cb73f4b2dce";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/costmap_cspace_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "255bf89103286b80d9a24972a40164f597a9fd4234ce5453adca8f60e4aaa129";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cpp-common/default.nix
+++ b/distros/noetic/cpp-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge }:
 buildRosPackage {
   pname = "ros-noetic-cpp-common";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/cpp_common/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "28a7892680c8c40eb4e77cd9c962abd22a0459fa9e69d73730ed3ebe3be5b9b7";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/cpp_common/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "94f8dc489e48f8848d861a063f5b3578f585de3c18cd45095976fbc9df44951d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cras-imu-tools/default.nix
+++ b/distros/noetic/cras-imu-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, geometry-msgs, nav-msgs, nodelet, sensor-msgs, std-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-cras-imu-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_imu_tools/-/archive/release/noetic/cras_imu_tools/1.0.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "1ca6633c70f3038c7ab5796510653e977a6f25f7fd9669c960a63c5e7750295c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common geometry-msgs nav-msgs nodelet sensor-msgs std-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with IMU data'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cras-laser-geometry/default.nix
+++ b/distros/noetic/cras-laser-geometry/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, laser-geometry, nodelet, roscpp, sensor-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-cras-laser-geometry";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry/-/archive/release/noetic/cras_laser_geometry/1.1.2-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "af16611168b59f9cd76d5fbaa8dad8a3f55d53d8e8e0328d347ad3fbce5ad344";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common laser-geometry nodelet roscpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with laser scans.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "e779f1ac3b6e4a381ac2766a4c2a39d233d486583bc4666cc2aa3ed6f2bfe7b5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "907b190bf0afa20e1b48174d1d48ca345f1e3cb46c5ac50ca3abc6ea9e40cc24";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "db6366afc2e40654ede21f36c555cfc11c30e0706f905f2d0cd2c1f52709982e";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "652cf984c54f3cf7818d055fc65bd246dfac35d492488201102a50da7cd4783d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "92fe5fb359b733d4a3499eabc45f4f283de7e0de9cba189afb9ad2135fd43319";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "9b80b7fed86147129b911cc5a0f3302158f31fa583ce1425994c59656da8bb21";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "04644873505600542a2d91910be23b35b18b96636044615c1d7922c546f880ae";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "e5bb69859968d409796ac7d916fe903963c1bf634eb7503627358b1171dede0a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "5b97473faa7afa6bbfd51b65e4883c6aab4073fa51637ba794a12302cd05aec4";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "9e16213b9e13ab15430dadbf00f5b4ba3273828ff9f3ab949ae6893ba7aec61b";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ camera-info-manager cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet roscpp rospy sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet pluginlib roscpp rospy sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "9a324409922e899ce60661cf859df951003fb1c200625b62ec57701de8f78d59";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "1aa6fa004e974bc955174a829f46ac919fcc2a84541addd7424403548c519a85";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "920ea955d88b70ced772563321f0f7a864509734004be516756c0bd1d1c6d228";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "7572dc2c62bf62853f392425aaf2afcfc8e381006870c0578ea544c043dc4d60";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.21.2-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.21.2-1.tar.gz";
-    name = "2.21.2-1.tar.gz";
-    sha256 = "def71b6966222bc7d48412e5486d7520da02e95d79c3fe968168be489525c18b";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "2a587768273730151efa4bea742095e03eee23068f0dfea45f09487808c0e73e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dialogflow-task-executive/default.nix
+++ b/distros/noetic/dialogflow-task-executive/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, catkin-virtualenv, message-generation, message-runtime, roslaunch, rostest, speech-recognition-msgs, std-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-dialogflow-task-executive";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/dialogflow_task_executive/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "30a1325eed964aa1e0d35ad4764ea7b4e3de5e0246b155ae051fc02b3308c35e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ actionlib-msgs catkin catkin-virtualenv message-generation roslaunch std-msgs ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ message-runtime speech-recognition-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS package for Google Dialogflow and launching apps via Dialogflow'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/downward/default.nix
+++ b/distros/noetic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python3, rostest, time }:
 buildRosPackage {
   pname = "ros-noetic-downward";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/downward/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "af167e3a93447efd3db9731aacadf13d6b554cb202743c05630892360766f16b";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/downward/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "43648e97ad5f6998d75ad3f1bfe3769c943944a910dea8e8bd94c5718bf61e6a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/euslisp/default.nix
+++ b/distros/noetic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-noetic-euslisp";
-  version = "9.29.0-r1";
+  version = "9.29.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/noetic/euslisp/9.29.0-1.tar.gz";
-    name = "9.29.0-1.tar.gz";
-    sha256 = "ecbf0b5ab05617eac190bb25eaf140fe576d01de47e779b5ad9c2a911d800693";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/noetic/euslisp/9.29.0-2.tar.gz";
+    name = "9.29.0-2.tar.gz";
+    sha256 = "c46c22dd8bc3fbe650fb4137d3bab113dfc97dd8db666a634860c67b6d24aa60";
   };
 
   buildType = "cmake";

--- a/distros/noetic/executive-smach/default.nix
+++ b/distros/noetic/executive-smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-noetic-executive-smach";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/executive_smach/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "c2c51641c783ba6a5dcf124bca35cc6788c33052138f1ce866ae6dd10b11802d";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/executive_smach/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "15366fae7e82149cdef48ae9fca33fc6acd5999a46c6afd25250646cabe16350";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ff/default.nix
+++ b/distros/noetic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-noetic-ff";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ff/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "957f20eed64325d0864b8a499672f657412f9c10ce6d6718c7157c4e7cda1d53";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ff/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "49c404fca5d769b971307eadfa407680d56388b4320e7fa57236f41dc1fd91dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ffha/default.nix
+++ b/distros/noetic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-noetic-ffha";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ffha/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "91b8e796e658087b953fff80f18b4391d53c7a86a4024d3b9eab3cc4e68b4c48";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ffha/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "c938dded78f6c43202f5b391d53cd396ae45fac99355ee0d4a86c34f6dc9b306";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "30386e5c50217489bf9422f1aaf9780f165834560566aaf511a837aa800317f2";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "406597dcc4dfb3dbb278fceb9a468aa47a59f29863992c3597f37ff2222a3559";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gdrive-ros/default.nix
+++ b/distros/noetic/gdrive-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-gdrive-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/gdrive_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "aeb66f26a0526ef1f136b938b1f2c8914e7052230f962d31ff814dda012a851c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv message-generation std-msgs ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ message-runtime rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Google drive upload and download package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -40,6 +40,8 @@ self: super: {
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
 
+ aques-talk = self.callPackage ./aques-talk {};
+
  arbotix = self.callPackage ./arbotix {};
 
  arbotix-controllers = self.callPackage ./arbotix-controllers {};
@@ -211,6 +213,8 @@ self: super: {
  catkin = self.callPackage ./catkin {};
 
  catkin-virtualenv = self.callPackage ./catkin-virtualenv {};
+
+ chaplus-ros = self.callPackage ./chaplus-ros {};
 
  checkerboard-detector = self.callPackage ./checkerboard-detector {};
 
@@ -506,6 +510,10 @@ self: super: {
 
  cpr-onav-description = self.callPackage ./cpr-onav-description {};
 
+ cras-imu-tools = self.callPackage ./cras-imu-tools {};
+
+ cras-laser-geometry = self.callPackage ./cras-laser-geometry {};
+
  create-bringup = self.callPackage ./create-bringup {};
 
  create-description = self.callPackage ./create-description {};
@@ -629,6 +637,8 @@ self: super: {
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
 
  diagnostics = self.callPackage ./diagnostics {};
+
+ dialogflow-task-executive = self.callPackage ./dialogflow-task-executive {};
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
@@ -1090,6 +1100,8 @@ self: super: {
 
  gazebo-video-monitors = self.callPackage ./gazebo-video-monitors {};
 
+ gdrive-ros = self.callPackage ./gdrive-ros {};
+
  gencpp = self.callPackage ./gencpp {};
 
  generic-throttle = self.callPackage ./generic-throttle {};
@@ -1133,6 +1145,8 @@ self: super: {
  gmcl = self.callPackage ./gmcl {};
 
  goal-passer = self.callPackage ./goal-passer {};
+
+ google-chat-ros = self.callPackage ./google-chat-ros {};
 
  gpio-controller = self.callPackage ./gpio-controller {};
 
@@ -1193,6 +1207,8 @@ self: super: {
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
  grpc = self.callPackage ./grpc {};
+
+ gtsam = self.callPackage ./gtsam {};
 
  handeye = self.callPackage ./handeye {};
 
@@ -1448,6 +1464,8 @@ self: super: {
 
  joystick-interrupt = self.callPackage ./joystick-interrupt {};
 
+ jsk-3rdparty = self.callPackage ./jsk-3rdparty {};
+
  jsk-calibration = self.callPackage ./jsk-calibration {};
 
  jsk-common = self.callPackage ./jsk-common {};
@@ -1603,8 +1621,6 @@ self: super: {
  laser-filtering = self.callPackage ./laser-filtering {};
 
  laser-filters = self.callPackage ./laser-filters {};
-
- laser-filters-jsk-patch = self.callPackage ./laser-filters-jsk-patch {};
 
  laser-geometry = self.callPackage ./laser-geometry {};
 
@@ -2028,6 +2044,8 @@ self: super: {
 
  mrpt-navigation = self.callPackage ./mrpt-navigation {};
 
+ mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
+
  mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
 
  mrpt-rbpf-slam = self.callPackage ./mrpt-rbpf-slam {};
@@ -2144,6 +2162,8 @@ self: super: {
 
  network-interface = self.callPackage ./network-interface {};
 
+ nfc-ros = self.callPackage ./nfc-ros {};
+
  nmea-comms = self.callPackage ./nmea-comms {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
@@ -2235,6 +2255,8 @@ self: super: {
  opw-kinematics = self.callPackage ./opw-kinematics {};
 
  osm-cartography = self.callPackage ./osm-cartography {};
+
+ osqp = self.callPackage ./osqp {};
 
  osqp-vendor = self.callPackage ./osqp-vendor {};
 
@@ -2371,6 +2393,8 @@ self: super: {
  pluginlib = self.callPackage ./pluginlib {};
 
  pluginlib-tutorials = self.callPackage ./pluginlib-tutorials {};
+
+ point-cloud-color = self.callPackage ./point-cloud-color {};
 
  point-cloud-transport-plugins = self.callPackage ./point-cloud-transport-plugins {};
 
@@ -2672,6 +2696,8 @@ self: super: {
 
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ respeaker-ros = self.callPackage ./respeaker-ros {};
+
  rgbd-launch = self.callPackage ./rgbd-launch {};
 
  ridgeback-control = self.callPackage ./ridgeback-control {};
@@ -2803,6 +2829,8 @@ self: super: {
  ros-environment = self.callPackage ./ros-environment {};
 
  ros-ethercat-eml = self.callPackage ./ros-ethercat-eml {};
+
+ ros-google-cloud-language = self.callPackage ./ros-google-cloud-language {};
 
  ros-ign = self.callPackage ./ros-ign {};
 
@@ -3350,6 +3378,8 @@ self: super: {
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
+ switchbot-ros = self.callPackage ./switchbot-ros {};
+
  swri-cli-tools = self.callPackage ./swri-cli-tools {};
 
  swri-console = self.callPackage ./swri-console {};
@@ -3797,5 +3827,9 @@ self: super: {
  ypspur-ros = self.callPackage ./ypspur-ros {};
 
  zbar-ros = self.callPackage ./zbar-ros {};
+
+ zdepth = self.callPackage ./zdepth {};
+
+ zdepth-image-transport = self.callPackage ./zdepth-image-transport {};
 
 }

--- a/distros/noetic/google-chat-ros/default.nix
+++ b/distros/noetic/google-chat-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, dialogflow-task-executive, gdrive-ros, message-generation, message-runtime, python3Packages, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-google-chat-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/google_chat_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "0fe151f2c055a11ba94868b089abfebb42c52f438dc809b287f728ef1909d431";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv message-generation python3Packages.setuptools ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ dialogflow-task-executive gdrive-ros message-runtime rospy std-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Use Google Chat API clients via ROS'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/gps-common/default.nix
+++ b/distros/noetic/gps-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, message-generation, message-runtime, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gps-common";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_common/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "9f1698a8af546ffc0e466dfda956ef9e0ce7d733eeb2aa7fc17790472e644854";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_common/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "5abd03d0635d912f745d654127904b42eba5102d6d93da93f7f14a884f894827";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gps-umd/default.nix
+++ b/distros/noetic/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd-client }:
 buildRosPackage {
   pname = "ros-noetic-gps-umd";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_umd/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "d558c65ce8b83fb5235b7165b3662eefba2126b23685b623b087d44a4a00fed1";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_umd/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "d0c9758976461cdca7ec9d88d7bf081507c639e2a4d6710872649aa017cd89e1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gpsd-client/default.nix
+++ b/distros/noetic/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd, pkg-config, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gpsd-client";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gpsd_client/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "dc8b37e6b30d5983609a9ca86c0dea4febbd2c8b9830a5d7ce698ac2d440b5a8";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gpsd_client/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ad74c898ec97ef7a030c1b253bf1998246c87fbf0446edf9a71f8e4d1450a5ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gtsam/default.nix
+++ b/distros/noetic/gtsam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb }:
+buildRosPackage {
+  pname = "ros-noetic-gtsam";
+  version = "4.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/gtsam-release/archive/release/noetic/gtsam/4.2.0-2.tar.gz";
+    name = "4.2.0-2.tar.gz";
+    sha256 = "9a193b03fdfec03eefc3d369af0032d2f12bd3abd5a84207e0593e7813a00bea";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost cmake eigen tbb ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''gtsam'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hri-rviz/default.nix
+++ b/distros/noetic/hri-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, hri, hri-msgs, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-hri-rviz";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "cd6d26e6326015a4f93aed18262afbefd5f25c4dbae23ad3b2d1c4dd2659f9b0";
+    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "10cf059a3e9adf071a2746aeea569f7e1fc7338e3f5479a8e966315f369f1088";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.2.2-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.2.3-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "b0b8cda9dceb618b4092f6118253585e00d36ed0808ad7bfca4295eb54074759";
+    sha256 = "786a10c74860a25f64a703b370ba9d844ee470891eddeb479c5b5a93383d94bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-3rdparty/default.nix
+++ b/distros/noetic/jsk-3rdparty/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, aques-talk, assimp-devel, bayesian-belief-networks, catkin, chaplus-ros, collada-urdf-jsk-patch, dialogflow-task-executive, downward, ff, ffha, google-chat-ros, google-cloud-texttospeech, influxdb-store, julius, julius-ros, libcmt, libsiftfast, lpg-planner, mini-maxwell, nfc-ros, opt-camera, osqp, pgm-learner, respeaker-ros, ros-google-cloud-language, ros-speech-recognition, rospatlite, rosping, rostwitter, sesame-ros, slic, switchbot-ros, voice-text, webrtcvad-ros, zdepth, zdepth-image-transport }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-3rdparty";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/jsk_3rdparty/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "fe44d465891fd3a398b0ac54ada77a1ea0a4b40cb3b21c90c11bc1b7a76fadda";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ aques-talk assimp-devel bayesian-belief-networks chaplus-ros collada-urdf-jsk-patch dialogflow-task-executive downward ff ffha google-chat-ros google-cloud-texttospeech influxdb-store julius julius-ros libcmt libsiftfast lpg-planner mini-maxwell nfc-ros opt-camera osqp pgm-learner respeaker-ros ros-google-cloud-language ros-speech-recognition rospatlite rosping rostwitter sesame-ros slic switchbot-ros voice-text webrtcvad-ros zdepth zdepth-image-transport ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains commonly used 3rdparty toolset for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/julius/default.nix
+++ b/distros/noetic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-noetic-julius";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/julius/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "014823789ce21da94f4a4338eb1a967c378ce71107a0bf578befe17b79584387";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/julius/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "c463981d736089578a41c410cf6a2096a22ba2a753dd9acfd6d7b67b6306db0b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libcmt/default.nix
+++ b/distros/noetic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-noetic-libcmt";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libcmt/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "5460174b56e8eedb403a1f24883e4da4ba5f86e50d57cc0fa95e18084694c092";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libcmt/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "498ae578ab3b3c00c5ed5aac566767570314edbbaef72711e229b8fbee88c783";
   };
 
   buildType = "cmake";

--- a/distros/noetic/libsiftfast/default.nix
+++ b/distros/noetic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, python3Packages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-noetic-libsiftfast";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libsiftfast/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "4069ebf700d60562e1e8b991a20930b26faaea96b74d5723c65cead215c7b445";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libsiftfast/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "22cdd64c7377bb355b22118fc76f59e2c2f9222b4014a145c0a864e6ee51e42c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lpg-planner/default.nix
+++ b/distros/noetic/lpg-planner/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, mk }:
 buildRosPackage {
   pname = "ros-noetic-lpg-planner";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/lpg_planner/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "c6a37a8be30644bb340534844822ed765cce283f7b7e4708834fffac523ba5e8";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/lpg_planner/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "29427556bb284892013b61603fbef119b214805f5d39f376939e01a89326c6b8";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin mk ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mini-maxwell/default.nix
+++ b/distros/noetic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-noetic-mini-maxwell";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/mini_maxwell/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "5cc4e6f489ebcd95ba061ee6c49c0929163c8704434bbfbe3d9ef0fdfd53990f";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/mini_maxwell/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "4f61846b93569fb7d263c36ab2c9aca3ae2360c14793ceacc6a03b960d25daf7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-path-planning/default.nix
+++ b/distros/noetic/mrpt-path-planning/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-path-planning";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "f343bf5f422b53ac663f7a6c52251b529a71f97af65cffd8f07975151ba333e5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 mvsim ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Path planning and navigation algorithms for robots/vehicles moving on planar environments. This library builds upon mrpt-nav and the theory behind PTGs to generate libraries of &quot;motion primitives&quot; for vehicles with arbitrary shape and realistic kinematics and dynamics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "7e4af4a4ff68588b9987027fd4bbd6d78bc013686b5191aa19a6efc6332c01aa";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "f1aa539c4ad7b5877a0a9e90b6538bbe5593f10fca176ae61d144e02dcf3f473";
   };
 
   buildType = "cmake";
-  buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
+  buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
   propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/neonavigation-rviz-plugins/default.nix
+++ b/distros/noetic/neonavigation-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, trajectory-tracker-rviz-plugins }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-rviz-plugins, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/neonavigation_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "effd352b1933ebc8ec68464755b7be27b2e701f36bfa13b1d4afe44bc12c81e0";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/neonavigation_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "2d3c51269310fb6617d2670c9c430b3663405e02500068e2b2073ace5ed91742";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ trajectory-tracker-rviz-plugins ];
+  propagatedBuildInputs = [ costmap-cspace-rviz-plugins trajectory-tracker-rviz-plugins ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/nfc-ros/default.nix
+++ b/distros/noetic/nfc-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-nfc-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/nfc_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "9fb85f5286e639935d7de19ed9b900633b3ef4799cf5522120dbbfbec510afdf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv ];
+  propagatedBuildInputs = [ message-generation message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The nfc_ros package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/opt-camera/default.nix
+++ b/distros/noetic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-opt-camera";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/opt_camera/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "0c00e853c675dd096a42190c862cfae422bc3897d7b9823b46dacb18ebad9d3e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/opt_camera/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "359407843f822ea792aaad63bf30a3b05ecb59d1c9933cbdbf9aa76f6d04f730";
   };
 
   buildType = "catkin";

--- a/distros/noetic/osqp/default.nix
+++ b/distros/noetic/osqp/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-osqp";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/osqp/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "878c82ff8c752a036c41211648eb0fa9b3656f9c4c799808dba894dc88022b74";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS wrapper for OSQP'';
+    license = with lib.licenses; [ "Apache" ];
+  };
+}

--- a/distros/noetic/point-cloud-color/default.nix
+++ b/distros/noetic/point-cloud-color/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, nodelet, point-cloud-transport, roscpp, sensor-msgs, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-point-cloud-color";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_color/-/archive/release/noetic/point_cloud_color/1.2.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "7c9f25a7a7cbce6ddf390bab8a3e4488e6544f26ee541e5198e97d00d0906eef";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cv-bridge image-transport nodelet point-cloud-transport roscpp sensor-msgs tf2-eigen tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package for coloring point clouds using calibrated cameras.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/point-cloud-transport-plugins/default.nix
+++ b/distros/noetic/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, draco-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-noetic-point-cloud-transport-plugins";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/noetic/point_cloud_transport_plugins/1.0.3-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/noetic/point_cloud_transport_plugins/1.0.5-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "375fe5797e3df3ea40fdf94cb86de19fd485219d3230cbcfb264bac16fac1697";
+    sha256 = "038c65e020094f02186dc2d4a91125e4a395657a56e4b7906fef0df252b7d3ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-clients/default.nix
+++ b/distros/noetic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, python3Packages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ec48963acb27603b1a8c263587f51a6d75d5043afcfcdfad004c61939a9bb9d8";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "abcd730e1b48291c87a729bd9778459b16797f7c13dfa94cb24c92cf24a0b8cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-msgs/default.nix
+++ b/distros/noetic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "50a7fbb919cef19e7fc1136fadb1379b05b32ead2bc6eb11c88a5bbfe8dfc5d5";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6050c7ec2bfeb73a3418c532fbb1758c2464db962cd0c4506e4c07567124f700";
   };
 
   buildType = "catkin";

--- a/distros/noetic/respeaker-ros/default.nix
+++ b/distros/noetic/respeaker-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, audio-common-msgs, catkin, catkin-virtualenv, dynamic-reconfigure, flac, geometry-msgs, jsk-tools, python3Packages, speech-recognition-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-respeaker-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/respeaker_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "54299b14fb5419c66dd971de0b140e4275eb803ed470627c7e2168544faa6f3b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv ];
+  checkInputs = [ jsk-tools ];
+  propagatedBuildInputs = [ angles audio-common-msgs dynamic-reconfigure flac geometry-msgs python3Packages.numpy python3Packages.pyaudio speech-recognition-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The respeaker_ros package'';
+    license = with lib.licenses; [ "Apache" ];
+  };
+}

--- a/distros/noetic/ridgeback-control/default.nix
+++ b/distros/noetic/ridgeback-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, twist-mux, urdf }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-control";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_control/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "1f1650f170467ab7e19a1cdcf7ce1bdb5a68299c09ec590db1a13feccef42947";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "710d5464781fb76807ecf2dfbcbbf391cdfa5766536f06aa9331a92d58ee5f3f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-description/default.nix
+++ b/distros/noetic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-description";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_description/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "00c742f64df089a27d09250b9f9e615889c2bf00d93c00ae640c3fa83376f22c";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "e42a070007eec9e4f23026a3de9c3781067b25e4ff60693fe324ffa1498871b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-msgs/default.nix
+++ b/distros/noetic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-msgs";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_msgs/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "c5ea43d5a76a14885722d87f62e46a6548738765821a1307c73da022dd2b7c05";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_msgs/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "d55a786d0b7e263801de2e86eec33c7e2b4d04a7df876d0d10e0dee6cac39651";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-navigation/default.nix
+++ b/distros/noetic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-navigation";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_navigation/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "952dfdee87834cf3dc2d14b97b27f94f0ec2d583aae802de9320efc9fa81975b";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_navigation/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "a5a9872dc2b50f74a11d60cc3df0d5254453ef40ab7fb470ab772bd3f45326fc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-google-cloud-language/default.nix
+++ b/distros/noetic/ros-google-cloud-language/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, diagnostic-msgs, message-generation, message-runtime, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-ros-google-cloud-language";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ros_google_cloud_language/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "a4e4b95e78868a5cfbb7abfd884e073a4b9529b79ea027a25012a7e625f9c335";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs message-runtime rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ros clinet library for google cloud language'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/roscpp-core/default.nix
+++ b/distros/noetic/roscpp-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, roscpp-serialization, roscpp-traits, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-core";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_core/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "d40d836804305c723cddab20b673c74bcdae047064a5f342b266b162830474e7";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_core/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "fdeb3bb02a2b119f1d270b28046bd0a11f36e64686beae3ce7a166bd4695719e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-serialization/default.nix
+++ b/distros/noetic/roscpp-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, roscpp-traits, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-serialization";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_serialization/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "ddbc65e42b525bdb29ec8795e05470984cec6c90839d16d577e6b752017e355a";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_serialization/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "349854ff6feedec540d14dda9c016964adb5b4d0398026a9bc05b1b765930c64";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-traits/default.nix
+++ b/distros/noetic/roscpp-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-traits";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_traits/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "4393d3b11553d92ae6044533a06583b40ffa8914b08ccf8127d0cb49ee1dbddf";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_traits/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "8c3418f8b4a57e921e55f39bd586db9ede2905b49b3983ec27b6ee623e7f2194";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospatlite/default.nix
+++ b/distros/noetic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospatlite";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rospatlite/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "f52f6aa6146511a5551db4f2b648bcd0ebe7908093dfb2a7a431297f380400e0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rospatlite/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "5c56f165128c3980917fee6417253fc26a983e9fe9e645ca137bb733b66fc7ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosping/default.nix
+++ b/distros/noetic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosping";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rosping/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "28c0281b4e9913467cde2e5284b903a6fa4e77d8127630449faf2db9e60262a1";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rosping/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "2c677da1ba00238a88e14c8391c9bee726de9fbe018a75d42a97c6e112311557";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostime/default.nix
+++ b/distros/noetic/rostime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common }:
 buildRosPackage {
   pname = "ros-noetic-rostime";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/rostime/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "7111aa9956e9e8ec623edd54c59b344c6488b65aed8b1d768a5a7a55b467c47c";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/rostime/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "9147416c5ab3b2593a22ae339ad7fe66630ac730431018352f4962f5f58d6e6b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostwitter/default.nix
+++ b/distros/noetic/rostwitter/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, git, mk, python3Packages, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, git, message-generation, message-runtime, mk, python3Packages, rospy, rostest, sound-play, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rostwitter";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rostwitter/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "227fc2677c3b13e7cb28d480ddc7b236f844154fc59d4c34901344566cd51df5";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rostwitter/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "d079175b1083e07a5a03a15e4f0c0c7cbaeec2a6fdceb102524fdb5c4c22264e";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin git mk ];
-  propagatedBuildInputs = [ python3Packages.requests python3Packages.requests_oauthlib python3Packages.simplejson rospy std-msgs ];
+  buildInputs = [ actionlib actionlib-msgs catkin git message-generation mk ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime python3Packages.requests python3Packages.requests_oauthlib python3Packages.simplejson rospy sound-play std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/septentrio-gnss-driver/default.nix
+++ b/distros/noetic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-septentrio-gnss-driver";
-  version = "1.2.3-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "39bf69095947dc7bb56e516115125e080aa568fbb5b65009f23df2b44c981dc1";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9f2000d11ba3315dc772bffcfc708df4e971e23be27b264166073d78c003e5bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sesame-ros/default.nix
+++ b/distros/noetic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-noetic-sesame-ros";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/sesame_ros/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "265fe6c7e55e6aa36a0fd730df7a9d701f86338c97eec080d7d30c454f7ca3cd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/sesame_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "7293e17b217df04f70947b9ec41601496549f1eaa86cc4b0b899f92f0e005177";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slic/default.nix
+++ b/distros/noetic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv, openssl }:
 buildRosPackage {
   pname = "ros-noetic-slic";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/slic/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "8e168ce461db9a27d3c703ba4559602761db0e4ea423454f890a1234719a2cdf";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/slic/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "a1e759834fd52662e76d417bc9439887133f0641bac02cde0909e9af740bb15c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/smach-msgs/default.nix
+++ b/distros/noetic/smach-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-smach-msgs";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_msgs/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "a71911113b4c6eab1eaabb737a5ae764d205a171bde70cd7b632caca042a830f";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_msgs/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "380f1091e12696e27afd375690bdf0d8f4d1fdb7cee2547093c05a0ba1928194";
   };
 
   buildType = "catkin";

--- a/distros/noetic/smach-ros/default.nix
+++ b/distros/noetic/smach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, rospy, rostest, rostopic, smach, smach-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-smach-ros";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_ros/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "79e4a3e08588fd56ccbbf0af327ef42fd9e3e5cf849129230340ce52fded072f";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_ros/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "8dbaedae6785bb0db9480f96c06c206d938d074b563c157a56cef140dcff6ea2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/smach/default.nix
+++ b/distros/noetic/smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-smach";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "ee2330d04fd4f3c737b8274e8cd9f167754adb7fcdf5cd7de7ce80635a285171";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "1dd31e12c74b5377743e80cd6b32eb41c18869ab59ea6e73f4f2e90021e7e438";
   };
 
   buildType = "catkin";

--- a/distros/noetic/switchbot-ros/default.nix
+++ b/distros/noetic/switchbot-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, python3Packages, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-switchbot-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/switchbot_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "cb8e83c3c40d4f238692b5e9c8ff721cba37d360781b3e516fed4bc9341c4987";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation python3Packages.setuptools ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime python3Packages.requests rospy std-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''use switchbot with ros'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/trajectory-tracker-rviz-plugins/default.nix
+++ b/distros/noetic/trajectory-tracker-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rviz, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/trajectory_tracker_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "74cefaa38f778b4300bc792456ff65dfc5741afa6a8a6d5aee8d56a75591107b";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/trajectory_tracker_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "1bd6a5cef3847fbb098e1aca26b2035c20f251798b8557f230b5526db3874ce1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/voice-text/default.nix
+++ b/distros/noetic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-voice-text";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/voice_text/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "05ae739b61950cd2321e45c980c4308fa4f8c9d8cee4a7e8bea67256ace289cc";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/voice_text/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "bfd97a07a4d42178e42cefac4574681aee3632810e93792cffec5a0b8956a367";
   };
 
   buildType = "catkin";

--- a/distros/noetic/zdepth-image-transport/default.nix
+++ b/distros/noetic/zdepth-image-transport/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, image-transport, message-generation, message-runtime, pluginlib, roscpp, sensor-msgs, std-msgs, zdepth }:
+buildRosPackage {
+  pname = "ros-noetic-zdepth-image-transport";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth_image_transport/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "e5df7326a2651d97968d72033827823025f3f734d7241dd1dd45a5487062a2b0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ image-transport message-runtime pluginlib roscpp sensor-msgs std-msgs zdepth ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The zdepth_image_transport package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/zdepth/default.nix
+++ b/distros/noetic/zdepth/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-zdepth";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "b42b58fa5454d032baeec2516fddddf1be41eabe967f8659125d101a09f104b3";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The zdepth package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ament-cmake-auto/default.nix
+++ b/distros/rolling/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-auto";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "c545c3be4b8b007f912b5afb7bd895ed334786dfd101b7ea0174e7d766c487ba";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1234bca8e440c33f028a7340e0e98bff5be52e918ee93d8f7a17aa7260dc4b7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-core/default.nix
+++ b/distros/rolling/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-core";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "aea68b872c9aa2e5cbe59d93d86c5e46c6817cf13c13aee086b5251b13f8b044";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a399ff0cc216418978e3bde1c9a791fdf7055962b389d56c6a80cd7600606f7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-definitions/default.nix
+++ b/distros/rolling/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-definitions";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "dd0693fdab190b90172747107d44b6bd40de4a699dbd1510c8cbd42247cee93a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1727fd4b78333df298cc04de40960b5b9e8bfceb57535f3ec0998facbd4884d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-dependencies";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "722ffe9f5156afa0c6749e17d7bb484416686a0b91c3fd089f914824f8593c5a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "f9d9597355bbdd6dcbd76b2f3f93d23b18f975c9da3a2f43cb4878524ec3e8eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-include-directories";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6d23af5bc5a6f316d83357bd2b71b76958a38f008804d902e35ee73e1c5a508e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1eb4b8b354a7d73c4ba9e276735eff6169ca10156c1dfef009dcda1e8663cb3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-interfaces/default.nix
+++ b/distros/rolling/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-interfaces";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5c8f8e2f264e9b927e23c1d43ebd321e0817f2390bdc072966f275ddaabe4683";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "011192f0f5bf21f6e5fe1323c69e613d884a79088b37211c1b373851fb9fe4d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-libraries/default.nix
+++ b/distros/rolling/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-libraries";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "a6ab7dbfe1993805c34ec17410c624105888657d35d8ca4165f5979886b0d668";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "09ff4f55a86c9c313700807afa327adcb815a36914888ba3a0704042598f4f30";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-link-flags/default.nix
+++ b/distros/rolling/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-link-flags";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d43c9fcb19ca614cc80858abb61e3cb823fbb373875aee46ef99c8106e9a3eff";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ad34e257c6d46d70b1e2e086fb40b63154b5c1a1747003bae2c59107475e1510";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-targets/default.nix
+++ b/distros/rolling/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-targets";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "7854ea694908e48868022a8e2194cabfacad8bbcace176c215ffbb788dbc7212";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c4b3cff799e9dbb060e40dce6853fa2e8fa694b51a5af7dd32af588b7a8e922b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gen-version-h/default.nix
+++ b/distros/rolling/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gen-version-h";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "afeba9a2580662b60bcfb00466fdae390a67bf08cc685d5e7c3bd79a38262d6a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "abb84305bb9db88919e045f42524fbefa54ceeefa9d1e75b016ebf57652515ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gmock/default.nix
+++ b/distros/rolling/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gmock";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "3d5db9101e862d07c3ad7ff4afe2ab33f334bb5eb4cf1d98a159bff3940433a7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ab7fdb75952b716be28db160e29bb6d50c53a6b2195459230badc0634ca1a10b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-google-benchmark/default.nix
+++ b/distros/rolling/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-google-benchmark";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5e87a2ece847f2ee1eb44f98153b3bcb291b764186a00fe445516a68e23882dd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1051e6716898f4adb3324c0d246645e18aa968815c8b53ec40e30d89b4e05625";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gtest/default.nix
+++ b/distros/rolling/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gtest";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "fee76480cb743297ad18c6bf1bf8463980c35a41811da27811c1c5449c179d5d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "b82a90605acff1473743f6df89a2227dbe16252358f8d7fa9fc7a340df0b8325";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-include-directories";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "252ddc4d1c267eb1ccec69116a358753e919bfe68bb3e17ab8c2c3d705f7af8c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ddf485478334ca52eb532c0f691b527751295628a6ecae127181969250bbd489";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-libraries/default.nix
+++ b/distros/rolling/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-libraries";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "255a01d8b89675e68f10af330a5589aac37b8a1e7ab0549786e1d66ba8719233";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "6fc0783344603b8271304417100f0f16dc0a1f06f091e29e291465960d9e04ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pytest/default.nix
+++ b/distros/rolling/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pytest";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e2b037545d30522731e9e1336979aef56e61cb162bdce087f2b686229bfde29b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "3ad199cf824f02ca2619c465e38c449549135243c5c25686a1eb323845b286c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-python/default.nix
+++ b/distros/rolling/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-python";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d08a0a442a64483e575b3633fa4de0c656882dcbba95a4993dc19f3396b4a0fa";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "67e352fc134ab5f8620ce3c65b1a242b87c505026b7447d8919c375c6cefc102";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-target-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-target-dependencies";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "fb20194b756126d9c46f9054e3249ae5a33382805c3c206313002d2316b72a1f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c385b420a896dd2931b035ec603cc63e44a95b059247e005fb5cc4ae7cd8a1af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-test/default.nix
+++ b/distros/rolling/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-test";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "606d441f4797cd1ea5316d3d26c3ab7c28de076811dbba66c216af7656d41d2a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a884039ed92a5d6a4a6b6b8864ba6751bd8d35feb09dcadeeee650f1c99b440c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-version/default.nix
+++ b/distros/rolling/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-version";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "eb0547314873e86363a0fa171bd1d4bcff021a7361c359dac891a4cb62a4e2bd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "cd700fb35fd5918e185814d6a17f3e91fbd14361cf5a2f5705f0d76cec19f6dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake/default.nix
+++ b/distros/rolling/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "088928bfa6ab195d9b4cf4be384795396cf49b4a9165d3e828ac5c8c099579e5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "618151dc08292b0bb26d9606fcd8a1379535e8f281b2a2623a94ba6d143223bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.2.1-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "239c2b38bb86f54e5e75aa74a7bcdff1b0152bee0d6738e59605e9287e117f51";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "5a4f9f520d5df2c77b3ce651767ae423541cc2369abff0b236c71c18d189488a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-402-driver/default.nix
+++ b/distros/rolling/canopen-402-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-402-driver";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_402_driver/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "65f10e69f3ad23cc7a517c4bd6a8ba977ec96f382488554939419c80f2cc6a8f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driiver for devices implementing CIA402 profile'';
+    license = with lib.licenses; [ "LGPL-v3" ];
+  };
+}

--- a/distros/rolling/canopen-base-driver/default.nix
+++ b/distros/rolling/canopen-base-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-core, canopen-interfaces, diagnostic-updater, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-base-driver";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_base_driver/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "8de0b2141fc32733f87034ff26e8db45fc5498b44335cb2b130a13ac2ac2348a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ boost canopen-core canopen-interfaces diagnostic-updater lely-core-libraries rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Library containing abstract CANopen driver class for ros2_canopen'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-core/default.nix
+++ b/distros/rolling/canopen-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, canopen-interfaces, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-core";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_core/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "dc2505c5bf144e1ed35eba888d102f54960135496a637af66e9f8b69ac49ff2e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ boost canopen-interfaces lely-core-libraries lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Core ros2_canopen functionalities such as DeviceContainer and master'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-fake-slaves/default.nix
+++ b/distros/rolling/canopen-fake-slaves/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-fake-slaves";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_fake_slaves/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "79f1b72f9358dda9f5ab89bc91284e90bace31a77ca47983e23b41d2fe4da6c1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ lely-core-libraries lifecycle-msgs rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package with mock canopen slave'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-interfaces/default.nix
+++ b/distros/rolling/canopen-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-interfaces";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_interfaces/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "6002d3ed989a9a4227a13fc21423bfdf061944701b9cc307da1d36cdedb770f6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Services and Messages for ros2_canopen stack'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-master-driver/default.nix
+++ b/distros/rolling/canopen-master-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, canopen-core, canopen-interfaces, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-master-driver";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_master_driver/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "26e762cd542cceae51502c049233dd4bc23ae76ecd64f2f942e272d414db72b1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ canopen-core canopen-interfaces lely-core-libraries rclcpp rclcpp-components rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Basic canopen master implementation'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-proxy-driver/default.nix
+++ b/distros/rolling/canopen-proxy-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-proxy-driver";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_proxy_driver/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "9d6f6d6d6065ac4932f87be42de18a91ef4114e42c6ddf70880bd8a2dce091e7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Simple proxy driver for the ros2_canopen stack'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-ros2-control/default.nix
+++ b/distros/rolling/canopen-ros2-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-ros2-control";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_control/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "2ca2bc8fa7ee0fba0c80a24de3418c355cc7f98a9972e8a633b367c94778e478";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-proxy-driver hardware-interface pluginlib rclcpp rclcpp-components rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros2_control wrapper for ros2_canopen functionalities'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-ros2-controllers/default.nix
+++ b/distros/rolling/canopen-ros2-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-ros2-controllers";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_controllers/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "66a52aeb4c94008a3c1c4dbd071d18f99655ba9fe2720b4bf4543c1a73ed0fd6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-interfaces canopen-proxy-driver controller-interface controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros2_control controllers for ros2_canopen functionalities'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-tests/default.nix
+++ b/distros/rolling/canopen-tests/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, canopen-402-driver, canopen-core, canopen-fake-slaves, canopen-proxy-driver, canopen-ros2-controllers, controller-manager, forward-command-controller, joint-state-broadcaster, joint-trajectory-controller, lely-core-libraries, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-tests";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_tests/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "01f0cae7f00b14dea5f0197d16f517f516a1ea672b815beea464228666b8c9e6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake lely-core-libraries ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-fake-slaves canopen-proxy-driver canopen-ros2-controllers controller-manager forward-command-controller joint-state-broadcaster joint-trajectory-controller robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package with tests for ros2_canopen'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-utils/default.nix
+++ b/distros/rolling/canopen-utils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, canopen-interfaces, lifecycle-msgs, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-utils";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_utils/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "223ced34a40d7f3071bcbbf9f03ce94f0cdb6d35b3457415044f5ab30bfc1c51";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ canopen-interfaces lifecycle-msgs rclpy std-msgs ];
+
+  meta = {
+    description = ''Utils for working with ros2_canopen.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen/default.nix
+++ b/distros/rolling/canopen/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, lely-core-libraries }:
+buildRosPackage {
+  pname = "ros-rolling-canopen";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "f3c1b6b3450e6138c76f4bb54333600d9bc93e19c26a9250f6cdce8007769501";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver lely-core-libraries ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta-package aggregating the ros2_canopen packages and documentation'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "bedbd1a3c23d7a04e3324eaf4cc9c4f1c2f9b8b9a7fb1ba2498b50fcdef267e6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "7066747849bc932938a084cc726a6163be1dd1cca0d221caec2bcf5607cbd012";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "b4bb3e87a8f3d3bd910c8ba79d8d44a6a3978470d28981aff50944696c5b0440";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "fae44a50f31d9d5df57ec8ccbfdfff154802e074916793e115edaad0dee0d10d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "c86b187c033efcbc528c2e7c8c787ed4e7cfffe5a9be3400f4b639fb657889e9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "e088e4c3d6b31a998e4e75813f9aa59f3883cd3800f2e53b05875658eef54644";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "12c7ea3e96d0b744065df9433768fd0fb4147298d3c571c1c2fd5e2b008d46fb";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "05e71fb99155c79f0bf9d6fd9cd9a74e2b9e8305e6cd2f1a6b25c029e0e17420";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -102,8 +102,6 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
- ament-cmake-vendor-package = self.callPackage ./ament-cmake-vendor-package {};
-
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
@@ -213,6 +211,30 @@ self: super: {
  camera-info-manager = self.callPackage ./camera-info-manager {};
 
  can-msgs = self.callPackage ./can-msgs {};
+
+ canopen = self.callPackage ./canopen {};
+
+ canopen-402-driver = self.callPackage ./canopen-402-driver {};
+
+ canopen-base-driver = self.callPackage ./canopen-base-driver {};
+
+ canopen-core = self.callPackage ./canopen-core {};
+
+ canopen-fake-slaves = self.callPackage ./canopen-fake-slaves {};
+
+ canopen-interfaces = self.callPackage ./canopen-interfaces {};
+
+ canopen-master-driver = self.callPackage ./canopen-master-driver {};
+
+ canopen-proxy-driver = self.callPackage ./canopen-proxy-driver {};
+
+ canopen-ros2-control = self.callPackage ./canopen-ros2-control {};
+
+ canopen-ros2-controllers = self.callPackage ./canopen-ros2-controllers {};
+
+ canopen-tests = self.callPackage ./canopen-tests {};
+
+ canopen-utils = self.callPackage ./canopen-utils {};
 
  cartographer = self.callPackage ./cartographer {};
 
@@ -721,6 +743,8 @@ self: super: {
  launch-xml = self.callPackage ./launch-xml {};
 
  launch-yaml = self.callPackage ./launch-yaml {};
+
+ lely-core-libraries = self.callPackage ./lely-core-libraries {};
 
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "2a01d9aa5845c2d30d4f2cbd082c77b0fb6a5f306c29c22f7fb4acb9f1006475";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "d512d1ccf236df73ace167ff6ab51b9f800a715fbd6b2a794b48c68de9018397";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ignition-cmake2-vendor/default.nix
+++ b/distros/rolling/ignition-cmake2-vendor/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, doxygen, git, ignition }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, ignition }:
 buildRosPackage {
   pname = "ros-rolling-ignition-cmake2-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ignition_cmake2_vendor-release/archive/release/rolling/ignition_cmake2_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "3aaaadd0e720a2585f5a63bafb513c6cc21bec5f8f6ca5716d27b13583a12fb6";
+    url = "https://github.com/ros2-gbp/ignition_cmake2_vendor-release/archive/release/rolling/ignition_cmake2_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "606f92ed13100c48aff54bfbeb765a7bec17c894b32d4234edb2db45d0613e23";
   };
 
-  buildType = "cmake";
-  buildInputs = [ ament-cmake-test cmake doxygen git ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ ignition.cmake2 ];
-  nativeBuildInputs = [ ament-cmake-test cmake doxygen git ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
     description = ''This package provides the Ignition CMake 2.x library.'';

--- a/distros/rolling/ignition-math6-vendor/default.nix
+++ b/distros/rolling/ignition-math6-vendor/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, eigen, git, ignition, ignition-cmake2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, eigen, ignition, ignition-cmake2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ignition-math6-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ignition_math6_vendor-release/archive/release/rolling/ignition_math6_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "2c826e03ad1e8c001c523beb98b407b1e0b34097dc2e0636a3a9886abaa4f340";
+    url = "https://github.com/ros2-gbp/ignition_math6_vendor-release/archive/release/rolling/ignition_math6_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "bd383d2067d415c5dd8ab728263f7d5e99be6636d6ed3c12cbe4f021dda718f6";
   };
 
-  buildType = "cmake";
-  buildInputs = [ ament-cmake-test cmake eigen git ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package eigen ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ ignition-cmake2-vendor ignition.math6 ];
-  nativeBuildInputs = [ ament-cmake-test cmake git ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
     description = ''This package provides the Ignition Math 6.x library.'';

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "11e00ba69208875f744d1cdd74b6d6fe05cb79d71b5ffed290c11b8f99834945";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "3dc32b4d9c33ad7095e0d4436ada5be294f01140ce3f448b80d33e60d84d192c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lely-core-libraries/default.nix
+++ b/distros/rolling/lely-core-libraries/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, autoconf, automake, git, libtool, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-lely-core-libraries";
+  version = "0.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/lely_core_libraries/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "6da08043f81f00d880cf9994d5558fae7c3fb8dfd4c718e13e20def1d03ab585";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake autoconf automake git libtool ];
+  propagatedBuildInputs = [ python3Packages.empy ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS wrapper for lely-core-libraries'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "b8dba7f08ffac2ce87ec45b6f22fcc5c22f5db9fc3389b887e7de9018170e265";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "699a47292e5bc6e68d900ad238b73389aa01312401f8a5d811851c3fa5306567";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/rc-reason-clients/default.nix
+++ b/distros/rolling/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "f12a3b67c6c5a8843c3b33c6064806d47045f3a6c38d05b4c3fc0debe15a4105";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "817dbcf9b2a34a691de40df8fd465f6dd129e5a8a0a9689dd289f9b5872ed7c0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rc-reason-msgs/default.nix
+++ b/distros/rolling/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1280b76742f55556a48e3d1323a862bc2a9d900c62cfe5f86cf3acfb127a1732";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "57aa5ff808fa68b6804305000e5d21c6aee38fa10ce2cafa7f3723468b551582";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc-examples/default.nix
+++ b/distros/rolling/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc-examples";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_examples/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "99a67052a7ebcc62dd76db04d35f61989dcc5c5b4b269ce808bed5282fda22db";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_examples/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "e3db30d5aac9e6e646cbda81e85772b081b28e89d597ca3c4409244dfb9a2826";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc-lifecycle/default.nix
+++ b/distros/rolling/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc-lifecycle";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_lifecycle/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "e3511b425b526d85118ff1b73dc61a367a1df28dd683b1e780f4e7f2f17333f7";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_lifecycle/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "9c04d158b345936fa79515a323f8b9b5af20699f1228df54985e7c2e277b1133";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc-parameter/default.nix
+++ b/distros/rolling/rclc-parameter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc-parameter";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_parameter/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "d0c4140e6702ff8794341250ac30e30c056eaec2b11d883401df60066a2f6ce6";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_parameter/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "5be033d6585a74e1ad3d0ff594db4330c7c175d0e4543ac5784ed529d672861a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc/default.nix
+++ b/distros/rolling/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcl-action, rclcpp, rclcpp-action, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "25791d10e312fb56a26ef04c64a1ad09b8704ee0e907ba99ff33b468a1018b37";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "eb8835f58fc5ad07d872d7d08570bb1e31a5be6684bcab8feb416c10e79fbbd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "e7a4c44fe1b89571d6e55e10948e7bc540f4d31d2d372dcf4b0c3da0398ded33";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "d09a83339bc1c5c7104fe0ca309a66c325524adf55d1995b388f8bd41a05c419";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "8493e021e124478c286b46ca0f9981a00d696c9a438c88ca8c56daff5a651c06";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "ddfed5d1895f02339be45cea9ba2c0c115dadecc2c936e770d07adef33717e49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "89b0d58d625181d28a5c173fa16944d73fbe48a55cbeeef0ef062be814c11ff4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "6eb720f1edb0d175e99d69ab9a67103fb08c6d9e3e5b66167350d362b73115f9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "3176e4846704f6ad109b36dcfc48da8deb9f628c2842307fb7da7c6a49386c96";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "4bed301a5278f792b79a22eac0f334eb7721775282856d8712dd0d80a5746ef5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "3.13.0-r1";
+  version = "3.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "19543ba7b6af952aa3df746e3c0fa30db35e6aa5d83c175f8843c4c998095f0f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.14.0-1.tar.gz";
+    name = "3.14.0-1.tar.gz";
+    sha256 = "e677f9353c38747694180d2fd93e66e8a26096b3348d01494b91bfa6e7da75b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/urg-node-msgs/default.nix
+++ b/distros/rolling/urg-node-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-urg-node-msgs";
-  version = "1.0.1-r6";
+  version = "1.0.1-r7";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urg_node_msgs-release/archive/release/rolling/urg_node_msgs/1.0.1-6.tar.gz";
-    name = "1.0.1-6.tar.gz";
-    sha256 = "61cae54e2424a0b4cf485a290efcc9ce9f62a5bcb5592a7ab51522727b72833b";
+    url = "https://github.com/ros2-gbp/urg_node_msgs-release/archive/release/rolling/urg_node_msgs/1.0.1-7.tar.gz";
+    name = "1.0.1-7.tar.gz";
+    sha256 = "93104cffb9894b6fafecd0795a4a57758150ff293d94ac19e1a7d1b9b6443422";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'melodic', 'noetic', 'rolling'] from nix-ros-overlay commit 381164fc34d6b9d8b59f4e45e19cad1bec709892.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.22.0-r1*
* *admittance-controller 2.21.0-r1 --> 2.22.0-r1*
* *ament-cmake 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-auto 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-core 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-definitions 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-dependencies 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-include-directories 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-interfaces 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-libraries 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-link-flags 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-targets 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-gen-version-h 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-gmock 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-google-benchmark 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-gtest 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-include-directories 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-libraries 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-nose 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-pytest 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-python 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-target-dependencies 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-test 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-version 1.3.4-r2 --> 1.3.5-r1*
* *behaviortree-cpp 4.2.1-r2 --> 4.3.1-r1*
* *bicycle-steering-controller 2.22.0-r1*
* *clearpath-config 0.0.2-r2*
* *clearpath-msgs 0.0.3-r1 --> 0.0.4-r1*
* *clearpath-platform-msgs 0.0.3-r1 --> 0.0.4-r1*
* *controller-interface 2.26.0-r1 --> 2.27.0-r1*
* *controller-manager 2.26.0-r1 --> 2.27.0-r1*
* *controller-manager-msgs 2.26.0-r1 --> 2.27.0-r1*
* *costmap-queue 1.1.7-r3 --> 1.1.8-r2*
* *depthai 2.21.2-r1 --> 2.22.0-r1*
* *depthai-bridge 2.7.2-r1 --> 2.7.3-r1*
* *depthai-descriptions 2.7.2-r1 --> 2.7.3-r1*
* *depthai-examples 2.7.2-r1 --> 2.7.3-r1*
* *depthai-filters 2.7.2-r1 --> 2.7.3-r1*
* *depthai-ros 2.7.2-r1 --> 2.7.3-r1*
* *depthai-ros-driver 2.7.2-r1 --> 2.7.3-r1*
* *depthai-ros-msgs 2.7.2-r1 --> 2.7.3-r1*
* *diff-drive-controller 2.21.0-r1 --> 2.22.0-r1*
* *dwb-core 1.1.7-r3 --> 1.1.8-r2*
* *dwb-critics 1.1.7-r3 --> 1.1.8-r2*
* *dwb-msgs 1.1.7-r3 --> 1.1.8-r2*
* *dwb-plugins 1.1.7-r3 --> 1.1.8-r2*
* *effort-controllers 2.21.0-r1 --> 2.22.0-r1*
* *fastrtps 2.6.4-r1 --> 2.6.5-r1*
* *force-torque-sensor-broadcaster 2.21.0-r1 --> 2.22.0-r1*
* *forward-command-controller 2.21.0-r1 --> 2.22.0-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gripper-controllers 2.21.0-r1 --> 2.22.0-r1*
* *hardware-interface 2.26.0-r1 --> 2.27.0-r1*
* *imu-sensor-broadcaster 2.21.0-r1 --> 2.22.0-r1*
* *joint-limits 2.26.0-r1 --> 2.27.0-r1*
* *joint-state-broadcaster 2.21.0-r1 --> 2.22.0-r1*
* *joint-trajectory-controller 2.21.0-r1 --> 2.22.0-r1*
* *librealsense2 2.51.1-r2 --> 2.54.1-r1*
* *lms1xx 1.0.0-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *nav-2d-msgs 1.1.7-r3 --> 1.1.8-r2*
* *nav-2d-utils 1.1.7-r3 --> 1.1.8-r2*
* *nav2-amcl 1.1.7-r3 --> 1.1.8-r2*
* *nav2-behavior-tree 1.1.7-r3 --> 1.1.8-r2*
* *nav2-behaviors 1.1.7-r3 --> 1.1.8-r2*
* *nav2-bringup 1.1.7-r3 --> 1.1.8-r2*
* *nav2-bt-navigator 1.1.7-r3 --> 1.1.8-r2*
* *nav2-collision-monitor 1.1.7-r3 --> 1.1.8-r2*
* *nav2-common 1.1.7-r3 --> 1.1.8-r2*
* *nav2-constrained-smoother 1.1.7-r3 --> 1.1.8-r2*
* *nav2-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-core 1.1.7-r3 --> 1.1.8-r2*
* *nav2-costmap-2d 1.1.7-r3 --> 1.1.8-r2*
* *nav2-dwb-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-lifecycle-manager 1.1.7-r3 --> 1.1.8-r2*
* *nav2-map-server 1.1.7-r3 --> 1.1.8-r2*
* *nav2-msgs 1.1.7-r3 --> 1.1.8-r2*
* *nav2-navfn-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-regulated-pure-pursuit-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-rotation-shim-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-rviz-plugins 1.1.7-r3 --> 1.1.8-r2*
* *nav2-simple-commander 1.1.7-r3 --> 1.1.8-r2*
* *nav2-smac-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-smoother 1.1.7-r3 --> 1.1.8-r2*
* *nav2-system-tests 1.1.7-r3 --> 1.1.8-r2*
* *nav2-theta-star-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-util 1.1.7-r3 --> 1.1.8-r2*
* *nav2-velocity-smoother 1.1.7-r3 --> 1.1.8-r2*
* *nav2-voxel-grid 1.1.7-r3 --> 1.1.8-r2*
* *nav2-waypoint-follower 1.1.7-r3 --> 1.1.8-r2*
* *navigation2 1.1.7-r3 --> 1.1.8-r2*
* *position-controllers 2.21.0-r1 --> 2.22.0-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *ros2-control 2.26.0-r1 --> 2.27.0-r1*
* *ros2-control-test-assets 2.26.0-r1 --> 2.27.0-r1*
* *ros2-controllers 2.21.0-r1 --> 2.22.0-r1*
* *ros2-controllers-test-nodes 2.21.0-r1 --> 2.22.0-r1*
* *ros2controlcli 2.26.0-r1 --> 2.27.0-r1*
* *rqt-controller-manager 2.26.0-r1 --> 2.27.0-r1*
* *rqt-joint-trajectory-controller 2.21.0-r1 --> 2.22.0-r1*
* *steering-controllers-library 2.22.0-r1*
* *transmission-interface 2.26.0-r1 --> 2.27.0-r1*
* *tricycle-controller 2.21.0-r1 --> 2.22.0-r1*
* *tricycle-steering-controller 2.22.0-r1*
* *velocity-controllers 2.21.0-r1 --> 2.22.0-r1*

Iron Changes:
-------------
* *ament-cmake 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-auto 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-core 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-definitions 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-dependencies 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-include-directories 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-interfaces 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-libraries 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-link-flags 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-targets 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-gen-version-h 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-gmock 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-google-benchmark 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-gtest 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-include-directories 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-libraries 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-pytest 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-python 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-target-dependencies 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-test 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-version 2.0.2-r2 --> 2.0.3-r1*
* *behaviortree-cpp 4.2.1-r1 --> 4.3.1-r1*
* *controller-interface 3.12.1-r2 --> 3.14.0-r1*
* *controller-manager 3.12.1-r2 --> 3.14.0-r1*
* *controller-manager-msgs 3.12.1-r2 --> 3.14.0-r1*
* *depthai 2.21.2-r1 --> 2.22.0-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *hardware-interface 3.12.1-r2 --> 3.14.0-r1*
* *joint-limits 3.12.1-r2 --> 3.14.0-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *rclc 3.0.9-r3 --> 5.0.1-r1*
* *rclc-examples 3.0.9-r3 --> 5.0.1-r1*
* *rclc-lifecycle 3.0.9-r3 --> 5.0.1-r1*
* *rclc-parameter 3.0.9-r3 --> 5.0.1-r1*
* *ros2-control 3.12.1-r2 --> 3.14.0-r1*
* *ros2-control-test-assets 3.12.1-r2 --> 3.14.0-r1*
* *ros2controlcli 3.12.1-r2 --> 3.14.0-r1*
* *rqt-controller-manager 3.12.1-r2 --> 3.14.0-r1*
* *transmission-interface 3.12.1-r2 --> 3.14.0-r1*

Melodic Changes:
----------------
* *costmap-cspace-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *cras-imu-tools 1.0.1-r1*
* *cras-laser-geometry 1.1.2-r1*
* *executive-smach 2.0.1 --> 2.0.3-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gps-common 0.3.3-r1 --> 0.3.4-r1*
* *gps-umd 0.3.3-r1 --> 0.3.4-r1*
* *gpsd-client 0.3.3-r1 --> 0.3.4-r1*
* *image-transport-codecs 2.2.2-r1 --> 2.2.3-r1*
* *neonavigation-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *point-cloud-color 1.2.1-r1*
* *point-cloud-transport-plugins 1.0.3-r1 --> 1.0.5-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *septentrio-gnss-driver 1.2.3-r2 --> 1.3.0-r1*
* *simple-grasping 0.3.1 --> 0.4.1-r1*
* *smach 2.0.1 --> 2.0.3-r1*
* *smach-msgs 2.0.1 --> 2.0.3-r1*
* *smach-ros 2.0.1 --> 2.0.3-r1*
* *trajectory-tracker-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*

Noetic Changes:
---------------
* *aques-talk 2.1.26-r1*
* *assimp-devel 2.1.21-r2 --> 2.1.26-r1*
* *bayesian-belief-networks 2.1.21-r2 --> 2.1.26-r1*
* *chaplus-ros 2.1.26-r1*
* *costmap-cspace-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *cpp-common 0.7.2-r1 --> 0.7.3-r1*
* *cras-imu-tools 1.0.1-r1*
* *cras-laser-geometry 1.1.2-r1*
* *depthai 2.21.2-r1 --> 2.22.0-r1*
* *depthai-bridge 2.7.2-r1 --> 2.7.3-r1*
* *depthai-descriptions 2.7.2-r1 --> 2.7.3-r1*
* *depthai-examples 2.7.2-r1 --> 2.7.3-r1*
* *depthai-filters 2.7.2-r1 --> 2.7.3-r1*
* *depthai-ros 2.7.2-r1 --> 2.7.3-r1*
* *depthai-ros-driver 2.7.2-r1 --> 2.7.3-r1*
* *depthai-ros-msgs 2.7.2-r1 --> 2.7.3-r1*
* *dialogflow-task-executive 2.1.26-r1*
* *downward 2.1.21-r2 --> 2.1.26-r1*
* *euslisp 9.29.0-r1 --> 9.29.0-r2*
* *executive-smach 2.5.1-r1 --> 2.5.2-r1*
* *ff 2.1.21-r2 --> 2.1.26-r1*
* *ffha 2.1.21-r2 --> 2.1.26-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gdrive-ros 2.1.26-r1*
* *google-chat-ros 2.1.26-r1*
* *gps-common 0.3.3-r1 --> 0.3.4-r1*
* *gps-umd 0.3.3-r1 --> 0.3.4-r1*
* *gpsd-client 0.3.3-r1 --> 0.3.4-r1*
* *gtsam 4.2.0-r2*
* *hri-rviz 0.3.1-r1 --> 0.4.0-r1*
* *image-transport-codecs 2.2.2-r1 --> 2.2.3-r1*
* *jsk-3rdparty 2.1.26-r1*
* *julius 2.1.21-r2 --> 2.1.26-r1*
* *libcmt 2.1.21-r2 --> 2.1.26-r1*
* *libsiftfast 2.1.21-r2 --> 2.1.26-r1*
* *lpg-planner 2.1.21-r2 --> 2.1.26-r1*
* *mini-maxwell 2.1.21-r2 --> 2.1.26-r1*
* *mrpt-path-planning 0.1.0-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *neonavigation-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *nfc-ros 2.1.26-r1*
* *opt-camera 2.1.21-r2 --> 2.1.26-r1*
* *osqp 2.1.26-r1*
* *point-cloud-color 1.2.1-r1*
* *point-cloud-transport-plugins 1.0.3-r1 --> 1.0.5-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *respeaker-ros 2.1.26-r1*
* *ridgeback-control 0.3.3-r2 --> 0.3.4-r1*
* *ridgeback-description 0.3.3-r2 --> 0.3.4-r1*
* *ridgeback-msgs 0.3.3-r2 --> 0.3.4-r1*
* *ridgeback-navigation 0.3.3-r2 --> 0.3.4-r1*
* *ros-google-cloud-language 2.1.26-r1*
* *roscpp-core 0.7.2-r1 --> 0.7.3-r1*
* *roscpp-serialization 0.7.2-r1 --> 0.7.3-r1*
* *roscpp-traits 0.7.2-r1 --> 0.7.3-r1*
* *rospatlite 2.1.21-r2 --> 2.1.26-r1*
* *rosping 2.1.21-r2 --> 2.1.26-r1*
* *rostime 0.7.2-r1 --> 0.7.3-r1*
* *rostwitter 2.1.21-r2 --> 2.1.26-r1*
* *septentrio-gnss-driver 1.2.3-r1 --> 1.3.0-r1*
* *sesame-ros 2.1.21-r2 --> 2.1.26-r1*
* *slic 2.1.21-r2 --> 2.1.26-r1*
* *smach 2.5.1-r1 --> 2.5.2-r1*
* *smach-msgs 2.5.1-r1 --> 2.5.2-r1*
* *smach-ros 2.5.1-r1 --> 2.5.2-r1*
* *switchbot-ros 2.1.26-r1*
* *trajectory-tracker-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *voice-text 2.1.21-r2 --> 2.1.26-r1*
* *zdepth 2.1.26-r1*
* *zdepth-image-transport 2.1.26-r1*

Rolling Changes:
----------------
* *ament-cmake 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-auto 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-core 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-definitions 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-dependencies 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-include-directories 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-interfaces 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-libraries 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-link-flags 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-targets 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-gen-version-h 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-gmock 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-google-benchmark 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-gtest 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-include-directories 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-libraries 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-pytest 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-python 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-target-dependencies 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-test 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-version 2.2.0-r1 --> 2.2.1-r1*
* *behaviortree-cpp 4.2.1-r1 --> 4.3.1-r1*
* *canopen 0.2.4-r1*
* *canopen-402-driver 0.2.4-r1*
* *canopen-base-driver 0.2.4-r1*
* *canopen-core 0.2.4-r1*
* *canopen-fake-slaves 0.2.4-r1*
* *canopen-interfaces 0.2.4-r1*
* *canopen-master-driver 0.2.4-r1*
* *canopen-proxy-driver 0.2.4-r1*
* *canopen-ros2-control 0.2.4-r1*
* *canopen-ros2-controllers 0.2.4-r1*
* *canopen-tests 0.2.4-r1*
* *canopen-utils 0.2.4-r1*
* *controller-interface 3.13.0-r1 --> 3.14.0-r1*
* *controller-manager 3.13.0-r1 --> 3.14.0-r1*
* *controller-manager-msgs 3.13.0-r1 --> 3.14.0-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *hardware-interface 3.13.0-r1 --> 3.14.0-r1*
* *ignition-cmake2-vendor 0.2.0-r1 --> 0.2.1-r1*
* *ignition-math6-vendor 0.2.0-r1 --> 0.2.1-r1*
* *joint-limits 3.13.0-r1 --> 3.14.0-r1*
* *lely-core-libraries 0.2.4-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *rclc 3.0.9-r2 --> 6.1.0-r1*
* *rclc-examples 3.0.9-r2 --> 6.1.0-r1*
* *rclc-lifecycle 3.0.9-r2 --> 6.1.0-r1*
* *rclc-parameter 3.0.9-r2 --> 6.1.0-r1*
* *ros2-control 3.13.0-r1 --> 3.14.0-r1*
* *ros2-control-test-assets 3.13.0-r1 --> 3.14.0-r1*
* *ros2controlcli 3.13.0-r1 --> 3.14.0-r1*
* *rqt-controller-manager 3.13.0-r1 --> 3.14.0-r1*
* *transmission-interface 3.13.0-r1 --> 3.14.0-r1*
* *urg-node-msgs 1.0.1-r6 --> 1.0.1-r7*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libqt5-svg
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] mapnik-utils
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] moveit_calibration_plugins
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-sphinx
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-mistune
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-vcstool
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote
 * [ ] xsimd
 * [ ] xtensor

