### PR TITLE
Make binaries from ament_python packages available in $out/lib/$pkg

### DIFF
--- a/distros/build-ros-package/default.nix
+++ b/distros/build-ros-package/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, pythonPackages, rosDistro, rosVersion }:
 { buildType ? "catkin"
+, pname
   # Too difficult to fix all the problems with the tests in each package
 , doCheck ? false
 # nixpkgs requires that either dontWrapQtApps is set or wrapQtAppsHook is added
@@ -10,17 +11,42 @@
 # correctly.
 , dontWrapQtApps ? true
 , CXXFLAGS ? ""
+, postInstall ? ""
 , passthru ? {}
 , ...
 }@args:
 
+let
+  # Convert pname to the original ROS package name (rosPkgName), e.g.,
+  # ros-humble-rqt-robot-monitor -> rqt_robot_monitor
+  wordsFromPname = builtins.filter (v: ! builtins.isList v) (builtins.split "-" pname);
+  wordsRosPkgName =
+    if (builtins.head wordsFromPname) == "ros" then
+      lib.drop 2 wordsFromPname # strip distro prefix (from nix-ros-overlay packages)
+    else
+      wordsFromPname;           # external packages might not use ros-distro- prefix
+  rosPkgName = builtins.concatStringsSep "_" wordsRosPkgName;
+in
 (if buildType == "ament_python" then pythonPackages.buildPythonPackage
 else stdenv.mkDerivation) (args // {
-  inherit doCheck dontWrapQtApps;
+  inherit pname doCheck dontWrapQtApps;
 
   # Disable warnings that cause "Log limit exceeded" errors on Hydra in lots of
   # packages that use Eigen
   CXXFLAGS = CXXFLAGS + "-Wno-deprecated-declarations -Wno-deprecated-copy";
+
+  # ament_python packages built by colcon install binaries to
+  # .../lib/$pkg. This is configured in setup.cfg in the package
+  # source. buildPythonPackage builds packages differently than colcon
+  # (via wheels) and ignores setup.cfg. Therefore, we have to move the
+  # binaries to lib manually.
+  postInstall = postInstall + lib.optionalString (buildType == "ament_python") ''
+    files=($out/bin/*)
+    if (( ''${#files[@]} )); then
+      mkdir -p $out/lib/${rosPkgName}
+      ln -sr "''${files[@]}" $out/lib/${rosPkgName}
+    fi
+  '';
 
   passthru = passthru // {
     rosPackage = true;


### PR DESCRIPTION
ROS 2 expects the binaries to be installed in $out/lib/$pkg (where $pkg is ROS package name) rather than in $out/bin, where buildPythonPackage installs them. Without binaries in $out/lib/$pkg, commands such as `ros2 run` and `ros2 launch` do not work.

The reason of this mismatch is difference in how colcon and buildPythonPackage build and install packages.

colcon builds Python packages by calling:

    setup.py egg_info ... build ... install ...

This command reads setup.cfg, which requests installation of binaries under lib, i.e., it contains:

    [install]
    install_scripts=$base/lib/my_package_name

On the other hand buildPythonPackage (used by ament_python packages in nix-ros-overlay) calls:

    setup.py bdist_wheel
    pip install dist/*.whl

This procedure ignores the content of setup.cfg.

This commit works around the differences by manually linking the binaries to the $out/lib/$pkg directory.

Fixes #230 