### PR TITLE
Build ROS Python packages like colcon

### DIFF
--- a/distros/build-ros-package/default.nix
+++ b/distros/build-ros-package/default.nix
@@ -37,8 +37,6 @@ else stdenv.mkDerivation) (args // {
 
   nativeBuildInputs = nativeBuildInputs ++ [ pythonPackages.setuptools ];
 
-  dontWrapPythonPrograms = true;
-
   buildPhase = ''
     runHook preBuild
 

--- a/distros/build-ros-package/default.nix
+++ b/distros/build-ros-package/default.nix
@@ -31,7 +31,10 @@ else stdenv.mkDerivation) (args // {
 } // lib.optionalAttrs (buildType == "ament_python") {
   dontUseCmakeConfigure = true;
 
-  # Modelled after colcon:
+  # Modelled after colcon.
+  # As of 0.12.1, colcon uses the legacy distutils install.py script, so we do
+  # the same. Using modern techniques, such as "pip install" with setuptools,
+  # causes issues due to differences in setup.cfg interpretation.
   # https://github.com/colcon/colcon-core/blob/0.12.1/colcon_core/task/python/build.py#L84
   format = "other";
 

--- a/distros/build-ros-package/default.nix
+++ b/distros/build-ros-package/default.nix
@@ -32,7 +32,7 @@ else stdenv.mkDerivation) (args // {
   dontUseCmakeConfigure = true;
 
   # Modelled after colcon:
-  # https://github.com/colcon/colcon-core/blob/master/colcon_core/task/python/build.py
+  # https://github.com/colcon/colcon-core/blob/0.12.1/colcon_core/task/python/build.py#L84
   format = "other";
 
   nativeBuildInputs = nativeBuildInputs ++ [ pythonPackages.setuptools ];

--- a/distros/build-ros-package/default.nix
+++ b/distros/build-ros-package/default.nix
@@ -57,8 +57,8 @@ else stdenv.mkDerivation) (args // {
 
   postFixup = ''
     ${postFixup}
-    find "$out/lib" -mindepth 1 -maxdepth 1 -type d ! -name '${pythonPackages.python.libPrefix}' -print0 | while read -d '''''' d; do
-      wrapPythonProgramsIn "$d" "$out $pythonPath"
+    find "$out/lib" -mindepth 1 -maxdepth 1 -type d ! -name '${pythonPackages.python.libPrefix}' -print0 | while read -d "" libpkgdir; do
+      wrapPythonProgramsIn "$libpkgdir" "$out $pythonPath"
     done
   '';
 })

--- a/distros/build-ros-package/default.nix
+++ b/distros/build-ros-package/default.nix
@@ -11,7 +11,8 @@
 , dontWrapQtApps ? true
 , nativeBuildInputs ? [ ]
 , CXXFLAGS ? ""
-, passthru ? {}
+, postFixup ? ""
+, passthru ? { }
 , ...
 }@args:
 
@@ -36,6 +37,8 @@ else stdenv.mkDerivation) (args // {
 
   nativeBuildInputs = nativeBuildInputs ++ [ pythonPackages.setuptools ];
 
+  dontWrapPythonPrograms = true;
+
   buildPhase = ''
     runHook preBuild
 
@@ -52,5 +55,12 @@ else stdenv.mkDerivation) (args // {
     python setup.py install --prefix="$out" --single-version-externally-managed --record /dev/null
 
     runHook postInstall
+  '';
+
+  postFixup = ''
+    ${postFixup}
+    find "$out/lib" -mindepth 1 -maxdepth 1 -type d ! -name '${pythonPackages.python.libPrefix}' -print0 | while read -d '''''' d; do
+      wrapPythonProgramsIn "$d" "$out $pythonPath"
+    done
   '';
 })

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -195,7 +195,7 @@ let
       dontWrapQtApps = false;
       nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
       postFixup = postFixup + ''
-        wrapQtApp "$out/bin/rqt_console"
+        wrapQtApp "$out/lib/rqt_console/rqt_console"
       '';
     });
 
@@ -205,7 +205,7 @@ let
       dontWrapQtApps = false;
       nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
       postFixup = postFixup + ''
-        wrapQtApp "$out/bin/rqt_graph"
+        wrapQtApp "$out/lib/rqt_graph/rqt_graph"
       '';
     });
 
@@ -242,7 +242,7 @@ let
       dontWrapQtApps = false;
       nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
       postFixup = postFixup + ''
-        wrapQtApp "$out/bin/rqt_plot"
+        wrapQtApp "$out/lib/rqt_plot/rqt_plot"
       '';
     });
     
@@ -287,7 +287,7 @@ let
       dontWrapQtApps = false;
       nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
       postFixup = postFixup + ''
-        wrapQtApp "$out/bin/rqt_shell"
+        wrapQtApp "$out/lib/rqt_shell/rqt_shell"
       '';
     });
 

--- a/distros/noetic/overrides.nix
+++ b/distros/noetic/overrides.nix
@@ -92,7 +92,7 @@ rosSelf: rosSuper: with rosSelf.lib; {
     postFixup ? "", ...
   }: {
     postFixup = postFixup + ''
-      wrapQtApp "$out/bin/rqt_image_view"
+      wrapQtApp "$out/lib/rqt_image_view/rqt_image_view"
     '';
   });
 

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -143,7 +143,7 @@ rosSelf: rosSuper: with rosSelf.lib; {
     postFixup ? "", ...
   }: {
     postFixup = postFixup + ''
-      wrapQtApp "$out/bin/rqt_robot_monitor"
+      wrapQtApp "$out/lib/rqt_robot_monitor/rqt_robot_monitor"
     '';
   });
 


### PR DESCRIPTION
[It seems](https://github.com/colcon/colcon-core/blob/99c03262ad7edd4af5954c424c9248e0c4fe7307/colcon_core/task/python/build.py#L91) that colcon uses the deprecated `setup.py`-style build and installation commands to build Python ROS packages.

This changes the `ament_python` variant of `buildRosPackage` to use those commands.

Fixes #230, #273.
Closes #270.

Tested with `ros-core` from Rolling, Foxy and Noetic.