### PR TITLE
Make buildEnv more flexible

### DIFF
--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -33,7 +33,7 @@ let
 
   propagatedPaths = propagatePackages paths;
 
-  env = (buildEnv (args // {
+  env = (buildEnv ((removeAttrs args [ "wrapPrograms" ]) // {
     name = "ros-env";
     # Only add ROS packages to environment. The rest are propagated like normal.
     # ROS packages propagate a huge number of dependencies, which are added all

--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -63,7 +63,8 @@ let
             --prefix PYTHONPATH : "$out/${python.sitePackages}" \
             --prefix CMAKE_PREFIX_PATH : "$out" \
             --prefix AMENT_PREFIX_PATH : "$out" \
-            --prefix ROS_PACKAGE_PATH : "$out/share"
+            --prefix ROS_PACKAGE_PATH : "$out/share" \
+            ''${rosWrapperArgs[@]}
         done
       fi
     '';


### PR DESCRIPTION
This PR changes `buildEnv` to:

- Stop passing `wrapPrograms` to `buildEnv` from Nixpkgs, preventing errors from occuring
- Allow adding custom values to `postBuild` and `passthru`
- Allow supplying custom arguments to `makeWrapper` (e.g. to set the default RMW implementation to work around #45)