### PR TITLE
rosdistro sync, Fri Jun 30 14:15:07 2023

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+buildRosPackage {
+  pname = "ros-humble-ackermann-steering-controller";
+  version = "2.23.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "69b0c02c92aa096136dd2a1d8be141dd46c65cc53901fb6a197e8ec0977ea782";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Steering controller for Ackermann kinematics. Rear fixed wheels are powering the vehicle and front wheels are steering it.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "1837839bc7efbb0385b3137810747d0882466f5c4256b0a315e07ae1b2b72830";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "c3161873517a1475d08b058c93864eca9f8da95cf4b11a5f6f35a67e0cee5777";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-auto/default.nix
+++ b/distros/humble/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-auto";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "79252bcd997e9e874778c8fdf4616b6980a0ecff56ea07c6e063b34962f5b5de";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "eb6b95a6da39bc3fde90d2b3ab0ba6b5b71924189400b15b08b1941ef9ae8bc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-core/default.nix
+++ b/distros/humble/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-core";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "103b98f3b56dc5312d3958924cc02c998ae7fe9e087e7228a45f32268c230974";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "c05e3c0719f2fc087cd4af182ac2368a6597bbc1b98306f1367ddbbf04ee2971";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-definitions/default.nix
+++ b/distros/humble/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-definitions";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "41068c0a96bd1267d0568209ff70a7527fb5ecd72ac2eac700fd80c3fdf15934";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "3d2638baf82355590ce9483e1f738821994b0b15309dbcd9237c978db68d2e88";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-dependencies/default.nix
+++ b/distros/humble/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-dependencies";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "483c0e2a98ed75824cf8773f1e89a25c97ead11a1e9a74443abbb63c30d32cd9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "548cc12d07b68caa4d84c77f51678076209c3cb00e8a6a031d18547e05336f44";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-include-directories/default.nix
+++ b/distros/humble/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-include-directories";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4ff7eac5dd1da9092086274674e4f91af23e3ac6412838b20d4805c4a1e58859";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "77adb3adc71302cca4db53cfc3af9fdf77c29be016504ce760aeaa3f5a07d347";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-interfaces/default.nix
+++ b/distros/humble/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-interfaces";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "fc28d927623608d83fe0d15c94d755583f9d3b08658d606571e9113b3097e373";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "bd6a0ac3cb12aed2a7793c575cfc7c2249529c95fb2793af63a2df06cb351dc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-libraries/default.nix
+++ b/distros/humble/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-libraries";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4229e0a8ace5f8ce5bdec3d39340ac6ae28ce5543d2b24948e1f3f263300ee56";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "6484a53839239de785bb7b6bd006c0ca3a893ed4372b312cd2d871e75374e329";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-link-flags/default.nix
+++ b/distros/humble/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-link-flags";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "1eb67d2647f123ff42fdc552cad3484e35c1a14f6375d975230aa070f51c9350";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "fc6e90fec1562a8dc1a32bc8c01a80bcd611d7b2f41a4ffc00edef60c1db65b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-targets/default.nix
+++ b/distros/humble/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-targets";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "a0b015ffc727f3f40592652d4bdc8775c9307f384c8f67c4313c7166f0f7b848";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "de09468f1cefc323da78db6b471a8e37a917d97e4c363e6e08f0050a9c51e9c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gen-version-h/default.nix
+++ b/distros/humble/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gen-version-h";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4f23e60ac06c001613cd23f0126682f9dc41b4193196be9976ee1a2774527303";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "6cd5fd074e20543f7c664e1fb5c312155f62a4feab6414212508bb920c23972f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gmock/default.nix
+++ b/distros/humble/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gmock";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ecd7a9bf528a1ab8dff1f284582cb50028fc52cb5bfed0d8dac45cd272949554";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "3e1013d4e2a329caab9e95ec039a21892c7b3cc1864c99dde16fb44ef2c3ac94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-google-benchmark/default.nix
+++ b/distros/humble/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-google-benchmark";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "414b68dc1dd928fd607bff5a684802e45ff61d2939770a3cbdc3b4e0eadf5ade";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "61b5b8b77056d31d59cde313693e984f7a54e81f74ae14dc0fdd8752050aa991";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gtest/default.nix
+++ b/distros/humble/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gtest";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "b8ec12df57850dfa21dac8c499f8353d5b1e146f0aaed3e72efc352e2d12312d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "9af876628a98e92b7c99f395acb240569c7fcfb355a4d296de9b891deffd83da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-include-directories/default.nix
+++ b/distros/humble/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-include-directories";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "5c74caf585da70b6b1631cda5d428df1822bef1d72be2a9bd1a6915a45559535";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "2a8a02d0e87d592e82f57c1afa4b0db34cef61a3b1b445a6732ada760d7d695f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-libraries/default.nix
+++ b/distros/humble/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-libraries";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "0f178c27bfd3690970645d821ba5ec477f693af5745f4d463f0eb1b5cefa061a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "5ee16b3c66e2bb9f0a6595042107e909fdbc58333b459a65f93fabbeb9e5342a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-nose/default.nix
+++ b/distros/humble/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-nose";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "4775449157340a6c8a409168a7616a5392b644c0f8e2591291a2b22ef558906b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "4eeb0f9a6f03ea11f13384ef23f24061ac9fd04700591c419f2b564208ece065";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pytest/default.nix
+++ b/distros/humble/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pytest";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ca1d4d92d658cfb9839c6722dc32377f3b252d8a57a8a43518cd2f2e5e6b2331";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "5b749179a6dadadea2b56e1948146b2205fddccad356b3dcfee4a6a77590244b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-python/default.nix
+++ b/distros/humble/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-python";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "6eb57f32300687dbd6f2275eecd1d73eb560a9ddd4ad9a2413835bd7ed5ec817";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "08c19d5e6f9e803c0edde9bf1104132f7b681ccd2ec3be0878bf5ef40495669e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-target-dependencies/default.nix
+++ b/distros/humble/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-target-dependencies";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "c9cb852059541447cf0236bb9b7eb67ea99c20e5d7ac6b4ff534ff8927e66fb8";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "3227dc0bc47d106909b1893449bf7f6116d6ebd1a789d2a165e1fb197bbb45c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-test/default.nix
+++ b/distros/humble/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-test";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ad92d734d45284816388c208c2026ad5f6da07b8cc1beb0356f199065cef0e9b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "691dec8726fdb028e5c9268c874c309fb8be74231ccd10728357cc77e6340a12";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-version/default.nix
+++ b/distros/humble/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-version";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "ac17c1f2a0c4d19c8c9c49699b381c73ddac3e24362da359b860df259346a66c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "d22aa8e92bf5913635eab765dc471758a28be773455d71acf2f1a310fa885ccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake/default.nix
+++ b/distros/humble/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake";
-  version = "1.3.4-r2";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.4-2.tar.gz";
-    name = "1.3.4-2.tar.gz";
-    sha256 = "1684718b9e10922fd46685c1125e8c9e0ed849f69146e21bdeb5f3f50c8fffe3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "074073fadbe10a41872a61b828621ce1dbdf1735352f24dff7f5d851c5f2bdea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/behaviortree-cpp-v3/default.nix
+++ b/distros/humble/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, cppzmq, ncurses, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp-v3";
-  version = "3.8.3-r2";
+  version = "3.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/humble/behaviortree_cpp_v3/3.8.3-2.tar.gz";
-    name = "3.8.3-2.tar.gz";
-    sha256 = "d22a62b0ec049141348ea40707aae4a32b4140ffae4dafcf0a1276aa2f51f905";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/humble/behaviortree_cpp_v3/3.8.4-1.tar.gz";
+    name = "3.8.4-1.tar.gz";
+    sha256 = "70c51085c57641ce4a7362b6d8a2da2b043301fd8f87ffaeb9b1271d2a543b63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.2.1-r2";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.2.1-2.tar.gz";
-    name = "4.2.1-2.tar.gz";
-    sha256 = "76c17254be3312c9ce9789fc8bccd96e81fe387607ccdc9551e9e01a23c760bf";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "da2dc9ff566c4d49324c061afbbbc298feae12ee5fac51041d78cd3b54de32ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+buildRosPackage {
+  pname = "ros-humble-bicycle-steering-controller";
+  version = "2.23.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "55b3726c2ee334d8f6d97a15b5c4f6850c71b7d127ec22c2ee69f87e702c0864";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Steering controller with bicycle kinematics. Rear fixed wheel is powering the vehicle and front wheel is steering.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/catch-ros2/default.nix
+++ b/distros/humble/catch-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-catch-ros2";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/humble/catch_ros2/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "e4ba4a5cffee11ece9a94a1236303ec46de57921c3afb2e2902c354f519e86f5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp ros2launch std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Catch2 testing framework for ROS 2 unit and integration tests.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-config";
+  version = "0.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.2-2.tar.gz";
+    name = "0.0.2-2.tar.gz";
+    sha256 = "0ffea88361b6ccd2aab37d7e96fbee16ef6f3c81fd1447713a26f53dc6ca8a0a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+
+  meta = {
+    description = ''Clearpath Configuration YAML Parser and Writer'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/clearpath-msgs/default.nix
+++ b/distros/humble/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-msgs";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "e988c3fdb73dd7c36ee762efdb7c41dbdf3d939f14360e648e6af5aa73901f0c";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "a55f459d96d9ea0214420798560f041d3290068d5b395a68ce605b5b02f286dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-msgs/default.nix
+++ b/distros/humble/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-msgs";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "b964f9e2cf355e7544501398db83a2677971f9f27ad5c32c773b1dbc51a8eb02";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "f337f2741b91d275ba709cfe3becb53c933b18ff17cd3c2e06e4e8345ae4b551";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "a7b0a33b2b96aae75d86e102f92284a47aead4317450577068c3224ef5da8e9a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "07cc4db872fd4ef12efd80f3ed1092f37b39cf28aa6e62162fefeb163ed378f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "50c9c35a4ff17da33bb232ad998f0d57182f1e87ebed6764812c762b19cbe376";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "8a00c859d0442d56b96d80e70e9a9a6f97ee309598c2c29efe5bf02d8cf92da9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "aa7d4cff53e6f2954b047bf020c983ca3c284ed40ee0e2efe4856b2344dc5f37";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "3abfd322045c45ac0b66ba7f085ae8dc066dc8b12f4d090553f5bf1358c1d7c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "a4e0a015e38cc1e03281e098f4186bb910d9fa6700a6470a85e17771a14e0043";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "18283f67abbd248fdfb75fdb635280d733bfeeaee538290478e9941d74fe69fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "6294219501ddf69915a6d480866830ed43a71ae6f22e835d412b15dbacc5c5b7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "15294191d0b8d31562d94c7bc81e9abbcdaa0620c3b50495ef1316a387d2ff94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "f2fb40e7c6f7b9291cb2de360d926ab6018cc153428644cfca03978de9afcef5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "e267f01c35e48df9c32a904db6d1487c7979278ef98d42c2882353189a66c6ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "0073cb16e4e515322520320edbce8b6eec28cf1f45c7f2b426ed43cb9f0bf4c9";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "1665abd5a3803ec1eb16c24c2c13c1566dc1adbca430942bea99b2342779d8fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "13e03b26407a0e4e324b0f0bb07fae759a148d7e4dcc8f847f494c6fdf3b4b76";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "6fa5276652635d72eddd4eae5b35fddf82b177f1b12c12403d489de71ab5118e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  propagatedBuildInputs = [ cv-bridge image-transport message-filters opencv rclcpp rclcpp-components sensor-msgs vision-msgs ];
+  propagatedBuildInputs = [ cv-bridge image-transport message-filters opencv rclcpp rclcpp-components sensor-msgs vision-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "03ed66141519eed62e763d172365d5066eb1413dc654f42f2d731f5cb2786b24";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "aa1c888e0c6f8c044df7e5c281b74366a0e918de57bfcb7d946d4ac9e7728a9a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs image-pipeline image-transport image-transport-plugins rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs image-pipeline image-transport image-transport-plugins pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "b69a10c464c1f72ee94744bd60a8eefeecba1eccde5d488c07b1c6f63af008b0";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "d505201c868c9ed903fd9b4962ba677dcd230104a61ef57b989a29f2d8c0019c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "5f2967bfbf32b98fa569711e289c6c793747d79611b52524d2d6182641c4f5e8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "4b835ef958d73fc9b5a8ddd086a90718546faf9474c4a0fe71c6678bca226052";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.21.2-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.21.2-1.tar.gz";
-    name = "2.21.2-1.tar.gz";
-    sha256 = "ce54a47f2c1368566c091aa3b57dc1f954f380b7b611eb6788245e7a5ca7a20a";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "d180d4256989f5dc06091b018383b9d211e504681946aadb76dd97a0128850c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "f6424a4838b5227d4b085f641b829c9d7379e8367e7d2bf48c0bc2e6aadcc616";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "786dd56f2c6d3eec21a8b9af2628bce54eaf49a256339d8450a44b077e4e78f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "1e68f6b74190a50779e61788fac5d21b2b5fee9316edcd1dc49b5a9f4d61e7b2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "bcead1d719abea2400bdc6e73f23899ea0320a8dcf9c7084cde8dfd0b7f5e95b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "966a6218e09ddc7535a560437dfac57fa5e11f6448b20e328b2788e7907e1681";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "a5bc665e5d3fcb1bceb1dc3bea69639f9abc11c26ed760040a12342ed9e2bb5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "63d50a6c2917fb6148717dc8eab05483346249cf33eb4f301043e30c01f03ce1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "7501261e764859262248f186a4697dc709f05156364037e7187391b9f5398fa2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "7f4d289b90260149a9a221d149de3ea8d0d7fbd06323d07ccb9533b656636b9a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f493f82a2d10765c5f55022215a796c051721cfd34bff4df427d6adae35e2aa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "bfaca4ef78ded6ab44dc4f4e4572c7db6a097ed0d046dc1b14cf07d267f1de35";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "15531cb1ae22f434bc76078cc63c9defffd492d0748db28b0ddd341e15e1cdaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/executive-smach/default.nix
+++ b/distros/humble/executive-smach/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smach, smach-msgs, smach-ros }:
+buildRosPackage {
+  pname = "ros-humble-executive-smach";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/executive_smach/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "ed74573e430a6787791f593439fe7afbfdb813f8e221bd87e18e31aaf1ebd816";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smach smach-msgs smach-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This metapackage depends on the SMACH library and ROS SMACH integration
+    packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fastrtps";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "e9309a16a3df6e187f88dd605eb37bd7095a911b35cb2ec2cf49289c25e3cbee";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "98990243a4732532b1f1b08d86b836c002c2c5ba6747560638d19c20fad97fed";
   };
 
   buildType = "cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "43a728652d845202b2c17b0eadeef024f3b24746fdfb89e330efdfb937a667f7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "d0b9d3b4b518493aed96c73cb56dddf37f6737931f217e18818f6c59726fa3dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "53d5fc98b2ea11444ca9853c188790eda4a39f4110c327b6041f454678bdbff3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "e7edd61313415f610c952790d4ad260b75b6a5b8675309f99ee4250c5a2729f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "5c17d5046c188b0e37c1c82ca374b48602c6071f56ae52ec29546c06e2d3dbd9";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "a0dfd6817965671ab9effe95e9447904c42a70db26621fa5301d1b2d97d10ca5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -8,6 +8,8 @@ self: super: {
 
  ackermann-msgs = self.callPackage ./ackermann-msgs {};
 
+ ackermann-steering-controller = self.callPackage ./ackermann-steering-controller {};
+
  action-msgs = self.callPackage ./action-msgs {};
 
  action-tutorials-cpp = self.callPackage ./action-tutorials-cpp {};
@@ -246,6 +248,8 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bicycle-steering-controller = self.callPackage ./bicycle-steering-controller {};
+
  bno055 = self.callPackage ./bno055 {};
 
  bond = self.callPackage ./bond {};
@@ -280,9 +284,13 @@ self: super: {
 
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
+ catch-ros2 = self.callPackage ./catch-ros2 {};
+
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
 
  class-loader = self.callPackage ./class-loader {};
+
+ clearpath-config = self.callPackage ./clearpath-config {};
 
  clearpath-msgs = self.callPackage ./clearpath-msgs {};
 
@@ -531,6 +539,8 @@ self: super: {
  examples-rclpy-pointcloud-publisher = self.callPackage ./examples-rclpy-pointcloud-publisher {};
 
  examples-tf2-py = self.callPackage ./examples-tf2-py {};
+
+ executive-smach = self.callPackage ./executive-smach {};
 
  fastcdr = self.callPackage ./fastcdr {};
 
@@ -888,6 +898,8 @@ self: super: {
 
  lifecycle-py = self.callPackage ./lifecycle-py {};
 
+ lms1xx = self.callPackage ./lms1xx {};
+
  logging-demo = self.callPackage ./logging-demo {};
 
  lsc-ros2-driver = self.callPackage ./lsc-ros2-driver {};
@@ -1052,11 +1064,15 @@ self: super: {
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
+ mp2p-icp = self.callPackage ./mp2p-icp {};
+
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
 
  mrpt2 = self.callPackage ./mrpt2 {};
 
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
+
+ mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
@@ -1972,6 +1988,12 @@ self: super: {
 
  smacc2-msgs = self.callPackage ./smacc2-msgs {};
 
+ smach = self.callPackage ./smach {};
+
+ smach-msgs = self.callPackage ./smach-msgs {};
+
+ smach-ros = self.callPackage ./smach-ros {};
+
  smclib = self.callPackage ./smclib {};
 
  snowbot-operating-system = self.callPackage ./snowbot-operating-system {};
@@ -2013,6 +2035,8 @@ self: super: {
  std-msgs = self.callPackage ./std-msgs {};
 
  std-srvs = self.callPackage ./std-srvs {};
+
+ steering-controllers-library = self.callPackage ./steering-controllers-library {};
 
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
@@ -2167,6 +2191,8 @@ self: super: {
  transmission-interface = self.callPackage ./transmission-interface {};
 
  tricycle-controller = self.callPackage ./tricycle-controller {};
+
+ tricycle-steering-controller = self.callPackage ./tricycle-steering-controller {};
 
  turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
 

--- a/distros/humble/gps-msgs/default.nix
+++ b/distros/humble/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-gps-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "cd3d660531259fc2fda0fd880dfaa7a485b0fd30b5894067aacf5726cfc6a687";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "14dabb8fb5ce2767fcc68397be71f45cce3c8ca19a4dedb54316a15a6a29aff1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gps-tools/default.nix
+++ b/distros/humble/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-gps-tools";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_tools/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "0baacc6037ec3f497522c5040a58cd027b8e0856e0aa7bfb6c80a4d471bb4a68";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_tools/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "f60e2d6c7bd2a0e70355a1794fbfdea194f2a52578d1205ac969d9bd52c5a47d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gps-umd/default.nix
+++ b/distros/humble/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-humble-gps-umd";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_umd/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "07815c3cb3ff305bfe1433c88435e80b146ae297b8c1b388e3cc88a7ce9fa4f3";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_umd/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "150b520e8984fe3eb9b557f3d509ebeb32dda1f66c40752cfc02ca53c73c356a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gpsd-client/default.nix
+++ b/distros/humble/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-gpsd-client";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gpsd_client/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "ad291bf8cd7298ce6d6d8731b365331519fcd0ef495bac7e179a3c39e81d03bc";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gpsd_client/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "d72bfbd5eebb5cc792a02a97f30d0620d1f2fa3d91b5ce04b3884b6e2fe9f239";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "c5aa41428392872000b085e0c5a094617b5d42407a60f293dff8806143edea24";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "53eb03a3b958e18b6fdc3cb701191643001a066423fb5ebef2cd8028e77a1350";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "2bbea1df93fb7ac02c080d4260a627d4a1964554892acf31bd1fa88a99d75d30";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "83974755177a8089bb96e039c2b360a4084f4a3e5b0860aafb494825579d1fe8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hey5-description/default.nix
+++ b/distros/humble/hey5-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, xacro }:
 buildRosPackage {
   pname = "ros-humble-hey5-description";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/hey5_description-release/archive/release/humble/hey5_description/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "8aa1a9ddef46f5b3e25e4447ffec02cacedc89b1efe0f15a175945d131929846";
+    url = "https://github.com/pal-gbp/hey5_description-release/archive/release/humble/hey5_description/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "f859d7d8dd5808ca0a7694aa90658b1ece198c3573cc6bcae002897b88ae6439";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ignition-cmake2-vendor/default.nix
+++ b/distros/humble/ignition-cmake2-vendor/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/ignition_cmake2_vendor-release/archive/release/humble/ignition_cmake2_vendor/0.0.2-2.tar.gz";
     name = "0.0.2-2.tar.gz";
-    sha256 = "dcb1ce243048b84ce324cd1eacd6af6fc767d53068f2fa2fe472eb8e08cdbb8f";
+    sha256 = "9fffa5d0f4bd7ea0eea709e603b2f6dd30511ec21b514d4950775a365ad61a4e";
   };
 
   buildType = "cmake";

--- a/distros/humble/ignition-math6-vendor/default.nix
+++ b/distros/humble/ignition-math6-vendor/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/ignition_math6_vendor-release/archive/release/humble/ignition_math6_vendor/0.0.2-2.tar.gz";
     name = "0.0.2-2.tar.gz";
-    sha256 = "fec674061b7a8feda3bdadf48c9ce762ba2170b39660f9cb763da882425167be";
+    sha256 = "829ad291e00604ebe981322945ce10f2666e3886dc53048af053d52ad79fc239";
   };
 
   buildType = "cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "7fce08330f8b876bd77976a9835e98e01fd6f2c888c2c0165f3f8ed65670567b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "92e68499b85fcadf2fc9bd9f0800639c893fe4db5be0bfa8da262813ca43c8c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "2d3072d68db37fad10c1075c5e8acde3a24d42a4928dd566c5d3b34e9e968282";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "b57b477bcb6bda838554d1ffaed70e2621172c80cdcd32dba12b31be6a01abe8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "47732499ec84406a8ce9a1e10c6de9608bbe6ffa37767c0776d0a11121b476b6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "16a11c007f8af33982364326c42d53e7ce294f4711f65311d0b21b5a97fddb9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "362a6a43da462ea756fe7f4f7779084d66ba6565f696d58d7de03fc65bf39976";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "c7e44fb8a37de1209f7f13db75d241ffea500f23fb57948b4cc5340ff524ef61";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-pal/default.nix
+++ b/distros/humble/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-pal";
-  version = "0.0.7-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "764916d7432a0d4755a2708874439c0ae5da95e2301dbb56d5334d32f31e56b5";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "56c91e655cd1287d2437b6f5b094e7fac323c4b4fed148c6b25620b0bcba6d18";
   };
 
   buildType = "ament_python";

--- a/distros/humble/librealsense2/default.nix
+++ b/distros/humble/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-humble-librealsense2";
-  version = "2.51.1-r2";
+  version = "2.54.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/humble/librealsense2/2.51.1-2.tar.gz";
-    name = "2.51.1-2.tar.gz";
-    sha256 = "32dc72f786c742dd110357cda1d3fb8b60841a53fe63b3aba4d9560f025494c2";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/humble/librealsense2/2.54.1-1.tar.gz";
+    name = "2.54.1-1.tar.gz";
+    sha256 = "4d24c5f3e178071855f666eae87966fb7f1faa29bbc48710c5e3ee478ea4c0bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/lms1xx/default.nix
+++ b/distros/humble/lms1xx/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, laser-geometry, rclcpp, sensor-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-lms1xx";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/LMS1xx-release/archive/release/humble/lms1xx/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7fffa4273c75cd2865f6d3a55b1aeb1b46d7a45a01e38cd60f5f772ab180be95";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs laser-geometry rclcpp sensor-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The lms1xx package contains a basic ROS 2 driver for the SICK LMS1xx line of LIDARs.'';
+    license = with lib.licenses; [ "LGPL" ];
+  };
+}

--- a/distros/humble/magic-enum/default.nix
+++ b/distros/humble/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-humble-magic-enum";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "8bc9f5be024e0368c866b921990a201092bcb497da1e6c2cfcb3e4e9ab04db2c";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "a920be4a38da07d0c58348e6317e6caca9f38e09b2b5f894254704d8ef313773";
   };
 
   buildType = "cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mp2p-icp";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "3872b33c2ccc8e6555191e346f3c3c485dcad191aa15b2ffcce0761e7a670201";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt-path-planning/default.nix
+++ b/distros/humble/mrpt-path-planning/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
+buildRosPackage {
+  pname = "ros-humble-mrpt-path-planning";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/humble/mrpt_path_planning/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "494cf2bcd1c04772531d516e656a1b5a37eb460f0e69e3c5e8d0cbb6d1a572db";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 mvsim ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Path planning and navigation algorithms for robots/vehicles moving on planar environments. This library builds upon mrpt-nav and the theory behind PTGs to generate libraries of &quot;motion primitives&quot; for vehicles with arbitrary shape and realistic kinematics and dynamics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "3ab16a904e12dbac4a196351d4e3f6adb8073a9b190e300fc89da58b17d9508e";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "4640af4d93f3432220ece29b4473027242c3ffaec47c0cbe6313c18349e37f00";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "584e41ccf6da7fe4bd961e4373936e1836a814a3f8c2c4347f87828d06069cd8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "58ff5c33f5fc87457324c215669b1f66f273ea026837ddbd582c4ea35b58ff99";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "c5bbe22e31c0d1a84032f337238f51f78670c1e719f253e4cd10021be2b85723";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "0bcb864d5acdd03191795c4e4dbd70c7d3ab26c36698d3fd99ed1db5d0a9b166";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "f94470a3223aed663bce1d297883808c7e6c40bafda0fdb1a1db17f67d488416";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "12edb43d3f4da9123864248d63654487e40c0ae07322c5a3110e29fa6c8614eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "97f5c712629324fe6c780b23db6bdf54ea97e752db6a96a717f43c6983163995";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f3cf93144b7295c6f89169199580f552bd2c9d6a38829e84f1744fa2ec3e6d18";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "a592b7f70723f90271dae9982b0e84773285468bdf3d419f4a219b40e1c13bc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "b22cec9f161b1ea76a1d66ea3d69e8ba13533ebef7b432f510a4cc72525d73e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "2c1d53fc686eb7b5badeeb26750a0e758de23764f1f277dbd528b3143f11fb4e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c4f3323259fed44144cb5db6798ee766685026a01cdbe8f1f225a2fb8a6699ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "7ed8eefe3e1957233c4ca6c6bd532c9117f566aabf4e3fd1bd5c316cd8eb121c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "142aea73e3fa5a3955c882c2958a1bd1b03dd553d8d453ddcfe3c970285e1ca6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "de3e2f4e660049aa0ac788353bc1de414579b23d48ac8dda061a8bd7ac8fbfed";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "81719f709a06bae22de7f95d7f3c7902a32d3118edd545f9375c2f3d308a0324";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "b23c5abdab85d51251dc2fcd1a8457e7d3dc7514c738e530922ec7e332e0e072";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "d631beb5937a9822a7d36299fdd1548fdb2c8240551f51434038e53dc5d6a5ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "fa245483fd066e85ea270c630902cad9c8e785b5c17b45869ebf773afb970624";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "1cf7e74f87e78c72b7825bee1073f837bcc7b3f91f78b9f238d758048f95bb97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "42b20b018a9eaabb6136cc33fcbd8ae97bc267fa8b21ad36d0495532f341d929";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "7f691c6fe45846d9fa41374c717398b17f67d356e0c987843af2873e078670f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "18daa328ce085d261b5d2d37a19b07705ac781395f386803407886cc88e94c96";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "a5c97c0117862acada5b2c39b719fe54a514ac760b63b6aca5cf4c8b800d305d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "928fc6d80667fef05e242f2644bae3ecb9b51e842edf49fbc67e717ab1e244bc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "359810688bb6f5502b5fde55267d39e7d2d3287be5d0f34ef6464a270bd96b77";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "9259772e70601d3caceebd949e543a5745bd94a48e404fb4984903c6cac96fb9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "de633bc517bcffac84cddc5f60eba7c81072632209061e26670467ea05fca30f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "88e23d598b174e73b056642c286207cf74098d815fc5cb6311290f8ec2e1fca7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "80caeae46edf6669ff2e6005a3cbe4d512fd8a08c5c958d28ed5a8da39f3e72d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "c0e0edea75a4d3f8a48b1a8bd88edde527087305a39f64b89eb83d36b6faeedb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "55596a49aa322347b2d595db566acabc119c3126583aa75caa5afcf3dfde7744";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "618ce9bcd28edc5491057a1b9023d0e2c6754ab2d2321c6b9565cbeb3b3fab04";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c6e5194c08dedc65c0028008b18defe750503f063ab4ca19e0622a7c1c63998e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "5181e72757e7ba4a29d485bd0cc436b251d03b81d2145b37166ee7f5e022c06f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "9fb4ac4d69c89e050ba15a0ea7b4e905ba4c8846532d16411b70f89021c7769c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "9680c7eaa2acf8416ead193463c07f3d4629d5a502c572ed5cca44fcccb1c037";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "d289b425ce5f7bc1e3ea1405031c881a739506dc4a6dc9d534587aa9cc1c7d65";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "de89428c521ce6f5dce048e1ddeda45987b890211667b5513824b4aa300794ff";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "fe66aabdc36346956210eca8be2edd5be13f7147394844a8ed8247ea8ee8b9d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "763ccca607ff9beccb0cd6eb5156a3c789eca52be394e5b12391c73f7781cf60";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f9e839d1aa3d98ae0a178b9ac3d2b45d7ee3d9b15006bfb8cd445a2bbd84af50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "fb1540bf2df1b8677ae96c1e67824ba78ba32438b811213d5011e312cdb2d6c7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "da48e98fc4d7b82c5388cf8ec85cfe8ab5674b2f2cf14804d15aa05f888eccef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "6c458cb7db6ff15cdd5b687286cb06e22dcd18981d2dbf3901b0c0a49fb7ad93";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "27bf09aab1ceb475bdaa5bff9465b49889e5def79464a6cb676891c3fee7477d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "7138508c54fdf3864f7e38aa07b2de7c8419f7b227ee9452edc1beb00885045d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "b9b5be3401d94d992d5fad6a30dd2fa0db46b37407233b315182566d44ca96a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "dcf142b4c6e53759aba78d91356857181c090d82342c1c954bcc740207e07359";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c2595417b9b8f86a28fb7c50654bde157f36ed383a3ef8edc565fa53ebbef197";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "554dfbfb50eb9fa90e9b29ad55697a0cae649a8d934df1895e473d8199c48466";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "ea54a42aaa2a302e287b98e21ba3b16ab6543ea3b0beec5116089798fcf1d423";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "1a50b281910d6a1495b5922e97c6258341acec494e5cf4b217370c7995a145f8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "1a099a226353b2c03febe1ab961f5ab5d0eab605f1096e7d8af559684322eba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "fc8ddc3504d298c6a7bb556a6494b6e3646c245c2046053d132f304dde52ad34";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "207055653a32f7a387e5ba2314b055cd8846f378681c448d26569bcb60135a82";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "324686c47fc96cc5c30a7bf7906d3026ae185bc6b2962d60fd884bd79b891409";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "c638c153e1019d650fa5118cdb5a7d85634ecc6cf94bd73a30438e3ec5d2dde8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "e50d739397b0f7cafa169df4a93cfef927f76cc317ec7a707bce6c63b75ee467";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "35001662df8e6b42dba77f809aaa098a6bf6fdf3835a7a2ffcbb19b85a64912f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "42c80a8e88ce6a93efe227f0c536863dd4abd106965fae1aa8d96069451a9d31";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "f807622da572d2f9d76851ade481137a32fd4a0083ebf8451c8c00aa3f334102";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.7-r3";
+  version = "1.1.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.7-3.tar.gz";
-    name = "1.1.7-3.tar.gz";
-    sha256 = "655b9d33649f8e3fccfc511928dac18192fa6aadec9d404e1ee58b0509320e13";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.8-2.tar.gz";
+    name = "1.1.8-2.tar.gz";
+    sha256 = "9c7fed8b7567eca8f8aa8195897fd823b8dc3744a0f58bce8208a453e21f8668";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gazebo-plugins/default.nix
+++ b/distros/humble/pal-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, control-toolbox, gazebo-dev, gazebo-msgs, gazebo-ros, nav-msgs, rclcpp, std-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-gazebo-plugins";
-  version = "4.0.3-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gazebo_plugins-release/archive/release/humble/pal_gazebo_plugins/4.0.3-1.tar.gz";
-    name = "4.0.3-1.tar.gz";
-    sha256 = "7b77e714af46c96100155b65ad402187e0a74ee701739b2cafb5b11a3dbfbd13";
+    url = "https://github.com/pal-gbp/pal_gazebo_plugins-release/archive/release/humble/pal_gazebo_plugins/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "41184dde484b2150cef96dba6ae2cbdd185324a33f3f6309ca1425596ae01900";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-navigation-cfg-bringup, pmb2-laser-sensors, pmb2-maps, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-navigation-cfg-bringup, pmb2-laser-sensors, pmb2-maps, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-pmb2-2dnav";
-  version = "4.0.4-r1";
+  version = "4.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.0.4-1.tar.gz";
-    name = "4.0.4-1.tar.gz";
-    sha256 = "77f0dc20d31c291d8b36927d07bd5c01317e02deaeb04c75cdac0344f52c4085";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.0.5-1.tar.gz";
+    name = "4.0.5-1.tar.gz";
+    sha256 = "da71e318798796cfb10a747873a6b791a2f33383efc0881b7120000ad9eb70da";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ pal-navigation-cfg-bringup pmb2-laser-sensors pmb2-maps rviz2 ];
+  propagatedBuildInputs = [ pal-navigation-cfg-bringup pmb2-laser-sensors pmb2-maps ros2launch rviz2 ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-pmb2-bringup";
-  version = "5.0.4-r1";
+  version = "5.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.0.4-1.tar.gz";
-    name = "5.0.4-1.tar.gz";
-    sha256 = "087cb3eb70cf665ee150c70e6c28968b3c4048b44f88c2b4e0734982d202733b";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.0.6-1.tar.gz";
+    name = "5.0.6-1.tar.gz";
+    sha256 = "294c3369472af42c530e188299691e9704989a0f21e74449b9ca6fc2a40a3a0c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ joy-teleop launch-pal pmb2-controller-configuration pmb2-description robot-state-publisher twist-mux ];
+  propagatedBuildInputs = [ geometry-msgs joy joy-teleop launch-pal pmb2-controller-configuration pmb2-description robot-state-publisher twist-mux ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, joint-state-broadcaster }:
 buildRosPackage {
   pname = "ros-humble-pmb2-controller-configuration";
-  version = "5.0.4-r1";
+  version = "5.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.0.4-1.tar.gz";
-    name = "5.0.4-1.tar.gz";
-    sha256 = "cc14f0313652266b30b4054b8381c57173ec36f40b10e5e71815f780688dc810";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.0.6-1.tar.gz";
+    name = "5.0.6-1.tar.gz";
+    sha256 = "bf2e3984671de8e4408844b3f6de76f2e75a3355219c335cfdfa6cc52b0c07f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pmb2-controller-configuration, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pmb2-description";
-  version = "5.0.4-r1";
+  version = "5.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.0.4-1.tar.gz";
-    name = "5.0.4-1.tar.gz";
-    sha256 = "d0f61cb69df7082566f852b8b377957e89e0080b4d23274caed80cf64a57ab08";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.0.6-1.tar.gz";
+    name = "5.0.6-1.tar.gz";
+    sha256 = "a214ace78e35ef51ef0166576307d1c322bc494ce8a94ce4bc82ec30ae48b80b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-gazebo/default.nix
+++ b/distros/humble/pmb2-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, pal-gazebo-plugins, pal-gazebo-worlds, pmb2-2dnav, pmb2-bringup, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-gazebo";
-  version = "4.0.3-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.0.3-1.tar.gz";
-    name = "4.0.3-1.tar.gz";
-    sha256 = "e0ee89999c93d74499f4c6af3a5813ae6a6b09cdd3233e282aba8b1f7404201b";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "d126ded63b5049ede90256ef78755bdc20e0ad6d3581de3cf51930a591c132f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-laser-sensors/default.nix
+++ b/distros/humble/pmb2-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, laser-filters }:
 buildRosPackage {
   pname = "ros-humble-pmb2-laser-sensors";
-  version = "4.0.4-r1";
+  version = "4.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.0.4-1.tar.gz";
-    name = "4.0.4-1.tar.gz";
-    sha256 = "18cc3463363cc01b4b82f066e011ad10bb28899fc514857894a2f6c4403d499b";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.0.5-1.tar.gz";
+    name = "4.0.5-1.tar.gz";
+    sha256 = "43c9ac1afab30b76c5b7afcf62694206d40e7990071518d9ad7c233abea85ed4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-maps/default.nix
+++ b/distros/humble/pmb2-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto }:
 buildRosPackage {
   pname = "ros-humble-pmb2-maps";
-  version = "4.0.4-r1";
+  version = "4.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_maps/4.0.4-1.tar.gz";
-    name = "4.0.4-1.tar.gz";
-    sha256 = "06c72511123f0b348eee99939f7fe8f7c7aaa963fb0bf2f949e73487ef73f784";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_maps/4.0.5-1.tar.gz";
+    name = "4.0.5-1.tar.gz";
+    sha256 = "de4d3426a261719cf7907702c9e4ceb8028bf5e1809b3a0d840a8096a81a1c31";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-laser-sensors, pmb2-maps }:
 buildRosPackage {
   pname = "ros-humble-pmb2-navigation";
-  version = "4.0.4-r1";
+  version = "4.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.0.4-1.tar.gz";
-    name = "4.0.4-1.tar.gz";
-    sha256 = "300b2e0b0ce4ed979ee436b119e654971459a8e3bec950a1df5d68efb722835a";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.0.5-1.tar.gz";
+    name = "4.0.5-1.tar.gz";
+    sha256 = "0fa5dd5b0111f852661e4e888bceeaacf0803e14e1beb645ec78dfd6aea3dbc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-robot";
-  version = "5.0.4-r1";
+  version = "5.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.0.4-1.tar.gz";
-    name = "5.0.4-1.tar.gz";
-    sha256 = "f76c8a3950fca8ad1bf5bf01d292dfde1c1721eed130ff461a67ddb81732ed35";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.0.6-1.tar.gz";
+    name = "5.0.6-1.tar.gz";
+    sha256 = "431db6f1995764b222bc736c8b4969581b77daf69343d23ffca9af2ae31b0602";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-simulation/default.nix
+++ b/distros/humble/pmb2-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-humble-pmb2-simulation";
-  version = "4.0.3-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.0.3-1.tar.gz";
-    name = "4.0.3-1.tar.gz";
-    sha256 = "90bffdfaa2003359542ac7e91b75595603129349830343eca1ef5e4b62188107";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "e444b21a10adef8b37d7e9885ee05cc28dcdd4fb62d591f72df63b34aac3fd86";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "d48f54e3626660e28168e1be8cf2c85391554ffd25733d04d583a8b2a7731135";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "84bf703ad51ff3b356f29631c6168d5365ec582353aafd16762e96da84e9525c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rc-reason-clients/default.nix
+++ b/distros/humble/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "25c88f019eacb627209b4e2acb8111b288f6f42f285b0abeb5330094e1befb9b";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "e97e9b874214e57645119ce0f6e83d78a281c21ea09a7d62cf06ec7b4c94963c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rc-reason-msgs/default.nix
+++ b/distros/humble/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "527d7ed3342ba3e54af4c763030e1683e31efc74b6b4205ef3a57e7e2d06db54";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "ae2db8d62dfec093c4d27b6ae935054694ba3c8be9d8b85346a2e93e245d9a3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realsense2-camera-msgs/default.nix
+++ b/distros/humble/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-realsense2-camera-msgs";
-  version = "4.51.1-r1";
+  version = "4.54.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/humble/realsense2_camera_msgs/4.51.1-1.tar.gz";
-    name = "4.51.1-1.tar.gz";
-    sha256 = "0a1b7df957dd5d3ea827c9233cf2dfbd779818c318cf26ea31f6adb60fcfee9c";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/humble/realsense2_camera_msgs/4.54.1-1.tar.gz";
+    name = "4.54.1-1.tar.gz";
+    sha256 = "01c0724574c3a63eb2ffe38404ab3c1bf13cc52c84930ee1837368da8e7b4a4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realsense2-camera/default.nix
+++ b/distros/humble/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-realsense2-camera";
-  version = "4.51.1-r1";
+  version = "4.54.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/humble/realsense2_camera/4.51.1-1.tar.gz";
-    name = "4.51.1-1.tar.gz";
-    sha256 = "0c85f59e0775a70bf9377a16efc5271eb8e072999bd8eddad169764b11b54fe6";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/humble/realsense2_camera/4.54.1-1.tar.gz";
+    name = "4.54.1-1.tar.gz";
+    sha256 = "af5f50b45b2b81145525ca8766415bfd46979d9748f98279eec1816de5b98024";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''RealSense camera package allowing access to Intel T265 Tracking module and SR300 and D400 3D cameras'';
+    description = ''RealSense camera package allowing access to Intel SR300 and D400 3D cameras'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/realsense2-description/default.nix
+++ b/distros/humble/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-realsense2-description";
-  version = "4.51.1-r1";
+  version = "4.54.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/humble/realsense2_description/4.51.1-1.tar.gz";
-    name = "4.51.1-1.tar.gz";
-    sha256 = "0c12eac0d6f965692471c1e273e9b6f376139216e21350d5d4ee0924614aec11";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/humble/realsense2_description/4.54.1-1.tar.gz";
+    name = "4.54.1-1.tar.gz";
+    sha256 = "78a48dab04d066fc81121b9c6199e3c3ce640bc75cc43b6090f5d494027f0907";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-api-msgs/default.nix
+++ b/distros/humble/rmf-api-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nlohmann_json, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-rmf-api-msgs";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/humble/rmf_api_msgs/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "81e1980a8869f42e676a032a80a462261c6fa4a9a4d5848b268074046081831e";
+    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/humble/rmf_api_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "6f7f218d3d21e84c9dec3135a00cb00fd8b38287bdafed384bc16f1546c12a93";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-building-sim-common/default.nix
+++ b/distros/humble/rmf-building-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, menge-vendor, rclcpp, rmf-building-map-msgs, rmf-door-msgs, rmf-lift-msgs }:
 buildRosPackage {
   pname = "ros-humble-rmf-building-sim-common";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_building_sim_common/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "cdf032549d3685e54782502cf6554a197b55dc75bf12ba3bc1ea638965ad84e2";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_building_sim_common/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "af451714e3df62bf511b05b9062c9a66a42ef19bacc64092b2a170211354cd94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-building-sim-gz-classic-plugins/default.nix
+++ b/distros/humble/rmf-building-sim-gz-classic-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-ros, menge-vendor, opencv, qt5, rclcpp, rmf-building-sim-common, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-humble-rmf-building-sim-gz-classic-plugins";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_building_sim_gz_classic_plugins/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "1a840d25ae1c311935c10de3c4ccfc59d52f5d92f20ce864f2da94de9abc7263";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_building_sim_gz_classic_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "cbaeba1ab34cd9991ca0929d04918cd9b20ac61125994e25f801af4a48f53239";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-robot-sim-common/default.nix
+++ b/distros/humble/rmf-robot-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rmf-robot-sim-common";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_robot_sim_common/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "9d06c69bb95398efe2e780be362ca9666425f77c0df1a5c9ac5c3d7bc2afeb11";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_robot_sim_common/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "de007b765498e45909a94d0c087e9dfd6ac756f4e93dc13b4bbce5024d674ddf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-robot-sim-gz-classic-plugins/default.nix
+++ b/distros/humble/rmf-robot-sim-gz-classic-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, gazebo-dev, gazebo-ros, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-robot-sim-common }:
 buildRosPackage {
   pname = "ros-humble-rmf-robot-sim-gz-classic-plugins";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_robot_sim_gz_classic_plugins/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "9508f6fd6646dff5afbfb96561c64f8f50c797966b788f8b1d03af4c28d230d4";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/humble/rmf_robot_sim_gz_classic_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "dc326a5d317f6ae89c0d25d1480fa4fb630c591d7ce745a17f18860b2c465db7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-task-sequence/default.nix
+++ b/distros/humble/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-humble-rmf-task-sequence";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task_sequence/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "e42c9cc7556981201fd2cfd57903f8a78e7881f44eef20562283f7d4d8b0549c";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task_sequence/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "1a519e80ea68c495673c704e076c40c28d2a8c4f2fb23b7d6941142aee386f24";
   };
 
   buildType = "cmake";

--- a/distros/humble/rmf-task/default.nix
+++ b/distros/humble/rmf-task/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-humble-rmf-task";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "58e7502df97eaf7c620d4ebd1d5e9fb9c04beca4dc88783aabc9a3fbe6e7d206";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "83c4cc097590d96c971310ff791249cf4ea694348eec2e78fde90184589518db";
   };
 
   buildType = "cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "ab297c74ce0e29177ee83f933f157c0ac1841ee60d3a7c99d7e2682f4943e504";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "f73c098314ae8ff0320ccafa1b3342f3785824e21d84ea8d5462fd20c1cb7e2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "6a9fc3db4fbc95648d184ce29dbc16612454166c27e9467622c574fbefd23c65";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "7b8662588e38c406e62304ca0a46afdc2e0a2dacc01381bfa7d4549785214556";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "657cdcf12d1f86a2b39e8ba8cbce8847445e069f1ed66b2208c9099af41ed304";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "4a671f30edb2cb51950bf8c7bd3ce759d3085f6691773bb08fe81257e401343e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, admittance-controller, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, tricycle-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "3ba2ac9d99eece88958c725e5d9a6314c38f3c2854483966cd98852d40464f26";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "f0f56d4d39a4866b433682311c9bdfba6ecd4db376ae27594442c67d3f6321fe";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ admittance-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers tricycle-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "fee5221ee2323ee58e52b58a0b98e27d410868fdecd2c14b29d7f4a2a383af8a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "fdaec55876c597ea5bed59f5ec3461c4dcf3aba4011d72a3523308eb66fc1dfe";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "37b0b3303f75045d312f02404efc777482b1f55f1bc2a5b47266ca73f4b18cf9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "20da3c66cb00ac10aa7a380bb25dfde0743246a1b95b7fcd520348c9ef5a9ea9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "bdcf62b403caabdde6afab9c80fc4f1ceace04aef3c60ec25fbf4dea5e3671a3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "b218af48461504d1cfc0b725e44917b4a77e7770567d46caee0a74c9a5009f42";
   };
 
   buildType = "ament_python";

--- a/distros/humble/smach-msgs/default.nix
+++ b/distros/humble/smach-msgs/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-smach-msgs";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "56f4cc3cc198df6341701c04c5009f5d81af7a3a1f7ab7fcc6ef2576c98f569b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-lint ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
+
+  meta = {
+    description = ''this package contains a set of messages that are used by the introspection
+    interfaces for smach.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/smach-ros/default.nix
+++ b/distros/humble/smach-ros/default.nix
@@ -1,0 +1,32 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, rclpy, smach, smach-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-smach-ros";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach_ros/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "5157e7204f95d37717d00ad3ca6f000863ecf719038614742923b941f19bd3be";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ rclpy smach smach-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The smach_ros package contains extensions for the SMACH library to
+    integrate it tightly with ROS.  For example, SMACH-ROS can call
+    ROS services, listen to ROS topics, and integrate
+    with <a href="http://www.ros.org/wiki/actionlib">actionlib</a>
+    both as a client, and a provider of action servers.  SMACH is a
+    new library that takes advantage of very old concepts in order to
+    quickly create robust robot behavior with maintainable and modular
+    code.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/smach/default.nix
+++ b/distros/humble/smach/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
+buildRosPackage {
+  pname = "ros-humble-smach";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "e39a503e4a6643716010ac47539bf8a6af86172ff5e0ce6b3556c6903f064fe5";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''SMACH is a task-level architecture for rapidly creating complex robot
+    behavior. At its core, SMACH is a ROS-independent Python library to build
+    hierarchical state machines. SMACH is a new library that takes advantage of
+    very old concepts in order to quickly create robust robot behavior with
+    maintainable and modular code.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-humble-steering-controllers-library";
+  version = "2.23.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "5f6cf93e53322fa66db3299aaa4235cda0b4e8fcd31a4b8ac338101d32d8b664";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for steering robot configurations including odometry and interfaces.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.26.0-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.26.0-1.tar.gz";
-    name = "2.26.0-1.tar.gz";
-    sha256 = "d9c60fb295278b1aec5f3f4b9afbc04457ea90400e52a19289c15263b655f4f6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "4a557766261a633ff5b0e281835c138145599f109fe5c050035a8586eff86fbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "4bbf26b3e7775f31226332bb5c0c2e0c8b343da59f95a3a426e86570666e7f82";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "af511fa747531dea1ce67b0e7840acf3343c81daf5d3d989fd29554dbfd8d0d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+buildRosPackage {
+  pname = "ros-humble-tricycle-steering-controller";
+  version = "2.23.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "b57b95ee5d5cd517c403ad3239167da0171c8983df98283c7cf1e40a5d1ed528";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Steering controller with tricycle kinematics. Rear fixed wheels are powering the vehicle and front wheel is steering.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/turtlesim/default.nix
+++ b/distros/humble/turtlesim/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.4.2-1.tar.gz";
     name = "1.4.2-1.tar.gz";
-    sha256 = "e259c12d06533fe5943d8b5c5606cb215d2b2cfb309e0aaae263f51f5147d6f3";
+    sha256 = "4790460ab3745e6f64057c0a1fc334348d7b55ed9905cb36a4143a177e1ea73a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tuw-airskin-msgs/default.nix
+++ b/distros/humble/tuw-airskin-msgs/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-tuw-airskin-msgs";
-  version = "0.0.15-r3";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_airskin_msgs/0.0.15-3.tar.gz";
-    name = "0.0.15-3.tar.gz";
-    sha256 = "d057a9181bb7291727636765d2f9cd8bc779b7281a84845190e99b24d5c44323";
+    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_airskin_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3968b52429fcf7d4ec3b1382b763efa23bd2ebcb3ade2725f378675f4a903b7e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/tuw-geometry-msgs/default.nix
+++ b/distros/humble/tuw-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-tuw-geometry-msgs";
-  version = "0.0.15-r3";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_geometry_msgs/0.0.15-3.tar.gz";
-    name = "0.0.15-3.tar.gz";
-    sha256 = "f6ccd98b7fcb5d13736ecdd73443478c3c7f146bd01b1521f3c9f1a165e617cd";
+    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_geometry_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "e5e5a6c445324fd17d884172890d4b95390d9f939c211529c49c5b71e7cd21df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tuw-geometry/default.nix
+++ b/distros/humble/tuw-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, opencv, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-tuw-geometry";
-  version = "0.0.9-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_geometry-release/archive/release/humble/tuw_geometry/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "58c3a98dc01f60051845b3da4f0909d6d59e17d3c9f475a080a982bbbac0f573";
+    url = "https://github.com/tuw-robotics/tuw_geometry-release/archive/release/humble/tuw_geometry/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "ead05b67d7d43c49d5bcfef73f5db67b4a81389db907feef1c64670d231e6faa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tuw-msgs/default.nix
+++ b/distros/humble/tuw-msgs/default.nix
@@ -2,19 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, tuw-airskin-msgs, tuw-geometry-msgs, tuw-multi-robot-msgs, tuw-nav-msgs, tuw-object-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, tuw-airskin-msgs, tuw-geometry-msgs, tuw-multi-robot-msgs, tuw-nav-msgs, tuw-object-msgs }:
 buildRosPackage {
   pname = "ros-humble-tuw-msgs";
-  version = "0.0.15-r3";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_msgs/0.0.15-3.tar.gz";
-    name = "0.0.15-3.tar.gz";
-    sha256 = "cb781c588bee83c19659879008785dad042bc3748c02d5fa145627f1a61a3539";
+    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "bc9a6396972d8ed7e10f4860a1f3ca3bf2ff7d5383e8d8f396f97f4ab1afc1e5";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ tuw-airskin-msgs tuw-geometry-msgs tuw-multi-robot-msgs tuw-nav-msgs tuw-object-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''The tuw_msgs meta package'';

--- a/distros/humble/tuw-multi-robot-msgs/default.nix
+++ b/distros/humble/tuw-multi-robot-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-tuw-multi-robot-msgs";
-  version = "0.0.15-r3";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_multi_robot_msgs/0.0.15-3.tar.gz";
-    name = "0.0.15-3.tar.gz";
-    sha256 = "117967978245241c618918cdb22c2563d2a4e201a4b54d6660a1bc265fd4765d";
+    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_multi_robot_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "8311ced2fd509760f887f3e7e4ad34081dd9c90c94e7780ffadb16a68de6efe1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/humble/tuw-nav-msgs/default.nix
+++ b/distros/humble/tuw-nav-msgs/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, tuw-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-tuw-nav-msgs";
-  version = "0.0.15-r3";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_nav_msgs/0.0.15-3.tar.gz";
-    name = "0.0.15-3.tar.gz";
-    sha256 = "097a436221df31971082e8427680686e7444461b2d97e3bfa929bac05f8f08bc";
+    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_nav_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "fdd695739c4bc35dd17c377b029b725adcfa99ba64354903d7681386d661beb0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs nav-msgs rosidl-default-runtime std-msgs tuw-geometry-msgs ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs nav-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/tuw-object-msgs/default.nix
+++ b/distros/humble/tuw-object-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-tuw-object-msgs";
-  version = "0.0.15-r3";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_object_msgs/0.0.15-3.tar.gz";
-    name = "0.0.15-3.tar.gz";
-    sha256 = "cf66f79dde719ec67d57e452135ca40929fd195a03da515f5cac81372ed527d3";
+    url = "https://github.com/tuw-robotics/tuw_msgs-release/archive/release/humble/tuw_object_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "80c41a288eda7ab1a3a16f7b55b42d1c92b815b07d4f3d785a30f37a1a807ee8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.2.7-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.7-1.tar.gz";
-    name = "2.2.7-1.tar.gz";
-    sha256 = "d8c6746a43f0b7569c929ea5da5ace1819db54336c55565261a7771897682c63";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "988eecb90062c67d645ef7ae518e6b87f415f0144fd6a447d311c2f61a42438e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.2.7-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.7-1.tar.gz";
-    name = "2.2.7-1.tar.gz";
-    sha256 = "a9b1fe06ed7b1514f9f709fd3f0ccd63e1f5e47d2a72430a5ae759f2c7b9cf80";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "dc152ff94cb45a07de35c6152b90638d526a53d658412def7291b9d0646d4a76";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.2.7-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.7-1.tar.gz";
-    name = "2.2.7-1.tar.gz";
-    sha256 = "1210d7825b3e4725b29a1fcf123834078dfd360eaf2885a4be1fc31b113cb381";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "9a4e65b1a18713714c433b30abe8429af2ccd50c8fe37b9e081ad973569c5e66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.2.7-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.7-1.tar.gz";
-    name = "2.2.7-1.tar.gz";
-    sha256 = "0b67990d7ed18be6292bd888e28f636904d4628282713c84a2465c588ff87b84";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "1dc640590b63bb9605094f17ed2c42b200da046cf2710b5defe8f2546a888282";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.2.7-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.7-1.tar.gz";
-    name = "2.2.7-1.tar.gz";
-    sha256 = "8dff96dadb21d87fe117a4afc67dffc153c734af7d54898145745fd29a0584f2";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "eb21f652aaec1444c69cd5567d9553cc09cba13f106b2dc9d316287902a7e4ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.2.7-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.7-1.tar.gz";
-    name = "2.2.7-1.tar.gz";
-    sha256 = "c974074ae3cb5b6a9a495294fb7f877adcce3c144bc37ac79d5bbd20ec294331";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "3bcdd234269809ce00921e120fb1ef97d232bab87c231237c1cc7d78dd84017f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.21.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.21.0-1.tar.gz";
-    name = "2.21.0-1.tar.gz";
-    sha256 = "7155adc3c9a50be800d07929339c54bfc282a60e8f53a0b012412035afceed16";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "9220d2e9f6649faff7b7e05d5ea129bd5840afeb2c3e31665193f40ff4d556fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-control/default.nix
+++ b/distros/humble/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-control";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "4dc26d93060ce3d7a7d25fe9b47f120e0eff25bd97cf27f3af21bebd0a62b1a2";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "1fcb4e7322b05963d91b82805cf2dc34bf1f29ff93a89b606e2a3c79d2fc5485";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "9a6093901c3d9e6c732c58f8bf6e33f62c4a1055b3ec0d73eb3ff589041aa3e6";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "468ae5c37a29d383a7720d4c5e5487e7eecf83dbf7cb43f07201a57f2d1a1ddd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-epuck/default.nix
+++ b/distros/humble/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-epuck";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "b46aa664652aed05bc2b519968a6c8e0ce1b6c2725d01c143ce8a16fe403cf59";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "4e589260f766f55c302ea7c4400934dc0b0172bb322fd538994d0e417106c4a4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-importer/default.nix
+++ b/distros/humble/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-importer";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "c701c0f3fe4c9f7c212cd93eb9081bddca9226850a563727f87b527d1f346b6b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "0f895821e7721306a8c457875c1ebb44d4c67cd1e7a5795c0c75e71fd70fb957";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-mavic/default.nix
+++ b/distros/humble/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-mavic";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "3f67ff97b7bf6be02b5032dad932ec6678e40877bea6c1f169a38dc209ddd74b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "fded8c6253e91d113399807f8c8f0966eb7619b10f886afb2c43a3fcbd9b3154";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-msgs/default.nix
+++ b/distros/humble/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-msgs";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "2f416e93a6f882e2833f23827eb23e6975f7f0a813a766b57126f5aaace6c56c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "9c10e7a9752f026ed2235d468e95e073918bdca1699b1e202a52a270754db1a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tesla";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "b180eebb17bc5c524f91e6a5da68c5d0e35123f2c5cf8cc20ec71767c02591d7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "ce798cdb9413534595f2e0be54bf295019115ac2daa12c1bc66c8732671f1ceb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tests/default.nix
+++ b/distros/humble/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tests";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "bda389d7ccf5eb11379f5594bfc55bafaeb8a4f201a26ac67df546c89835948b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "51f04558081b37c04f483751eef96612b472cd79a1fccf3fe5fce015536f0c09";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tiago/default.nix
+++ b/distros/humble/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tiago";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "2e792ccf934859c795d8f948b0271c0ccf425c5e7735617e96afcbfc3d1f438b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "01681a6041d9f849624aa73cf46ddd0987f369c6e7baca6708c5813a31795e50";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-turtlebot/default.nix
+++ b/distros/humble/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-turtlebot";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "4ab67a1d655e64b9fb0b73875211dbda463291fdd3757faa25d3b6257df39f3c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "2949faadc1977caceb5e6a439bfe2fd0f223f244ed1cbfbdc6cf39feb8e41818";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-universal-robot/default.nix
+++ b/distros/humble/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-universal-robot";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "7d433a2a298ef55ad554c620975314357f7eace9c62850e05074b3795d97fc68";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "5480a809ef5396e9982482259e502784773b9f8ad72904427e3cff359a7fe266";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2/default.nix
+++ b/distros/humble/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "4aefad1b8108a72c5d8f890c4ed74d878324957a76b6333aca923527e490d370";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "71bb94e9a768b98c9776d211426bcc7941aa29e84d12c526698bce489475dfea";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "1d54cfbddf204e5fcd4abcd72b7e05518056ceca5b955d2ccf220b5b030a9b72";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "c9c1a07b05beb286b454215e700c00c749fdd572a6432559723d1a85d37068c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "cea075f97157286252fe5093158b34c0ce47544c929d1eb3621aa61cd0a037c9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "c6665573698d6952f997242afc896fd986eb5b2cb9207328343f300febddad61";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-auto/default.nix
+++ b/distros/iron/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-auto";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "24c1bae12124e08c64ba25e146dee3d194b7b79e524e6a070976bcfaf1159161";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f2412dd4cecdbe9d1a1f10bd11c4a0691faeac16d4fd70cdafeebce744c501b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-core/default.nix
+++ b/distros/iron/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-core";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "64f95de3cd815e18155000eea34a30b8d0ddd4dfeb9cc1713c7b5f94a24e201c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "7a9de8482aff77d0194a52364d7e97540af85edefac22e88bda5dbd3b1111bb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-definitions/default.nix
+++ b/distros/iron/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-definitions";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "ba4644adc79a1a6326a6d8fb1647274cad241e2892db9d5db119751c21da5aaf";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "282d5de031937b5282f4783042742fa6ba12d20da006736746c62fca3dbc359f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-dependencies/default.nix
+++ b/distros/iron/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-dependencies";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "1f235975badec9554027c37f27ba9ec36ef15734ffed5dff60f3837a771cd940";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2e81dfdd5df113ee47f3b2d127821b507ac006407999317d5fe338903c5e1269";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-include-directories/default.nix
+++ b/distros/iron/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-include-directories";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "0927eb469d0653bdab7d5660c0fbd04c9c0223daee19a13faac98eb293c92161";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a1db6ecae340f695e58641ec537cf673712c47965ea84b96acda3468d3c7a007";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-interfaces/default.nix
+++ b/distros/iron/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-interfaces";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "df37e085d38bc9ba219d58a4381a325ec786d0bb8c4a48f21da574599a7aee03";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "08a5c80213905983de9cf7d8325332837c36617d935d667c1d3fdc2b3e4125be";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-libraries/default.nix
+++ b/distros/iron/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-libraries";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "4c5c3043d26630dbbfd87cf052816f7e4097da5deb25da1e3a851a158b7cf388";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "b8a391cd7d8e9e4dd6f6b3b9c4348cd32543ce27997d4be0701182dfbb990446";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-link-flags/default.nix
+++ b/distros/iron/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-link-flags";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "b24f450af63160de6f9cd2be6a23dd953cf4f3069d7d4edce7b7f6b5725e92b6";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "baf68dcb21a84e3ed209b92f8674b4df3f36b4c33aefd3443b859bba6617638d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-targets/default.nix
+++ b/distros/iron/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-targets";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "c479aa7d0ee82398be4760f6ba0a08ad9f14d2d326efaeb6f12f9f324cbebaf0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "91710a34ca5865df1ce8151e4f46167b86081577d4ea2158399f0502ffada859";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gen-version-h/default.nix
+++ b/distros/iron/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gen-version-h";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "ea58b00c7d467436406c571449e75b369b3b704c091eca994ea151b0be68a553";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f947b05e180a613609d58702fad526c7d4e1d76b6c165cb61c80437472ba252e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gmock/default.nix
+++ b/distros/iron/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gmock";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "b260b7a7381ee10000ab9ed0134884bcee6735d9d3b59c406b72cb3bcce9ed15";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "4aa77161e81a4378eaaa73c203825d9fafda11cf13466657b7d967c160746d15";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-google-benchmark/default.nix
+++ b/distros/iron/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-google-benchmark";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "acaa4dc6692a5e0838071cf1abb9d2781b93b6bec765f989c34d8a6beea5d36f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "8ac453a1aa03cc3b095286d0f0d3ae3da8750c68f280a27fafccfbeebb50c0ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gtest/default.nix
+++ b/distros/iron/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gtest";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "d03d1fd2f2e9a0dc6a4f4a4eee8df2b3179255856b1caff5cb3a1677ad7a96d0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a713c488c550f795b972d357a574bf7470044d29f53d1b6b56f2efa7cc270771";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-include-directories/default.nix
+++ b/distros/iron/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-include-directories";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "3fd61da12f68459012ffca1fb6bb66f24005092a0875214e7dbe60ff6d36aaf3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "fc1844dd5cc25b47a8cf789578dace16fdf6d5e83c8b53315ff7739fc308d3cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-libraries/default.nix
+++ b/distros/iron/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-libraries";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "0dc30dbc9ebbdf412888e9dc190471ec2d7488f5c68ff46e7b6603680bbf604d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "08b9475583e805630930e7d46fa6d25ff79022b658bb75f48c94c1571f9af304";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pytest/default.nix
+++ b/distros/iron/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pytest";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "3bc71fc8b1340e6425d50b526516b2172c2e701199ed2ff4913e1ed1928883b9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "6d5c99756c9d212b62bb63bbfecb51a9b7b3025819a4b626d874063b11395d59";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-python/default.nix
+++ b/distros/iron/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-python";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "1c84ead3f131d363eaf95b76a2b548b8858c3025ca4d5301ff4e04a9ee84e88e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5e8d912a66e82b4f56a9b23995d98574f6c02ba4ca62a8e082ce9284cddc168d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-target-dependencies/default.nix
+++ b/distros/iron/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-target-dependencies";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "e89d106d6437e5219dad37dfccefb8cb0a834c1f3d237de121893b35d3818597";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f26815d7d79bd0e8d9999ec879b80f90115ec72b64ed73899afd213c2f27d572";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-test/default.nix
+++ b/distros/iron/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-test";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "c819c30ebbfc12a6cbf2b0bbdaf545febfc6c36132e1fb588a9eb3cf219afc15";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ee30a27078e3448e72be82f2d91d956277a0f1410212f7fafa8074c116b368a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-version/default.nix
+++ b/distros/iron/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-version";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "e1ef13a54fa80209049696f07227cabb1c82bee4323046e0435fef5ad955fc2c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "04fb4886abdd06619c2da88bfcc37b7790739f89181b062c4dae17211df09388";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake/default.nix
+++ b/distros/iron/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake";
-  version = "2.0.2-r2";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "d1231e41bdd97bee78bab5d6c1f86096aa667b35910aaf08b84e6599b1e2825d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ddae13dce739f826668ee72cf092c396211037d8e2cd22cda9e343bcb4006ccf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/behaviortree-cpp-v3/default.nix
+++ b/distros/iron/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, cppzmq, ncurses, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp-v3";
-  version = "3.8.3-r5";
+  version = "3.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/iron/behaviortree_cpp_v3/3.8.3-5.tar.gz";
-    name = "3.8.3-5.tar.gz";
-    sha256 = "63077541ba24e15ea5f3e6bf259ad09c89dd6688e982338ef07974bb5ddd1a1e";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/iron/behaviortree_cpp_v3/3.8.4-1.tar.gz";
+    name = "3.8.4-1.tar.gz";
+    sha256 = "f7f6c031e931c0e7d0d03dc3d1dcadbe7ed7ae03ffa55c6f881caf2d4ebe1ee8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.2.1-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "9fef0b37e34517f052f2283c30c6813697dd35ef3d6451af4fe3eb44eab05a33";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "b43e6d852ca344290d1c333a6038d5fa5ac94911be219164562f03170a88d60c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "10e08bc991b0e0a0062eb81394e61d4dfb476cbc1063881377736c1f6792c2ab";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "03b32e84c58ee486cf9ba8862b92c47b6913de518ceafd32da1a6077b33309fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/catch-ros2/default.nix
+++ b/distros/iron/catch-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
+buildRosPackage {
+  pname = "ros-iron-catch-ros2";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/iron/catch_ros2/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "64d4f6f2970b47a7be4872cf5b7ebd3d5c25572545fb80c10d7d6f9a0c54467e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp ros2launch std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Catch2 testing framework for ROS 2 unit and integration tests.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "19f57a7a97b6a591736b102aa723ae7424732bf241e079f0a12dc148451b61bf";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "9e8e9a0140839d4c81d221f617c36717a79ae5cb703581b18fbdf9bfe5836bf0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "326861295391f5002efc8944e8e6b7a0ce16e1d8a4268ad7c62d2e0c4dcaff82";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "77d794e34b9a4b94bde7d8a6fb4652e73235a9018bc291cb13cf888ed1fe0777";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "131b1c5f38d1a9b8fa89aa0614bcb48556947557f512134e27e4a9413dad12eb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "3978068b12da19e33086f35276011e1c1885b0ac8f6c52fcf6d3ee240c69d5af";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/iron/depthai-bridge/default.nix
+++ b/distros/iron/depthai-bridge/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-iron-depthai-bridge";
+  version = "2.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "51151ff829029b0c95268d8d7d69d521bf2cfeb83f9d321f389c192ac8e46839";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ boost camera-info-manager cv-bridge depthai depthai-ros-msgs image-transport opencv rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs vision-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The depthai_bridge package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/depthai-descriptions/default.nix
+++ b/distros/iron/depthai-descriptions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-iron-depthai-descriptions";
+  version = "2.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "cce712ba28452cbf1545d37a8bd184cfaeab23ddeda949d3266fca06c2ab65ba";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The depthai_descriptions package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/depthai-examples/default.nix
+++ b/distros/iron/depthai-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-iron-depthai-examples";
+  version = "2.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "50de152f3bd11e4f27c95ab128547f9157fb2e12a1d30fd5ebc82789f676ad55";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depth-image-proc depthai depthai-bridge depthai-descriptions depthai-ros-msgs foxglove-msgs image-transport opencv rclcpp robot-state-publisher ros-environment rviz-imu-plugin sensor-msgs std-msgs stereo-msgs vision-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The depthai_examples package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/depthai-filters/default.nix
+++ b/distros/iron/depthai-filters/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-iron-depthai-filters";
+  version = "2.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "d417b3017f25107f4c2e4364169c80b249726fa8047a04f7c0c0dc55cb5a2b70";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  propagatedBuildInputs = [ cv-bridge image-transport message-filters opencv rclcpp rclcpp-components sensor-msgs vision-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''Depthai filters package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/depthai-ros-driver/default.nix
+++ b/distros/iron/depthai-ros-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+buildRosPackage {
+  pname = "ros-iron-depthai-ros-driver";
+  version = "2.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "816239e760be7aac51243d42f4851234bb5ad30f6d418469302412c54d2cfebd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs image-pipeline image-transport image-transport-plugins pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Depthai ROS Monolithic node.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/depthai-ros-msgs/default.nix
+++ b/distros/iron/depthai-ros-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
+buildRosPackage {
+  pname = "ros-iron-depthai-ros-msgs";
+  version = "2.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "46b2fab39083631eef909bd302b7d360646466fad5fffbd045fed07109c3f5c3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclcpp rosidl-default-generators sensor-msgs std-msgs vision-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package to keep interface independent of the driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/depthai-ros/default.nix
+++ b/distros/iron/depthai-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
+buildRosPackage {
+  pname = "ros-iron-depthai-ros";
+  version = "2.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "e5c1f3699f4ddf3f6e062bfd27c38386f5c906ec2a57f32a95196a707ea23fb8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-driver depthai-ros-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The depthai-ros package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/depthai/default.nix
+++ b/distros/iron/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-depthai";
-  version = "2.21.2-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.21.2-1.tar.gz";
-    name = "2.21.2-1.tar.gz";
-    sha256 = "9c665686be6a7214434e186b337a7f3efefdf6e42b731e0231755f8d456a210b";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "ab355885dad8c0908d0735bd9f42c41d9b645408964792f3fe68b113414fa345";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "863ce3462946c85ab0cd5e03f050ae2c1838e8c94c0ec16043f7eaeaca0e6f12";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "cb06fd3d2ace4281e32c9b38730dd791bc2e4b6bac3c6737d2a5251be74af9df";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "0a564a264986439188f266eb9f8ff4ebf39c28cc5d949da0b201f6dd5aaaa137";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "5a2f95a9e497179a23d48040e10e4347e14bb459af7d83471bb6a9dfc97932b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/executive-smach/default.nix
+++ b/distros/iron/executive-smach/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, smach, smach-msgs, smach-ros }:
+buildRosPackage {
+  pname = "ros-iron-executive-smach";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/executive_smach/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "53be40cbe0c92234be7d271daeb2a49384defdc0ea648c103801aecd2d001bb2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ smach smach-msgs smach-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This metapackage depends on the SMACH library and ROS SMACH integration
+    packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "7cbec91c76068745945822e4e7f205a4319e655b328138543e1f89fcc52e4593";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "0232439ad174ea6f4730911b889f77212be59cc9749dd3d9e4a19601173c1a10";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "2f337dfbdd743de1c4b58adfe1b60588cb8a530c143234923f6b3667c35db271";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "5004cb8b81550b3b199839f6c91478e4e26960258780f6882d4db545ece72b24";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/foxglove-bridge/default.nix
+++ b/distros/iron/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "b2d705766a7fef5cab173d3bdd962bb6236eea1783ed6c6f9314f314ac08d42d";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "f0d3eb2e22dfa76635bc2389357ec7f80b492035b600e744de7cf6b3c423aa1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -102,8 +102,6 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
- ament-cmake-vendor-package = self.callPackage ./ament-cmake-vendor-package {};
-
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
@@ -224,6 +222,8 @@ self: super: {
 
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
+ catch-ros2 = self.callPackage ./catch-ros2 {};
+
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
 
  class-loader = self.callPackage ./class-loader {};
@@ -273,6 +273,20 @@ self: super: {
  depth-image-proc = self.callPackage ./depth-image-proc {};
 
  depthai = self.callPackage ./depthai {};
+
+ depthai-ros = self.callPackage ./depthai-ros {};
+
+ depthai-bridge = self.callPackage ./depthai-bridge {};
+
+ depthai-descriptions = self.callPackage ./depthai-descriptions {};
+
+ depthai-examples = self.callPackage ./depthai-examples {};
+
+ depthai-filters = self.callPackage ./depthai-filters {};
+
+ depthai-ros-driver = self.callPackage ./depthai-ros-driver {};
+
+ depthai-ros-msgs = self.callPackage ./depthai-ros-msgs {};
 
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
@@ -461,6 +475,8 @@ self: super: {
  examples-rclpy-pointcloud-publisher = self.callPackage ./examples-rclpy-pointcloud-publisher {};
 
  examples-tf2-py = self.callPackage ./examples-tf2-py {};
+
+ executive-smach = self.callPackage ./executive-smach {};
 
  fastcdr = self.callPackage ./fastcdr {};
 
@@ -768,6 +784,8 @@ self: super: {
 
  libpointmatcher = self.callPackage ./libpointmatcher {};
 
+ librealsense2 = self.callPackage ./librealsense2 {};
+
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
 
  libyaml-vendor = self.callPackage ./libyaml-vendor {};
@@ -932,11 +950,15 @@ self: super: {
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
+ mp2p-icp = self.callPackage ./mp2p-icp {};
+
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
 
  mrpt2 = self.callPackage ./mrpt2 {};
 
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
+
+ mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
@@ -1279,6 +1301,12 @@ self: super: {
  rcss3d-nao = self.callPackage ./rcss3d-nao {};
 
  rcutils = self.callPackage ./rcutils {};
+
+ realsense2-camera = self.callPackage ./realsense2-camera {};
+
+ realsense2-camera-msgs = self.callPackage ./realsense2-camera-msgs {};
+
+ realsense2-description = self.callPackage ./realsense2-description {};
 
  realtime-tools = self.callPackage ./realtime-tools {};
 
@@ -1737,6 +1765,12 @@ self: super: {
  smacc2 = self.callPackage ./smacc2 {};
 
  smacc2-msgs = self.callPackage ./smacc2-msgs {};
+
+ smach = self.callPackage ./smach {};
+
+ smach-msgs = self.callPackage ./smach-msgs {};
+
+ smach-ros = self.callPackage ./smach-ros {};
 
  smclib = self.callPackage ./smclib {};
 

--- a/distros/iron/gps-msgs/default.nix
+++ b/distros/iron/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-gps-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gps_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "e9e293659d62ba04a4df6dd0fd0557ed4176a0cbbe97c3504869f7a6cf56ba39";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gps_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "f59e0d1b6e8238e9bd45160312663a5334db79da1c4ea9b4274d96a6a12f326b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gps-tools/default.nix
+++ b/distros/iron/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-gps-tools";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gps_tools/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "36b00bab97e0405714a70f5f482f59358722382340b077d9cbcea704e28ee273";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gps_tools/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "c837f605ccf287af58f56a53018a6ddc156e016427e5b92e32f355000acf093a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gps-umd/default.nix
+++ b/distros/iron/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-iron-gps-umd";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gps_umd/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "14aec0db052d9817a25e61b7889e614f9ee5088ba650ea02eef64bb2a76d89a6";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gps_umd/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "464d4fe5ef19d530e1f77bde0fd1d8fc1caeca0837cbd258f7f6309240805d64";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gpsd-client/default.nix
+++ b/distros/iron/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-gpsd-client";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gpsd_client/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "d66aa0e61a811a5a84f1bc41e9b40aec50b1fff70339572876fbaa016d446e46";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/iron/gpsd_client/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "3c0aefa30110d2e99721dd75bfc6ecd6df033a7c8944512177130f5ebe70d990";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "1baaa69687ddd9a2dd694d9a846da998d6eafc82277044874a89e7fea914bdaf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "4f23a7312150fd4f0f13d061facdb042cc8bb24c2e741a42cc14590726d2015e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "25d537ca8a0c965f90e782797a3f73036593b5291ff65f39029e0612dfc6746f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "26a075adfdf5baa61d0e615888a53333585f075d2b0cc6c91bd389e7bf8d53f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "166babc7cfab397ccff7b7170e5a0ccc9b2a12560c8048d55550a0a033c7aaa7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "67f3b4ab410af3d1b4f425cc1ee2c00bf30078750df7de94dba27b1e3b4efd4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "4b74966369e0fd6d808edc46a2ec28821c653bff500fce4b54b971f856a1e234";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "ca5aa2ef604943871ed6d68de8a7380ff940e7f1a6f56ec3dba4864f073248a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "af199dcfe1f9e22ced01021a96240a1fc3a3b3216ee21f23e1b0c39dce22fe50";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "b0bdc7b2ebe9adeb63f09e399245b2b40f906de55acf4ddb1ad831b04e295e36";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "cf4c97c1b022fc2c5acc6a3c2d0c3759f36dada797e916490ed348b427775a95";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "8da6a7453057c32e2953ae37e2bb750f897e400deb306dc49f5a88c8b5121675";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/librealsense2/default.nix
+++ b/distros/iron/librealsense2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
+buildRosPackage {
+  pname = "ros-iron-librealsense2";
+  version = "2.54.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/iron/librealsense2/2.54.1-2.tar.gz";
+    name = "2.54.1-2.tar.gz";
+    sha256 = "eb4d2acfece2cc2f579507fd6718f0e40fab95574cb0c45e3cf61ca60ad8cb37";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake libusb1 openssl pkg-config udev ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Library for controlling and capturing data from the Intel(R) RealSense(TM) D400 devices.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/magic-enum/default.nix
+++ b/distros/iron/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-iron-magic-enum";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/iron/magic_enum/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "803e25e0160c5cc0b2823d93e3cfd86f5e871b1e40dd48aa524af883676bee0e";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/iron/magic_enum/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "91a8fe99d1630ad43ddc7e7c10fcf46df22a96c6124786ed5f2c164cf9c483cb";
   };
 
   buildType = "cmake";

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mp2p-icp";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "608efb4608578efc6e40df089c27d578c5fecd6e9149ce57539919ac40402a5c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mrpt-path-planning/default.nix
+++ b/distros/iron/mrpt-path-planning/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
+buildRosPackage {
+  pname = "ros-iron-mrpt-path-planning";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/iron/mrpt_path_planning/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "894431be27b5c6f0b240413eef280e0312bf560abc545e2b28789d51b7b16c37";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 mvsim ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Path planning and navigation algorithms for robots/vehicles moving on planar environments. This library builds upon mrpt-nav and the theory behind PTGs to generate libraries of &quot;motion primitives&quot; for vehicles with arbitrary shape and realistic kinematics and dynamics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "492d4a46e15c44a9f954d2c7a5175e82e4b98e61ea486c20b5f1703d9fe67f7f";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "8c1cf5ea034235fdf1e8ed900e87f41f64a9f5375cadaf0d44eb0fde2f96f28c";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "b6d35e54f35a74b13f2b3278bf5e2319920427151c452cce750c66f2636f56e8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "e92c4f2723fae802510ae91d575369ab710e976182089475dd4f9208771e5d18";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rc-reason-clients/default.nix
+++ b/distros/iron/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1c9bae15eaf94702c2ae23e4d32611d5028e4770d41051b5e5121782757fd72e";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6d4db486918945f395bd95cfdbbf655bfc33597f7610a31b1daa23d730876a02";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rc-reason-msgs/default.nix
+++ b/distros/iron/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "bc33f63c0c28ec03bc4c402f56388c2a73df87c128a2b097242710988dc67ecd";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/iron/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "30d1720b6732b245d578ca35d16626262ddccba29362554aee42606c0863592e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc-examples/default.nix
+++ b/distros/iron/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc-examples";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_examples/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "b1fc6db030cae1d15084a570a94239bb8ca4c0b3bc9cb0a7cfb0aade0367270f";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_examples/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "5050ea3a6bb86bf1219b8b9ed1a50cc19014242bceac4215bb4a7704de894439";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc-lifecycle/default.nix
+++ b/distros/iron/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc-lifecycle";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_lifecycle/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "84bf07cb5d904d7920a72d283979eb493127621210e136e954501cee4050e692";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_lifecycle/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "0e29084b4dea7b7a00177466b5f7e74bcd938892ff1d9cada26876c3f9cf67cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc-parameter/default.nix
+++ b/distros/iron/rclc-parameter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc-parameter";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_parameter/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "5256b396bf6ad6aad508908a2eaae4d2b0b30d632cf35f4600421c17cdc80071";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc_parameter/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "a381dabd2d9d9c51ced210b3453de03364a7d4413051338dc61cb01e65540f7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclc/default.nix
+++ b/distros/iron/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcl-action, rclcpp, rclcpp-action, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclc";
-  version = "3.0.9-r3";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc/3.0.9-3.tar.gz";
-    name = "3.0.9-3.tar.gz";
-    sha256 = "71f0a4e7882ec2fbf68724f96103e467d77db040a394c8e145948d65c1b263bb";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/iron/rclc/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "a1fb3fda135580c3701685ba46180989cc20b99ec5a39f84eb84e7f0f14dea77";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/realsense2-camera-msgs/default.nix
+++ b/distros/iron/realsense2-camera-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-realsense2-camera-msgs";
+  version = "4.54.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/iron/realsense2_camera_msgs/4.54.1-1.tar.gz";
+    name = "4.54.1-1.tar.gz";
+    sha256 = "9f3344779a624ebc086a63f25d11ed231bf7cb6373ebaf8ddc210b7e1b41cb9a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''RealSense camera_msgs package containing realsense camera messages definitions'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/realsense2-camera/default.nix
+++ b/distros/iron/realsense2-camera/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-iron-realsense2-camera";
+  version = "4.54.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/iron/realsense2_camera/4.54.1-1.tar.gz";
+    name = "4.54.1-1.tar.gz";
+    sha256 = "c3931ec9de32992bbed32ed680c54ca9e5ec67ccb026b24d89264c74bd3205ac";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge diagnostic-updater eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense camera package allowing access to Intel SR300 and D400 3D cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/realsense2-description/default.nix
+++ b/distros/iron/realsense2-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-iron-realsense2-description";
+  version = "4.54.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/iron/realsense2_description/4.54.1-1.tar.gz";
+    name = "4.54.1-1.tar.gz";
+    sha256 = "18c06546d35406b65747ec04d856847189eb48a8cb54ed33cc39e8be8c18aa01";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch-ros rclcpp rclcpp-components realsense2-camera-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense description package for Intel 3D D400 cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/rmf-api-msgs/default.nix
+++ b/distros/iron/rmf-api-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nlohmann_json, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-rmf-api-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/iron/rmf_api_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "dd8b281518bba80b949778ceef472bb748d3c3d6c0af5b9a7e175b3d37bacc56";
+    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/iron/rmf_api_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "93b37e0bdc3dd6ad469018b95ce6092daa50ca30760f86ff2ce8cd2ebf003c49";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-building-sim-common/default.nix
+++ b/distros/iron/rmf-building-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, menge-vendor, rclcpp, rmf-building-map-msgs, rmf-door-msgs, rmf-lift-msgs }:
 buildRosPackage {
   pname = "ros-iron-rmf-building-sim-common";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_building_sim_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "3b41ffa7a3f4cdfa6248de2c449546463b69cb0b4725bc21d088e08b60c9fc6c";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_building_sim_common/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "9ece7eeab6996cc58d7babf2a9d5b9bdd1e16a3a984c079a44d15f67426426d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-building-sim-gz-classic-plugins/default.nix
+++ b/distros/iron/rmf-building-sim-gz-classic-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-ros, menge-vendor, opencv, qt5, rclcpp, rmf-building-sim-common, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-iron-rmf-building-sim-gz-classic-plugins";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_building_sim_gz_classic_plugins/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "68ce33d1f0dcc9689dad630d357f48f344427601cf2945fe9ac750ff885e171d";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_building_sim_gz_classic_plugins/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d7357a21c6e8d04a0056701ef562608dd46379dcf0249c562f7c2bfe55357ed6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-robot-sim-common/default.nix
+++ b/distros/iron/rmf-robot-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rmf-robot-sim-common";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_robot_sim_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6be279473793066dcb10d03b2a433baf88751e05376cc70573af3ba14d0693f1";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_robot_sim_common/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "2cb012169d9268632138939550a98147baf5d1ffd54c01ff81c979a213f27cb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-robot-sim-gz-classic-plugins/default.nix
+++ b/distros/iron/rmf-robot-sim-gz-classic-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, gazebo-dev, gazebo-ros, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-robot-sim-common }:
 buildRosPackage {
   pname = "ros-iron-rmf-robot-sim-gz-classic-plugins";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_robot_sim_gz_classic_plugins/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "9868f0a1ac8bdebf8ed3297f285d93cea5ca0fb7b9e58ce45193a7d059121eb8";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/iron/rmf_robot_sim_gz_classic_plugins/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "41ed98c346cc0e3154c4ec6845adb5e8ec6a9db8f5579e289af183be7b51d076";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-task-sequence/default.nix
+++ b/distros/iron/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-iron-rmf-task-sequence";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task_sequence/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4b1c7c9961e6432e720cd82ddc89279f378471cc86324809dc7c3a1f2cf60faf";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task_sequence/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "43fc6c646910664d69e9b97cffe034760b8d2288142d3aafd63a6ac15f9f41db";
   };
 
   buildType = "cmake";

--- a/distros/iron/rmf-task/default.nix
+++ b/distros/iron/rmf-task/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-iron-rmf-task";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "9bf347341eda956abf373548c70503e6ab883b1a19a83a51de85505b354cfb11";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "68c66032b5891a4a5095ea5630ce78133523122fd1b299bb9c65097b90560123";
   };
 
   buildType = "cmake";

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "30b0f4f8a279c2cce514c11402f5bece91aadcc9d625d93c5f12e7af8792ad4e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "6cd2108e3bffbbdf8fe2b2dfc09ac5a7ef6e285e2910fa89682fae231fd8c9c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "935ec95b2f1f0df5e1c5d176afc67b5f40ac8c878fc19cae87040a3f19547240";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "fef1e4c8ddbaa92fa3fadf9464607ce8be3d8b26136dea6def41ab0e57898d25";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "e6b7086cd446af017d889aeaf760143d1b54aed4facec35d5b93217c497f73e3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "ddfdefd53f57a422a98756a40066a6818b161c18fd12d4f7f41369e65513b6cc";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "6c448105001d6b2f182beb5f583baaf33163ac990909a2cc601ab780cc245d70";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "92d2c6bebfcdcb57560acdea51d487c541fb30fd1b5a0eadd384bafd223d1a40";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "93a3c2f96989f6110c0698f71de2340c0d45ebb36eedc7ba96cc3ed3fce03499";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "e2ebb80d0437ac352807b17b09cbe2c84b1310cfca5204f046cc698d9dab808a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "28d1e604e0bd429034a8a7496cf9e16ec2bb38a89c1315084cf0cc69c7b0aa7c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "1286a8380d1d8f0b3f8c9e3840cb7d1f37988c1d03eb0ad3c1af84a3ba4fe3bc";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "c0e10794f0a7cc3febf8219b85bc9b7f915f9e585369fd53b33cce5c35634271";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "60f742b2b4dde4b20c2036143f062b949d2b679bd060dc30008da7ef8b90d097";
   };
 
   buildType = "ament_python";

--- a/distros/iron/smach-msgs/default.nix
+++ b/distros/iron/smach-msgs/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-smach-msgs";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "2cfbc6adb4a978bf436485a2090228139df76c9554414d09f583d2c43acc6592";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-lint ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
+
+  meta = {
+    description = ''this package contains a set of messages that are used by the introspection
+    interfaces for smach.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/smach-ros/default.nix
+++ b/distros/iron/smach-ros/default.nix
@@ -1,0 +1,32 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, rclpy, smach, smach-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-iron-smach-ros";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach_ros/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "48553ee2114560ed7db4276bb3f5783ef829bcd73b85e25a2f3640d5c9b3aa45";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ rclpy smach smach-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The smach_ros package contains extensions for the SMACH library to
+    integrate it tightly with ROS.  For example, SMACH-ROS can call
+    ROS services, listen to ROS topics, and integrate
+    with <a href="http://www.ros.org/wiki/actionlib">actionlib</a>
+    both as a client, and a provider of action servers.  SMACH is a
+    new library that takes advantage of very old concepts in order to
+    quickly create robust robot behavior with maintainable and modular
+    code.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/smach/default.nix
+++ b/distros/iron/smach/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
+buildRosPackage {
+  pname = "ros-iron-smach";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "2ac4779cea397c8c461519e82f44b270fe15109b7cbc5147626aa399f14d0e4b";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''SMACH is a task-level architecture for rapidly creating complex robot
+    behavior. At its core, SMACH is a ROS-independent Python library to build
+    hierarchical state machines. SMACH is a new library that takes advantage of
+    very old concepts in order to quickly create robust robot behavior with
+    maintainable and modular code.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "f02fe8bc1bfe9010465ef194caf3682f1c638c98850db864b26f9416a4b11dcc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "13b7be475253c2eeb077e9549fd053e936a1e5b7a6bc4229ead78190b96b9d20";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.12.1-r2";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.12.1-2.tar.gz";
-    name = "3.12.1-2.tar.gz";
-    sha256 = "352bd2ae788f0ce90745b78c4ace947026519c3fd0d895190e8a89cbc57d57a4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "f78ef1a6b66e5e9d26cdded475b4641f90f3eddf728d46883c7f61ef6cd31cbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "1142fae7da10e71ee0351de7959bfbae67d9a89a9a6b9f1f25b0b3c41f658421";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "4d6bfed1e72386db1b0e7585c451e1cafe47c0900c48ef7208b9e07f7309eb02";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "e2911ada958fb4dbc29f8230b0f3ea0ea38e5774bda846cdcd7a72af892fe64b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "1adf27f1e9b2d6ca981bfb06098021030a4c119c9f57b3aa0b73f89a30a8aeb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "74c2bc3177e34c372f75934e44afc431a8d653c4b9719523a4641e98afbf558f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "932f78fd0f87ea3e2798845ba5610c3ea7413934411b859ab3c9a1db2261d65f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-control/default.nix
+++ b/distros/iron/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-control";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_control/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "a906485ef3c5dd7d79b40eb11bcab1c34c7ca25c761f4f9dd123810c5b5ffa88";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_control/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "be92fe4cbbacf3c5d490e409b4e08befc7d0f4c595062806bb2e8ef1a7913617";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-driver/default.nix
+++ b/distros/iron/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-driver";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_driver/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "4fea019166323367289833e0019b5e0e31befadbc4358fffe97eb79ffba2fc86";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_driver/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "794ccb84dbc422e8f7b70298d8bd7657c956db9915d3afc9d30628adbd8495bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-epuck/default.nix
+++ b/distros/iron/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-epuck";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_epuck/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "571aefdcb07a8eea37ca1faae4411dcb59532f94c84fdec14e56563050f41f6a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_epuck/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "238efdff393c82e7a218bd967c09b09096eb23aec994f852ae46da2d41f36615";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-importer/default.nix
+++ b/distros/iron/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-importer";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_importer/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "c35a3c52ae1f32ee5ad078348b3c2d86706faca623ae77b575fb3224a4c507ac";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_importer/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "ebffb825db1b4b53418d70c0f5c770c4afb8c6b927aab01f8a7aa22dadca8760";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-mavic/default.nix
+++ b/distros/iron/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-mavic";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_mavic/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "eeef5a6c5e797cd372b2cd01abed9959cf3bbbb587065fca69ad8879d7d4039c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_mavic/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "7029f0dd11e934039230e384c5ca29e54ee53dd249395c436d0c4cde2fdc513c";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-msgs/default.nix
+++ b/distros/iron/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-msgs";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_msgs/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "9d2f30ada23b0a922c7395d16c2b6f0d5cafc8c5988f10f56967cf2786541f91";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_msgs/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "5327a4137eae6037fda2a9d23af3767417dec5005a45776a49b3f28b4841da31";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-tesla/default.nix
+++ b/distros/iron/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tesla";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tesla/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "7b96fb3e5fe622f4d7f6fcfd806204aa97ef85d379ea5f1e6ca3a9162cba6313";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tesla/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "e5dfc070b336689f9a6407fa7a6f646611ba7ff6f1f0680c938be423e760013f";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-tests/default.nix
+++ b/distros/iron/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tests";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tests/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "8a9bb605292398b3d3c38f08dc17c39ac40e99220fab70d3ddf03078bdc1fed0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tests/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "66d49bdc13f401aec75c739bff179dce12df6d5477815b76c6829750eddcc13d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-tiago/default.nix
+++ b/distros/iron/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tiago";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tiago/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "025ba0885688bdf30679f9bf48740e36b6cd4abeb3dacd322dba563e71009059";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tiago/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "25f81cda79cc4f6f0e7d2291b842940b8fefd749faec91cbf256ba7afebeb733";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-turtlebot/default.nix
+++ b/distros/iron/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-turtlebot";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_turtlebot/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "9ef6030b8754d23fbf2b2f7945615c6a6eb272880f35ac3b68c76ab9e9c7157d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_turtlebot/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "208e029775e3bb5d222379809b463cbf74e7d75468d262713050d66716ce2930";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-universal-robot/default.nix
+++ b/distros/iron/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-universal-robot";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_universal_robot/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "26425cc57af4174ade292425bd493111e9b0c6e17fe0bba71a55ff424df899eb";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_universal_robot/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "f6a7c51ff74d5ad24786c61af42b4c0200d403ae27e48058bb2e9c05690a2fc4";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2/default.nix
+++ b/distros/iron/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "4e60edd328bcd36c45fd0e4cf60b5042deff2ee1260e5a411defb1cc36bee224";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "60f97e2d0151be1ad00be60c827c0896f301965ae9362ef1e604d50f7151e494";
   };
 
   buildType = "ament_python";

--- a/distros/melodic/costmap-cspace-rviz-plugins/default.nix
+++ b/distros/melodic/costmap-cspace-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, qt5, roscpp, roslint, rviz }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/costmap_cspace_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "bcd73822b9dd77d03b425ddad5918adea6d64ac3e9b7bbe8f4605ef9048af760";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/costmap_cspace_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "71d6175db707daf9106b869a957398f1da44c549dbaa6ac3a8d734c7b2332991";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cras-imu-tools/default.nix
+++ b/distros/melodic/cras-imu-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, geometry-msgs, nav-msgs, nodelet, sensor-msgs, std-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-melodic-cras-imu-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_imu_tools/-/archive/release/melodic/cras_imu_tools/1.0.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "9b817cebe3bb0d2d3b3a982edab8497eedb9a4f8f19c91120480c5fc2f510e0f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common geometry-msgs nav-msgs nodelet sensor-msgs std-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with IMU data'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/cras-laser-geometry/default.nix
+++ b/distros/melodic/cras-laser-geometry/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, laser-geometry, nodelet, roscpp, sensor-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-cras-laser-geometry";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry/-/archive/release/melodic/cras_laser_geometry/1.1.2-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "282c97c2aa1f7c560f53765196a35d02ec77fa7225101d3fa939480a54c5e5b6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common laser-geometry nodelet roscpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with laser scans.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/executive-smach/default.nix
+++ b/distros/melodic/executive-smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-executive-smach";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/executive_smach/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "5266563dc0f5888791fbf077127b3bb5539550c93496a103a4b0f3e1bafef697";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/executive_smach/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c6f4e3dca18e632c85fc175bb016e8c6998fcea02bd6000b3d41c00e29b13a74";
   };
 
   buildType = "catkin";

--- a/distros/melodic/foxglove-bridge/default.nix
+++ b/distros/melodic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-melodic-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "1a976d0d6a364bb4b51f7c9f71fa5aa0e96088949fda5c6cd91cc35907aabd4c";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/melodic/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "6ac0ef80b230832983e291973fe147328072cf658798d0eddf7441c75a88b0d7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -618,6 +618,10 @@ self: super: {
 
  cpu-temperature-diagnostics = self.callPackage ./cpu-temperature-diagnostics {};
 
+ cras-imu-tools = self.callPackage ./cras-imu-tools {};
+
+ cras-laser-geometry = self.callPackage ./cras-laser-geometry {};
+
  create-bringup = self.callPackage ./create-bringup {};
 
  create-description = self.callPackage ./create-description {};
@@ -2859,6 +2863,8 @@ self: super: {
  pluginlib = self.callPackage ./pluginlib {};
 
  pluginlib-tutorials = self.callPackage ./pluginlib-tutorials {};
+
+ point-cloud-color = self.callPackage ./point-cloud-color {};
 
  point-cloud-publisher-tutorial = self.callPackage ./point-cloud-publisher-tutorial {};
 

--- a/distros/melodic/gps-common/default.nix
+++ b/distros/melodic/gps-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, message-generation, message-runtime, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-gps-common";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_common/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "06528187c6d9c788cdae1cd1b7c92953d09e49337a1820f9898f7bb9e51e8935";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_common/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "581e8d2f049bbff34bc0d28c57531f6e660be5a0382b2c6ec21895052e9d1801";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gps-umd/default.nix
+++ b/distros/melodic/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd-client }:
 buildRosPackage {
   pname = "ros-melodic-gps-umd";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_umd/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "35dec4ec952f063ec3265e29eea27c8814c28a11899371c3816d4912c76741b7";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gps_umd/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "c5991c11b09136690bbe3841b841b5c75233c89c31510d70127cac10f4d920fd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gpsd-client/default.nix
+++ b/distros/melodic/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd, pkg-config, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-gpsd-client";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gpsd_client/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "adf1eb7857e1de99693e8b0826b037bc3562caf6f21e015d0023146e21d47ecd";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/melodic/gpsd_client/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9638164d61ad7d708032f5068f873980b4090b70726cb3147fb50c4d73789a89";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-transport-codecs/default.nix
+++ b/distros/melodic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, pythonPackages, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-image-transport-codecs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/melodic/image_transport_codecs/2.2.2-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/melodic/image_transport_codecs/2.2.3-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "ac6e2a0cf6b5edd4cbb9a0a966fd84b123f6c60894272661fe8a88769635e7da";
+    sha256 = "bb4faa447143819d0bffe0abb1a8b0f18e5e1650f8366da239ae682a14a88227";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-rviz-plugins/default.nix
+++ b/distros/melodic/neonavigation-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, trajectory-tracker-rviz-plugins }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-rviz-plugins, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/neonavigation_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "79c1f10964f90287b135a6ffaf4b990828625d5f68ed97e4d8ec7773b2c8832e";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/neonavigation_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "023740620e951a376a54bced6fdd64b66e11c67e0078ef6e28cc44ea54fff2a0";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ trajectory-tracker-rviz-plugins ];
+  propagatedBuildInputs = [ costmap-cspace-rviz-plugins trajectory-tracker-rviz-plugins ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/point-cloud-color/default.nix
+++ b/distros/melodic/point-cloud-color/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, nodelet, point-cloud-transport, roscpp, sensor-msgs, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-point-cloud-color";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_color/-/archive/release/melodic/point_cloud_color/1.2.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "dec704b3ca07a05afd49c2a4c7df7d2fd1a03b390dd87576560338dfce49dd14";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cv-bridge image-transport nodelet point-cloud-transport roscpp sensor-msgs tf2-eigen tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package for coloring point clouds using calibrated cameras.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/point-cloud-transport-plugins/default.nix
+++ b/distros/melodic/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, draco-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-melodic-point-cloud-transport-plugins";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/melodic/point_cloud_transport_plugins/1.0.3-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/melodic/point_cloud_transport_plugins/1.0.5-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "45523d8fed826b961a2b185779b143f3b9742432e3fa3bca15753d55228b355f";
+    sha256 = "b7d1dd4ff02a511b6e42035a9d5d8ef0cc7047fb886b306de1c0a7f019daccd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-clients/default.nix
+++ b/distros/melodic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, pythonPackages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "5680aca20acb26716ada6a8fb89a11b099535eab0eea9976e07cb35e2379feb9";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "f6198732d4e87f351743c1ab26ec97f5bbb39388b5674a1deeaa8a8b21c6e71a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-msgs/default.nix
+++ b/distros/melodic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ed41aa1d94c1f1f73d7b36a780e835adebd9fb42dbcce24e1be957b952f6e684";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "13ca795687d15af9b4c2982c1f6a7102dd7042b842a2b626893b2bc905f13c2b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/septentrio-gnss-driver/default.nix
+++ b/distros/melodic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-septentrio-gnss-driver";
-  version = "1.2.3-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.2.3-2.tar.gz";
-    name = "1.2.3-2.tar.gz";
-    sha256 = "06bad4f5068960ec8c7adb2133dd0fc7eff960e6fdae3c2401c577d80f09b701";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/melodic/septentrio_gnss_driver/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7c8ead556a7d887fe2ac1c02d7569057ba8066a00e056f085e8c9655d2dc7e8d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/simple-grasping/default.nix
+++ b/distros/melodic/simple-grasping/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf, vtkWithQt5 }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-simple-grasping";
-  version = "0.3.1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/simple_grasping-release/archive/release/melodic/simple_grasping/0.3.1-0.tar.gz";
-    name = "0.3.1-0.tar.gz";
-    sha256 = "1dada4bbf81347bac9d7fee738e20246ec4f6f25a8983a7edda10894bd896a54";
+    url = "https://github.com/ros-gbp/simple_grasping-release/archive/release/melodic/simple_grasping/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5f4b636cc6d5e50fb1aabff62b7f43299aa56d4344fa82f74b17d0fa37990870";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules message-generation ];
-  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf vtkWithQt5 ];
+  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/smach-msgs/default.nix
+++ b/distros/melodic/smach-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-smach-msgs";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_msgs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "b42e7a31e5e9ee3fcec7388566ca1a78d2af773c2e0bc7428d4f2d62ed732bcf";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "476fe42075f0b02c261d9b468e585d988ec2f8afca42cb3caf4d0b465cee4b45";
   };
 
   buildType = "catkin";

--- a/distros/melodic/smach-ros/default.nix
+++ b/distros/melodic/smach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, rospy, rostest, rostopic, smach, smach-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-smach-ros";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_ros/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "2a6062c9bb60b5cea300784b67e7c977b1cd42bc7117c0d5bea7122eb04d37ed";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach_ros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "04573f2454e319ed33b8d7e1038c13ddd7f2d85f88ed3a47c46e3f2e2c8f7c45";
   };
 
   buildType = "catkin";

--- a/distros/melodic/smach/default.nix
+++ b/distros/melodic/smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-smach";
-  version = "2.0.1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "37de5727c98e7aa222670ad40229cfe239e2907f25ec0d7133b4ec2c29eb6c7c";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/melodic/smach/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "432350b9408615075e0f13acdd5cbd80dd18b35deebdf8fdb45a04d8cb0f6994";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker-rviz-plugins/default.nix
+++ b/distros/melodic/trajectory-tracker-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rviz, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/trajectory_tracker_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "644e1c112888474dc2bee1a80c94dfa76798cfeca77fad982e691b88088d220d";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/melodic/trajectory_tracker_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "a4140671aeac1c451bf611ab0533b9d211216a3a27d687dd269da4dd321c75f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aques-talk/default.nix
+++ b/distros/noetic/aques-talk/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
+buildRosPackage {
+  pname = "ros-noetic-aques-talk";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/aques_talk/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "23a718587034dbc0eb16f95cc5c83c892925b5be0f55dffbbb238b4d96c150aa";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ kakasi nkf sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS interface aques_talk demo program'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/assimp-devel/default.nix
+++ b/distros/noetic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-noetic-assimp-devel";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/assimp_devel/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "6263583e257e9315af21c2303407fc683187673d6a618e294385b7498bb6f2e7";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/assimp_devel/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "e8e1d96cbd67690f2d08c69cc97bb158f37a5502d2db01d0b19d524ba57a89d3";
   };
 
   buildType = "catkin";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''assimp library'';
-    license = with lib.licenses; [ "LGPL" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/bayesian-belief-networks/default.nix
+++ b/distros/noetic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-noetic-bayesian-belief-networks";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/bayesian_belief_networks/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "d1d29e63bcd7143dda22e3de735cb375146b274c9c2e3c34859759f091665ed9";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/bayesian_belief_networks/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "2fe668ade379094723382cf451a6c2115ad22fea43586006cee1c0a9d3332f36";
   };
 
   buildType = "catkin";

--- a/distros/noetic/behaviortree-cpp-v3/default.nix
+++ b/distros/noetic/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cppzmq, ncurses, ros-environment, roslib }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp-v3";
-  version = "3.8.3-r1";
+  version = "3.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/noetic/behaviortree_cpp_v3/3.8.3-1.tar.gz";
-    name = "3.8.3-1.tar.gz";
-    sha256 = "a292ac9c9a32d2eb44983ea9113049457de25f9b86898b52c3e7d64bc002b786";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/noetic/behaviortree_cpp_v3/3.8.4-1.tar.gz";
+    name = "3.8.4-1.tar.gz";
+    sha256 = "3ecdcc33c5dd26e1a77c4d7d3e22c756ebdd9080dafdd919cf2582a9cbe87a6e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/chaplus-ros/default.nix
+++ b/distros/noetic/chaplus-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-chaplus-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/chaplus_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "ae79ee80c96bbf0e602474b0cb400a1992e7f9507e101daa4545c24fb228d5ef";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ python3Packages.requests rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ROS package for chaplus service'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/costmap-cspace-rviz-plugins/default.nix
+++ b/distros/noetic/costmap-cspace-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, qt5, roscpp, roslint, rviz }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/costmap_cspace_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "6c2f6975ca322e23f1254669e5744fffdebe59cefbca478728e34cb73f4b2dce";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/costmap_cspace_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "255bf89103286b80d9a24972a40164f597a9fd4234ce5453adca8f60e4aaa129";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cpp-common/default.nix
+++ b/distros/noetic/cpp-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge }:
 buildRosPackage {
   pname = "ros-noetic-cpp-common";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/cpp_common/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "28a7892680c8c40eb4e77cd9c962abd22a0459fa9e69d73730ed3ebe3be5b9b7";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/cpp_common/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "94f8dc489e48f8848d861a063f5b3578f585de3c18cd45095976fbc9df44951d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cras-imu-tools/default.nix
+++ b/distros/noetic/cras-imu-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, geometry-msgs, nav-msgs, nodelet, sensor-msgs, std-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-cras-imu-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_imu_tools/-/archive/release/noetic/cras_imu_tools/1.0.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "1ca6633c70f3038c7ab5796510653e977a6f25f7fd9669c960a63c5e7750295c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common geometry-msgs nav-msgs nodelet sensor-msgs std-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with IMU data'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cras-laser-geometry/default.nix
+++ b/distros/noetic/cras-laser-geometry/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cras-cpp-common, laser-geometry, nodelet, roscpp, sensor-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-cras-laser-geometry";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/cras_laser_geometry/-/archive/release/noetic/cras_laser_geometry/1.1.2-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "af16611168b59f9cd76d5fbaa8dad8a3f55d53d8e8e0328d347ad3fbce5ad344";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cras-cpp-common laser-geometry nodelet roscpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for working with laser scans.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "e779f1ac3b6e4a381ac2766a4c2a39d233d486583bc4666cc2aa3ed6f2bfe7b5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "4f9aa89e9b83caa3fe8a8297526a294e7ab5f39162b549e8fa7c720238a5143a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "db6366afc2e40654ede21f36c555cfc11c30e0706f905f2d0cd2c1f52709982e";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "2074fba81fc8018daaa44f430bbca7410de2d0ea0465b3f2e192424635ea3ce6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "92fe5fb359b733d4a3499eabc45f4f283de7e0de9cba189afb9ad2135fd43319";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "1a4c52c6e6d0979ca585ae8d7395a534954d09ffb21a3fad98921dab560880ef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "04644873505600542a2d91910be23b35b18b96636044615c1d7922c546f880ae";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "5548bf677e5bae757c24c04c4a4022bc5e63dc998ed0378f739a1ac7e780218e";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet opencv roscpp sensor-msgs vision-msgs ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet opencv roscpp sensor-msgs vision-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "5b97473faa7afa6bbfd51b65e4883c6aab4073fa51637ba794a12302cd05aec4";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "ed7a3691475891139088b3b4244cc3e80e44ad5bc6b0c95dc6284b577cf97692";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ camera-info-manager cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet roscpp rospy sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet pluginlib roscpp rospy sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "9a324409922e899ce60661cf859df951003fb1c200625b62ec57701de8f78d59";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "704be1d24026515a283644fe81cbff3581c3fd5bae0a4960c4a21d6ab252f4c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.7.2-r1";
+  version = "2.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "920ea955d88b70ced772563321f0f7a864509734004be516756c0bd1d1c6d228";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.7.4-1.tar.gz";
+    name = "2.7.4-1.tar.gz";
+    sha256 = "0833152b64b72262c4e6ab4e84840ddadd736e0051ff2f41151632de4cdd1bcd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.21.2-r1";
+  version = "2.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.21.2-1.tar.gz";
-    name = "2.21.2-1.tar.gz";
-    sha256 = "def71b6966222bc7d48412e5486d7520da02e95d79c3fe968168be489525c18b";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.22.0-1.tar.gz";
+    name = "2.22.0-1.tar.gz";
+    sha256 = "2a587768273730151efa4bea742095e03eee23068f0dfea45f09487808c0e73e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dialogflow-task-executive/default.nix
+++ b/distros/noetic/dialogflow-task-executive/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, catkin-virtualenv, message-generation, message-runtime, roslaunch, rostest, speech-recognition-msgs, std-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-dialogflow-task-executive";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/dialogflow_task_executive/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "30a1325eed964aa1e0d35ad4764ea7b4e3de5e0246b155ae051fc02b3308c35e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ actionlib-msgs catkin catkin-virtualenv message-generation roslaunch std-msgs ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ message-runtime speech-recognition-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS package for Google Dialogflow and launching apps via Dialogflow'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/downward/default.nix
+++ b/distros/noetic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python3, rostest, time }:
 buildRosPackage {
   pname = "ros-noetic-downward";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/downward/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "af167e3a93447efd3db9731aacadf13d6b554cb202743c05630892360766f16b";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/downward/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "43648e97ad5f6998d75ad3f1bfe3769c943944a910dea8e8bd94c5718bf61e6a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/euslisp/default.nix
+++ b/distros/noetic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-noetic-euslisp";
-  version = "9.29.0-r1";
+  version = "9.29.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/noetic/euslisp/9.29.0-1.tar.gz";
-    name = "9.29.0-1.tar.gz";
-    sha256 = "ecbf0b5ab05617eac190bb25eaf140fe576d01de47e779b5ad9c2a911d800693";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/noetic/euslisp/9.29.0-2.tar.gz";
+    name = "9.29.0-2.tar.gz";
+    sha256 = "c46c22dd8bc3fbe650fb4137d3bab113dfc97dd8db666a634860c67b6d24aa60";
   };
 
   buildType = "cmake";

--- a/distros/noetic/executive-smach/default.nix
+++ b/distros/noetic/executive-smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-noetic-executive-smach";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/executive_smach/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "c2c51641c783ba6a5dcf124bca35cc6788c33052138f1ce866ae6dd10b11802d";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/executive_smach/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "15366fae7e82149cdef48ae9fca33fc6acd5999a46c6afd25250646cabe16350";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ff/default.nix
+++ b/distros/noetic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-noetic-ff";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ff/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "957f20eed64325d0864b8a499672f657412f9c10ce6d6718c7157c4e7cda1d53";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ff/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "49c404fca5d769b971307eadfa407680d56388b4320e7fa57236f41dc1fd91dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ffha/default.nix
+++ b/distros/noetic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-noetic-ffha";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ffha/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "91b8e796e658087b953fff80f18b4391d53c7a86a4024d3b9eab3cc4e68b4c48";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ffha/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "c938dded78f6c43202f5b391d53cd396ae45fac99355ee0d4a86c34f6dc9b306";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "30386e5c50217489bf9422f1aaf9780f165834560566aaf511a837aa800317f2";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "406597dcc4dfb3dbb278fceb9a468aa47a59f29863992c3597f37ff2222a3559";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gdrive-ros/default.nix
+++ b/distros/noetic/gdrive-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-gdrive-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/gdrive_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "aeb66f26a0526ef1f136b938b1f2c8914e7052230f962d31ff814dda012a851c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv message-generation std-msgs ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ message-runtime rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Google drive upload and download package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -40,6 +40,8 @@ self: super: {
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
 
+ aques-talk = self.callPackage ./aques-talk {};
+
  arbotix = self.callPackage ./arbotix {};
 
  arbotix-controllers = self.callPackage ./arbotix-controllers {};
@@ -211,6 +213,8 @@ self: super: {
  catkin = self.callPackage ./catkin {};
 
  catkin-virtualenv = self.callPackage ./catkin-virtualenv {};
+
+ chaplus-ros = self.callPackage ./chaplus-ros {};
 
  checkerboard-detector = self.callPackage ./checkerboard-detector {};
 
@@ -506,6 +510,10 @@ self: super: {
 
  cpr-onav-description = self.callPackage ./cpr-onav-description {};
 
+ cras-imu-tools = self.callPackage ./cras-imu-tools {};
+
+ cras-laser-geometry = self.callPackage ./cras-laser-geometry {};
+
  create-bringup = self.callPackage ./create-bringup {};
 
  create-description = self.callPackage ./create-description {};
@@ -629,6 +637,8 @@ self: super: {
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
 
  diagnostics = self.callPackage ./diagnostics {};
+
+ dialogflow-task-executive = self.callPackage ./dialogflow-task-executive {};
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
@@ -1090,6 +1100,8 @@ self: super: {
 
  gazebo-video-monitors = self.callPackage ./gazebo-video-monitors {};
 
+ gdrive-ros = self.callPackage ./gdrive-ros {};
+
  gencpp = self.callPackage ./gencpp {};
 
  generic-throttle = self.callPackage ./generic-throttle {};
@@ -1133,6 +1145,8 @@ self: super: {
  gmcl = self.callPackage ./gmcl {};
 
  goal-passer = self.callPackage ./goal-passer {};
+
+ google-chat-ros = self.callPackage ./google-chat-ros {};
 
  gpio-controller = self.callPackage ./gpio-controller {};
 
@@ -1193,6 +1207,8 @@ self: super: {
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
  grpc = self.callPackage ./grpc {};
+
+ gtsam = self.callPackage ./gtsam {};
 
  handeye = self.callPackage ./handeye {};
 
@@ -1261,6 +1277,8 @@ self: super: {
  hpp-fcl = self.callPackage ./hpp-fcl {};
 
  hri = self.callPackage ./hri {};
+
+ hri-actions-msgs = self.callPackage ./hri-actions-msgs {};
 
  hri-msgs = self.callPackage ./hri-msgs {};
 
@@ -1448,6 +1466,8 @@ self: super: {
 
  joystick-interrupt = self.callPackage ./joystick-interrupt {};
 
+ jsk-3rdparty = self.callPackage ./jsk-3rdparty {};
+
  jsk-calibration = self.callPackage ./jsk-calibration {};
 
  jsk-common = self.callPackage ./jsk-common {};
@@ -1603,8 +1623,6 @@ self: super: {
  laser-filtering = self.callPackage ./laser-filtering {};
 
  laser-filters = self.callPackage ./laser-filters {};
-
- laser-filters-jsk-patch = self.callPackage ./laser-filters-jsk-patch {};
 
  laser-geometry = self.callPackage ./laser-geometry {};
 
@@ -2028,6 +2046,8 @@ self: super: {
 
  mrpt-navigation = self.callPackage ./mrpt-navigation {};
 
+ mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
+
  mrpt-rawlog = self.callPackage ./mrpt-rawlog {};
 
  mrpt-rbpf-slam = self.callPackage ./mrpt-rbpf-slam {};
@@ -2144,6 +2164,8 @@ self: super: {
 
  network-interface = self.callPackage ./network-interface {};
 
+ nfc-ros = self.callPackage ./nfc-ros {};
+
  nmea-comms = self.callPackage ./nmea-comms {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
@@ -2235,6 +2257,8 @@ self: super: {
  opw-kinematics = self.callPackage ./opw-kinematics {};
 
  osm-cartography = self.callPackage ./osm-cartography {};
+
+ osqp = self.callPackage ./osqp {};
 
  osqp-vendor = self.callPackage ./osqp-vendor {};
 
@@ -2371,6 +2395,8 @@ self: super: {
  pluginlib = self.callPackage ./pluginlib {};
 
  pluginlib-tutorials = self.callPackage ./pluginlib-tutorials {};
+
+ point-cloud-color = self.callPackage ./point-cloud-color {};
 
  point-cloud-transport-plugins = self.callPackage ./point-cloud-transport-plugins {};
 
@@ -2672,6 +2698,8 @@ self: super: {
 
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ respeaker-ros = self.callPackage ./respeaker-ros {};
+
  rgbd-launch = self.callPackage ./rgbd-launch {};
 
  ridgeback-control = self.callPackage ./ridgeback-control {};
@@ -2803,6 +2831,8 @@ self: super: {
  ros-environment = self.callPackage ./ros-environment {};
 
  ros-ethercat-eml = self.callPackage ./ros-ethercat-eml {};
+
+ ros-google-cloud-language = self.callPackage ./ros-google-cloud-language {};
 
  ros-ign = self.callPackage ./ros-ign {};
 
@@ -3148,6 +3178,8 @@ self: super: {
 
  rviz-python-tutorial = self.callPackage ./rviz-python-tutorial {};
 
+ rviz-robot-description-topic = self.callPackage ./rviz-robot-description-topic {};
+
  rviz-satellite = self.callPackage ./rviz-satellite {};
 
  rviz-tool-cursor = self.callPackage ./rviz-tool-cursor {};
@@ -3349,6 +3381,8 @@ self: super: {
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
+
+ switchbot-ros = self.callPackage ./switchbot-ros {};
 
  swri-cli-tools = self.callPackage ./swri-cli-tools {};
 
@@ -3797,5 +3831,9 @@ self: super: {
  ypspur-ros = self.callPackage ./ypspur-ros {};
 
  zbar-ros = self.callPackage ./zbar-ros {};
+
+ zdepth = self.callPackage ./zdepth {};
+
+ zdepth-image-transport = self.callPackage ./zdepth-image-transport {};
 
 }

--- a/distros/noetic/google-chat-ros/default.nix
+++ b/distros/noetic/google-chat-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, dialogflow-task-executive, gdrive-ros, message-generation, message-runtime, python3Packages, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-google-chat-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/google_chat_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "0fe151f2c055a11ba94868b089abfebb42c52f438dc809b287f728ef1909d431";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv message-generation python3Packages.setuptools ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ dialogflow-task-executive gdrive-ros message-runtime rospy std-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Use Google Chat API clients via ROS'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/gps-common/default.nix
+++ b/distros/noetic/gps-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, message-generation, message-runtime, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gps-common";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_common/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "9f1698a8af546ffc0e466dfda956ef9e0ce7d733eeb2aa7fc17790472e644854";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_common/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "5abd03d0635d912f745d654127904b42eba5102d6d93da93f7f14a884f894827";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gps-umd/default.nix
+++ b/distros/noetic/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd-client }:
 buildRosPackage {
   pname = "ros-noetic-gps-umd";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_umd/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "d558c65ce8b83fb5235b7165b3662eefba2126b23685b623b087d44a4a00fed1";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_umd/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "d0c9758976461cdca7ec9d88d7bf081507c639e2a4d6710872649aa017cd89e1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gpsd-client/default.nix
+++ b/distros/noetic/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd, pkg-config, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gpsd-client";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gpsd_client/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "dc8b37e6b30d5983609a9ca86c0dea4febbd2c8b9830a5d7ce698ac2d440b5a8";
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gpsd_client/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ad74c898ec97ef7a030c1b253bf1998246c87fbf0446edf9a71f8e4d1450a5ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gtsam/default.nix
+++ b/distros/noetic/gtsam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb }:
+buildRosPackage {
+  pname = "ros-noetic-gtsam";
+  version = "4.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/gtsam-release/archive/release/noetic/gtsam/4.2.0-2.tar.gz";
+    name = "4.2.0-2.tar.gz";
+    sha256 = "9a193b03fdfec03eefc3d369af0032d2f12bd3abd5a84207e0593e7813a00bea";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost cmake eigen tbb ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''gtsam'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hri-actions-msgs/default.nix
+++ b/distros/noetic/hri-actions-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation }:
+buildRosPackage {
+  pname = "ros-noetic-hri-actions-msgs";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/hri_actions_msgs-release/archive/release/noetic/hri_actions_msgs/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "50ea4d9a33d3223d1e129e78de1bae0560abe2422d23b2ea6744d413db04dfd9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Action definitions useful for Human-Robot Interaction'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hri-rviz/default.nix
+++ b/distros/noetic/hri-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, hri, hri-msgs, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-hri-rviz";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "cd6d26e6326015a4f93aed18262afbefd5f25c4dbae23ad3b2d1c4dd2659f9b0";
+    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "10cf059a3e9adf071a2746aeea569f7e1fc7338e3f5479a8e966315f369f1088";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.2.2-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.2.3-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "b0b8cda9dceb618b4092f6118253585e00d36ed0808ad7bfca4295eb54074759";
+    sha256 = "786a10c74860a25f64a703b370ba9d844ee470891eddeb479c5b5a93383d94bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-3rdparty/default.nix
+++ b/distros/noetic/jsk-3rdparty/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, aques-talk, assimp-devel, bayesian-belief-networks, catkin, chaplus-ros, collada-urdf-jsk-patch, dialogflow-task-executive, downward, ff, ffha, google-chat-ros, google-cloud-texttospeech, influxdb-store, julius, julius-ros, libcmt, libsiftfast, lpg-planner, mini-maxwell, nfc-ros, opt-camera, osqp, pgm-learner, respeaker-ros, ros-google-cloud-language, ros-speech-recognition, rospatlite, rosping, rostwitter, sesame-ros, slic, switchbot-ros, voice-text, webrtcvad-ros, zdepth, zdepth-image-transport }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-3rdparty";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/jsk_3rdparty/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "fe44d465891fd3a398b0ac54ada77a1ea0a4b40cb3b21c90c11bc1b7a76fadda";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ aques-talk assimp-devel bayesian-belief-networks chaplus-ros collada-urdf-jsk-patch dialogflow-task-executive downward ff ffha google-chat-ros google-cloud-texttospeech influxdb-store julius julius-ros libcmt libsiftfast lpg-planner mini-maxwell nfc-ros opt-camera osqp pgm-learner respeaker-ros ros-google-cloud-language ros-speech-recognition rospatlite rosping rostwitter sesame-ros slic switchbot-ros voice-text webrtcvad-ros zdepth zdepth-image-transport ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains commonly used 3rdparty toolset for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/julius/default.nix
+++ b/distros/noetic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-noetic-julius";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/julius/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "014823789ce21da94f4a4338eb1a967c378ce71107a0bf578befe17b79584387";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/julius/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "c463981d736089578a41c410cf6a2096a22ba2a753dd9acfd6d7b67b6306db0b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libcmt/default.nix
+++ b/distros/noetic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-noetic-libcmt";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libcmt/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "5460174b56e8eedb403a1f24883e4da4ba5f86e50d57cc0fa95e18084694c092";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libcmt/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "498ae578ab3b3c00c5ed5aac566767570314edbbaef72711e229b8fbee88c783";
   };
 
   buildType = "cmake";

--- a/distros/noetic/libsiftfast/default.nix
+++ b/distros/noetic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, python3Packages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-noetic-libsiftfast";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libsiftfast/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "4069ebf700d60562e1e8b991a20930b26faaea96b74d5723c65cead215c7b445";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libsiftfast/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "22cdd64c7377bb355b22118fc76f59e2c2f9222b4014a145c0a864e6ee51e42c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lpg-planner/default.nix
+++ b/distros/noetic/lpg-planner/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, mk }:
 buildRosPackage {
   pname = "ros-noetic-lpg-planner";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/lpg_planner/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "c6a37a8be30644bb340534844822ed765cce283f7b7e4708834fffac523ba5e8";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/lpg_planner/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "29427556bb284892013b61603fbef119b214805f5d39f376939e01a89326c6b8";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin mk ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/magic-enum/default.nix
+++ b/distros/noetic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-magic-enum";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "a4be09aa238eb0497da57fef087243a6685e9d471f96691e2be98476d18cfad0";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "e373d29493a4c9bad7be05105e9894f6905fe24ac54a607236853903499b0a9d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mini-maxwell/default.nix
+++ b/distros/noetic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-noetic-mini-maxwell";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/mini_maxwell/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "5cc4e6f489ebcd95ba061ee6c49c0929163c8704434bbfbe3d9ef0fdfd53990f";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/mini_maxwell/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "4f61846b93569fb7d263c36ab2c9aca3ae2360c14793ceacc6a03b960d25daf7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-path-planning/default.nix
+++ b/distros/noetic/mrpt-path-planning/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-path-planning";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "f343bf5f422b53ac663f7a6c52251b529a71f97af65cffd8f07975151ba333e5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 mvsim ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Path planning and navigation algorithms for robots/vehicles moving on planar environments. This library builds upon mrpt-nav and the theory behind PTGs to generate libraries of &quot;motion primitives&quot; for vehicles with arbitrary shape and realistic kinematics and dynamics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "7e4af4a4ff68588b9987027fd4bbd6d78bc013686b5191aa19a6efc6332c01aa";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "f1aa539c4ad7b5877a0a9e90b6538bbe5593f10fca176ae61d144e02dcf3f473";
   };
 
   buildType = "cmake";
-  buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
+  buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
   propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/neonavigation-rviz-plugins/default.nix
+++ b/distros/noetic/neonavigation-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, trajectory-tracker-rviz-plugins }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-rviz-plugins, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/neonavigation_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "effd352b1933ebc8ec68464755b7be27b2e701f36bfa13b1d4afe44bc12c81e0";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/neonavigation_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "2d3c51269310fb6617d2670c9c430b3663405e02500068e2b2073ace5ed91742";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ trajectory-tracker-rviz-plugins ];
+  propagatedBuildInputs = [ costmap-cspace-rviz-plugins trajectory-tracker-rviz-plugins ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/nfc-ros/default.nix
+++ b/distros/noetic/nfc-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-nfc-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/nfc_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "9fb85f5286e639935d7de19ed9b900633b3ef4799cf5522120dbbfbec510afdf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv ];
+  propagatedBuildInputs = [ message-generation message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The nfc_ros package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/opt-camera/default.nix
+++ b/distros/noetic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-opt-camera";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/opt_camera/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "0c00e853c675dd096a42190c862cfae422bc3897d7b9823b46dacb18ebad9d3e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/opt_camera/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "359407843f822ea792aaad63bf30a3b05ecb59d1c9933cbdbf9aa76f6d04f730";
   };
 
   buildType = "catkin";

--- a/distros/noetic/osqp/default.nix
+++ b/distros/noetic/osqp/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-osqp";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/osqp/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "878c82ff8c752a036c41211648eb0fa9b3656f9c4c799808dba894dc88022b74";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS wrapper for OSQP'';
+    license = with lib.licenses; [ "Apache" ];
+  };
+}

--- a/distros/noetic/point-cloud-color/default.nix
+++ b/distros/noetic/point-cloud-color/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, nodelet, point-cloud-transport, roscpp, sensor-msgs, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-point-cloud-color";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_color/-/archive/release/noetic/point_cloud_color/1.2.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "7c9f25a7a7cbce6ddf390bab8a3e4488e6544f26ee541e5198e97d00d0906eef";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cv-bridge image-transport nodelet point-cloud-transport roscpp sensor-msgs tf2-eigen tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package for coloring point clouds using calibrated cameras.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/point-cloud-transport-plugins/default.nix
+++ b/distros/noetic/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, draco-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-noetic-point-cloud-transport-plugins";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/noetic/point_cloud_transport_plugins/1.0.3-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/point_cloud_transport_plugins/-/archive/release/noetic/point_cloud_transport_plugins/1.0.5-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "375fe5797e3df3ea40fdf94cb86de19fd485219d3230cbcfb264bac16fac1697";
+    sha256 = "038c65e020094f02186dc2d4a91125e4a395657a56e4b7906fef0df252b7d3ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-clients/default.nix
+++ b/distros/noetic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, python3Packages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ec48963acb27603b1a8c263587f51a6d75d5043afcfcdfad004c61939a9bb9d8";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "abcd730e1b48291c87a729bd9778459b16797f7c13dfa94cb24c92cf24a0b8cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-msgs/default.nix
+++ b/distros/noetic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "50a7fbb919cef19e7fc1136fadb1379b05b32ead2bc6eb11c88a5bbfe8dfc5d5";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6050c7ec2bfeb73a3418c532fbb1758c2464db962cd0c4506e4c07567124f700";
   };
 
   buildType = "catkin";

--- a/distros/noetic/respeaker-ros/default.nix
+++ b/distros/noetic/respeaker-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, audio-common-msgs, catkin, catkin-virtualenv, dynamic-reconfigure, flac, geometry-msgs, jsk-tools, python3Packages, speech-recognition-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-respeaker-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/respeaker_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "54299b14fb5419c66dd971de0b140e4275eb803ed470627c7e2168544faa6f3b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv ];
+  checkInputs = [ jsk-tools ];
+  propagatedBuildInputs = [ angles audio-common-msgs dynamic-reconfigure flac geometry-msgs python3Packages.numpy python3Packages.pyaudio speech-recognition-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The respeaker_ros package'';
+    license = with lib.licenses; [ "Apache" ];
+  };
+}

--- a/distros/noetic/ridgeback-control/default.nix
+++ b/distros/noetic/ridgeback-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, twist-mux, urdf }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-control";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_control/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "1f1650f170467ab7e19a1cdcf7ce1bdb5a68299c09ec590db1a13feccef42947";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "710d5464781fb76807ecf2dfbcbbf391cdfa5766536f06aa9331a92d58ee5f3f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-description/default.nix
+++ b/distros/noetic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-description";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_description/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "00c742f64df089a27d09250b9f9e615889c2bf00d93c00ae640c3fa83376f22c";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "e42a070007eec9e4f23026a3de9c3781067b25e4ff60693fe324ffa1498871b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-msgs/default.nix
+++ b/distros/noetic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-msgs";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_msgs/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "c5ea43d5a76a14885722d87f62e46a6548738765821a1307c73da022dd2b7c05";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_msgs/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "d55a786d0b7e263801de2e86eec33c7e2b4d04a7df876d0d10e0dee6cac39651";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ridgeback-navigation/default.nix
+++ b/distros/noetic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ridgeback-navigation";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_navigation/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "952dfdee87834cf3dc2d14b97b27f94f0ec2d583aae802de9320efc9fa81975b";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/noetic/ridgeback_navigation/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "a5a9872dc2b50f74a11d60cc3df0d5254453ef40ab7fb470ab772bd3f45326fc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-google-cloud-language/default.nix
+++ b/distros/noetic/ros-google-cloud-language/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, diagnostic-msgs, message-generation, message-runtime, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-ros-google-cloud-language";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ros_google_cloud_language/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "a4e4b95e78868a5cfbb7abfd884e073a4b9529b79ea027a25012a7e625f9c335";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs message-runtime rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ros clinet library for google cloud language'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.4.0-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "724e0b9dd9e5fe54ec6aae8409e4e84ce2e34534c8f452a3e06b68059c34fdd5";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "0fcc0d4b2f93845861121abdc922edc22b2af2cff0d01d05cec61e6f73e0d96b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/roscpp-core/default.nix
+++ b/distros/noetic/roscpp-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, roscpp-serialization, roscpp-traits, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-core";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_core/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "d40d836804305c723cddab20b673c74bcdae047064a5f342b266b162830474e7";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_core/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "fdeb3bb02a2b119f1d270b28046bd0a11f36e64686beae3ce7a166bd4695719e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-serialization/default.nix
+++ b/distros/noetic/roscpp-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, roscpp-traits, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-serialization";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_serialization/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "ddbc65e42b525bdb29ec8795e05470984cec6c90839d16d577e6b752017e355a";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_serialization/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "349854ff6feedec540d14dda9c016964adb5b4d0398026a9bc05b1b765930c64";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-traits/default.nix
+++ b/distros/noetic/roscpp-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-traits";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_traits/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "4393d3b11553d92ae6044533a06583b40ffa8914b08ccf8127d0cb49ee1dbddf";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_traits/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "8c3418f8b4a57e921e55f39bd586db9ede2905b49b3983ec27b6ee623e7f2194";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospatlite/default.nix
+++ b/distros/noetic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospatlite";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rospatlite/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "f52f6aa6146511a5551db4f2b648bcd0ebe7908093dfb2a7a431297f380400e0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rospatlite/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "5c56f165128c3980917fee6417253fc26a983e9fe9e645ca137bb733b66fc7ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosping/default.nix
+++ b/distros/noetic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosping";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rosping/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "28c0281b4e9913467cde2e5284b903a6fa4e77d8127630449faf2db9e60262a1";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rosping/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "2c677da1ba00238a88e14c8391c9bee726de9fbe018a75d42a97c6e112311557";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostime/default.nix
+++ b/distros/noetic/rostime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common }:
 buildRosPackage {
   pname = "ros-noetic-rostime";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/rostime/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "7111aa9956e9e8ec623edd54c59b344c6488b65aed8b1d768a5a7a55b467c47c";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/rostime/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "9147416c5ab3b2593a22ae339ad7fe66630ac730431018352f4962f5f58d6e6b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostwitter/default.nix
+++ b/distros/noetic/rostwitter/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, git, mk, python3Packages, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, git, message-generation, message-runtime, mk, python3Packages, rospy, rostest, sound-play, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rostwitter";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rostwitter/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "227fc2677c3b13e7cb28d480ddc7b236f844154fc59d4c34901344566cd51df5";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rostwitter/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "d079175b1083e07a5a03a15e4f0c0c7cbaeec2a6fdceb102524fdb5c4c22264e";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin git mk ];
-  propagatedBuildInputs = [ python3Packages.requests python3Packages.requests_oauthlib python3Packages.simplejson rospy std-msgs ];
+  buildInputs = [ actionlib actionlib-msgs catkin git message-generation mk ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime python3Packages.requests python3Packages.requests_oauthlib python3Packages.simplejson rospy sound-play std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rviz-robot-description-topic/default.nix
+++ b/distros/noetic/rviz-robot-description-topic/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt5, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-rviz-robot-description-topic";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rviz_robot_description_topic-release/archive/release/noetic/rviz_robot_description_topic/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d20aa85917a01c8c72dfc1e2cd98d680d21e274a9b2659c07c8d1c474b958e65";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ qt5.qtbase rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RobotModel display using a `/robot_description` topic instead of a parameter'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/septentrio-gnss-driver/default.nix
+++ b/distros/noetic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, rosconsole, roscpp, roscpp-serialization, rostime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-septentrio-gnss-driver";
-  version = "1.2.3-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "39bf69095947dc7bb56e516115125e080aa568fbb5b65009f23df2b44c981dc1";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9f2000d11ba3315dc772bffcfc708df4e971e23be27b264166073d78c003e5bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sesame-ros/default.nix
+++ b/distros/noetic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-noetic-sesame-ros";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/sesame_ros/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "265fe6c7e55e6aa36a0fd730df7a9d701f86338c97eec080d7d30c454f7ca3cd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/sesame_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "7293e17b217df04f70947b9ec41601496549f1eaa86cc4b0b899f92f0e005177";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slic/default.nix
+++ b/distros/noetic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv, openssl }:
 buildRosPackage {
   pname = "ros-noetic-slic";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/slic/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "8e168ce461db9a27d3c703ba4559602761db0e4ea423454f890a1234719a2cdf";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/slic/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "a1e759834fd52662e76d417bc9439887133f0641bac02cde0909e9af740bb15c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/smach-msgs/default.nix
+++ b/distros/noetic/smach-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-smach-msgs";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_msgs/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "a71911113b4c6eab1eaabb737a5ae764d205a171bde70cd7b632caca042a830f";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_msgs/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "380f1091e12696e27afd375690bdf0d8f4d1fdb7cee2547093c05a0ba1928194";
   };
 
   buildType = "catkin";

--- a/distros/noetic/smach-ros/default.nix
+++ b/distros/noetic/smach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, rospy, rostest, rostopic, smach, smach-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-smach-ros";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_ros/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "79e4a3e08588fd56ccbbf0af327ef42fd9e3e5cf849129230340ce52fded072f";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach_ros/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "8dbaedae6785bb0db9480f96c06c206d938d074b563c157a56cef140dcff6ea2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/smach/default.nix
+++ b/distros/noetic/smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-smach";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "ee2330d04fd4f3c737b8274e8cd9f167754adb7fcdf5cd7de7ce80635a285171";
+    url = "https://github.com/ros-gbp/executive_smach-release/archive/release/noetic/smach/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "1dd31e12c74b5377743e80cd6b32eb41c18869ab59ea6e73f4f2e90021e7e438";
   };
 
   buildType = "catkin";

--- a/distros/noetic/switchbot-ros/default.nix
+++ b/distros/noetic/switchbot-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, python3Packages, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-switchbot-ros";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/switchbot_ros/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "cb8e83c3c40d4f238692b5e9c8ff721cba37d360781b3e516fed4bc9341c4987";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation python3Packages.setuptools ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime python3Packages.requests rospy std-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''use switchbot with ros'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/tesseract-collision/default.nix
+++ b/distros/noetic/tesseract-collision/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, libyamlcpp, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
+{ lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-collision";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "1c680b025f020de8eccc87863862da768ec8d8210b632b981cc64f5407ed6dbc";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_collision/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "7b4700e14ef3e2b7cf184fcf2603a0e5efeafcbd113cc4d64865ba2a64ba1a18";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ros-industrial-cmake-boilerplate ];
   checkInputs = [ gbenchmark gtest tesseract-scene-graph ];
-  propagatedBuildInputs = [ boost bullet console-bridge eigen fcl libyamlcpp llvmPackages.openmp tesseract-common tesseract-geometry tesseract-support ];
+  propagatedBuildInputs = [ boost bullet console-bridge eigen fcl libyamlcpp tesseract-common tesseract-geometry tesseract-support ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, libyamlcpp, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "8ae0559beefae5e965ffe8e680f37a302aefc58cd8092d7b2905d6f4b72de2a8";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "690ec4baf2d64d619520ccb9c67d17be897c6f7cd6bc4abb6712a6b504c60061";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-environment/default.nix
+++ b/distros/noetic/tesseract-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, llvmPackages, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-kinematics, tesseract-scene-graph, tesseract-srdf, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-environment";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "ca9fb6425c1cd5687b8c33038e6e8eab9a21fc5dc3b20d029c5e71beca5ab66f";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "3875e07c8819e387335eb4e0688edbbbae8eacb260b85b3155cf4d1f4a22066c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "cedef07fcc00b545a14246f9c944a97d67ef5349d9d16ecb6e12d1a3c071a49a";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "d39221fb48d4e93b88ce51910abcb5aa7a662d66a8b9e3917973dee85f5960d2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, liblapack, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "57dd1329a32d50e2119e242400d5d9d7a5f109f76bff7491207c04cc672fa488";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "9e3e053956086bb513d205237844304f5d29fe5c533df16682e79820c68e7f96";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "fe0d7ae85e22379da889ce996d5e18cf5662d6b87234a2e7203a4aeb6b475603";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "6481f75922da04b475af695f571551350c0de2682b4c0b002af93d699cd2c350";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "6fbbe41290561418129d46f2a9bc4565e5834879f05ace4d2c0be67a9cf54eb3";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "a216fb433f57fa393a4c7ebeca42b5cc86c50922b2c6114be84448ee0c1ed4da";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-state-solver/default.nix
+++ b/distros/noetic/tesseract-state-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-state-solver";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "bab133597b7bb4451429e9372bfa8e5dfd3b34326090e34a46798241ebb68583";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_state_solver/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "dad36be50db61544df29d40a22d7d602921038f56d191dd3c2db6044c5d27e9f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtest, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "f0b62778f0b3e32ed7aec100bf5f9990488346f2403a4b436ce186526c25cf04";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "d255a8f356bb056ffc65d452e683f96ce356a930eb7217c1c7ebfd61d03eee94";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "5879737a556f0b9f65dc1de4ac7e0972477e096b4c8706b084a21f243f077ef7";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "d65b9d6df0c3d4eb4e495dcc4f937e84a8fffe69de44f4ff8f7af2dacc00b1a5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph, tesseract-state-solver }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.15.2-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "97917dd8429d60184b3a597a876b9a623ce34f3cd7fab01bc9f16a7295a2b2b8";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "5c5251096fd634cbe851478e45426dc9de6de1787504da1496332463bb8a872a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/trajectory-tracker-rviz-plugins/default.nix
+++ b/distros/noetic/trajectory-tracker-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rviz, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker-rviz-plugins";
-  version = "0.11.6-r1";
+  version = "0.11.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/trajectory_tracker_rviz_plugins/0.11.6-1.tar.gz";
-    name = "0.11.6-1.tar.gz";
-    sha256 = "74cefaa38f778b4300bc792456ff65dfc5741afa6a8a6d5aee8d56a75591107b";
+    url = "https://github.com/at-wat/neonavigation_rviz_plugins-release/archive/release/noetic/trajectory_tracker_rviz_plugins/0.11.7-1.tar.gz";
+    name = "0.11.7-1.tar.gz";
+    sha256 = "1bd6a5cef3847fbb098e1aca26b2035c20f251798b8557f230b5526db3874ce1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/voice-text/default.nix
+++ b/distros/noetic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-voice-text";
-  version = "2.1.21-r2";
+  version = "2.1.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/voice_text/2.1.21-2.tar.gz";
-    name = "2.1.21-2.tar.gz";
-    sha256 = "05ae739b61950cd2321e45c980c4308fa4f8c9d8cee4a7e8bea67256ace289cc";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/voice_text/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "bfd97a07a4d42178e42cefac4574681aee3632810e93792cffec5a0b8956a367";
   };
 
   buildType = "catkin";

--- a/distros/noetic/webots-ros/default.nix
+++ b/distros/noetic/webots-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, moveit-simple-controller-manager, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-webots-ros";
-  version = "2023.0.0-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/2023.0.0-1.tar.gz";
-    name = "2023.0.0-1.tar.gz";
-    sha256 = "05ebb7d96c29c12d054743870411fe330a77e5f48373baab922a9e4dbbd05a22";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "862b0f471ff3c6d5e7835eece2641c5a9de65286c7a98a988273a9a97164bf29";
   };
 
   buildType = "catkin";

--- a/distros/noetic/zdepth-image-transport/default.nix
+++ b/distros/noetic/zdepth-image-transport/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, image-transport, message-generation, message-runtime, pluginlib, roscpp, sensor-msgs, std-msgs, zdepth }:
+buildRosPackage {
+  pname = "ros-noetic-zdepth-image-transport";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth_image_transport/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "e5df7326a2651d97968d72033827823025f3f734d7241dd1dd45a5487062a2b0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ image-transport message-runtime pluginlib roscpp sensor-msgs std-msgs zdepth ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The zdepth_image_transport package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/zdepth/default.nix
+++ b/distros/noetic/zdepth/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-zdepth";
+  version = "2.1.26-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth/2.1.26-1.tar.gz";
+    name = "2.1.26-1.tar.gz";
+    sha256 = "b42b58fa5454d032baeec2516fddddf1be41eabe967f8659125d101a09f104b3";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The zdepth package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "cb9a4e6512be8d6f8a8f0bc7db9b35860adfde430e3d05bb64c49a3389a2f7f9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "0ca52e7dd702d284bfb72bab9b66c5191e2c97245ffe0cb36d0482871b88b86e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "aa44c687a8b020e7459903475e0907494b423e9ecb9878fb1618b303b7a688ff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "3b748a72b1ca3510f2666d3520366a107416f6cbb5352f61c0abc42e46df0f01";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-auto/default.nix
+++ b/distros/rolling/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-auto";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "c545c3be4b8b007f912b5afb7bd895ed334786dfd101b7ea0174e7d766c487ba";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1234bca8e440c33f028a7340e0e98bff5be52e918ee93d8f7a17aa7260dc4b7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-core/default.nix
+++ b/distros/rolling/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-core";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "aea68b872c9aa2e5cbe59d93d86c5e46c6817cf13c13aee086b5251b13f8b044";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a399ff0cc216418978e3bde1c9a791fdf7055962b389d56c6a80cd7600606f7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-definitions/default.nix
+++ b/distros/rolling/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-definitions";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "dd0693fdab190b90172747107d44b6bd40de4a699dbd1510c8cbd42247cee93a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1727fd4b78333df298cc04de40960b5b9e8bfceb57535f3ec0998facbd4884d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-dependencies";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "722ffe9f5156afa0c6749e17d7bb484416686a0b91c3fd089f914824f8593c5a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "f9d9597355bbdd6dcbd76b2f3f93d23b18f975c9da3a2f43cb4878524ec3e8eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-include-directories";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6d23af5bc5a6f316d83357bd2b71b76958a38f008804d902e35ee73e1c5a508e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1eb4b8b354a7d73c4ba9e276735eff6169ca10156c1dfef009dcda1e8663cb3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-interfaces/default.nix
+++ b/distros/rolling/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-interfaces";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5c8f8e2f264e9b927e23c1d43ebd321e0817f2390bdc072966f275ddaabe4683";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "011192f0f5bf21f6e5fe1323c69e613d884a79088b37211c1b373851fb9fe4d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-libraries/default.nix
+++ b/distros/rolling/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-libraries";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "a6ab7dbfe1993805c34ec17410c624105888657d35d8ca4165f5979886b0d668";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "09ff4f55a86c9c313700807afa327adcb815a36914888ba3a0704042598f4f30";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-link-flags/default.nix
+++ b/distros/rolling/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-link-flags";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d43c9fcb19ca614cc80858abb61e3cb823fbb373875aee46ef99c8106e9a3eff";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ad34e257c6d46d70b1e2e086fb40b63154b5c1a1747003bae2c59107475e1510";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-targets/default.nix
+++ b/distros/rolling/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-targets";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "7854ea694908e48868022a8e2194cabfacad8bbcace176c215ffbb788dbc7212";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c4b3cff799e9dbb060e40dce6853fa2e8fa694b51a5af7dd32af588b7a8e922b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gen-version-h/default.nix
+++ b/distros/rolling/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gen-version-h";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "afeba9a2580662b60bcfb00466fdae390a67bf08cc685d5e7c3bd79a38262d6a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "abb84305bb9db88919e045f42524fbefa54ceeefa9d1e75b016ebf57652515ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gmock/default.nix
+++ b/distros/rolling/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gmock";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "3d5db9101e862d07c3ad7ff4afe2ab33f334bb5eb4cf1d98a159bff3940433a7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ab7fdb75952b716be28db160e29bb6d50c53a6b2195459230badc0634ca1a10b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-google-benchmark/default.nix
+++ b/distros/rolling/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-google-benchmark";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5e87a2ece847f2ee1eb44f98153b3bcb291b764186a00fe445516a68e23882dd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1051e6716898f4adb3324c0d246645e18aa968815c8b53ec40e30d89b4e05625";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gtest/default.nix
+++ b/distros/rolling/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gtest";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "fee76480cb743297ad18c6bf1bf8463980c35a41811da27811c1c5449c179d5d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "b82a90605acff1473743f6df89a2227dbe16252358f8d7fa9fc7a340df0b8325";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-include-directories";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "252ddc4d1c267eb1ccec69116a358753e919bfe68bb3e17ab8c2c3d705f7af8c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ddf485478334ca52eb532c0f691b527751295628a6ecae127181969250bbd489";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-libraries/default.nix
+++ b/distros/rolling/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-libraries";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "255a01d8b89675e68f10af330a5589aac37b8a1e7ab0549786e1d66ba8719233";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "6fc0783344603b8271304417100f0f16dc0a1f06f091e29e291465960d9e04ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pytest/default.nix
+++ b/distros/rolling/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pytest";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e2b037545d30522731e9e1336979aef56e61cb162bdce087f2b686229bfde29b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "3ad199cf824f02ca2619c465e38c449549135243c5c25686a1eb323845b286c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-python/default.nix
+++ b/distros/rolling/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-python";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d08a0a442a64483e575b3633fa4de0c656882dcbba95a4993dc19f3396b4a0fa";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "67e352fc134ab5f8620ce3c65b1a242b87c505026b7447d8919c375c6cefc102";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-target-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-target-dependencies";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "fb20194b756126d9c46f9054e3249ae5a33382805c3c206313002d2316b72a1f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c385b420a896dd2931b035ec603cc63e44a95b059247e005fb5cc4ae7cd8a1af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-test/default.nix
+++ b/distros/rolling/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-test";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "606d441f4797cd1ea5316d3d26c3ab7c28de076811dbba66c216af7656d41d2a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a884039ed92a5d6a4a6b6b8864ba6751bd8d35feb09dcadeeee650f1c99b440c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-version/default.nix
+++ b/distros/rolling/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-version";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "eb0547314873e86363a0fa171bd1d4bcff021a7361c359dac891a4cb62a4e2bd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "cd700fb35fd5918e185814d6a17f3e91fbd14361cf5a2f5705f0d76cec19f6dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake/default.nix
+++ b/distros/rolling/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "088928bfa6ab195d9b4cf4be384795396cf49b4a9165d3e828ac5c8c099579e5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "618151dc08292b0bb26d9606fcd8a1379535e8f281b2a2623a94ba6d143223bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/behaviortree-cpp-v3/default.nix
+++ b/distros/rolling/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, cppzmq, ncurses, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp-v3";
-  version = "3.8.3-r4";
+  version = "3.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/rolling/behaviortree_cpp_v3/3.8.3-4.tar.gz";
-    name = "3.8.3-4.tar.gz";
-    sha256 = "d7ac0bb6684af8e5f94bfb9f1c79cf93393eeb6f240bd469ab5bc633b8edacec";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/rolling/behaviortree_cpp_v3/3.8.4-1.tar.gz";
+    name = "3.8.4-1.tar.gz";
+    sha256 = "323d52552e0c385f6d92870fae6a2218f3bb21b8a0151bc1338ac7147fa6cb6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.2.1-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "239c2b38bb86f54e5e75aa74a7bcdff1b0152bee0d6738e59605e9287e117f51";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "5a4f9f520d5df2c77b3ce651767ae423541cc2369abff0b236c71c18d189488a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "2f82c91f6862727fb14cfea6b625d7ef4ad41130450706fdf3ba9ce709bce3a2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "09f34e1ef15f8ad772a22a15be7a4a94fe1ed3c282657d325a4d453eace7c8e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/canopen-402-driver/default.nix
+++ b/distros/rolling/canopen-402-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-402-driver";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_402_driver/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "c23348c61efeac649370139582709bdf986cca698cb299cc32565ae1e114e899";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ boost canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driiver for devices implementing CIA402 profile'';
+    license = with lib.licenses; [ "LGPL-v3" ];
+  };
+}

--- a/distros/rolling/canopen-base-driver/default.nix
+++ b/distros/rolling/canopen-base-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, boost, canopen-core, canopen-interfaces, diagnostic-updater, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-base-driver";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_base_driver/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "21c211f0a0c77ce1937e098fcefab70928827b9a9d4f88bafa5f6ecf5f359a29";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ boost canopen-core canopen-interfaces diagnostic-updater lely-core-libraries rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Library containing abstract CANopen driver class for ros2_canopen'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-core/default.nix
+++ b/distros/rolling/canopen-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, boost, canopen-interfaces, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-core";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_core/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "5462b09f92123730a5f9ff93c25f7851f99a195e9223b2498cc19a640b4f39bb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ boost canopen-interfaces lely-core-libraries lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Core ros2_canopen functionalities such as DeviceContainer and master'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-fake-slaves/default.nix
+++ b/distros/rolling/canopen-fake-slaves/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, lely-core-libraries, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-fake-slaves";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_fake_slaves/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "78f10e79ae29f10498ce7ae9fa01f1199546f76019cddcc681fb42e156b8355e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ lely-core-libraries lifecycle-msgs rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package with mock canopen slave'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-interfaces/default.nix
+++ b/distros/rolling/canopen-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-interfaces";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_interfaces/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "f0bac4d871afa9ae62c665b531738630c9c78764ad2ac186ea01b766a43cbf8a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Services and Messages for ros2_canopen stack'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-master-driver/default.nix
+++ b/distros/rolling/canopen-master-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, canopen-core, canopen-interfaces, lely-core-libraries, rclcpp, rclcpp-components, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-master-driver";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_master_driver/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "c904a445c0a73e4983fdf2bfdcd444da437bdea111e8e0fa49a50e8a65df69ef";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ canopen-core canopen-interfaces lely-core-libraries rclcpp rclcpp-components rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Basic canopen master implementation'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-proxy-driver/default.nix
+++ b/distros/rolling/canopen-proxy-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, canopen-base-driver, canopen-core, canopen-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-proxy-driver";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_proxy_driver/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "4ad2d17220a722f72c79ff825765f5e65404b261276fdf75ca50ab19bbca9866";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ canopen-base-driver canopen-core canopen-interfaces rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Simple proxy driver for the ros2_canopen stack'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-ros2-control/default.nix
+++ b/distros/rolling/canopen-ros2-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-core, canopen-proxy-driver, hardware-interface, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-ros2-control";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_control/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "98872c24a0c0ebecad53ed25284f7401b161fc7166b64aadc14974b72c2eab31";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-proxy-driver hardware-interface pluginlib rclcpp rclcpp-components rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros2_control wrapper for ros2_canopen functionalities'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-ros2-controllers/default.nix
+++ b/distros/rolling/canopen-ros2-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, canopen-402-driver, canopen-interfaces, canopen-proxy-driver, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-ros2-controllers";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_ros2_controllers/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "cc8988883113b2403e0fee751ce5c740f91c66a5afdc08eb071b4624d32b1ba1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-interfaces canopen-proxy-driver controller-interface controller-manager hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros2_control controllers for ros2_canopen functionalities'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-tests/default.nix
+++ b/distros/rolling/canopen-tests/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, canopen-402-driver, canopen-core, canopen-fake-slaves, canopen-proxy-driver, canopen-ros2-controllers, controller-manager, forward-command-controller, joint-state-broadcaster, joint-trajectory-controller, lely-core-libraries, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-tests";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_tests/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "391782a9089f063b108f6e4f95bbf20e37c8ad15081fba8bcd57db5ed80a2718";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake lely-core-libraries ];
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-core canopen-fake-slaves canopen-proxy-driver canopen-ros2-controllers controller-manager forward-command-controller joint-state-broadcaster joint-trajectory-controller robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package with tests for ros2_canopen'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen-utils/default.nix
+++ b/distros/rolling/canopen-utils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, canopen-interfaces, lifecycle-msgs, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-canopen-utils";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen_utils/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "ac06faf52a1ada2f0df5034f55416402e54aefa9048763f5e4e0ddb529de39f8";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ canopen-interfaces lifecycle-msgs rclpy std-msgs ];
+
+  meta = {
+    description = ''Utils for working with ros2_canopen.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/canopen/default.nix
+++ b/distros/rolling/canopen/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, canopen-402-driver, canopen-base-driver, canopen-core, canopen-interfaces, canopen-proxy-driver, lely-core-libraries }:
+buildRosPackage {
+  pname = "ros-rolling-canopen";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/canopen/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "ad7c83e581d210e20b09ecc8c7e891f0c13443eb2e20209fa116fade3812438e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ canopen-402-driver canopen-base-driver canopen-core canopen-interfaces canopen-proxy-driver lely-core-libraries ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta-package aggregating the ros2_canopen packages and documentation'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/catch-ros2/default.nix
+++ b/distros/rolling/catch-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-catch-ros2";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/rolling/catch_ros2/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "fa1709a9486c489ade25f08d6d7350ff5693619699421d5e615f79703df9c80b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp ros2launch std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Catch2 testing framework for ROS 2 unit and integration tests.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "bedbd1a3c23d7a04e3324eaf4cc9c4f1c2f9b8b9a7fb1ba2498b50fcdef267e6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "b5c8e4d085c0e3c388e15045fda0012ecba797879ffad42f23ce99189e8c8b6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "b4bb3e87a8f3d3bd910c8ba79d8d44a6a3978470d28981aff50944696c5b0440";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "49306266b8cc21d5598e2a69d91da90bdcc583eea210b7c97a60657054f1fae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "c86b187c033efcbc528c2e7c8c787ed4e7cfffe5a9be3400f4b639fb657889e9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "5759c826d000c2d9652b0051d948af1c0d1a960b8e5473e136f1a9663eec9cb8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "6fbd01127aa9bce85d0f7345fd0bec6771ce9b64640e2c471bd833233df4566e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "7a9f1f25084e9f1be92305d0f14f93df80521a0c51ef26700cac478ad3da260d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "bc2d807439249faa64ae09d731f9d152d0cfe40239d9dec47570c0030650aaed";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "1215a5777c65152de06d04e9f5a4034b05070365d9b9f89c0dd6aa2506e970fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "e74e0bd22ab3f10fcc2445f70e6ea681d2cd61d2f20c450715b08483ec5cb95a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "5ab67c00d1542207aff6ad6e6744050de7607449046e4004958638083e25427e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "3aef2b9a91baedc290534a92f0afeaf7b92945e4609f1aeddac374a81dde10f7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "ce4ad20e3f810ae271f7bc295ccd0f87dc61c2120c3ac24066adcfb316127588";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "12c7ea3e96d0b744065df9433768fd0fb4147298d3c571c1c2fd5e2b008d46fb";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "05e71fb99155c79f0bf9d6fd9cd9a74e2b9e8305e6cd2f1a6b25c029e0e17420";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -102,8 +102,6 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
- ament-cmake-vendor-package = self.callPackage ./ament-cmake-vendor-package {};
-
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
@@ -214,6 +212,30 @@ self: super: {
 
  can-msgs = self.callPackage ./can-msgs {};
 
+ canopen = self.callPackage ./canopen {};
+
+ canopen-402-driver = self.callPackage ./canopen-402-driver {};
+
+ canopen-base-driver = self.callPackage ./canopen-base-driver {};
+
+ canopen-core = self.callPackage ./canopen-core {};
+
+ canopen-fake-slaves = self.callPackage ./canopen-fake-slaves {};
+
+ canopen-interfaces = self.callPackage ./canopen-interfaces {};
+
+ canopen-master-driver = self.callPackage ./canopen-master-driver {};
+
+ canopen-proxy-driver = self.callPackage ./canopen-proxy-driver {};
+
+ canopen-ros2-control = self.callPackage ./canopen-ros2-control {};
+
+ canopen-ros2-controllers = self.callPackage ./canopen-ros2-controllers {};
+
+ canopen-tests = self.callPackage ./canopen-tests {};
+
+ canopen-utils = self.callPackage ./canopen-utils {};
+
  cartographer = self.callPackage ./cartographer {};
 
  cartographer-ros = self.callPackage ./cartographer-ros {};
@@ -223,6 +245,8 @@ self: super: {
  cartographer-rviz = self.callPackage ./cartographer-rviz {};
 
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
+
+ catch-ros2 = self.callPackage ./catch-ros2 {};
 
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
 
@@ -722,6 +746,8 @@ self: super: {
 
  launch-yaml = self.callPackage ./launch-yaml {};
 
+ lely-core-libraries = self.callPackage ./lely-core-libraries {};
+
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
@@ -896,11 +922,15 @@ self: super: {
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
+ mp2p-icp = self.callPackage ./mp2p-icp {};
+
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
 
  mrpt2 = self.callPackage ./mrpt2 {};
 
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
+
+ mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "671c657e7f89482891a81e84a124a32d6d7c0a300752e36c19eb73bbb97dc5df";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "c59ea0ccacd5a0193359140f7d57c690dd7dfb0fe2c961d93c634674cec4fc69";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "2a01d9aa5845c2d30d4f2cbd082c77b0fb6a5f306c29c22f7fb4acb9f1006475";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "42c5fc09df98d3c37259d72fa1ce5aef0c90b2bfca6be9c55fd47381d818de23";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ignition-cmake2-vendor/default.nix
+++ b/distros/rolling/ignition-cmake2-vendor/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, doxygen, git, ignition }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, ignition }:
 buildRosPackage {
   pname = "ros-rolling-ignition-cmake2-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ignition_cmake2_vendor-release/archive/release/rolling/ignition_cmake2_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "3aaaadd0e720a2585f5a63bafb513c6cc21bec5f8f6ca5716d27b13583a12fb6";
+    url = "https://github.com/ros2-gbp/ignition_cmake2_vendor-release/archive/release/rolling/ignition_cmake2_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "606f92ed13100c48aff54bfbeb765a7bec17c894b32d4234edb2db45d0613e23";
   };
 
-  buildType = "cmake";
-  buildInputs = [ ament-cmake-test cmake doxygen git ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ ignition.cmake2 ];
-  nativeBuildInputs = [ ament-cmake-test cmake doxygen git ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
     description = ''This package provides the Ignition CMake 2.x library.'';

--- a/distros/rolling/ignition-math6-vendor/default.nix
+++ b/distros/rolling/ignition-math6-vendor/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint, cmake, eigen, git, ignition, ignition-cmake2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, eigen, ignition, ignition-cmake2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ignition-math6-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ignition_math6_vendor-release/archive/release/rolling/ignition_math6_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "2c826e03ad1e8c001c523beb98b407b1e0b34097dc2e0636a3a9886abaa4f340";
+    url = "https://github.com/ros2-gbp/ignition_math6_vendor-release/archive/release/rolling/ignition_math6_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "bd383d2067d415c5dd8ab728263f7d5e99be6636d6ed3c12cbe4f021dda718f6";
   };
 
-  buildType = "cmake";
-  buildInputs = [ ament-cmake-test cmake eigen git ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package eigen ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ ignition-cmake2-vendor ignition.math6 ];
-  nativeBuildInputs = [ ament-cmake-test cmake git ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
     description = ''This package provides the Ignition Math 6.x library.'';

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "9891592ab812b03309e6f19a3a60347a7b08d4ae1d1752ce9c639a19e40781af";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "6fdf4a628a3ea4a9e81d2fee480675b2ebbe30cc94c6705c65d258dde2f0cf5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "11e00ba69208875f744d1cdd74b6d6fe05cb79d71b5ffed290c11b8f99834945";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "d0cdfe5f8a29f44b64008cb2af88b300db71930f44f1fbf15291db215aceee28";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "bac42a79406b34cb1cfe9b523f37baddbb17742ee7da82bfe031165487baf7fe";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "5243e16372b02aae8b69c4822906566e36809dba9a1792c6c54f0a10cc7b28dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "2464e9adc385f1bc8b3881c440a5ab8dec67841ba1f24af4641b49dd3df4bd37";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "41cd411a8d68977dcb9e4899c319bb063103147ba3f1325aa1c6ff95ae1e2a49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lely-core-libraries/default.nix
+++ b/distros/rolling/lely-core-libraries/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, autoconf, automake, git, libtool, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-lely-core-libraries";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_canopen-release/archive/release/rolling/lely_core_libraries/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "f0c38eb7b26a7963586cdc883167a2d10abd2016b62c69212563de7bef8230a8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake autoconf automake git libtool ];
+  propagatedBuildInputs = [ python3Packages.empy ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS wrapper for lely-core-libraries'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/magic-enum/default.nix
+++ b/distros/rolling/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-magic-enum";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/rolling/magic_enum/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "f11a0fe5590db604cec7d166facbb3fc6f394afc6d7c1521e99b9ef0123188b0";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/rolling/magic_enum/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "7254ba1e519089e0cbcf346d268e79acc910e305230b722b5bbd49b084611a3d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mp2p-icp";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "8de115b2eefabbf22f67c0e9df510cb1a95beb2ea329a6b6e5102bd4c2d482de";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt-path-planning/default.nix
+++ b/distros/rolling/mrpt-path-planning/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
+buildRosPackage {
+  pname = "ros-rolling-mrpt-path-planning";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/rolling/mrpt_path_planning/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "fbd6e9741daa984cd34dea3124560e2a1632b1bb8a9429baf8a697f961cdc94f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mrpt2 mvsim ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Path planning and navigation algorithms for robots/vehicles moving on planar environments. This library builds upon mrpt-nav and the theory behind PTGs to generate libraries of &quot;motion primitives&quot; for vehicles with arbitrary shape and realistic kinematics and dynamics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.9.0-r2";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.9.0-2.tar.gz";
-    name = "2.9.0-2.tar.gz";
-    sha256 = "b8dba7f08ffac2ce87ec45b6f22fcc5c22f5db9fc3389b887e7de9018170e265";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "699a47292e5bc6e68d900ad238b73389aa01312401f8a5d811851c3fa5306567";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 tinyxml-2 udev wxGTK zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "07f26624e20db9a0081a463376e5868174ac2417c37577bd0d96e8ba028ad400";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "a0f7538c2f99a16de06c2f813f8811eff9a2164cc4d880acf15e555c81b80b30";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rc-reason-clients/default.nix
+++ b/distros/rolling/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rc-reason-clients";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_clients/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "f12a3b67c6c5a8843c3b33c6064806d47045f3a6c38d05b4c3fc0debe15a4105";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_clients/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "817dbcf9b2a34a691de40df8fd465f6dd129e5a8a0a9689dd289f9b5872ed7c0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rc-reason-msgs/default.nix
+++ b/distros/rolling/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rc-reason-msgs";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1280b76742f55556a48e3d1323a862bc2a9d900c62cfe5f86cf3acfb127a1732";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "57aa5ff808fa68b6804305000e5d21c6aee38fa10ce2cafa7f3723468b551582";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc-examples/default.nix
+++ b/distros/rolling/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc-examples";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_examples/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "99a67052a7ebcc62dd76db04d35f61989dcc5c5b4b269ce808bed5282fda22db";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_examples/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "e3db30d5aac9e6e646cbda81e85772b081b28e89d597ca3c4409244dfb9a2826";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc-lifecycle/default.nix
+++ b/distros/rolling/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc-lifecycle";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_lifecycle/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "e3511b425b526d85118ff1b73dc61a367a1df28dd683b1e780f4e7f2f17333f7";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_lifecycle/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "9c04d158b345936fa79515a323f8b9b5af20699f1228df54985e7c2e277b1133";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc-parameter/default.nix
+++ b/distros/rolling/rclc-parameter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc-parameter";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_parameter/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "d0c4140e6702ff8794341250ac30e30c056eaec2b11d883401df60066a2f6ce6";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc_parameter/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "5be033d6585a74e1ad3d0ff594db4330c7c175d0e4543ac5784ed529d672861a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclc/default.nix
+++ b/distros/rolling/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcl-action, rclcpp, rclcpp-action, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclc";
-  version = "3.0.9-r2";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc/3.0.9-2.tar.gz";
-    name = "3.0.9-2.tar.gz";
-    sha256 = "25791d10e312fb56a26ef04c64a1ad09b8704ee0e907ba99ff33b468a1018b37";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/rolling/rclc/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "eb8835f58fc5ad07d872d7d08570bb1e31a5be6684bcab8feb416c10e79fbbd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-api-msgs/default.nix
+++ b/distros/rolling/rmf-api-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nlohmann_json, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rmf-api-msgs";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/rolling/rmf_api_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "5792f3e25beec46d574ff4fae3b2f77363dddfd58ee239536811c8bfede5051f";
+    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/rolling/rmf_api_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d98ffe2714cb55bc42eb3c4ee2a99456feecf6e5d0062491bf9b90879fc58890";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-building-sim-common/default.nix
+++ b/distros/rolling/rmf-building-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, menge-vendor, rclcpp, rmf-building-map-msgs, rmf-door-msgs, rmf-lift-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-building-sim-common";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_building_sim_common/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "3130ced7406f1a3bf8af8d0d23c9713b7df0a26b2024440649b164e204c0002c";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_building_sim_common/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "8450d0e13732b04d3780e1e19ddabb269b1ecdbdda40833e52c5e426b19a0f74";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-building-sim-gz-classic-plugins/default.nix
+++ b/distros/rolling/rmf-building-sim-gz-classic-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-ros, menge-vendor, opencv, qt5, rclcpp, rmf-building-sim-common, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-building-sim-gz-classic-plugins";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_building_sim_gz_classic_plugins/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "a1950cb65818248fc3f8d2a4c246d45092e0e03bfaac869f0a08ee12b2048f90";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_building_sim_gz_classic_plugins/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "95e2528fed300a09acfa01d733a93293dd9f3202f60a0145c0dd3827015138c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-robot-sim-common/default.nix
+++ b/distros/rolling/rmf-robot-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rmf-robot-sim-common";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_common/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "19bd32d10e31755cc1c657b9ba9923d70abd4480a32bfa1f54729f46e3d621f9";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_common/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "7fd63d4fbb971cb28c4f2894964f414da030ce4bbef8f73627addca60ac184c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-robot-sim-gz-classic-plugins/default.nix
+++ b/distros/rolling/rmf-robot-sim-gz-classic-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, gazebo-dev, gazebo-ros, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-robot-sim-common }:
 buildRosPackage {
   pname = "ros-rolling-rmf-robot-sim-gz-classic-plugins";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_gz_classic_plugins/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "f3cccc7bcb22d35c7c93e6efc2ec3dd8221c9c99b44aaab97e3c041fc1f6a2ef";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_gz_classic_plugins/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d2a5cc4a6ae2073096df7a601cb6bdab8eba21d1de1103ad89f076e8fbe37e82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-task-sequence/default.nix
+++ b/distros/rolling/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-sequence";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "ef68a68b9be0f09df5665068700230f53352ad3947d524e17182c56f8e97bcaf";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "9e17bcbce80e6ec343b1db366cc09aebd727722a39767b4dbc4932ab7d4c489a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmf-task/default.nix
+++ b/distros/rolling/rmf-task/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5c1f7c2632fd06e24641915e47cb2fcae20ee7c032d1be33d674e11440a9240e";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "0d4661c6769cffc6762ce9c24cdfe0b9e96f7d03ed5f9448362a96e97e074ec2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "e7a4c44fe1b89571d6e55e10948e7bc540f4d31d2d372dcf4b0c3da0398ded33";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "6d7aef3c572928c382a90907bdd0fb5f783238563a9b49a54181951a5bfdc403";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "8493e021e124478c286b46ca0f9981a00d696c9a438c88ca8c56daff5a651c06";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "1015ff6e94b58d111220bd5909d31936e941071f77d03f7b7f21401fcfd5d965";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "79be934c257f4d004f7d394fe7bf9a9646db52d5a046d3345df510dcd46ea926";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "b78dfca9f1564d41debbc75e765dbbc0171b8f96bafbbf719978edcfd4184dc2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "53d107ce4618a86408dc1d7b1b7fa729f44489d27a02b076e1bb7f95ac914f58";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "6c4232eaed94b12b470d54802df183ae993c360867569c1a0b8f7a1bbacc11ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "89b0d58d625181d28a5c173fa16944d73fbe48a55cbeeef0ef062be814c11ff4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "b06d8fe34d21232953881cb4b4b586ce124edabf02f98705365cb78e7ea74c88";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "3176e4846704f6ad109b36dcfc48da8deb9f628c2842307fb7da7c6a49386c96";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "144a0acdae85f311d856fcfa72dbe356abf3675dfcbf85814ad775f80bdf8218";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "bc8131774f591427af1743276f4698c519bd559048a69f7bbf188749e85d00f2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "e863a46c34a2cdfe6360aa4bcfbd2ba4e2f8070f304c4e311ac87b293bf053ae";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "3e79cbe56fa097788f475b07f4084da67e6bb2cc008d3e688244fe62167f2b5a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "4cf6f5c92ff409f19e72bf4d44b89688216ce8e2267188a82ec5812659d75c15";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "3.13.0-r1";
+  version = "3.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.13.0-1.tar.gz";
-    name = "3.13.0-1.tar.gz";
-    sha256 = "19543ba7b6af952aa3df746e3c0fa30db35e6aa5d83c175f8843c4c998095f0f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.15.0-1.tar.gz";
+    name = "3.15.0-1.tar.gz";
+    sha256 = "b517a2718e802420986352a3e6842149df17fd10dea394fb3be51fe6eef002de";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "aade45486033cdcc6e5006f4b225f6d980d709e93ac1709e9d2b4d521e26693f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "d35963a00f7f010eab614364b249f1fc6a293c7233bb1e44ea6c22105ca3becf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "5c9e65a1de9e7e89d529e34990f7bb1e0c48d54ceb7789ea51c084db4e331c5e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "05dc39ef68646cb491e864c8c4c8496dd447ba194cfc90bb39ef1a1d513e98af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/urg-node-msgs/default.nix
+++ b/distros/rolling/urg-node-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-urg-node-msgs";
-  version = "1.0.1-r6";
+  version = "1.0.1-r7";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urg_node_msgs-release/archive/release/rolling/urg_node_msgs/1.0.1-6.tar.gz";
-    name = "1.0.1-6.tar.gz";
-    sha256 = "61cae54e2424a0b4cf485a290efcc9ce9f62a5bcb5592a7ab51522727b72833b";
+    url = "https://github.com/ros2-gbp/urg_node_msgs-release/archive/release/rolling/urg_node_msgs/1.0.1-7.tar.gz";
+    name = "1.0.1-7.tar.gz";
+    sha256 = "93104cffb9894b6fafecd0795a4a57758150ff293d94ac19e1a7d1b9b6443422";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "3.10.1-r1";
+  version = "3.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.10.1-1.tar.gz";
-    name = "3.10.1-1.tar.gz";
-    sha256 = "cb76c820b2b24aceb517003b599e62d2ee36e3eb2f6dc5a93585b1ea377f9477";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.11.0-1.tar.gz";
+    name = "3.11.0-1.tar.gz";
+    sha256 = "9fc3e7fe76e6c3498b49e000af0d19c1b17be546828b27cbe72c05947b33541f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-control/default.nix
+++ b/distros/rolling/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-control";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "fb95620927937ac8483c8b01e2fda8fe38b7174c974f7a1bbeb9661f3e70153e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "c09c09cc787aa48482dc428703359576210c3e8275248150680cf38ffe3bfb70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "23136537d00aa71acabd28c3e13d8afddd5d40b43402f87ccb991eeec96e390a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "79900e40a057638889841e0919152d5b347215287b4e351a1067f3507d31fbd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-epuck/default.nix
+++ b/distros/rolling/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-epuck";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "7fac020ba7585569c353ddde73ff88c83b6d817a85c3cc51254bac21e21e61ad";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "afbdc371f2f1eaa7bf6a1b59ec84dc8565ceed40c6b65c73d03c07fc42fc7579";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-importer/default.nix
+++ b/distros/rolling/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-importer";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "48f8537f47fd0eab39eaed7b7c40537ef1eb6b9585bcf3322bd2e1e1a6eca56e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "4f1fdcff08a5cc3922f1fe877b44962800155746046b8a88e09ca7dfeeca82f7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-mavic/default.nix
+++ b/distros/rolling/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-mavic";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "cac384d16776164927f04eb1980cf56a3d8fe46e9a052784c68a789e51139345";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "5b7e324288e1351acc7b7d5ac8f3b963e3ed286e3d4000363f44d6f1ba3162d8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-msgs/default.nix
+++ b/distros/rolling/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-msgs";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "11e57286cea912e3cca6fe050ecbc57301ee8c13b8c59f8d48073cc1440a468d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "24ebf0306cd5d731a93362fcc4128f2ee4207d360b392a9d701e95db5a96e16b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tesla";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "8b8f70c3611db55487c1936a19d6b5e76ba3d1446f3a49598eea8f425f8fdade";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "144661cd0e32a6167b6cbfb28e9c25fbd90fe02dab8d3bbe1d7f9a48c78c2898";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tests/default.nix
+++ b/distros/rolling/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tests";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "9e8dcd92fab0b38c5556edf078a12dc4826e1eecd86abcfe2d4616b483c25f08";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "f4516c2fa4c2079d1038d9baeb7b1b9c5a14944c05a727c032eb480784ab26c0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tiago/default.nix
+++ b/distros/rolling/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tiago";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "0a0c17202f5858a9b9ad205f447ffd57651ae5487256d6373b859d255ff3b92b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "528c7a19212dfbcf180d37d40806b691f0481c6cb4574be679e18f106d3f6990";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-turtlebot/default.nix
+++ b/distros/rolling/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-turtlebot";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "6fe08d8b367ce74b2ea6b1e6045d038a1ff1e1d86ce18742a1bc18d1bbe6e3fb";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "98cfadab40bda0bb5c8c775fcea0c11b9e3a2e779628e5474c44deb55b4d311a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-universal-robot/default.nix
+++ b/distros/rolling/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-universal-robot";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "3615c2dc16309a347211e93a0de2e0f2466f6306cfc945f1dbce2c957229445f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "906a59bc08ccddcc9c375b56a4ff963e9d31348783375ed6841a54dfeaa04ed0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2/default.nix
+++ b/distros/rolling/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2";
-  version = "2023.0.4-r1";
+  version = "2023.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.0.4-1.tar.gz";
-    name = "2023.0.4-1.tar.gz";
-    sha256 = "c282919afc6ddbb6f915ed5b261338f7b191813d70001307bd92b53e0b21d39a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.0-1.tar.gz";
+    name = "2023.1.0-1.tar.gz";
+    sha256 = "9e73981db8b44a2f1d0007047ca3a0412c00630c23f0387e4a3ebcf494cd0abc";
   };
 
   buildType = "ament_python";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'melodic', 'noetic', 'rolling'] from nix-ros-overlay commit 381164fc34d6b9d8b59f4e45e19cad1bec709892.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.23.0-r1*
* *admittance-controller 2.21.0-r1 --> 2.23.0-r1*
* *ament-cmake 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-auto 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-core 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-definitions 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-dependencies 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-include-directories 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-interfaces 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-libraries 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-link-flags 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-export-targets 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-gen-version-h 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-gmock 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-google-benchmark 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-gtest 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-include-directories 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-libraries 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-nose 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-pytest 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-python 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-target-dependencies 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-test 1.3.4-r2 --> 1.3.5-r1*
* *ament-cmake-version 1.3.4-r2 --> 1.3.5-r1*
* *behaviortree-cpp 4.2.1-r2 --> 4.3.1-r1*
* *behaviortree-cpp-v3 3.8.3-r2 --> 3.8.4-r1*
* *bicycle-steering-controller 2.23.0-r1*
* *catch-ros2 0.1.0-r1*
* *clearpath-config 0.0.2-r2*
* *clearpath-msgs 0.0.3-r1 --> 0.0.4-r1*
* *clearpath-platform-msgs 0.0.3-r1 --> 0.0.4-r1*
* *controller-interface 2.26.0-r1 --> 2.28.0-r1*
* *controller-manager 2.26.0-r1 --> 2.28.0-r1*
* *controller-manager-msgs 2.26.0-r1 --> 2.28.0-r1*
* *costmap-queue 1.1.7-r3 --> 1.1.8-r2*
* *depthai 2.21.2-r1 --> 2.22.0-r1*
* *depthai-bridge 2.7.2-r1 --> 2.7.4-r1*
* *depthai-descriptions 2.7.2-r1 --> 2.7.4-r1*
* *depthai-examples 2.7.2-r1 --> 2.7.4-r1*
* *depthai-filters 2.7.2-r1 --> 2.7.4-r1*
* *depthai-ros 2.7.2-r1 --> 2.7.4-r1*
* *depthai-ros-driver 2.7.2-r1 --> 2.7.4-r1*
* *depthai-ros-msgs 2.7.2-r1 --> 2.7.4-r1*
* *diff-drive-controller 2.21.0-r1 --> 2.23.0-r1*
* *dwb-core 1.1.7-r3 --> 1.1.8-r2*
* *dwb-critics 1.1.7-r3 --> 1.1.8-r2*
* *dwb-msgs 1.1.7-r3 --> 1.1.8-r2*
* *dwb-plugins 1.1.7-r3 --> 1.1.8-r2*
* *effort-controllers 2.21.0-r1 --> 2.23.0-r1*
* *executive-smach 3.0.2-r1*
* *fastrtps 2.6.4-r1 --> 2.6.5-r1*
* *force-torque-sensor-broadcaster 2.21.0-r1 --> 2.23.0-r1*
* *forward-command-controller 2.21.0-r1 --> 2.23.0-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gps-msgs 2.0.1-r1 --> 2.0.2-r1*
* *gps-tools 2.0.1-r1 --> 2.0.2-r1*
* *gps-umd 2.0.1-r1 --> 2.0.2-r1*
* *gpsd-client 2.0.1-r1 --> 2.0.2-r1*
* *gripper-controllers 2.21.0-r1 --> 2.23.0-r1*
* *hardware-interface 2.26.0-r1 --> 2.28.0-r1*
* *hey5-description 3.0.2-r1 --> 3.0.3-r1*
* *imu-sensor-broadcaster 2.21.0-r1 --> 2.23.0-r1*
* *joint-limits 2.26.0-r1 --> 2.28.0-r1*
* *joint-state-broadcaster 2.21.0-r1 --> 2.23.0-r1*
* *joint-trajectory-controller 2.21.0-r1 --> 2.23.0-r1*
* *launch-pal 0.0.7-r1 --> 0.0.8-r1*
* *librealsense2 2.51.1-r2 --> 2.54.1-r1*
* *lms1xx 1.0.0-r1*
* *magic-enum 0.9.2-r1 --> 0.9.3-r1*
* *mp2p-icp 0.1.0-r1*
* *mrpt-path-planning 0.1.0-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *nav-2d-msgs 1.1.7-r3 --> 1.1.8-r2*
* *nav-2d-utils 1.1.7-r3 --> 1.1.8-r2*
* *nav2-amcl 1.1.7-r3 --> 1.1.8-r2*
* *nav2-behavior-tree 1.1.7-r3 --> 1.1.8-r2*
* *nav2-behaviors 1.1.7-r3 --> 1.1.8-r2*
* *nav2-bringup 1.1.7-r3 --> 1.1.8-r2*
* *nav2-bt-navigator 1.1.7-r3 --> 1.1.8-r2*
* *nav2-collision-monitor 1.1.7-r3 --> 1.1.8-r2*
* *nav2-common 1.1.7-r3 --> 1.1.8-r2*
* *nav2-constrained-smoother 1.1.7-r3 --> 1.1.8-r2*
* *nav2-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-core 1.1.7-r3 --> 1.1.8-r2*
* *nav2-costmap-2d 1.1.7-r3 --> 1.1.8-r2*
* *nav2-dwb-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-lifecycle-manager 1.1.7-r3 --> 1.1.8-r2*
* *nav2-map-server 1.1.7-r3 --> 1.1.8-r2*
* *nav2-msgs 1.1.7-r3 --> 1.1.8-r2*
* *nav2-navfn-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-regulated-pure-pursuit-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-rotation-shim-controller 1.1.7-r3 --> 1.1.8-r2*
* *nav2-rviz-plugins 1.1.7-r3 --> 1.1.8-r2*
* *nav2-simple-commander 1.1.7-r3 --> 1.1.8-r2*
* *nav2-smac-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-smoother 1.1.7-r3 --> 1.1.8-r2*
* *nav2-system-tests 1.1.7-r3 --> 1.1.8-r2*
* *nav2-theta-star-planner 1.1.7-r3 --> 1.1.8-r2*
* *nav2-util 1.1.7-r3 --> 1.1.8-r2*
* *nav2-velocity-smoother 1.1.7-r3 --> 1.1.8-r2*
* *nav2-voxel-grid 1.1.7-r3 --> 1.1.8-r2*
* *nav2-waypoint-follower 1.1.7-r3 --> 1.1.8-r2*
* *navigation2 1.1.7-r3 --> 1.1.8-r2*
* *pal-gazebo-plugins 4.0.3-r1 --> 4.0.4-r1*
* *pmb2-2dnav 4.0.4-r1 --> 4.0.5-r1*
* *pmb2-bringup 5.0.4-r1 --> 5.0.6-r1*
* *pmb2-controller-configuration 5.0.4-r1 --> 5.0.6-r1*
* *pmb2-description 5.0.4-r1 --> 5.0.6-r1*
* *pmb2-gazebo 4.0.3-r1 --> 4.0.4-r1*
* *pmb2-laser-sensors 4.0.4-r1 --> 4.0.5-r1*
* *pmb2-maps 4.0.4-r1 --> 4.0.5-r1*
* *pmb2-navigation 4.0.4-r1 --> 4.0.5-r1*
* *pmb2-robot 5.0.4-r1 --> 5.0.6-r1*
* *pmb2-simulation 4.0.3-r1 --> 4.0.4-r1*
* *position-controllers 2.21.0-r1 --> 2.23.0-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *realsense2-camera 4.51.1-r1 --> 4.54.1-r1*
* *realsense2-camera-msgs 4.51.1-r1 --> 4.54.1-r1*
* *realsense2-description 4.51.1-r1 --> 4.54.1-r1*
* *rmf-api-msgs 0.0.2-r1 --> 0.0.3-r1*
* *rmf-building-sim-common 2.0.1-r1 --> 2.0.2-r1*
* *rmf-building-sim-gz-classic-plugins 2.0.1-r1 --> 2.0.2-r1*
* *rmf-robot-sim-common 2.0.1-r1 --> 2.0.2-r1*
* *rmf-robot-sim-gz-classic-plugins 2.0.1-r1 --> 2.0.2-r1*
* *rmf-task 2.1.4-r1 --> 2.1.5-r1*
* *rmf-task-sequence 2.1.4-r1 --> 2.1.5-r1*
* *ros2-control 2.26.0-r1 --> 2.28.0-r1*
* *ros2-control-test-assets 2.26.0-r1 --> 2.28.0-r1*
* *ros2-controllers 2.21.0-r1 --> 2.23.0-r1*
* *ros2-controllers-test-nodes 2.21.0-r1 --> 2.23.0-r1*
* *ros2controlcli 2.26.0-r1 --> 2.28.0-r1*
* *rqt-controller-manager 2.26.0-r1 --> 2.28.0-r1*
* *rqt-joint-trajectory-controller 2.21.0-r1 --> 2.23.0-r1*
* *smach 3.0.2-r1*
* *smach-msgs 3.0.2-r1*
* *smach-ros 3.0.2-r1*
* *steering-controllers-library 2.23.0-r1*
* *transmission-interface 2.26.0-r1 --> 2.28.0-r1*
* *tricycle-controller 2.21.0-r1 --> 2.23.0-r1*
* *tricycle-steering-controller 2.23.0-r1*
* *tuw-airskin-msgs 0.0.15-r3 --> 0.2.1-r1*
* *tuw-geometry 0.0.9-r1 --> 0.1.1-r1*
* *tuw-geometry-msgs 0.0.15-r3 --> 0.2.1-r1*
* *tuw-msgs 0.0.15-r3 --> 0.2.1-r1*
* *tuw-multi-robot-msgs 0.0.15-r3 --> 0.2.1-r1*
* *tuw-nav-msgs 0.0.15-r3 --> 0.2.1-r1*
* *tuw-object-msgs 0.0.15-r3 --> 0.2.1-r1*
* *ur 2.2.7-r1 --> 2.2.8-r1*
* *ur-bringup 2.2.7-r1 --> 2.2.8-r1*
* *ur-calibration 2.2.7-r1 --> 2.2.8-r1*
* *ur-controllers 2.2.7-r1 --> 2.2.8-r1*
* *ur-dashboard-msgs 2.2.7-r1 --> 2.2.8-r1*
* *ur-moveit-config 2.2.7-r1 --> 2.2.8-r1*
* *velocity-controllers 2.21.0-r1 --> 2.23.0-r1*
* *webots-ros2 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-control 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-driver 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-epuck 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-importer 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-mavic 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-msgs 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tesla 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tests 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tiago 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-turtlebot 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-universal-robot 2023.0.4-r1 --> 2023.1.0-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.10.1-r1 --> 3.11.0-r1*
* *admittance-controller 3.10.1-r1 --> 3.11.0-r1*
* *ament-cmake 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-auto 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-core 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-definitions 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-dependencies 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-include-directories 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-interfaces 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-libraries 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-link-flags 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-export-targets 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-gen-version-h 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-gmock 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-google-benchmark 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-gtest 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-include-directories 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-libraries 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-pytest 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-python 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-target-dependencies 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-test 2.0.2-r2 --> 2.0.3-r1*
* *ament-cmake-version 2.0.2-r2 --> 2.0.3-r1*
* *behaviortree-cpp 4.2.1-r1 --> 4.3.1-r1*
* *behaviortree-cpp-v3 3.8.3-r5 --> 3.8.4-r1*
* *bicycle-steering-controller 3.10.1-r1 --> 3.11.0-r1*
* *catch-ros2 0.1.0-r1*
* *controller-interface 3.12.1-r2 --> 3.15.0-r1*
* *controller-manager 3.12.1-r2 --> 3.15.0-r1*
* *controller-manager-msgs 3.12.1-r2 --> 3.15.0-r1*
* *depthai 2.21.2-r1 --> 2.22.0-r1*
* *depthai-bridge 2.7.4-r1*
* *depthai-descriptions 2.7.4-r1*
* *depthai-examples 2.7.4-r1*
* *depthai-filters 2.7.4-r1*
* *depthai-ros 2.7.4-r1*
* *depthai-ros-driver 2.7.4-r1*
* *depthai-ros-msgs 2.7.4-r1*
* *diff-drive-controller 3.10.1-r1 --> 3.11.0-r1*
* *effort-controllers 3.10.1-r1 --> 3.11.0-r1*
* *executive-smach 3.0.2-r1*
* *force-torque-sensor-broadcaster 3.10.1-r1 --> 3.11.0-r1*
* *forward-command-controller 3.10.1-r1 --> 3.11.0-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gps-msgs 2.0.1-r1 --> 2.0.2-r1*
* *gps-tools 2.0.1-r1 --> 2.0.2-r1*
* *gps-umd 2.0.1-r1 --> 2.0.2-r1*
* *gpsd-client 2.0.1-r1 --> 2.0.2-r1*
* *gripper-controllers 3.10.1-r1 --> 3.11.0-r1*
* *hardware-interface 3.12.1-r2 --> 3.15.0-r1*
* *imu-sensor-broadcaster 3.10.1-r1 --> 3.11.0-r1*
* *joint-limits 3.12.1-r2 --> 3.15.0-r1*
* *joint-state-broadcaster 3.10.1-r1 --> 3.11.0-r1*
* *joint-trajectory-controller 3.10.1-r1 --> 3.11.0-r1*
* *librealsense2 2.54.1-r2*
* *magic-enum 0.9.2-r1 --> 0.9.3-r1*
* *mp2p-icp 0.1.0-r1*
* *mrpt-path-planning 0.1.0-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *position-controllers 3.10.1-r1 --> 3.11.0-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *rclc 3.0.9-r3 --> 5.0.1-r1*
* *rclc-examples 3.0.9-r3 --> 5.0.1-r1*
* *rclc-lifecycle 3.0.9-r3 --> 5.0.1-r1*
* *rclc-parameter 3.0.9-r3 --> 5.0.1-r1*
* *realsense2-camera 4.54.1-r1*
* *realsense2-camera-msgs 4.54.1-r1*
* *realsense2-description 4.54.1-r1*
* *rmf-api-msgs 0.1.0-r1 --> 0.1.1-r1*
* *rmf-building-sim-common 2.1.0-r1 --> 2.1.1-r1*
* *rmf-building-sim-gz-classic-plugins 2.1.0-r1 --> 2.1.1-r1*
* *rmf-robot-sim-common 2.1.0-r1 --> 2.1.1-r1*
* *rmf-robot-sim-gz-classic-plugins 2.1.0-r1 --> 2.1.1-r1*
* *rmf-task 2.2.0-r1 --> 2.2.1-r1*
* *rmf-task-sequence 2.2.0-r1 --> 2.2.1-r1*
* *ros2-control 3.12.1-r2 --> 3.15.0-r1*
* *ros2-control-test-assets 3.12.1-r2 --> 3.15.0-r1*
* *ros2-controllers 3.10.1-r1 --> 3.11.0-r1*
* *ros2-controllers-test-nodes 3.10.1-r1 --> 3.11.0-r1*
* *ros2controlcli 3.12.1-r2 --> 3.15.0-r1*
* *rqt-controller-manager 3.12.1-r2 --> 3.15.0-r1*
* *rqt-joint-trajectory-controller 3.10.1-r1 --> 3.11.0-r1*
* *smach 3.0.2-r1*
* *smach-msgs 3.0.2-r1*
* *smach-ros 3.0.2-r1*
* *steering-controllers-library 3.10.1-r1 --> 3.11.0-r1*
* *transmission-interface 3.12.1-r2 --> 3.15.0-r1*
* *tricycle-controller 3.10.1-r1 --> 3.11.0-r1*
* *tricycle-steering-controller 3.10.1-r1 --> 3.11.0-r1*
* *velocity-controllers 3.10.1-r1 --> 3.11.0-r1*
* *webots-ros2 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-control 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-driver 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-epuck 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-importer 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-mavic 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-msgs 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tesla 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tests 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tiago 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-turtlebot 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-universal-robot 2023.0.4-r1 --> 2023.1.0-r1*

Melodic Changes:
----------------
* *costmap-cspace-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *cras-imu-tools 1.0.1-r1*
* *cras-laser-geometry 1.1.2-r1*
* *executive-smach 2.0.1 --> 2.0.3-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gps-common 0.3.3-r1 --> 0.3.4-r1*
* *gps-umd 0.3.3-r1 --> 0.3.4-r1*
* *gpsd-client 0.3.3-r1 --> 0.3.4-r1*
* *image-transport-codecs 2.2.2-r1 --> 2.2.3-r1*
* *neonavigation-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *point-cloud-color 1.2.1-r1*
* *point-cloud-transport-plugins 1.0.3-r1 --> 1.0.5-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *septentrio-gnss-driver 1.2.3-r2 --> 1.3.0-r1*
* *simple-grasping 0.3.1 --> 0.4.1-r1*
* *smach 2.0.1 --> 2.0.3-r1*
* *smach-msgs 2.0.1 --> 2.0.3-r1*
* *smach-ros 2.0.1 --> 2.0.3-r1*
* *trajectory-tracker-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*

Noetic Changes:
---------------
* *aques-talk 2.1.26-r1*
* *assimp-devel 2.1.21-r2 --> 2.1.26-r1*
* *bayesian-belief-networks 2.1.21-r2 --> 2.1.26-r1*
* *behaviortree-cpp-v3 3.8.3-r1 --> 3.8.4-r1*
* *chaplus-ros 2.1.26-r1*
* *costmap-cspace-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *cpp-common 0.7.2-r1 --> 0.7.3-r1*
* *cras-imu-tools 1.0.1-r1*
* *cras-laser-geometry 1.1.2-r1*
* *depthai 2.21.2-r1 --> 2.22.0-r1*
* *depthai-bridge 2.7.2-r1 --> 2.7.4-r1*
* *depthai-descriptions 2.7.2-r1 --> 2.7.4-r1*
* *depthai-examples 2.7.2-r1 --> 2.7.4-r1*
* *depthai-filters 2.7.2-r1 --> 2.7.4-r1*
* *depthai-ros 2.7.2-r1 --> 2.7.4-r1*
* *depthai-ros-driver 2.7.2-r1 --> 2.7.4-r1*
* *depthai-ros-msgs 2.7.2-r1 --> 2.7.4-r1*
* *dialogflow-task-executive 2.1.26-r1*
* *downward 2.1.21-r2 --> 2.1.26-r1*
* *euslisp 9.29.0-r1 --> 9.29.0-r2*
* *executive-smach 2.5.1-r1 --> 2.5.2-r1*
* *ff 2.1.21-r2 --> 2.1.26-r1*
* *ffha 2.1.21-r2 --> 2.1.26-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gdrive-ros 2.1.26-r1*
* *google-chat-ros 2.1.26-r1*
* *gps-common 0.3.3-r1 --> 0.3.4-r1*
* *gps-umd 0.3.3-r1 --> 0.3.4-r1*
* *gpsd-client 0.3.3-r1 --> 0.3.4-r1*
* *gtsam 4.2.0-r2*
* *hri-actions-msgs 0.4.2-r1*
* *hri-rviz 0.3.1-r1 --> 0.4.0-r1*
* *image-transport-codecs 2.2.2-r1 --> 2.2.3-r1*
* *jsk-3rdparty 2.1.26-r1*
* *julius 2.1.21-r2 --> 2.1.26-r1*
* *libcmt 2.1.21-r2 --> 2.1.26-r1*
* *libsiftfast 2.1.21-r2 --> 2.1.26-r1*
* *lpg-planner 2.1.21-r2 --> 2.1.26-r1*
* *magic-enum 0.9.2-r1 --> 0.9.3-r1*
* *mini-maxwell 2.1.21-r2 --> 2.1.26-r1*
* *mrpt-path-planning 0.1.0-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *neonavigation-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *nfc-ros 2.1.26-r1*
* *opt-camera 2.1.21-r2 --> 2.1.26-r1*
* *osqp 2.1.26-r1*
* *point-cloud-color 1.2.1-r1*
* *point-cloud-transport-plugins 1.0.3-r1 --> 1.0.5-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *respeaker-ros 2.1.26-r1*
* *ridgeback-control 0.3.3-r2 --> 0.3.4-r1*
* *ridgeback-description 0.3.3-r2 --> 0.3.4-r1*
* *ridgeback-msgs 0.3.3-r2 --> 0.3.4-r1*
* *ridgeback-navigation 0.3.3-r2 --> 0.3.4-r1*
* *ros-google-cloud-language 2.1.26-r1*
* *ros-industrial-cmake-boilerplate 0.4.0-r1 --> 0.4.7-r1*
* *roscpp-core 0.7.2-r1 --> 0.7.3-r1*
* *roscpp-serialization 0.7.2-r1 --> 0.7.3-r1*
* *roscpp-traits 0.7.2-r1 --> 0.7.3-r1*
* *rospatlite 2.1.21-r2 --> 2.1.26-r1*
* *rosping 2.1.21-r2 --> 2.1.26-r1*
* *rostime 0.7.2-r1 --> 0.7.3-r1*
* *rostwitter 2.1.21-r2 --> 2.1.26-r1*
* *rviz-robot-description-topic 1.0.0-r1*
* *septentrio-gnss-driver 1.2.3-r1 --> 1.3.0-r1*
* *sesame-ros 2.1.21-r2 --> 2.1.26-r1*
* *slic 2.1.21-r2 --> 2.1.26-r1*
* *smach 2.5.1-r1 --> 2.5.2-r1*
* *smach-msgs 2.5.1-r1 --> 2.5.2-r1*
* *smach-ros 2.5.1-r1 --> 2.5.2-r1*
* *switchbot-ros 2.1.26-r1*
* *tesseract-collision 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-common 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-environment 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-geometry 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-kinematics 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-scene-graph 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-srdf 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-state-solver 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-support 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-urdf 0.15.2-r1 --> 0.18.0-r1*
* *tesseract-visualization 0.15.2-r1 --> 0.18.0-r1*
* *trajectory-tracker-rviz-plugins 0.11.6-r1 --> 0.11.7-r1*
* *voice-text 2.1.21-r2 --> 2.1.26-r1*
* *webots-ros 2023.0.0-r1 --> 2023.1.0-r1*
* *zdepth 2.1.26-r1*
* *zdepth-image-transport 2.1.26-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 3.10.1-r1 --> 3.11.0-r1*
* *admittance-controller 3.10.1-r1 --> 3.11.0-r1*
* *ament-cmake 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-auto 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-core 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-definitions 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-dependencies 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-include-directories 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-interfaces 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-libraries 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-link-flags 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-export-targets 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-gen-version-h 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-gmock 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-google-benchmark 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-gtest 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-include-directories 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-libraries 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-pytest 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-python 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-target-dependencies 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-test 2.2.0-r1 --> 2.2.1-r1*
* *ament-cmake-version 2.2.0-r1 --> 2.2.1-r1*
* *behaviortree-cpp 4.2.1-r1 --> 4.3.1-r1*
* *behaviortree-cpp-v3 3.8.3-r4 --> 3.8.4-r1*
* *bicycle-steering-controller 3.10.1-r1 --> 3.11.0-r1*
* *canopen 0.2.6-r1*
* *canopen-402-driver 0.2.6-r1*
* *canopen-base-driver 0.2.6-r1*
* *canopen-core 0.2.6-r1*
* *canopen-fake-slaves 0.2.6-r1*
* *canopen-interfaces 0.2.6-r1*
* *canopen-master-driver 0.2.6-r1*
* *canopen-proxy-driver 0.2.6-r1*
* *canopen-ros2-control 0.2.6-r1*
* *canopen-ros2-controllers 0.2.6-r1*
* *canopen-tests 0.2.6-r1*
* *canopen-utils 0.2.6-r1*
* *catch-ros2 0.1.0-r1*
* *controller-interface 3.13.0-r1 --> 3.15.0-r1*
* *controller-manager 3.13.0-r1 --> 3.15.0-r1*
* *controller-manager-msgs 3.13.0-r1 --> 3.15.0-r1*
* *diff-drive-controller 3.10.1-r1 --> 3.11.0-r1*
* *effort-controllers 3.10.1-r1 --> 3.11.0-r1*
* *force-torque-sensor-broadcaster 3.10.1-r1 --> 3.11.0-r1*
* *forward-command-controller 3.10.1-r1 --> 3.11.0-r1*
* *foxglove-bridge 0.6.2-r1 --> 0.6.3-r1*
* *gripper-controllers 3.10.1-r1 --> 3.11.0-r1*
* *hardware-interface 3.13.0-r1 --> 3.15.0-r1*
* *ignition-cmake2-vendor 0.2.0-r1 --> 0.2.1-r1*
* *ignition-math6-vendor 0.2.0-r1 --> 0.2.1-r1*
* *imu-sensor-broadcaster 3.10.1-r1 --> 3.11.0-r1*
* *joint-limits 3.13.0-r1 --> 3.15.0-r1*
* *joint-state-broadcaster 3.10.1-r1 --> 3.11.0-r1*
* *joint-trajectory-controller 3.10.1-r1 --> 3.11.0-r1*
* *lely-core-libraries 0.2.6-r1*
* *magic-enum 0.9.2-r1 --> 0.9.3-r1*
* *mp2p-icp 0.1.0-r1*
* *mrpt-path-planning 0.1.0-r1*
* *mrpt2 2.9.0-r2 --> 2.9.3-r1*
* *position-controllers 3.10.1-r1 --> 3.11.0-r1*
* *rc-reason-clients 0.3.0-r1 --> 0.3.1-r1*
* *rc-reason-msgs 0.3.0-r1 --> 0.3.1-r1*
* *rclc 3.0.9-r2 --> 6.1.0-r1*
* *rclc-examples 3.0.9-r2 --> 6.1.0-r1*
* *rclc-lifecycle 3.0.9-r2 --> 6.1.0-r1*
* *rclc-parameter 3.0.9-r2 --> 6.1.0-r1*
* *rmf-api-msgs 0.2.0-r1 --> 0.2.1-r1*
* *rmf-building-sim-common 2.2.0-r1 --> 2.2.1-r1*
* *rmf-building-sim-gz-classic-plugins 2.2.0-r1 --> 2.2.1-r1*
* *rmf-robot-sim-common 2.2.0-r1 --> 2.2.1-r1*
* *rmf-robot-sim-gz-classic-plugins 2.2.0-r1 --> 2.2.1-r1*
* *rmf-task 2.3.0-r1 --> 2.3.1-r1*
* *rmf-task-sequence 2.3.0-r1 --> 2.3.1-r1*
* *ros2-control 3.13.0-r1 --> 3.15.0-r1*
* *ros2-control-test-assets 3.13.0-r1 --> 3.15.0-r1*
* *ros2-controllers 3.10.1-r1 --> 3.11.0-r1*
* *ros2-controllers-test-nodes 3.10.1-r1 --> 3.11.0-r1*
* *ros2controlcli 3.13.0-r1 --> 3.15.0-r1*
* *rqt-controller-manager 3.13.0-r1 --> 3.15.0-r1*
* *rqt-joint-trajectory-controller 3.10.1-r1 --> 3.11.0-r1*
* *steering-controllers-library 3.10.1-r1 --> 3.11.0-r1*
* *transmission-interface 3.13.0-r1 --> 3.15.0-r1*
* *tricycle-controller 3.10.1-r1 --> 3.11.0-r1*
* *tricycle-steering-controller 3.10.1-r1 --> 3.11.0-r1*
* *urg-node-msgs 1.0.1-r6 --> 1.0.1-r7*
* *velocity-controllers 3.10.1-r1 --> 3.11.0-r1*
* *webots-ros2 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-control 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-driver 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-epuck 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-importer 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-mavic 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-msgs 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tesla 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tests 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-tiago 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-turtlebot 2023.0.4-r1 --> 2023.1.0-r1*
* *webots-ros2-universal-robot 2023.0.4-r1 --> 2023.1.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libqt5-svg
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] mapnik-utils
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] moveit_calibration_plugins
 * [ ] ocl-icd-opencl-dev
 * [ ] postgresql-postgis
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-sphinx
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-mistune
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-pysnmp
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-vcstool
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote
 * [ ] xsimd
 * [ ] xtensor

