### PR TITLE
rosdistro sync, Fri Jul 28 13:37:31 2023

### DIFF
--- a/distros/humble/ament-clang-format/default.nix
+++ b/distros/humble/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-clang-format";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_format/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "50748c1e2732bb9d104fe5834dfc94e945e185915f36282db9b307fa430ed888";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_format/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "990a4f81a75ebd6aa2c77f39ea9ed61691ea0d5f207c81674f01d931ac21de33";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-clang-tidy/default.nix
+++ b/distros/humble/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-clang-tidy";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_tidy/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "24f3e63c16cb6b60774f18025faa8edaf7d509eea92282c7c5bfa7d84bbff748";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_tidy/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "e3cf15ac7db7aacc53ff8497a81865c58104a249126fcffc359a7a43b254cd98";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cmake-clang-format/default.nix
+++ b/distros/humble/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-clang-format";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_format/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "1155c9a7b89e70929c60b8d37aabcd6c3011f33a1d62868c76e53acd9edfe5a4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_format/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "e1683e60ccd4a8ba46f10de4e317700e10e997cd7ad4289a323eb30017a4fbd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-clang-tidy/default.nix
+++ b/distros/humble/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-clang-tidy";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_tidy/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "de9c86a378181cd32c3aeb96d29b37ec1467504c56d66dba3613cb646b732d22";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_tidy/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "2c32cf98876f8302245264007abf5aaa099d2a82bbf76545dfce306092a52154";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-copyright/default.nix
+++ b/distros/humble/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-copyright";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_copyright/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "78d982b342c425f50eea1425a4e15e961baf3a7c96f36dd3e972c185325f52d7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_copyright/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "632ecb7f866d61b178aaba39b90be969d3371c8bbd3e247666df32cdddc3857e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-cppcheck/default.nix
+++ b/distros/humble/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-cppcheck";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cppcheck/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "12ce8522a24fab41c5c90f167c442e7c184aa1ba9faf8176230e54a0ea542ffb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cppcheck/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "010010ba284aa804e9d6f06e62ce7cc260aadfe422aebb1c0296b49752e3e749";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-cpplint/default.nix
+++ b/distros/humble/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-cpplint";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cpplint/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "9b512278b558ca595da675ddc3f27db5618f07b277ed80cd7d6c82871449688f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cpplint/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "130cc2b9b5dea425e54a9fe478c3bc61a735ace856295a97a8e43480b2e467b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-flake8/default.nix
+++ b/distros/humble/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-flake8";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_flake8/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "ce8be7e5c14a4a69343acd6a7f9ad968abd2f6aa225c726acd4c7cf179f8a2a8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_flake8/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "ac0b3f5e3a32c9f30d5f51964dd369e9007f998407145aef2787f82c8d511370";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-lint-cmake/default.nix
+++ b/distros/humble/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-lint-cmake";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_lint_cmake/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "e62bebf1528683ec244225e3a830a73be76827e2c3f9115e4beb4c58d9c7effc";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_lint_cmake/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "ed53fc5d0df0693d1b79fecee442b361f6866dbfd7cf3bfd829d8e2c5a7ffaec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-mypy/default.nix
+++ b/distros/humble/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-mypy";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_mypy/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "59dd160147646a900e699afa51d9110c127655ec403a218c6f84b406bcbe75f9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_mypy/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "390743f08bca249efced10096aa795f26f27fc042326335efb9fa164f6526de5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pclint/default.nix
+++ b/distros/humble/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pclint";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pclint/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "b19f65ea4c9527067a5a7cc2feeeb9c599ad00ae2c101954d9196c0c237600da";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pclint/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "ddbbc0f84e598fc67817ffca2469d6e11c0fb7ac028f363857e0d2b983f07367";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pep257/default.nix
+++ b/distros/humble/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pep257";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pep257/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "65e3c4445aed625f989be48a8c1c469f7302fbccccd0c441a4981e4b86143da4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pep257/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "53f776a272924af7a96fb4a609673f226dc47bc308c06642fafcb010c33aceff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pycodestyle/default.nix
+++ b/distros/humble/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pycodestyle";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pycodestyle/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "57e1044e8a0710a505ee7d69cf015ec001e4eb29070a9703e2c71e27f1af33c6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pycodestyle/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "41b474f86008a253eb42c1a59e3bbd4778a6d976cbd87612f97421be3952d7dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pyflakes/default.nix
+++ b/distros/humble/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pyflakes";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pyflakes/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "e661b4964898e6d26e4fefefddce640ba529ca3575faa79f716c711f80100ed5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pyflakes/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "c153a6a12621dbbd3f7c79cda2341f7446fc8f99526813ba3e766f6d3f971fac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-uncrustify/default.nix
+++ b/distros/humble/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-uncrustify";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_uncrustify/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "71adfacc9cc13c41efa2576e8721dc78acd173afc98bfd2ca8092c32d18fb3d1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_uncrustify/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "44b71c265521bed035ba9edb49b7eeecf27246a011da5ca997619446cedbe7e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-xmllint/default.nix
+++ b/distros/humble/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-xmllint";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_xmllint/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "f761b8e72ac409f648990dfbb66f58f949479b8386ce511c30c983d349a35965";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_xmllint/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "73770135229386e1191c719b51c186938c53d2d93d07b82c0f162409b35ae195";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-copyright/default.nix
+++ b/distros/humble/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-copyright";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_copyright/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "f511f23e017894914ed86289398243c0723110f32968ac4ce735f7e22a550291";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_copyright/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "211b52f844ffd9b0a311dd75868b005c88034a16bbea52b215492ec33c2f64fd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cppcheck/default.nix
+++ b/distros/humble/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-humble-ament-cppcheck";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cppcheck/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "a642456a07c51c67ffe1c0cb7bf5c98fbf761b68b86eac2f040d6d97a6882fa3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cppcheck/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "b7c9e0121f96db669be06730e44ed237ac378bb73c0b6f0923dc3419bf1d7c1a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cpplint/default.nix
+++ b/distros/humble/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-cpplint";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cpplint/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "483c1b8857b68fd79013fee712c3e50c759a29f140f154885604c3ef65283d0d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cpplint/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "30dc9767d733476209dc21502817493edd1be126973bc73568788a1ea31578cb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-flake8/default.nix
+++ b/distros/humble/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-flake8";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_flake8/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "671b5e8f03648800083fa10f83559737a55a6beb65b1e042b569e219d1186bcc";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_flake8/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "f3b481ea3ab7299b441605bc9f5aa5b843f79d47db617fd9a2f63fb1a21a9cc3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-lint-auto/default.nix
+++ b/distros/humble/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-auto";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_auto/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "788e6af0bc6dc16a0a75a8cb0d0aa820877b83b2b0266a346f3381d3d00f69c9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_auto/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "b1e910511e4fb7c385c2c36804aafb356a7c34380ef6c7237550386e9705ffbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-lint-cmake/default.nix
+++ b/distros/humble/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-cmake";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_cmake/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "6ffc94252a453cbd43c4b6df17d679e760a376c38726a7327007ceef8467deeb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_cmake/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "d3f708cf16f126fed3ff89a333b958a65dc46d28aa5725468e6f777f5f8219a5";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-lint-common/default.nix
+++ b/distros/humble/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-common";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_common/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "505c9e10b88a8eb0a37866d5a5bc7405bc160b01fa92df07a86f58203aecf423";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_common/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "272b6b6adefd9fca9f3a2929f96d812724489eab5bdc46a2af021ceb62a83f1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-lint/default.nix
+++ b/distros/humble/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-humble-ament-lint";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "92cae4d967ac67fdec87484b1f5b097d70f6702017f1b7712fd906ac0bf0b066";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "7cc63054678276af19d9ddb8999fa0a88e70e5a1205874a9f9d4c9fea1472c5a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-mypy/default.nix
+++ b/distros/humble/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-mypy";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_mypy/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "bee6040998a5a3acdf66f5d8191286d5d9b7ee9e9f54e3b1b100fa90187dfbd0";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_mypy/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "0c1c2bba8c6b48a8fce994f8660170ffeb9c686857caa46cf8dee2663a34319e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pclint/default.nix
+++ b/distros/humble/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-pclint";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pclint/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "614cd9c985284ba2a93232d5107a7fe0c08c01d3a60cb78bacfc5e0a70eee852";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pclint/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "05138c8a1da422221432b116717f8f727ff43074d2b0a82d474d504ff9073afc";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pep257/default.nix
+++ b/distros/humble/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-pep257";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pep257/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "ef19a5f218356c6cd418e0bb39215a4b522992de3f12739f1f4dab2264176149";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pep257/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "40940977c96b2b94fa038c4c9a67756820cf3349b57ff265131fc5d631decaa5";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pycodestyle/default.nix
+++ b/distros/humble/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-pycodestyle";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pycodestyle/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "c7160ce634a0a55b133a30f94e21987971ab17888955205649fcaa2dbd8387e5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pycodestyle/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "b8565f073503ab0260a2a1ac220de4c244e3577d5eb6ac08621a2c30b91b8671";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pyflakes/default.nix
+++ b/distros/humble/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-pyflakes";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pyflakes/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "8e2af9116c30e98a010d6d9135701e6076d368ab7da81777e08c977d4d91ac00";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pyflakes/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "ffe685e918eada4d11009cea033fb9b6c8e15182909fa08f83e6b92208e626a2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-uncrustify/default.nix
+++ b/distros/humble/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-uncrustify";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_uncrustify/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "6aa3cec2d87f3c5b32f964992a85bd504553e8baa0a2d927703e2193d7656272";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_uncrustify/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "9c96ec76c23819d361b2d5826ed445f9e1c1857ef6f18883ea4d5c2c31f5ae01";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-xmllint/default.nix
+++ b/distros/humble/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-xmllint";
-  version = "0.12.6-r1";
+  version = "0.12.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_xmllint/0.12.6-1.tar.gz";
-    name = "0.12.6-1.tar.gz";
-    sha256 = "5c2a191373f64eb90a31ed750177e35e69e7bb6bc9fd027db1b36717c8e1438f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_xmllint/0.12.7-2.tar.gz";
+    name = "0.12.7-2.tar.gz";
+    sha256 = "57fffed5f4009fb172061ee87bdba1018702f6cdd8f2da6e3b03f81c272adab8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/camera-calibration-parsers/default.nix
+++ b/distros/humble/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration-parsers";
-  version = "3.1.5-r1";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "9ee2dd3488180480026f73faba7bd6b481cb7abb690461cfe817c7f47ed879d8";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "4331d663f56f6a3018abc5026755e73db8667bf1d5e943578136611a531744ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-info-manager/default.nix
+++ b/distros/humble/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager";
-  version = "3.1.5-r1";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "9b05e22d64c48e0d4362f2a8e8680dc42d7a348aa9a6f980b937e7e2a3fb571c";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "30e7b7abdc640a5f46911219afdced165d2c0d69ced5734a3f18c5771371bcf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "d6d738d8d6b5a3a3c75405ab1af00bb4ae6812f51736fc6457b198716ce21ac5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "0a2b1123f675920b026b4e89f312546f33d73e26f9e81b6577e74b1e3f83a157";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "bfb3d5bc9c43880506203f37d1bd88f73b6e63657c77e41c35dba4401ed7731e";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "b7742e7b29a3e41b7c35718e8770fd213afef97b0a8cab87b06b1a1c5f7030a2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "ea7ae1242d845b5985afd32166c1216ead315b7ff0214c3502dc4a63893c059f";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "5d49b66149517124a2a1c92af05687bf57251a955f426e4e4cedbe0e1b69d8d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "3c6bf232aaf28e25a0d83e8e7616e821fb5c3a4779e29e4cf275bcd8d50f54ca";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "8e5ea2f00c6f04676af7da84c92b258a914b45c5f23104eaf00bfb0f201966f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "e8278adce58804b92d6fdb4c19daab067675c55f62f772000120fccbf6147402";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "e84a637016c2a92298389de01b78f33c7707e98299014ec7f7a79888602190cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-gz/default.nix
+++ b/distros/humble/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-gz";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "bb5b369b6e45865796b2445c8207de486b888d4d1a861e8b038467a4aaeb311e";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "a5f41a7697cde6a75a7acafb4226f857b8017e771bebada9cc7d4247de1de601";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-gz/default.nix
+++ b/distros/humble/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, ign-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-gz";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "f0f75e297ff54a3e6ee2b8641cf871d502ac45dda92e2c3835ebc53d856a9c88";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "2a128b387307e45c7749b7dc77c2f52f089dc22b4380bc74d32579afed4b7ab8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "92982c617f012d31204b13359bdbdd8048375f32bb10f817b3be0a15af9d2a2d";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "a831a04cf625396994aef385abfd1ac7686d683441d76178d03404062c3c785c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-nav2-demos/default.nix
+++ b/distros/humble/clearpath-nav2-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, nav2-bringup, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-nav2-demos";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/humble/clearpath_nav2_demos/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "0e0d3e550de48b33a15917451d3d81dce7c5d04715979a197c068ade5d00c423";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clearpath-config nav2-bringup slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Nav2 demos for Clearpath robots'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "0a9d8024fa2c50149940375e7c81a1640120af7d379f5ade0d5c8302ebe1de0d";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "034fdca21e9161c32ca26f9b96af440bb399fea9f6b7949d04aa33c0cf0a2925";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "c8d6e3226924c21f0e164db584aaa4be010184d940f1d2f12af8ddc2b71d7dff";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "348c2c3df687888b9bea52a353821ebfda3b57f50d88926abda8907f2055fe54";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "ac5e832329b04ffa59523401b6496e5f9520b3694c6abb77b56f8baf4763a133";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "eb5e984753feccb386ea62a51ae2fc132aaa23619a0cbbc22d1f34a6e5d136f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-simulator/default.nix
+++ b/distros/humble/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-simulator";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "e49ef01848b8e76a971b214298549fb4dc4be9c083bce3aebf3d45f5d317ef05";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "b7cc8cff10f9798e8a3686010739744db51f2abd1a6f3c16e5dcfd4700a0c56f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthimage-to-laserscan/default.nix
+++ b/distros/humble/depthimage-to-laserscan/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, image-geometry, opencv, rclcpp, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-geometry, opencv, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthimage-to-laserscan";
-  version = "2.5.0-r3";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/humble/depthimage_to_laserscan/2.5.0-3.tar.gz";
-    name = "2.5.0-3.tar.gz";
-    sha256 = "264167c62be2c48e22df9e97e206b3b0fa854b2377b11d54d0cdeb5dfc56bb3e";
+    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/humble/depthimage_to_laserscan/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "18a8f72fc4dd7ba2629cf15f988af657ed51fe5029c921bffb48822380e218d2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ image-geometry opencv rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/humble/examples-tf2-py/default.nix
+++ b/distros/humble/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-examples-tf2-py";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "66fed0b4846fef3afa4a099941cafd3c66e30d7035e9cf6131594698fb15b335";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "49ad11ad11749b96b90325ddd82356e12409c9fa5687a18faa880a61114b0ae9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/executive-smach/default.nix
+++ b/distros/humble/executive-smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, smach, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-humble-executive-smach";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/executive_smach/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "ed74573e430a6787791f593439fe7afbfdb813f8e221bd87e18e31aaf1ebd816";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/executive_smach/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "1e3f021902b14e9d1137c1f1f1e0ac711eed9ba2b50e46b0afe92d2a61b71fa6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fastrtps-cmake-module/default.nix
+++ b/distros/humble/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-fastrtps-cmake-module";
-  version = "2.2.0-r2";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/fastrtps_cmake_module/2.2.0-2.tar.gz";
-    name = "2.2.0-2.tar.gz";
-    sha256 = "67b27cf23415494ed271615dc43e0b46871e80f6ca9ed69e341d6117cfe6abf5";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/fastrtps_cmake_module/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "2b2296e4c4762ff6e9e42241affe7489e7893fde75d4277591b28bc47153fbd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-humble-flir-camera-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8201bdeba40fd3c63ba85693475ae3d0899695d46aecf800a444106afac2900c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''FLIR camera Description package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-flir-camera-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "e3482c62b1df16fd2def73034a19f62d333b647c593da086720e97692520ab5a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''messages related to flir camera driver'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/humble/generate-parameter-library-example/default.nix
+++ b/distros/humble/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-example";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "c1212b73cb73a342c439c2543e280d7b1bee01b5ce03b1513790b53893051064";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9b39413bcb6a7ea845200b0a22e2686c060dcd47048ac81eecbf09910ebaf0b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-py/default.nix
+++ b/distros/humble/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-py";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "f8687155eab492e462fc7dc2abc8ac37e94514228b1842d93ca98e1e2bbca3dc";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "b24e2832a0270de8af3c684f6c380230c6408af030b001970a0780d16d703476";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rsl, tcb-span, tl-expected }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "cc11fda90bd0c111696b1294480f45cb667a4dc88b7f4005272cb636ef77af1d";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "207143bd2c5449a5e69c802d064440eaea75266db5bfd822ea066226cfffb165";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ fmt generate-parameter-library-py parameter-traits rclcpp rclcpp-lifecycle rsl tcb-span tl-expected ];
-  nativeBuildInputs = [ ament-cmake generate-parameter-library-py ];
+  propagatedBuildInputs = [ fmt generate-parameter-library-py parameter-traits rclcpp rclcpp-lifecycle rclpy rsl tcb-span tl-expected ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python generate-parameter-library-py ];
 
   meta = {
     description = ''CMake to generate ROS parameter library.'';

--- a/distros/humble/generate-parameter-module-example/default.nix
+++ b/distros/humble/generate-parameter-module-example/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-generate-parameter-module-example";
+  version = "0.3.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "9aa8e179024fe60427f8c6a35296b72cd0f9bb3b3815892357ae80ce94930c43";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library for a python module'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -312,6 +312,8 @@ self: super: {
 
  clearpath-msgs = self.callPackage ./clearpath-msgs {};
 
+ clearpath-nav2-demos = self.callPackage ./clearpath-nav2-demos {};
+
  clearpath-platform = self.callPackage ./clearpath-platform {};
 
  clearpath-platform-description = self.callPackage ./clearpath-platform-description {};
@@ -580,6 +582,10 @@ self: super: {
 
  find-object-2d = self.callPackage ./find-object-2d {};
 
+ flir-camera-description = self.callPackage ./flir-camera-description {};
+
+ flir-camera-msgs = self.callPackage ./flir-camera-msgs {};
+
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
  fmi-adapter = self.callPackage ./fmi-adapter {};
@@ -633,6 +639,8 @@ self: super: {
  generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
 
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
+
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -824,9 +832,21 @@ self: super: {
 
  kinematics-interface-kdl = self.callPackage ./kinematics-interface-kdl {};
 
+ kinova-gen3-6dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-6dof-robotiq-2f-85-moveit-config {};
+
+ kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
+
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
 
  kobuki-velocity-smoother = self.callPackage ./kobuki-velocity-smoother {};
+
+ kortex-api = self.callPackage ./kortex-api {};
+
+ kortex-bringup = self.callPackage ./kortex-bringup {};
+
+ kortex-description = self.callPackage ./kortex-description {};
+
+ kortex-driver = self.callPackage ./kortex-driver {};
 
  lanelet2 = self.callPackage ./lanelet2 {};
 
@@ -1660,6 +1680,10 @@ self: super: {
 
  robot-upstart = self.callPackage ./robot-upstart {};
 
+ robotiq-controllers = self.callPackage ./robotiq-controllers {};
+
+ robotiq-description = self.callPackage ./robotiq-description {};
+
  robotraconteur = self.callPackage ./robotraconteur {};
 
  ros2-control = self.callPackage ./ros2-control {};
@@ -1954,8 +1978,6 @@ self: super: {
 
  rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
 
- rviz-common = self.callPackage ./rviz-common {};
-
  rviz-default-plugins = self.callPackage ./rviz-default-plugins {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
@@ -2049,6 +2071,8 @@ self: super: {
  spacenav = self.callPackage ./spacenav {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
 
  splsm-7 = self.callPackage ./splsm-7 {};
 

--- a/distros/humble/geometry2/default.nix
+++ b/distros/humble/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-humble-geometry2";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "95b87eea33a7c44aa851f3e49257c028f2390b1aac18c922c73e692d175555b3";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "e2b26740787a0e6c21b3a689f7a4854756fc15656d1e477b93b52b65ba2432b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/google-benchmark-vendor/default.nix
+++ b/distros/humble/google-benchmark-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gbenchmark, git }:
 buildRosPackage {
   pname = "ros-humble-google-benchmark-vendor";
-  version = "0.1.1-r2";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/google_benchmark_vendor-release/archive/release/humble/google_benchmark_vendor/0.1.1-2.tar.gz";
-    name = "0.1.1-2.tar.gz";
-    sha256 = "ebd71b641bbcec01396c4e495525eb8c2ccd92580fe6ce2a14d82dc50d714c4e";
+    url = "https://github.com/ros2-gbp/google_benchmark_vendor-release/archive/release/humble/google_benchmark_vendor/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "62136f74690014cc2411088bfc493c78693a5641a49dd898222d35e9ce0e46b0";
   };
 
   buildType = "cmake";

--- a/distros/humble/image-common/default.nix
+++ b/distros/humble/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-common";
-  version = "3.1.5-r1";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "8546964936eef73a71f6279a6f11b5e672af35175c4e41e6a866b02f58a400db";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "351fb492a563575850a31bdcbd8385a0075bbd916bc917c11226c0824000cc7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-transport/default.nix
+++ b/distros/humble/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-transport";
-  version = "3.1.5-r1";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "658ccd667e3617fbbf1fa72966ed741f83faf8ee2d946d8436c4bb4d25ea4f85";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "707798757458816b9fb50febd5981d96544cd1e7b72fa98b729a32f6640807cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/humble/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-humble-kinova-gen3-6dof-robotiq-2f-85-moveit-config";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "045fd2a30e01e1f8141cef782247887fbcd04015ceb1f529ce096f6547a0a69c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the gen3 with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/humble/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-humble-kinova-gen3-7dof-robotiq-2f-85-moveit-config";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "8cfa36b0ae2c34d782c829264aae7a941f7aa0684d41465740809d0541b4d2d7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the gen3 with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/kortex-api/default.nix
+++ b/distros/humble/kortex-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-kortex-api";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_api/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "a2215b09bae7687b8d02ee71775033d219ecd15afb96b7aa519ce32574cc6768";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''kortex_api'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/kortex-bringup/default.nix
+++ b/distros/humble/kortex-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, gazebo-ros2-control, gripper-controllers, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, kortex-description, kortex-driver, launch, launch-ros, rclpy, robotiq-description, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-humble-kortex-bringup";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_bringup/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "236374ddcbe72dd98900913fef3609663f58c909786120ba3be0590eb8f62deb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ controller-manager gazebo-ros2-control gripper-controllers joint-state-broadcaster joint-state-publisher joint-trajectory-controller kortex-description kortex-driver launch launch-ros rclpy robotiq-description rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Launch file and run-time configurations, e.g. controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/kortex-description/default.nix
+++ b/distros/humble/kortex-description/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, robotiq-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-humble-kortex-description";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_description/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "b32072a36491874256a68765cb4e829647df5e35cf9c3526ca060328606f6a24";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui joint-trajectory-controller picknik-reset-fault-controller picknik-twist-controller robot-state-publisher robotiq-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>URDF and xacro description package for Kortex robots</p>
+    <p>This package contains configuration data, 3D models and launch files
+for Kortex arms and supported grippers</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/kortex-driver/default.nix
+++ b/distros/humble/kortex-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, hardware-interface, kortex-api, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-kortex-driver";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_driver/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "53a5047576cbb737a4bb2534bdc23aa2d226117484562dd59e9437cc71ad6867";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ hardware-interface kortex-api pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver package for the Kinova Robot Hardware.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/launch-ros/default.nix
+++ b/distros/humble/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-launch-ros";
-  version = "0.19.4-r1";
+  version = "0.19.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "89cf57568dd4785a1dd355ab8a1274adfaf8006612c2c2f85313d0d82489b72a";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.5-2.tar.gz";
+    name = "0.19.5-2.tar.gz";
+    sha256 = "370a430def9e405893b6d98249cec341d634ff02245ef09aed3c083cbf113af9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing-ros/default.nix
+++ b/distros/humble/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ros";
-  version = "0.19.4-r1";
+  version = "0.19.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "cb72c89a1269cae62e715373817c4ddd64631fe70d9eefe25c0089ffb1a1892b";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.5-2.tar.gz";
+    name = "0.19.5-2.tar.gz";
+    sha256 = "a4b2c523948e836e357d29d09f9e218b27151f9eddcb8b72bb66d40186fe787a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "d419954640b193bdd5e5ccbf3bd813fa8efb13efd9ac076840fc8e77a02c97ac";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "fee50904b8871dc6a9de4010851dc7d25f847b5c103363a946a9d5923bf0778c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-driver/default.nix
+++ b/distros/humble/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, git, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-driver";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "3a7353c6805b543ec5453d2eeea57bfb13a3c5093ca96d4c9fae7ddf7f53fd40";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ad25c567541c9fa1d5fe4f92e2daaeaad761c1745b67622934b6793d62a3d138";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-examples/default.nix
+++ b/distros/humble/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-examples";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "898190338926fe38d52a5f1613ce3a4de56da9d14f888f0fce8d19d62bf2bae2";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8645895ec645071682c3c4bbefecff5c2f2d7de39037d0021f3f042613fc527c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-msgs/default.nix
+++ b/distros/humble/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-msgs";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "c63a961d77dcadf53d0b56744086a9ce272e1b8d09054d8bc166dd7da440b0db";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e55bfa5710c6e347f9cc0b2656a18c9fbf94480324445773928fa9eda6485f64";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-rqt/default.nix
+++ b/distros/humble/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-rqt";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "353b69d71096a74dffea48fdf79fbed796473acfe92d02021a3c681c81df2d7d";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a9bc772d5f1f50f08d9cf3aeec49ef95efe4b0cc0474da7c9510be2cc11e2913";
   };
 
   buildType = "ament_python";

--- a/distros/humble/pal-navigation-cfg-bringup/default.nix
+++ b/distros/humble/pal-navigation-cfg-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, nav2-bringup }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-navigation-cfg-params, ros2launch }:
 buildRosPackage {
   pname = "ros-humble-pal-navigation-cfg-bringup";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_bringup/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "24876b3b7d095a63de4ce244b77981623c7bba3441713572f7091b89fc2e12eb";
+    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_bringup/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "5733a0ecf0ff6148e2dc1ffc8e81594947ebe02b755b144513f1e7be0a910bf2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav2-bringup ];
+  propagatedBuildInputs = [ launch-pal nav2-bringup pal-navigation-cfg-params ros2launch ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pal-navigation-cfg-params/default.nix
+++ b/distros/humble/pal-navigation-cfg-params/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-pal-navigation-cfg-params";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_params/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "daa09954ede58fa13c8c2466d91589bef33242d81f1d41fef82cb83346043c14";
+    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg_params/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "df6fa4e7e7b79f3c3a4c3ac39e22a2a9ffb0c4a1ab1f2afc6ffb13324b5c06ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-navigation-cfg/default.nix
+++ b/distros/humble/pal-navigation-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, pal-navigation-cfg-bringup, pal-navigation-cfg-params }:
 buildRosPackage {
   pname = "ros-humble-pal-navigation-cfg";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "f4d59355f3792a1cfdf11429906745cce258e18f6f194f301df901ca9b3724fe";
+    url = "https://github.com/pal-gbp/pal_navigation_cfg_public-release/archive/release/humble/pal_navigation_cfg/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d3085c7d874d2c2bbecc4891a8b00b39311ffb9f8e7dd056f115c8a805ace7b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-parameter-traits";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "8291208523c526865c83e3f7eac21db4a5389f399b20cabafb35c5cc68f85de9";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "60284c63b0bcbd189029d78553e822e67d3e3bef96d0d917ce68f0688ac37a5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/picknik-reset-fault-controller/default.nix
+++ b/distros/humble/picknik-reset-fault-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
 buildRosPackage {
   pname = "ros-humble-picknik-reset-fault-controller";
-  version = "0.0.1-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/humble/picknik_reset_fault_controller/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "c0ab6c76211d8feb3c85c3db6ecf0243ff0d569e6c000b63e47309f575c9e8e5";
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/humble/picknik_reset_fault_controller/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "ab82211ab758ca4b71404a6234d1b2de7bfc6154ac4228a3ee77ca315401769f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/picknik-twist-controller/default.nix
+++ b/distros/humble/picknik-twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
 buildRosPackage {
   pname = "ros-humble-picknik-twist-controller";
-  version = "0.0.1-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/humble/picknik_twist_controller/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "88fe65b60536cde66480fc75cd915ed3704803715e224aa951fd32425a4ecf91";
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/humble/picknik_twist_controller/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "aa5861298283a04c10af410eff459b4f67c40cf15c20bc5af321e99f2ade8c5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-action/default.nix
+++ b/distros/humble/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rcl-action";
-  version = "5.3.3-r1";
+  version = "5.3.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.3-1.tar.gz";
-    name = "5.3.3-1.tar.gz";
-    sha256 = "7e90320f626046d0e206d6d48e3113d919ecc3a5b0af6c6626ac70270b08124d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.4-3.tar.gz";
+    name = "5.3.4-3.tar.gz";
+    sha256 = "d6b53052c63fc97fba5b3f44a39e8822afdbfadd02ab5329a9d626ec6e7cfe18";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-lifecycle/default.nix
+++ b/distros/humble/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl-lifecycle";
-  version = "5.3.3-r1";
+  version = "5.3.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.3-1.tar.gz";
-    name = "5.3.3-1.tar.gz";
-    sha256 = "e3e4c3c80cdce91c1cdacb154e1b0103cd0f3ab28141ce78c0361566f855d0e7";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.4-3.tar.gz";
+    name = "5.3.4-3.tar.gz";
+    sha256 = "6d8aaedb73a18d29f32f033d55c0d72998c70df8a8e508290ade3f984481b46c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-yaml-param-parser/default.nix
+++ b/distros/humble/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-humble-rcl-yaml-param-parser";
-  version = "5.3.3-r1";
+  version = "5.3.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.3-1.tar.gz";
-    name = "5.3.3-1.tar.gz";
-    sha256 = "d2d1e11ae2be7840c258396d71d9f48fb37cf835a97d317b5ff7eed1d2b16c55";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.4-3.tar.gz";
+    name = "5.3.4-3.tar.gz";
+    sha256 = "31d0e6710df41a1093dba1043003a59f547862be9670510b9185ec07340e2f80";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl/default.nix
+++ b/distros/humble/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl";
-  version = "5.3.3-r1";
+  version = "5.3.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.3-1.tar.gz";
-    name = "5.3.3-1.tar.gz";
-    sha256 = "545c51fa8c092f1afa1ac87a7ada351bf7aefea80d403f96dc363f6f2fa74e71";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.4-3.tar.gz";
+    name = "5.3.4-3.tar.gz";
+    sha256 = "47acbce528e095f32dce0243a81f353b9a584c4d9d665e7044cb1afde53240f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-action/default.nix
+++ b/distros/humble/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-action";
-  version = "16.0.4-r2";
+  version = "16.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.4-2.tar.gz";
-    name = "16.0.4-2.tar.gz";
-    sha256 = "913e8d3d0d2a4ae3deca76048f0a638ab026cd9330af39301d108dae8d97fac0";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.5-2.tar.gz";
+    name = "16.0.5-2.tar.gz";
+    sha256 = "566012792c3f9dc2b905a0f8dd2a37bbad6d12095fb19b9b986bf4e995fe04ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-components/default.nix
+++ b/distros/humble/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-components";
-  version = "16.0.4-r2";
+  version = "16.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.4-2.tar.gz";
-    name = "16.0.4-2.tar.gz";
-    sha256 = "8c77328b489117a13782a8a1f094aa9ab42b771b9efd6d62d2a13f146d8b06e6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.5-2.tar.gz";
+    name = "16.0.5-2.tar.gz";
+    sha256 = "390f0062449155255c14cb3a65b3511fe97b7f516087c0ecee621e03fe31b6ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-lifecycle/default.nix
+++ b/distros/humble/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-lifecycle";
-  version = "16.0.4-r2";
+  version = "16.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.4-2.tar.gz";
-    name = "16.0.4-2.tar.gz";
-    sha256 = "cd424b010894f3d15d5fca5015462a8281e991a5341d84b0578d0bbf9c93414f";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.5-2.tar.gz";
+    name = "16.0.5-2.tar.gz";
+    sha256 = "fd26251bb7da261ee261af923b89a174f67707e9af7b24f9384f7b6d4a412380";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp/default.nix
+++ b/distros/humble/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rclcpp";
-  version = "16.0.4-r2";
+  version = "16.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.4-2.tar.gz";
-    name = "16.0.4-2.tar.gz";
-    sha256 = "120d869d193c2798617a179150c61fc8efb8e6c18ffe4f8b07fa905ddc9a2003";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.5-2.tar.gz";
+    name = "16.0.5-2.tar.gz";
+    sha256 = "5bb6025168de2a00ba10614fb6d60453e38f09784d98e3b080372cb161888ded";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclpy/default.nix
+++ b/distros/humble/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclpy";
-  version = "3.3.8-r2";
+  version = "3.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.8-2.tar.gz";
-    name = "3.3.8-2.tar.gz";
-    sha256 = "520634b7c23368a142f06aa7f6e8bcf620bfd2b0f5962307d68106221a0fe8a5";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.9-1.tar.gz";
+    name = "3.3.9-1.tar.gz";
+    sha256 = "80ee364a00aeccab49a57d8d7d4c671852430249478532615b7d21c65b1bd8f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-connextdds-common/default.nix
+++ b/distros/humble/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-rmw-connextdds-common";
-  version = "0.11.1-r2";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds_common/0.11.1-2.tar.gz";
-    name = "0.11.1-2.tar.gz";
-    sha256 = "5e6ecf7df102a5db269f662284e21f952806e509a9eecc5701e287831a7eac91";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds_common/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "ef1e11f55370064c80d9921c7a69999c5bcf08f77419da816f1b95d69b054012";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-connextdds/default.nix
+++ b/distros/humble/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-humble-rmw-connextdds";
-  version = "0.11.1-r2";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds/0.11.1-2.tar.gz";
-    name = "0.11.1-2.tar.gz";
-    sha256 = "bbf18dfe4bd7af0e2482435d20a39313397e0916bb7553db7209ee4b4489d4d8";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "94cb333746fe8612d47286c99eb5b1c4b8052fcc01b6b42e43948862b48b7f22";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-cpp";
-  version = "6.2.2-r1";
+  version = "6.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.2-1.tar.gz";
-    name = "6.2.2-1.tar.gz";
-    sha256 = "d7ac19ec177e19f6d44543d0192ca1f85366cfc93bbbedfb775bff2e6a4c5a8b";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.3-1.tar.gz";
+    name = "6.2.3-1.tar.gz";
+    sha256 = "3c5211690474965643ccacb4cbd3a346acb5343bf5ef1850a97bfbe531c8490c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-dynamic-cpp";
-  version = "6.2.2-r1";
+  version = "6.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.2-1.tar.gz";
-    name = "6.2.2-1.tar.gz";
-    sha256 = "c86d46653ee0312f4d91f7de7564d8cb1d28a2f7b488bf2822af0971acc91758";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.3-1.tar.gz";
+    name = "6.2.3-1.tar.gz";
+    sha256 = "285146bd149cb7cd235976cd9cad9b917af3d4f6e4e4f5b2bfc7a61c5311f05d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-shared-cpp";
-  version = "6.2.2-r1";
+  version = "6.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.2-1.tar.gz";
-    name = "6.2.2-1.tar.gz";
-    sha256 = "7714786f855c543ccd128a1b30039b2bf63b2931bcce0fa5e340fb87936876ac";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.3-1.tar.gz";
+    name = "6.2.3-1.tar.gz";
+    sha256 = "6f4eba36e0b3c202f6271f8850f6bd12ba0dd0b2d4cb503df8bdc2de5c76bb11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-upstart/default.nix
+++ b/distros/humble/robot-upstart/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-robot-upstart";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/humble/robot_upstart/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "310d5e60443ca37dce66b7240c80bd21ddd1e29ba8479b88468c7d64474432e9";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/humble/robot_upstart/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "69ed49909e2d2ef215129252b073e8f563b4e2d41f04e80db9eff51dcc987df4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/robotiq-controllers/default.nix
+++ b/distros/humble/robotiq-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-interface, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-robotiq-controllers";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_robotiq_gripper-release/archive/release/humble/robotiq_controllers/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "90b44105a1cc9ddbceb94d79d4d43feb0675cc9e0ad0546159f7dc9495561dfa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-interface std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controllers for the Robotiq gripper.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/robotiq-description/default.nix
+++ b/distros/humble/robotiq-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-ros, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-humble-robotiq-description";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_robotiq_gripper-release/archive/release/humble/robotiq_description/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "44f15e1fb3cb47647454ff3ccf70368b7c740b6b81cd594994404f46556ad717";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-ros robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF and xacro description package for the Robotiq gripper.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ros2action/default.nix
+++ b/distros/humble/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2action";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "6e2146d4d8c60583c8b509a027f9659f6960600f680c984aff1c4b6d5541ea66";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "2c8537aee41ba5a6c0b37091296afdf950c58851a4cc8382822d550b4c04bf1e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2bag/default.nix
+++ b/distros/humble/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py }:
 buildRosPackage {
   pname = "ros-humble-ros2bag";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "5dcab7dc6d68dfda090bf34dccb789a3570f9a11402ae5ed41a43094d7f305c8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "a58d23bd941411f5a9189f43506de8dd13617628f362b425065740ccb6b4e207";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2cli-test-interfaces/default.nix
+++ b/distros/humble/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ros2cli-test-interfaces";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "cd79c5dd393c9f496fa99fea14f6e20d3ec71724c4b073023fbeecb530a84f4e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "be69e06ffc306455ab5e96d1243c9f23a87c63c382129a083dbb6f5d3130af34";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2cli/default.nix
+++ b/distros/humble/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2cli";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "a1a261edb55e0530679961499da9015480be07b522fb5a17d2b72021cfebb2f2";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "b5f383bef9c50358646e82845226267462b49adf8e1d99a5e006a79c1a738023";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2component/default.nix
+++ b/distros/humble/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2component";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "26f1b050a4fa433e2e8a80017cba2b6cc0ed2af4bb7f0cc90df07b74f6eb4b14";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "c66888a5014ac0ed6c30e89e67613999903b2f26f3565aca7ec56500c973adec";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2doctor/default.nix
+++ b/distros/humble/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2doctor";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "d18a576a5b1e5b75caff4880fcaa6769d1a73950ff805f0da29fe3c8f966b2f3";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "d7971aed999a346fee24e2de112524824363ce505bb9e59ac29d4c85021632df";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2interface/default.nix
+++ b/distros/humble/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2interface";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "e56f2c6ff450f97a3e930c1e39d80e4905d9a473053e5501cdf20640183ea767";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "d0d8746d8a89737ff045d1fa5f50494e0d66982272381b10dd06df99ac151c42";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2launch/default.nix
+++ b/distros/humble/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2launch";
-  version = "0.19.4-r1";
+  version = "0.19.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "a689fa1aa26379df252acd8afbb0372fc82670c8e69607a49ec6ff7773aebfca";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.5-2.tar.gz";
+    name = "0.19.5-2.tar.gz";
+    sha256 = "07a3e8b7553fd404f1b5025d49f5e67f3a74825d64d31b8f56adcaf9b1b7576d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/humble/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle-test-fixtures";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "eb05d22a94623293f4511c65d919e175562b317f73aa4a03f753f3bc4761169e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "8a7cd40253bc8300dda8d32f20890aaeb762def2718fca3df6235999b2bce72a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2lifecycle/default.nix
+++ b/distros/humble/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "9b836877684cc69de7168d8970721940a5a73a289d57f7c9c43145a29a3822c4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "f81e57ee020585a650a770615a0f4a71f6e6ca53432b632d5db757c79bed19e3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2multicast/default.nix
+++ b/distros/humble/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2multicast";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "83c7b4c19af6261e8090b804733bfb60dcb5ea3acfbff041a2b525bb5e550f41";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "09c856a9c9b0b369cf5265ded068d23815d9c968d3daa4e2b9c785bf32e95ee2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2node/default.nix
+++ b/distros/humble/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2node";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "0b984c1a4269d3609a3dd31ef68451077e4390eeaef0e8148413e0b9de39449e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "d28aa947e1682a92032420744d52fc7030015d20aa7298150e7ad8414343e265";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2param/default.nix
+++ b/distros/humble/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2param";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "95b44d07c0ed56f9c0e42c10708f1f14f306e1c858f294c31c691cb7f6a907b7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "061b63778470f6f2cdf652b7fb97682fcbf06ced53ca7e90de9538d8263f6b1f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2pkg/default.nix
+++ b/distros/humble/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2pkg";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "4d880485c302c948a58ad60b1b223ebe27e4aeb9b32f8a980a1f01f28b8be299";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "878c4afb8d84ff4099da38e64efe7b634178b4d4315dcce34797c90e986f38ee";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2run/default.nix
+++ b/distros/humble/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2run";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "fbd15614e4e69b4888f7e411bab7b77e2080eb729dd9166da7533426cda1c1a7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "8f20fe90154efa9c914240c6cc0e85731427fef8c3a43ea091bbbe043aca2351";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2service/default.nix
+++ b/distros/humble/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2service";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "9816037a9575b54b82a6ad48cbcd61f20f06d57f1611a1104ec287df353dddfc";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "4ecdf5130b7f2805b6f5efb7403a1098fb5bd0f8b143346a04dffed2070e8223";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2topic/default.nix
+++ b/distros/humble/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2topic";
-  version = "0.18.6-r1";
+  version = "0.18.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.6-1.tar.gz";
-    name = "0.18.6-1.tar.gz";
-    sha256 = "cb5edd2add3be2d1ad070738692420c739e9591b7d92b8c25e3e534b4f4676dc";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.7-1.tar.gz";
+    name = "0.18.7-1.tar.gz";
+    sha256 = "097623e20de56749783a0b957e2b386074ed4e02f930b5fd549bbaa5b3ee966e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosbag2-compression-zstd/default.nix
+++ b/distros/humble/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression-zstd";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "b016da8e412a5f12979fafd797e4cc50efac32b0ba926b2c077b0bd87962b5c2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "aac77eea7a2a2b760481ef177cfba01f65ca4a74f6dc517f8bd88f68add1d1b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-compression/default.nix
+++ b/distros/humble/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "49a23de4c98c109c7b7164cbde92b3d885d0961f40336d45dde5b80e87fa30f7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "0a28ac98b319647211126cacac2705048228d68cec2e2a09d1c48ca8f363c89d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-cpp/default.nix
+++ b/distros/humble/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-cpp";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "4256878b52ff99b8a66e653ec42a8301650920e29c57bc3054c83c2444a633b7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "d7a84b9029069d079aeba5814a753d7ab27e148cb31455df2f59d652a62b6322";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-interfaces/default.nix
+++ b/distros/humble/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-interfaces";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "14b09735c41a12d670d7ec61db5c84dae2e039155920d14971744f9085f688f3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "e8f79831babd0bfd82f236c99284ff3583cee92fb5a2879ec463b79ec64fe350";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-performance-benchmarking/default.nix
+++ b/distros/humble/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rmw, rosbag2-compression, rosbag2-cpp, rosbag2-storage, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-performance-benchmarking";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "57593463fa65bf13c2676de0811e4812fe68ff86250e3dd71295ecc0fecb57bf";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "06d5f05c07ae5f8d44c2f103fdb70aa0b2c9af53d02716745b9ec35d70f7263f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-py/default.nix
+++ b/distros/humble/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-py";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "1685a7271719e45c600e2cf06a0838478c4aadea18bb5ead3bc5c47c16f89274";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "cfab04c1ccdf2b47c96bf0d97e5331da23cd8725174fde43958ed6a2cf8d81b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-default-plugins/default.nix
+++ b/distros/humble/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-default-plugins";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "675f4c6f4c73b477b7a72df1d99a967f6e6c489db4a8e9cf664ef434495c2936";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "c983f95374a1b388d387fa298d0f616d6082c969ac9e8ab3d846b004d5c3dd4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap-testdata/default.nix
+++ b/distros/humble/rosbag2-storage-mcap-testdata/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap-testdata";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "886c6d7b50c086184c818602c1828c92f2ad7a0d1b1afa5bda33828cb8e5bcfa";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "1926e751206a63693ef29351b6c58744b9d32598b7be0684399b5efc165c2a7c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-storage-mcap-testdata, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "f4ccb1d07633d421cb54615e6c168c182a067b16d8a5be62b0e56e94e78086fc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "87d6e1809672a4a2bb86119954419e32132318cb316e772eedba177b4c92fd97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage/default.nix
+++ b/distros/humble/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "9c19e87d26f16c16525c5375f6e9b9aa61101ee4c2fe2c0464da8dd0f68cde0b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "d994c244cb846f891b98b146d5c1ae4534eb305810a15f9063574dfd5a179991";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-test-common/default.nix
+++ b/distros/humble/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-test-common";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "7b35ee92ec21cd37c4b692e9aa23460b5cbe8a8587bf28d31eb8a41d5acfbf6b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "c44cc6a55c2befe9d3767d4a261232cb00439c6fbf936320913cbda0dd3567c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-tests/default.nix
+++ b/distros/humble/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-tests";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "2d6c08af87de16065034ca002747a3694c0289f25ab33c697e95c6bfd918f7c8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "4487d2ac144c3c5e012a131bc2211a3f31ba5c7d3d39fa3636e1aafffd70ff17";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-transport/default.nix
+++ b/distros/humble/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-transport";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "f11c89bc5b3fe20f844576a0d0f49780c01d9aebfbd9c99341c6b8deab0e057c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "bd6ad77377b86891a06547b6c98f808976e3c4670d42f8d0bc517b59c525c02d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2/default.nix
+++ b/distros/humble/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "62cf0df52841a7098a31fcb81c7962797826837f67565c0fc63a61d5600236af";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "a83befcc262570de3c4d58878a2270a743101267a2aa205d4f6446d9b2fb02f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-adapter/default.nix
+++ b/distros/humble/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-humble-rosidl-adapter";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_adapter/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "454d8c14715eaeada18b5e2ead992cabfd2f310b56727910370fab72d690bc6a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_adapter/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "37b20be0a7df3fb224d2ed4026fe988e45f9f42ad01ffaee4ba8f496546fc9ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-cli/default.nix
+++ b/distros/humble/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-rosidl-cli";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cli/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "4433a5902065f400a4fd438e0663ad5a5a2900382c9121d56ec402450d0d3271";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cli/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "61a1967dc31f9368d063ef29572d271d1032c8f4342b286dafa57f8dda0caa2d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosidl-cmake/default.nix
+++ b/distros/humble/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter, rosidl-parser }:
 buildRosPackage {
   pname = "ros-humble-rosidl-cmake";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cmake/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "06f09be35abc2db16eeb49f890b0c775ec4e84c238f4b5ede10d211728f08986";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cmake/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "16a7e5ce9c45cc29d9671867899bc7cc0d9897a8a3e81c8a452c66ab1576a4bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-generator-c/default.nix
+++ b/distros/humble/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-interface, test-interface-files }:
 buildRosPackage {
   pname = "ros-humble-rosidl-generator-c";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_c/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "11ce9241c8c8c9303b47ae050cd8d994aeca93a4dd759cc0116ec75f14952825";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_c/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "e851b414b03d0ad63e00b280b033373a6b761dc109b2f07c687a75ca9426c1df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-generator-cpp/default.nix
+++ b/distros/humble/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, test-interface-files }:
 buildRosPackage {
   pname = "ros-humble-rosidl-generator-cpp";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_cpp/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "98637e8223df9a4e1a797b6f3a2752ac959544ad96bd1799cd2b977505089d0e";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_cpp/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "cb959063177c70d39a6e7b4235dea51b4ee960522eb720edfc8131d944914204";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-parser/default.nix
+++ b/distros/humble/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-humble-rosidl-parser";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_parser/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "3ececdeb8fc8d6951ae537558c98be69cd6cc473e24f5a72cc4166cbd0b8ce1e";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_parser/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "0c79cd3d40b54f02dc25f3eca6e0bb3fc2f0bd384eea66b811fd4612f65ba820";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-runtime-c/default.nix
+++ b/distros/humble/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-humble-rosidl-runtime-c";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_c/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "50256badd9c03f0b253a16d4f406cf05b751e5544d13c7c07d06786ceae906c4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_c/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "3077bcd57eb763c9ab6558b400f61c4b0afcad24411dea161ed4a8fc88f31f66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-runtime-cpp/default.nix
+++ b/distros/humble/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-runtime-cpp";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_cpp/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "32440b5fdfd8df90e002bccc3a9d1bd4ec5a0ea2dacb4a85d1bcb73024883fc1";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_cpp/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "b29d4f051dad094079f8fa63f02bcd5944155fc980bc9c0a7a0ba5234c036a0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-c/default.nix
+++ b/distros/humble/rosidl-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-c";
-  version = "2.0.0-r2";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_c/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "98e0dc0df20ebf3a9b8222db07d970f3bbe67ed937a4ee72c6a73e053378b510";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_c/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5816fac5efd88677d67125061a7807540e9971ca397af1074b3c9817ac4ab103";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-cpp/default.nix
+++ b/distros/humble/rosidl-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-cpp";
-  version = "2.0.0-r2";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_cpp/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "a3b0abbad82f87096c59792214c0e3adbf9e9234296b0ccee0dd5542eafa6c88";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_cpp/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ba1b7e214f768a9e534f10f1f4f1fa24d4789fb13fce4fd8f6475ffcc06f93a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/humble/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-fastrtps-c";
-  version = "2.2.0-r2";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_c/2.2.0-2.tar.gz";
-    name = "2.2.0-2.tar.gz";
-    sha256 = "a200141f07014302a96b7ccfd0ad0addc33a3512e0ede31c91120673a843299a";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_c/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "0edf6260edaff0ebb7fde488d4d1218c3f406689b46f052d73fb841b164a81e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/humble/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-cpp, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-fastrtps-cpp";
-  version = "2.2.0-r2";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_cpp/2.2.0-2.tar.gz";
-    name = "2.2.0-2.tar.gz";
-    sha256 = "853b3c4cac63a416be3fc2de4bfb58e5eb57b7761ec4821fc08ea43150814ab8";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/humble/rosidl_typesupport_fastrtps_cpp/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9b807f5c8fd473e2e756bf48505da49557c9d46907340a2918101b16b08657bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-interface/default.nix
+++ b/distros/humble/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-interface";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_interface/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "c33b7040c0373090b51b4e96f31033999c1b22e6d57d8d34c31dc63610003511";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_interface/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "4de29433cbd289372fa62c118e8c05bccdf0d1ab9b750fb365315f2ace1ac94d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/humble/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-introspection-c";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_c/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "5c3cac9854c9139b602417c7f565867eb25f3cf4e1a5f80c9fc615dff1664c74";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_c/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "29e118363d12fce5690010ba7ad0f7e0335d943c4b3a0f411f74ef58e61e7c6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/humble/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-introspection-cpp";
-  version = "3.1.4-r1";
+  version = "3.1.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_cpp/3.1.4-1.tar.gz";
-    name = "3.1.4-1.tar.gz";
-    sha256 = "efe1c14446cbecc66469d96ad265c21c2e6c2f90f4474c2ba30548fd9464483c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_cpp/3.1.5-2.tar.gz";
+    name = "3.1.5-2.tar.gz";
+    sha256 = "a15c3e97a83895198284e34303915e2a71f79aa24121ed55701eeaf09df42bbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rplidar-ros/default.nix
+++ b/distros/humble/rplidar-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, rclcpp, rclcpp-components, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rplidar-ros";
-  version = "2.1.0-r1";
+  version = "2.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rplidar_ros-release/archive/release/humble/rplidar_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "607951a119995e471d3c5d19b9022d54a2ee4de7d92865036f19ec9433b17885";
+    url = "https://github.com/ros2-gbp/rplidar_ros-release/archive/release/humble/rplidar_ros/2.1.3-3.tar.gz";
+    name = "2.1.3-3.tar.gz";
+    sha256 = "79f22d1d2ec3c84af02f20927ae2cf04f1ef262db1378a0ed354060758d0496e";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-ros ];
 
   meta = {
-    description = ''The rplidar ros package, support rplidar A2/A1 and A3/S1'';
+    description = ''The rplidar ros package, support rplidar A1/A2/A3/S1/S2/S3/T1'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/humble/rti-connext-dds-cmake-module/default.nix
+++ b/distros/humble/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-rti-connext-dds-cmake-module";
-  version = "0.11.1-r2";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rti_connext_dds_cmake_module/0.11.1-2.tar.gz";
-    name = "0.11.1-2.tar.gz";
-    sha256 = "9c498b779e8eda7f7c78c5ddf69c86e4a3b23cc8ed5e29942571b0dc6bc5ee67";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rti_connext_dds_cmake_module/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "6dac21c0a4cfa62302a0e325626b656786848ebaa728709493775f2fa01bb169";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.5-r1";
+  version = "11.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "9da96537676e0e93412377cc24dfc1f5507828cd8e78f28923ae7000637353df";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.6-1.tar.gz";
+    name = "11.2.6-1.tar.gz";
+    sha256 = "c2427ef8df263dc6b129c14acb0ff34fbec5ad855797518a90ee4e2dd1ffaa86";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.5-r1";
+  version = "11.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "0dddae01bd7e0560544bac307785ba212fdfc907fac80b2126b7c3249a226f23";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.6-1.tar.gz";
+    name = "11.2.6-1.tar.gz";
+    sha256 = "79c23d24c9a09be1580f0341ae1f112f52eb9c952941e186d942b073b5362cfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.5-r1";
+  version = "11.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "68b2eb8c8d90995b49ea56c68816964d1dcc436b65c79b01e3ae2c785c0922f8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.6-1.tar.gz";
+    name = "11.2.6-1.tar.gz";
+    sha256 = "32b323ae80ecbf26600785a406d8d4edaeb5a849711634393e4aec27bdf25553";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.5-r1";
+  version = "11.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "07e2def153798b8407916c6cecd132b73529375c915f88c4e1782784a1e5d3ce";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.6-1.tar.gz";
+    name = "11.2.6-1.tar.gz";
+    sha256 = "66cc1398a449945ad9b99f245194523415bbbd797a10bb013204e4731bd53003";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.5-r1";
+  version = "11.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "8d8d4483c241f3eb4d5d4db4f43f1424270dc67078bdc967e82802da1a26bfaa";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.6-1.tar.gz";
+    name = "11.2.6-1.tar.gz";
+    sha256 = "e0d265fe8eb313bbe60cdbed728f54149787d55bb7307a725eb3252051deb26e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.5-r1";
+  version = "11.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "793e05f1d3e766314008e74cc0571f24f399364032a51c4d4e5edafcd969b7ac";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.6-1.tar.gz";
+    name = "11.2.6-1.tar.gz";
+    sha256 = "d190ce743d4f7f6e5f2f1c568f83fd5787bc3a3ce2af6f5df4d22bdc5ffc49a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.5-r1";
+  version = "11.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "f171d9daab96f755dbaf602733bad56f230fb25cb1a3e96f14f5ac716f051296";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.6-1.tar.gz";
+    name = "11.2.6-1.tar.gz";
+    sha256 = "34b179cdf3f6455819166c40e83b7de1b80bdfab01d4c6931ac0f5400ba57851";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/septentrio-gnss-driver/default.nix
+++ b/distros/humble/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-septentrio-gnss-driver";
-  version = "1.2.3-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "e9491556e95a5479e791883ce8487055c38ccd9c19fdda56c3fd8fc1d25d5404";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "1978cb93f8d9f66781c60dc696a792bea148e07ca7ca72deff1e028516a4c931";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/shared-queues-vendor/default.nix
+++ b/distros/humble/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-shared-queues-vendor";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "39c82ee7664aee677ee724436ae36be4a8b67ee47344b25ff45294f870e0ee6f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "b785b8ebd6d647d4d1d1aad41b73465ac3f7ca06e4a5c58511d87672a1e1fe78";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/smacc2-msgs/default.nix
+++ b/distros/humble/smacc2-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-smacc2-msgs";
-  version = "2.3.8-r1";
+  version = "2.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/humble/smacc2_msgs/2.3.8-1.tar.gz";
-    name = "2.3.8-1.tar.gz";
-    sha256 = "755684ac10b0d1a73f3e9f3aed3ab06d0275e7d08904057af040de571cf44333";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/humble/smacc2_msgs/2.3.18-1.tar.gz";
+    name = "2.3.18-1.tar.gz";
+    sha256 = "b817e5b81935c29714060282c7f05b516cca703c42085f64f5bb09307893334f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/humble/smacc2/default.nix
+++ b/distros/humble/smacc2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, lttng-ust, rcl, rclcpp, rclcpp-action, smacc2-msgs, tracetools, tracetools-launch, tracetools-trace }:
 buildRosPackage {
   pname = "ros-humble-smacc2";
-  version = "2.3.8-r1";
+  version = "2.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/humble/smacc2/2.3.8-1.tar.gz";
-    name = "2.3.8-1.tar.gz";
-    sha256 = "8bc01311dc0597bcafc521b0bf8454e2aef8f1ee3aaf4bbe94e25e6ae50ca56f";
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/humble/smacc2/2.3.18-1.tar.gz";
+    name = "2.3.18-1.tar.gz";
+    sha256 = "a6a67168f1359fe9aeb90c1d5b079e5263d0fd2e1243b4be21bae0176e0bd20f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/smach-msgs/default.nix
+++ b/distros/humble/smach-msgs/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-smach-msgs";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach_msgs/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "56f4cc3cc198df6341701c04c5009f5d81af7a3a1f7ab7fcc6ef2576c98f569b";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach_msgs/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "335b06f5d7769cb1cb6dfc30a295228ccfbbf9ef67c6ff4d32d775c78d40992c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
-  checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-lint ];
+  buildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-pep257 rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-uncrustify ament-lint ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-pep257 rosidl-default-generators ];
 
   meta = {
     description = ''this package contains a set of messages that are used by the introspection

--- a/distros/humble/smach-ros/default.nix
+++ b/distros/humble/smach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, rclpy, smach, smach-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-smach-ros";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach_ros/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "5157e7204f95d37717d00ad3ca6f000863ecf719038614742923b941f19bd3be";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach_ros/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "779b84924acc16a683f382352faba8ad08e81d3eceb93e34ecc26ed456113fd2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/smach/default.nix
+++ b/distros/humble/smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-smach";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "e39a503e4a6643716010ac47539bf8a6af86172ff5e0ce6b3556c6903f064fe5";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/humble/smach/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "407b55c6a7cca4b66377c95ecd861d6afd32ef7c28d1cc935080930c197ac74b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, flir-camera-msgs, image-transport, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-spinnaker-camera-driver";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "3f920f77e4e7ea8604179e704d67c41f85332711e7eb2f2021fe0bc704c89df2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ camera-info-manager flir-camera-msgs image-transport rclcpp rclcpp-components sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver for flir spinnaker sdk'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/humble/sqlite3-vendor/default.nix
+++ b/distros/humble/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-humble-sqlite3-vendor";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "889496ef10bbe49b6089013f06da01a9f6eb1a37ac8fdc60a10d69462b6dbfd2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "fe1673a778e780a0aa2150fbfc8e4303133c353ee4f123c45229f08e78eb8b50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-bullet/default.nix
+++ b/distros/humble/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-bullet";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "fb5cc6aeec0e6bf14eb6503ace5dfa445c4d8f5784fa865ed4889bc097bae885";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "33de12fb4fca9b590ba9d25fd524809738ad9309c2a75bf06524ad7d34ab189f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen-kdl/default.nix
+++ b/distros/humble/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen-kdl";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "7686ea71d89f2081ceca5f4abb9a9a960afae0ceb7950aa12505262eabe8ad8a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "3dc7c9eee33fd374d9b4c127474d921afdca91e37ee2f2eb39181aa383d4c3d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen/default.nix
+++ b/distros/humble/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "d74400a14ab77a098b74aba97b8a705796b71d5032ea413b0f2247c3506c6649";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "c2369dad6a56c9aed13d17ab7ee98cbbdf0f8db642c495a8c562888b3cb932f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-geometry-msgs/default.nix
+++ b/distros/humble/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-geometry-msgs";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "491d1a2bad7e141b0e719c1aec1ffb14c4665671717e58535b1899bdc2a89ad1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "75117b2e399dbb3cec71c473ce71c92e8965606febeab57f403653d2432ea999";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-kdl/default.nix
+++ b/distros/humble/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-kdl";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "7aed90b1c386fc3051ac4445f0cb0382981fff6b52cc8617bc25ad033505052c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "bf39369dd0ea777e96219d06677f55965f78eab39a7e161b3d3359226a29b55e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-msgs/default.nix
+++ b/distros/humble/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-tf2-msgs";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "650de913bc6bcc117496af458294cf5d4648aa2f47e587f23f80c5620331eaa2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "89b2afc95e32990bd6f4c6760b5642a4c17454dcec2d62f08de440cc18e543c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-py/default.nix
+++ b/distros/humble/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-py";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "8ba16b1df6b9d2faf7f1c25b2d11c46301900451c459ba043d30469e05589205";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "d8a718bf8b3bb747540b8d2345bd9ac922c21651926859f63459869b030be594";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-ros-py/default.nix
+++ b/distros/humble/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros-py";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "754428b5ad170ded3f735a7f6867d9ff14fb76660ff8916470953b0a475c6ca6";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "bab526a49b49ae68f410e04aa0b1b40d4d661b6741f0dc33d8b913d5f216067c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-ros/default.nix
+++ b/distros/humble/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "df5157b962a33fafe1c0599528ef7696dd2df76aff57adb019bd4fb5d21b17de";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "ee740d60576248000bea64a21e237e56cb329473e74b197af1a9f3aa4037c895";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-sensor-msgs/default.nix
+++ b/distros/humble/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-sensor-msgs";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "3aef70ffdaa9c832e5c6ef978e01f91199781a2af5db144312c71ee21f785066";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "d1412d97b07dfd95d566b7ffd814975ed8aa4d4d2470a3b3f1317a260078627f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-tools/default.nix
+++ b/distros/humble/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-tools";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "0cd97cf91c5efa6e34fe1f2a68ebba8808afa6a0b790ce91769c8caf448d65c4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "0f94a9b3115fb2c18ac351c08b7c2058ca40dc8c443550eb81efebf5981d8c54";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2/default.nix
+++ b/distros/humble/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-tf2";
-  version = "0.25.2-r1";
+  version = "0.25.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.2-1.tar.gz";
-    name = "0.25.2-1.tar.gz";
-    sha256 = "6179ccf7d00247551c8869eae8f158b88465c39cbc5d3fce112e2463ed5bb5a2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.3-1.tar.gz";
+    name = "0.25.3-1.tar.gz";
+    sha256 = "a97490b440b12cc8681b79ba03d5db8063e129994505e038b93d64128c94cccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlesim/default.nix
+++ b/distros/humble/turtlesim/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.4.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/humble/turtlesim/1.4.2-1.tar.gz";
     name = "1.4.2-1.tar.gz";
-    sha256 = "4790460ab3745e6f64057c0a1fc334348d7b55ed9905cb36a4143a177e1ea73a";
+    sha256 = "e259c12d06533fe5943d8b5c5606cb215d2b2cfb309e0aaae263f51f5147d6f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-control/default.nix
+++ b/distros/humble/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-control";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "054bdd8847d0db9a142212f4a66a42e3941e53afc5ffa4d62240830a5dd197e1";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "8cb585237a3a4d35c43ce2ea8c79ac8f431b7f23c280a9cfbda2a0f91d4b52ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, libyamlcpp, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "f5ec53a01865571a40d1640601c97b547a9ea610ddfdf9c6777339a22dc7c046";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "356ab68445bb7a1303f5ecc264e44d34d89e41c062da63731e0e564c19dbe22a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs libyamlcpp pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/humble/webots-ros2-epuck/default.nix
+++ b/distros/humble/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-epuck";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "d5f0aa5fce03c7170e5eb36490804335b8b7607dc028dd60ebd80393fc98ad25";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "32ea34d91bbec806e5bcadcad021d15b973e22e21b299b38f76cf5eec26f707d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-importer/default.nix
+++ b/distros/humble/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-importer";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "54e4a2755ce29c843e8d4c7d6051a8bb1d54445fc1bee6a238b78414d2e55466";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "56c2ac406cd39012342f10a457911185d007b9dbfb379f397f7a63c5fa23e6e0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-mavic/default.nix
+++ b/distros/humble/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-mavic";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "99925efdf7b3e3751415f1dcaa9235967209f86eec8fb98b566a865e4b216c31";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "dc40ba781d21bee3e6629904afe143aa15ccafdb9c73f23a7b83da1dfa631213";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-msgs/default.nix
+++ b/distros/humble/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-msgs";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "1e186c72a7518392489bdf3de47d324b160dfa6c46f91f9323a09cbe3e60b6a0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "852687c6bb39b61111915589583d2f8fce3647f8478975165d88c88bbd90b2b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tesla";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "a04f2aa3aff71a8bc91a85cfd4e86e1fb9c9c5477a0e7e9c909771b26876f3bc";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "537cec542f2f73343589075eb530dff61c9330932b1559c2b8cc1129b7f34b2b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tests/default.nix
+++ b/distros/humble/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tests";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "59b867748291b74adde5bd5dcc505ccdc0bc3bd8aea62128e5fb7f0295149a62";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "4f78ad72d1649c432e18b28ffc04d64d848a1228dcaa55c1218ec19682b12f28";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tiago/default.nix
+++ b/distros/humble/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tiago";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "6de8abbf0e0aa6b97ce07d9a4d5a62c46d0441c1a6063227f10779579822ef78";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "56a6b951f962857c8ce20a244ea159ecc5cb73d9dd115fdf15ff759a3866aea7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-turtlebot/default.nix
+++ b/distros/humble/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-turtlebot";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "39358d95b015e4b9472a98de0608d589f3790bf4dda63cd101a2147caf2ea1ca";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "c0ec2d713d234035f7ab55244eaeba1e58b22cd6d96bb6093dd5850b8982f335";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-universal-robot/default.nix
+++ b/distros/humble/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-universal-robot";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "c75905adc2dc8ba732bcbe3766286af944f6fe98598607549755d6943e056b71";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "9de204d5ffce4715b74f4410ac331d1c50b44bc93370a446e3c895584679ce0e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2/default.nix
+++ b/distros/humble/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "47644b2c5df180a801996bd7a2dfed13cd9f2e6993e1ae772a8846307dd0317c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "981c3533191989d32b5027b0dfe5d82f13b94f118f328a00461502b7c410d3d4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/zstd-vendor/default.nix
+++ b/distros/humble/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-vendor";
-  version = "0.15.6-r1";
+  version = "0.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.6-1.tar.gz";
-    name = "0.15.6-1.tar.gz";
-    sha256 = "bbf6aec71139c7a1ebe7968200a6afa74bcc205fd5f4de7b36b1e737779e7abe";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.7-1.tar.gz";
+    name = "0.15.7-1.tar.gz";
+    sha256 = "798c2fd991241547e2374ac1a48eace5cfe4d35527c073cd3eb1f46bda398902";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "c9c1a07b05beb286b454215e700c00c749fdd572a6432559723d1a85d37068c1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "94990e50a5b4b8377e1c811ab6b00313499019d7edd48bd83266f9ca69d24d03";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "c6665573698d6952f997242afc896fd986eb5b2cb9207328343f300febddad61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "ba7a2ce140a88eaaccadb7b55e63e609838271147a6dd6f60352cfb14083540a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "03b32e84c58ee486cf9ba8862b92c47b6913de518ceafd32da1a6077b33309fd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "86e72a7b063b6404d1ee8c817f6cada77f9bc65738724e09bb8b6e7bf53ea7c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/camera-calibration-parsers/default.nix
+++ b/distros/iron/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-camera-calibration-parsers";
-  version = "4.2.0-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.0-3.tar.gz";
-    name = "4.2.0-3.tar.gz";
-    sha256 = "5e533144a5a9897b7f9bbf9da2d8ecf9aa60b6aab14fd2fdd01fff3743ac62a2";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "4e1d474d3cc9169f364812f5f1b56ed75498f822c3195a31af751a83ac6e25a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/camera-info-manager/default.nix
+++ b/distros/iron/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-camera-info-manager";
-  version = "4.2.0-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.0-3.tar.gz";
-    name = "4.2.0-3.tar.gz";
-    sha256 = "a93155ed606b59d0e6372238ee375e6307e9f00cc1d64405a55ed5ed2dcb19ec";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "1853ad846e4fa3e6fc3f8965bec0155aa8198f74d28c9270ca7d52679ff89016";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/cascade-lifecycle-msgs/default.nix
+++ b/distros/iron/cascade-lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-cascade-lifecycle-msgs";
-  version = "1.0.3-r5";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/cascade_lifecycle_msgs/1.0.3-5.tar.gz";
-    name = "1.0.3-5.tar.gz";
-    sha256 = "fab04493dbb7628e5765738e8b8549c39536eeafe555ece8cb15c2e36f020f59";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/cascade_lifecycle_msgs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "63b073f2cac4c5b729d550691d7073a2474a812a662357394a0687322d6668b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "9e8e9a0140839d4c81d221f617c36717a79ae5cb703581b18fbdf9bfe5836bf0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "b24e7bec3d7f1cdc0e8bb793d493253c12e6191835b06c1512b4afafcea830e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "77d794e34b9a4b94bde7d8a6fb4652e73235a9018bc291cb13cf888ed1fe0777";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "a1d8555fe12c3c22ab20bc99f99130d75d2a5b2313345a2e052dea68068d9cec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "3978068b12da19e33086f35276011e1c1885b0ac8f6c52fcf6d3ee240c69d5af";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "7c3ac0d4142567587a376f2633616678197b7693b2a16ee2491b6e6b3a9b32a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthimage-to-laserscan/default.nix
+++ b/distros/iron/depthimage-to-laserscan/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, image-geometry, opencv, rclcpp, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-geometry, opencv, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthimage-to-laserscan";
-  version = "2.5.0-r5";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/iron/depthimage_to_laserscan/2.5.0-5.tar.gz";
-    name = "2.5.0-5.tar.gz";
-    sha256 = "71c2a9cd84170042cd409dd005e5a915465458ede5cd2d5c6dc811b3851e618f";
+    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/iron/depthimage_to_laserscan/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "823bbbbcce9f340af6b0649007b7a101bdc56c41bed3dac1a48da7ec66333145";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ image-geometry opencv rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "cb06fd3d2ace4281e32c9b38730dd791bc2e4b6bac3c6737d2a5251be74af9df";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "149eb8f6f9215e5d48b65291c8111b9442f78057610fd45322f6b4bb607b6c5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "5a2f95a9e497179a23d48040e10e4347e14bb459af7d83471bb6a9dfc97932b9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "482554839ec3fab5a48e276bd71c536606441519b26ff079d33836cafe49395f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/executive-smach/default.nix
+++ b/distros/iron/executive-smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, smach, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-iron-executive-smach";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/executive_smach/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "53be40cbe0c92234be7d271daeb2a49384defdc0ea648c103801aecd2d001bb2";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/executive_smach/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "cd0bdcc71f138bb6ddde3473c977002b9bde036d06db1425562f924a275e9117";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "0232439ad174ea6f4730911b889f77212be59cc9749dd3d9e4a19601173c1a10";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "6f26903f3f9a16d3a24d6f2f34e5c7102f357a4ad23d7e479d0730d3666cb9c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "5004cb8b81550b3b199839f6c91478e4e26960258780f6882d4db545ece72b24";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "2726d1a47b592923a21332cbdfb6dc95d3da9144458a466f0b53439af90f0608";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/foxglove-bridge/default.nix
+++ b/distros/iron/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-foxglove-bridge";
-  version = "0.6.4-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "bf48b24fb619d6a5fb8777f82d7a93691e5de7823fd0055cba88d6d4782ee71e";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "80a97ca43cab6a25f6bc39d2cfd34dfff16426e76a1fac8bc143f6f5b2fb7530";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components rosgraph-msgs zlib ];
+  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/generate-parameter-library-example/default.nix
+++ b/distros/iron/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-example";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "f343ee54f5dac50edf4732f8648fef282b8b28d888fbb2ca90ba0c6a4d3ccf6e";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "c59570915f1c71cb708c8ad0578538d0ef520e7cece6732220162d251d837217";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generate-parameter-library-py/default.nix
+++ b/distros/iron/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-py";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "698b2100f6fd967d94c4558e702675445b93ff8317ac685d448cb9bb6b5cfadf";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "331eb017c89114b191a43b12a264040a5c150f5fd0d9afd75fe1083927fab580";
   };
 
   buildType = "ament_python";

--- a/distros/iron/generate-parameter-library/default.nix
+++ b/distros/iron/generate-parameter-library/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rsl, tcb-span, tl-expected }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "839664c803c583cb4c2fa4782511db14a6adea80204c6195efe3b623be2a9a92";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "896f4ef98f7d8a29302bd2d24c7c1055cd9ec684acc23b9494e7d4180fe5f5a6";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ fmt generate-parameter-library-py parameter-traits rclcpp rclcpp-lifecycle rsl tcb-span tl-expected ];
-  nativeBuildInputs = [ ament-cmake generate-parameter-library-py ];
+  propagatedBuildInputs = [ fmt generate-parameter-library-py parameter-traits rclcpp rclcpp-lifecycle rclpy rsl tcb-span tl-expected ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python generate-parameter-library-py ];
 
   meta = {
     description = ''CMake to generate ROS parameter library.'';

--- a/distros/iron/generate-parameter-module-example/default.nix
+++ b/distros/iron/generate-parameter-module-example/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-generate-parameter-module-example";
+  version = "0.3.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_module_example/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0091e7d3be0820fd322706ea37ea96a58bee7e808e16bf0d54cee0e79a1ca509";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library for a python module'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -556,6 +556,8 @@ self: super: {
 
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
 
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
+
  geodesy = self.callPackage ./geodesy {};
 
  geographic-info = self.callPackage ./geographic-info {};
@@ -626,6 +628,8 @@ self: super: {
 
  gtsam = self.callPackage ./gtsam {};
 
+ gz-ros2-control-demos = self.callPackage ./gz-ros2-control-demos {};
+
  hardware-interface = self.callPackage ./hardware-interface {};
 
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
@@ -643,8 +647,6 @@ self: super: {
  iceoryx-posh = self.callPackage ./iceoryx-posh {};
 
  ifm3d-core = self.callPackage ./ifm3d-core {};
-
- ign-ros2-control-demos = self.callPackage ./ign-ros2-control-demos {};
 
  ignition-cmake2-vendor = self.callPackage ./ignition-cmake2-vendor {};
 
@@ -714,11 +716,23 @@ self: super: {
 
  kinematics-interface-kdl = self.callPackage ./kinematics-interface-kdl {};
 
+ kinova-gen3-6dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-6dof-robotiq-2f-85-moveit-config {};
+
+ kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
+
  kobuki-core = self.callPackage ./kobuki-core {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
 
  kobuki-velocity-smoother = self.callPackage ./kobuki-velocity-smoother {};
+
+ kortex-api = self.callPackage ./kortex-api {};
+
+ kortex-bringup = self.callPackage ./kortex-bringup {};
+
+ kortex-description = self.callPackage ./kortex-description {};
+
+ kortex-driver = self.callPackage ./kortex-driver {};
 
  lanelet2 = self.callPackage ./lanelet2 {};
 
@@ -1152,11 +1166,43 @@ self: super: {
 
  picknik-ament-copyright = self.callPackage ./picknik-ament-copyright {};
 
+ picknik-reset-fault-controller = self.callPackage ./picknik-reset-fault-controller {};
+
+ picknik-twist-controller = self.callPackage ./picknik-twist-controller {};
+
  pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
 
  pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
 
  pinocchio = self.callPackage ./pinocchio {};
+
+ plansys2-bringup = self.callPackage ./plansys2-bringup {};
+
+ plansys2-bt-actions = self.callPackage ./plansys2-bt-actions {};
+
+ plansys2-core = self.callPackage ./plansys2-core {};
+
+ plansys2-domain-expert = self.callPackage ./plansys2-domain-expert {};
+
+ plansys2-executor = self.callPackage ./plansys2-executor {};
+
+ plansys2-lifecycle-manager = self.callPackage ./plansys2-lifecycle-manager {};
+
+ plansys2-msgs = self.callPackage ./plansys2-msgs {};
+
+ plansys2-pddl-parser = self.callPackage ./plansys2-pddl-parser {};
+
+ plansys2-planner = self.callPackage ./plansys2-planner {};
+
+ plansys2-popf-plan-solver = self.callPackage ./plansys2-popf-plan-solver {};
+
+ plansys2-problem-expert = self.callPackage ./plansys2-problem-expert {};
+
+ plansys2-terminal = self.callPackage ./plansys2-terminal {};
+
+ plansys2-tests = self.callPackage ./plansys2-tests {};
+
+ plansys2-tools = self.callPackage ./plansys2-tools {};
 
  plotjuggler = self.callPackage ./plotjuggler {};
 
@@ -1177,6 +1223,8 @@ self: super: {
  polygon-rviz-plugins = self.callPackage ./polygon-rviz-plugins {};
 
  polygon-utils = self.callPackage ./polygon-utils {};
+
+ popf = self.callPackage ./popf {};
 
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
@@ -1427,6 +1475,10 @@ self: super: {
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
+
+ robotiq-controllers = self.callPackage ./robotiq-controllers {};
+
+ robotiq-description = self.callPackage ./robotiq-description {};
 
  ros2-control = self.callPackage ./ros2-control {};
 

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "4f23a7312150fd4f0f13d061facdb042cc8bb24c2e741a42cc14590726d2015e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "db14590f2783b48ce970f3c22801dd32badb99caec429e6a4a8a07edb68db4dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gz-ros2-control-demos/default.nix
+++ b/distros/iron/gz-ros2-control-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-iron-gz-ros2-control-demos";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-controls/gz_ros2_control/archive/release/iron/gz_ros2_control_demos/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "7da3b265dd017964d7865a7072e498c71b2fa647f182b6f6b25868494d10b5ad";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-action ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''gz_ros2_control_demos'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "26a075adfdf5baa61d0e615888a53333585f075d2b0cc6c91bd389e7bf8d53f9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "74e8cb630c7aa6fd4b23af62ea2eeb77d46d46bbeda03315562abdf3ee6bc3bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-common/default.nix
+++ b/distros/iron/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-iron-image-common";
-  version = "4.2.0-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.0-3.tar.gz";
-    name = "4.2.0-3.tar.gz";
-    sha256 = "1c4f8fe34fabde1189e03e1a4eb405467ad13947be204fa7aed20c3565bf5f5f";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "887c6d4339794cca465578a1f7984f64d6999b96c99bff92d62613112e43ea99";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-transport/default.nix
+++ b/distros/iron/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-image-transport";
-  version = "4.2.0-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.0-3.tar.gz";
-    name = "4.2.0-3.tar.gz";
-    sha256 = "81807c294a17c65f0989edece59828627c9f8ea8f6228f8c10aec16bdcb68d6d";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "19d9b91552a8916d0db86e4bad967ff618b29c6de46212eaee0c329680dd0b75";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "67f3b4ab410af3d1b4f425cc1ee2c00bf30078750df7de94dba27b1e3b4efd4f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "a73733a271259816da7afc934f68953be1c3291bea7c7801586e148ec145ffac";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "ca5aa2ef604943871ed6d68de8a7380ff940e7f1a6f56ec3dba4864f073248a7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "ea5c38f36ab73399ce0a4cdca21a81000f32f1e42306389fcef90c6866bae850";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "b0bdc7b2ebe9adeb63f09e399245b2b40f906de55acf4ddb1ad831b04e295e36";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "169dd1c91b96f470ea1f7426461c10e5ce60d9fbf26376befbd0f28ab7da466d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "8da6a7453057c32e2953ae37e2bb750f897e400deb306dc49f5a88c8b5121675";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "acfdea3d3e1361bb2f08bc75e644f1d008408ef4b92f4a6ef6bd161d86b54710";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/iron/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-iron-kinova-gen3-6dof-robotiq-2f-85-moveit-config";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "bcdd9c83e1bd11aca58bafaebc5d62838a1cb21d7dc424b8a834b3e63e13576c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the gen3 with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/iron/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-iron-kinova-gen3-7dof-robotiq-2f-85-moveit-config";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "7d0d466c1d4cfe991afa6b9bbedd391f4cb9034ff4f1c906143b3c6254a931a3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the gen3 with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/kortex-api/default.nix
+++ b/distros/iron/kortex-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-iron-kortex-api";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_api/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "59201ee61a5167c7ba2e695e91f2a30f4be95d27232202e0ade6f99a49ba4662";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''kortex_api'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/kortex-bringup/default.nix
+++ b/distros/iron/kortex-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, gazebo-ros2-control, gripper-controllers, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, kortex-description, kortex-driver, launch, launch-ros, rclpy, robotiq-description, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-iron-kortex-bringup";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_bringup/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "245626ecf6eaf80091f36665bd8f4dfe1b00eb78f1d9ffcb1c7cad5f430b26b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ controller-manager gazebo-ros2-control gripper-controllers joint-state-broadcaster joint-state-publisher joint-trajectory-controller kortex-description kortex-driver launch launch-ros rclpy robotiq-description rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Launch file and run-time configurations, e.g. controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/kortex-description/default.nix
+++ b/distros/iron/kortex-description/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, robotiq-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-iron-kortex-description";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_description/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "c86a19e2b49905e4239260e4adae9e11bac1dcbdebe4ea92c80de2b8009320db";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui joint-trajectory-controller picknik-reset-fault-controller picknik-twist-controller robot-state-publisher robotiq-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>URDF and xacro description package for Kortex robots</p>
+    <p>This package contains configuration data, 3D models and launch files
+for Kortex arms and supported grippers</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/kortex-driver/default.nix
+++ b/distros/iron/kortex-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, hardware-interface, kortex-api, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-iron-kortex-driver";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_driver/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2a1f0e97a297f050db11527616371bce1d51bbbd4a35008bd28ec8744e4e94e9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ hardware-interface kortex-api pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver package for the Kinova Robot Hardware.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/microstrain-inertial-driver/default.nix
+++ b/distros/iron/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, git, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-driver";
-  version = "3.0.1-r3";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_driver/3.0.1-3.tar.gz";
-    name = "3.0.1-3.tar.gz";
-    sha256 = "cc51aefe27ac994e83c5880960f8a351912b5bd6fe596fbb714f5555e5ee7a19";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b0808d7616f04635a000c5967a58109ea8df886395348c12355be16821b727a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-examples/default.nix
+++ b/distros/iron/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-examples";
-  version = "3.0.1-r3";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_examples/3.0.1-3.tar.gz";
-    name = "3.0.1-3.tar.gz";
-    sha256 = "dbe0a64436bb4bd718116555a8fbf1e11cd3393a2a58a5178652ca7a8d27dfd5";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_examples/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ae07a4aec8e3ff3a67cb902a2e22858e4f6b38325d4ba8cb27fb97d85e4aedc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-msgs/default.nix
+++ b/distros/iron/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-msgs";
-  version = "3.0.1-r3";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_msgs/3.0.1-3.tar.gz";
-    name = "3.0.1-3.tar.gz";
-    sha256 = "3b7a54b55d279c4421b3f98608279b7412bedad8b40abedc0aca599754994316";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "3c5cf6e23744d31582bed942bd173f0e9beb1be8890419a8aba198e6aa1d11c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-rqt/default.nix
+++ b/distros/iron/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-rqt";
-  version = "3.0.1-r3";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_rqt/3.0.1-3.tar.gz";
-    name = "3.0.1-3.tar.gz";
-    sha256 = "b84b4d37869acc9d40d47cb520ecc1eb4d1062ab91a9ee359880355e792db943";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_rqt/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8c9917bde1b00018979bffabf5065d0d81574ed022462eb8aaf6d9226fdf67b8";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.9.4-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.9.4-1.tar.gz";
-    name = "2.9.4-1.tar.gz";
-    sha256 = "b5032ace94bab1267bfa72330d1fee0d87ad9ae9e51bc1962045f9f615773b1b";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "613bcfa3c5637b3c8622848d05b391e45d6a6e8982c728e9a1cecfe141f7bb5e";
   };
 
   buildType = "cmake";

--- a/distros/iron/parameter-traits/default.nix
+++ b/distros/iron/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-parameter-traits";
-  version = "0.3.3-r2";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.3-2.tar.gz";
-    name = "0.3.3-2.tar.gz";
-    sha256 = "58b731b40ace7ab71467229cf87d6d0a95f3a4ea0951a421408aaeb89f637be6";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "85a414a5a5bfe223d8e45e64e29281b924c96eaa6c5b2a6a13a1bab63905aa0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/picknik-reset-fault-controller/default.nix
+++ b/distros/iron/picknik-reset-fault-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
+buildRosPackage {
+  pname = "ros-iron-picknik-reset-fault-controller";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/iron/picknik_reset_fault_controller/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "717610e49b98eac14ac00bf75ae79faaa3f96d9feef62f7785715c0cd2e7b17e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ controller-interface example-interfaces geometry-msgs rclcpp realtime-tools ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS 2 controller that offers a service to clear faults in a hardware interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/picknik-twist-controller/default.nix
+++ b/distros/iron/picknik-twist-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
+buildRosPackage {
+  pname = "ros-iron-picknik-twist-controller";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/iron/picknik_twist_controller/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "4be8f7de161bebe6ff96becc6cec6d0b65533500829ce84e4e91c025095ffab1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ controller-interface example-interfaces geometry-msgs rclcpp realtime-tools ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Subscribes to twist msg and forwards to hardware'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-bringup/default.nix
+++ b/distros/iron/plansys2-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-bringup";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_bringup/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "289ca01aa856e839ee243101a937e21377837e37093947d09b877c33234d1af2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common launch launch-testing ];
+  propagatedBuildInputs = [ launch-ros plansys2-domain-expert plansys2-executor plansys2-lifecycle-manager plansys2-planner plansys2-problem-expert rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Bringup scripts and configurations for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-bt-actions/default.nix
+++ b/distros/iron/plansys2-bt-actions/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-bt-actions";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_bt_actions/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "ce33f97ae9b5275409d171cfadb48c7cf24802477d5fa50c5cc041f04fd7e21c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs plansys2-msgs test-msgs ];
+  propagatedBuildInputs = [ action-msgs behaviortree-cpp-v3 cppzmq plansys2-executor rclcpp rclcpp-action rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Problem Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-core/default.nix
+++ b/distros/iron/plansys2-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-core";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_core/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "0cb8a01cd8583d39ee75f4900351f6d70cdbecd852a23cacd2dc63fc8975895a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-pddl-parser pluginlib rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based core  for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-domain-expert/default.nix
+++ b/distros/iron/plansys2-domain-expert/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-domain-expert";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_domain_expert/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "cc4dec20eb764b51ab98b44a678b931ed71f84abb98a27b2487edb8b03adb562";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-core plansys2-msgs plansys2-pddl-parser plansys2-popf-plan-solver rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Domain Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-executor/default.nix
+++ b/distros/iron/plansys2-executor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, pluginlib, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-executor";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_executor/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "5ddbc3d808bfd04e1d240d2bab53012a6f022075b70176f693065acaa8dcdfb1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 cppzmq lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert pluginlib popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Executor module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-lifecycle-manager/default.nix
+++ b/distros/iron/plansys2-lifecycle-manager/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-lifecycle-manager";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_lifecycle_manager/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "b173b88225355cf64fb9ea33e593dcc875e8b193acf6ba289459965ed93f0f41";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ lifecycle-msgs rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A controller/manager for the lifecycle nodes of the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-msgs/default.nix
+++ b/distros/iron/plansys2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-msgs";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_msgs/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "67fffe446b14bf2523aa88a4534eafdcb983e6a64f94b7c081905b25d40a621d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rclcpp rosidl-default-generators std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages and service files for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-pddl-parser/default.nix
+++ b/distros/iron/plansys2-pddl-parser/default.nix
@@ -1,0 +1,34 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-pddl-parser";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_pddl_parser/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "506665575fea2ca48b4136b1bdff58bad64211a2d5d6299b1d48f08a5a8fdca8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains a library for parsing PDDL domains and problems.
+  
+    This package derives from the work of Anders Jonsson, contained in https://github.com/wisdompoet/universal-pddl-parser.git
+    with many modifications by Francisco Martin:
+      * ROS2 packaging
+      * Source code structure refactor
+      * CMakeLists.txt for cmake compilation
+      * Reading from String instead of files
+      * Licensing'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-planner/default.nix
+++ b/distros/iron/plansys2-planner/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-planner";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_planner/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "13e57dd4db97ae47928b29e372a1c81f5ddd46c2a69cf2353c08d1ab0cbe6f37";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-popf-plan-solver plansys2-problem-expert pluginlib rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based Planner module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-popf-plan-solver/default.nix
+++ b/distros/iron/plansys2-popf-plan-solver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-popf-plan-solver";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_popf_plan_solver/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "c6a8caeb7dc5bc2de38ab45874c0ed4edc1fd3a5c253e850ae0956e8702395cd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp plansys2-core pluginlib popf rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based Planner module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-problem-expert/default.nix
+++ b/distros/iron/plansys2-problem-expert/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, qt5, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-problem-expert";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_problem_expert/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "74bba957c59ecf2d8a385c5222809a715a775303de7ccabeb145ce77b3211374";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser qt5.qtbase rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Problem Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-terminal/default.nix
+++ b/distros/iron/plansys2-terminal/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-terminal";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_terminal/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "597542d9dfb568f0fa35e8fd102a9644eaaccb9e6da69e75b689ba7799d3fefc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common lifecycle-msgs ];
+  propagatedBuildInputs = [ plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle readline ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A terminal tool for monitor and manage the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-tests/default.nix
+++ b/distros/iron/plansys2-tests/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-tests";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_tests/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "0fc76f0618ef6258a07e7f067549206b4b889477cd54e0d8362ba2970707f918";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 lifecycle-msgs plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the tests package for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/plansys2-tools/default.nix
+++ b/distros/iron/plansys2-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, qt5, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
+buildRosPackage {
+  pname = "ros-iron-plansys2-tools";
+  version = "2.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_tools/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "f0ebb4d1cbcae3807f7536a8d0ce076c6f9c5f9459bce9981470cf98165bd793";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake qt5.qtbase ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-problem-expert qt-gui-cpp rclcpp rclcpp-lifecycle rqt-gui rqt-gui-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A set of tools for monitoring ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/popf/default.nix
+++ b/distros/iron/popf/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bison, cbc, clp, flex, rclcpp }:
+buildRosPackage {
+  pname = "ros-iron-popf";
+  version = "0.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/popf-release/archive/release/iron/popf/0.0.15-1.tar.gz";
+    name = "0.0.15-1.tar.gz";
+    sha256 = "fb037442684697f2ce1bcec339ab8fe9a44ee4c74d35f74c1e9c1f54aad1d416";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ bison cbc clp flex rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The POPF package'';
+    license = with lib.licenses; [ "GPL-2.0-only" ];
+  };
+}

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "e92c4f2723fae802510ae91d575369ab710e976182089475dd4f9208771e5d18";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "7de8ce3a12906f6ccaab6e09f7bc792a5f01e95146e4445c2e7c235cdaae5fe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/iron/rclcpp-cascade-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-cascade-lifecycle";
-  version = "1.0.3-r5";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/rclcpp_cascade_lifecycle/1.0.3-5.tar.gz";
-    name = "1.0.3-5.tar.gz";
-    sha256 = "26f5ceedbabb6c2ae68eef1b1a5a507e2b3cea686ce2ea99b2adc87d2d40a656";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/rclcpp_cascade_lifecycle/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "938948c178767f26c23f6f4e43a4eb206dc82cfca4e14df7cdd02c7f37fe9da8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robotiq-controllers/default.nix
+++ b/distros/iron/robotiq-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-interface, std-srvs }:
+buildRosPackage {
+  pname = "ros-iron-robotiq-controllers";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_robotiq_gripper-release/archive/release/iron/robotiq_controllers/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "09dbc74922749bd02df2050106166ddd5d647eca20b95aa0c3831cb4e705cadf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-interface std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controllers for the Robotiq gripper.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/robotiq-description/default.nix
+++ b/distros/iron/robotiq-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-ros, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-iron-robotiq-description";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_robotiq_gripper-release/archive/release/iron/robotiq_description/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "94c5b06d1a5d69a88aceb37c200cc16af93631789bdbb645b4b64e8253d27c39";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-ros robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF and xacro description package for the Robotiq gripper.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "6cd2108e3bffbbdf8fe2b2dfc09ac5a7ef6e285e2910fa89682fae231fd8c9c2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "80da42dcbda988372f67be21e32fb8ec4f0ba53821d0704da14b3aedfcf52b87";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "fef1e4c8ddbaa92fa3fadf9464607ce8be3d8b26136dea6def41ab0e57898d25";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "c297c52eaa33fe729d63e49db37292475c35ea683a9977111bd11698d534e9df";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "ddfdefd53f57a422a98756a40066a6818b161c18fd12d4f7f41369e65513b6cc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "59652ddfcb7a73adcf80c332cb66c03b6bcac89de263de8dd5821d53d1909300";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "92d2c6bebfcdcb57560acdea51d487c541fb30fd1b5a0eadd384bafd223d1a40";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "0682ddc0263ba5e904704b0a2acdaa13928536746c0c60742e714f90a74d58aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "e2ebb80d0437ac352807b17b09cbe2c84b1310cfca5204f046cc698d9dab808a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "c22ab30166a1c50dd93ed0224ea79e8fea44ea079a3bd3f2c062bf9a8f2acd6f";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "1286a8380d1d8f0b3f8c9e3840cb7d1f37988c1d03eb0ad3c1af84a3ba4fe3bc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "1b333d4c8a916ce701a9c98388cf91c332243970d0fcfc29c1fd686a44490e2d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "60f742b2b4dde4b20c2036143f062b949d2b679bd060dc30008da7ef8b90d097";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "1fe58e805a193057de4e51d1513e1bf7bea72de564fb635ba80c100a1098f8f2";
   };
 
   buildType = "ament_python";

--- a/distros/iron/septentrio-gnss-driver/default.nix
+++ b/distros/iron/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-septentrio-gnss-driver";
-  version = "1.2.3-r3";
+  version = "1.3.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/iron/septentrio_gnss_driver/1.2.3-3.tar.gz";
-    name = "1.2.3-3.tar.gz";
-    sha256 = "9567300688f2d37db821404d469805f79b0efe26f592b2bc425aecefa9ec01e8";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/iron/septentrio_gnss_driver/1.3.1-3.tar.gz";
+    name = "1.3.1-3.tar.gz";
+    sha256 = "e3965febb3deebbb5e4d17b731e8a19164b093345f395875756861de3ba2fa8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/simple-launch/default.nix
+++ b/distros/iron/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-iron-simple-launch";
-  version = "1.7.0-r3";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.7.0-3.tar.gz";
-    name = "1.7.0-3.tar.gz";
-    sha256 = "7a53a623f847e1e9c117a97e9ee8f856c70750bdcbf6cfeda0114d181be31a48";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "973e8ab0426c7158d2717e9a0776d34a674502ecdc2444e50ae79dad128a2012";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/smach-msgs/default.nix
+++ b/distros/iron/smach-msgs/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-smach-msgs";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach_msgs/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "2cfbc6adb4a978bf436485a2090228139df76c9554414d09f583d2c43acc6592";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach_msgs/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "e0c70d21a3f07f5b9103768fc51a9e0cd2e2c323dfa28562050fe6b086d7eb2c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
-  checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-lint ];
+  buildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-pep257 rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-uncrustify ament-lint ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-pep257 rosidl-default-generators ];
 
   meta = {
     description = ''this package contains a set of messages that are used by the introspection

--- a/distros/iron/smach-ros/default.nix
+++ b/distros/iron/smach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, rclpy, smach, smach-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-smach-ros";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach_ros/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "48553ee2114560ed7db4276bb3f5783ef829bcd73b85e25a2f3640d5c9b3aa45";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach_ros/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "6bb61f7fef8e17fcff3dd72d44b2ac08c87e45581a150d5a05dc02ea353ade0c";
   };
 
   buildType = "ament_python";

--- a/distros/iron/smach/default.nix
+++ b/distros/iron/smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-iron-smach";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "2ac4779cea397c8c461519e82f44b270fe15109b7cbc5147626aa399f14d0e4b";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/iron/smach/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "8c3b247d97e14a6fe7b32cc3dcc5025783c37c0b39c4f437470ab23df50fb6ea";
   };
 
   buildType = "ament_python";

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "13b7be475253c2eeb077e9549fd053e936a1e5b7a6bc4229ead78190b96b9d20";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "089a6ce6084df8dfeaaff3b619fe00a310da485781e06233c45b96ed6a89840f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "f78ef1a6b66e5e9d26cdded475b4641f90f3eddf728d46883c7f61ef6cd31cbc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "b79c0ba449e0f22798e4cfe99653d94ce868b41e812d6e61bf90aa37bfa51ccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "4d6bfed1e72386db1b0e7585c451e1cafe47c0900c48ef7208b9e07f7309eb02";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "b869bcfb91bb10d3d450f5ef24766a627359f2fba0018aa0888608474963233d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "1adf27f1e9b2d6ca981bfb06098021030a4c119c9f57b3aa0b73f89a30a8aeb7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "d2a2af5333a62e39d1da2315542f03d5d6433a476d0eaae59c06023e63dc8b75";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/turtlesim/default.nix
+++ b/distros/iron/turtlesim/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.6.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/iron/turtlesim/1.6.1-1.tar.gz";
     name = "1.6.1-1.tar.gz";
-    sha256 = "4790460ab3745e6f64057c0a1fc334348d7b55ed9905cb36a4143a177e1ea73a";
+    sha256 = "96163d1ee724c4326d699e44b4603b7d292e77fbe0e40133dcbb17a0ccdd6f3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-client-library/default.nix
+++ b/distros/iron/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-iron-ur-client-library";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "bcfc99c3e423e7caa82beb06e58dbe03452098c116f3be35c68b071562de21aa";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "a6404ecb85dc1af3e61512d11c614b1d93206927e4ec938ffe48d30f4b7c3f4c";
   };
 
   buildType = "cmake";

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "932f78fd0f87ea3e2798845ba5610c3ea7413934411b859ab3c9a1db2261d65f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "cb61ce70460d95f8cce6c2e175420d16a76d59c92470c0d168ea22608ba8566d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-control/default.nix
+++ b/distros/iron/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-control";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_control/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "be92fe4cbbacf3c5d490e409b4e08befc7d0f4c595062806bb2e8ef1a7913617";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_control/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "c43cf5d50fc6e279b11c447230da23553cb90b08409c345ae9be237ebc3ab4ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-driver/default.nix
+++ b/distros/iron/webots-ros2-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, libyamlcpp, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-driver";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_driver/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "794ccb84dbc422e8f7b70298d8bd7657c956db9915d3afc9d30628adbd8495bc";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_driver/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "64fccdd7f85b354b94338844720b7d4f12a4bc64c5cd0d71e5cde7883357b3ed";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs libyamlcpp pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/iron/webots-ros2-epuck/default.nix
+++ b/distros/iron/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-epuck";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_epuck/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "238efdff393c82e7a218bd967c09b09096eb23aec994f852ae46da2d41f36615";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_epuck/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "d546ddab11fa4fcd71fa52af4014241380e88877505caf95b954034b749e1318";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-importer/default.nix
+++ b/distros/iron/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-importer";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_importer/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "ebffb825db1b4b53418d70c0f5c770c4afb8c6b927aab01f8a7aa22dadca8760";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_importer/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "113950243dfa7dd9a978d55d313e9202f5e9df5be2ead46ed77fada95d9ea9e8";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-mavic/default.nix
+++ b/distros/iron/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-mavic";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_mavic/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "7029f0dd11e934039230e384c5ca29e54ee53dd249395c436d0c4cde2fdc513c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_mavic/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "352eb11d4b9c8bf0d936dac23451bf110a7c771e47871e1807046ec296324d18";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-msgs/default.nix
+++ b/distros/iron/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-msgs";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_msgs/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "5327a4137eae6037fda2a9d23af3767417dec5005a45776a49b3f28b4841da31";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_msgs/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "3e69f8dd2256c2f2e4cface2975a67843a259b79658e266b35088b71fe84c016";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-tesla/default.nix
+++ b/distros/iron/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tesla";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tesla/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "e5dfc070b336689f9a6407fa7a6f646611ba7ff6f1f0680c938be423e760013f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tesla/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "e927abf95a989c2bd26ecd17eb2c179d146084d2faf7ec53c2049dc82c4ec259";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-tests/default.nix
+++ b/distros/iron/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tests";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tests/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "66d49bdc13f401aec75c739bff179dce12df6d5477815b76c6829750eddcc13d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tests/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "7aec1a0351bfefd0177ecee3cd6fdf67b61ad6d7ff64c42cca7f041f4a62f4c3";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-tiago/default.nix
+++ b/distros/iron/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tiago";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tiago/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "25f81cda79cc4f6f0e7d2291b842940b8fefd749faec91cbf256ba7afebeb733";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tiago/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "25fe1835d28c1f033045b91a3cfca6637b854f9788f948478f16003b3b63a442";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-turtlebot/default.nix
+++ b/distros/iron/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-turtlebot";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_turtlebot/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "208e029775e3bb5d222379809b463cbf74e7d75468d262713050d66716ce2930";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_turtlebot/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "3c40d599d1260c525df83aaaf039690e7366e3c05fe9300116e470cb62263275";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-universal-robot/default.nix
+++ b/distros/iron/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-universal-robot";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_universal_robot/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "f6a7c51ff74d5ad24786c61af42b4c0200d403ae27e48058bb2e9c05690a2fc4";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_universal_robot/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "cb217fe2963c49d6c9fc66e5fc69fc12637ddd65ebf75965d3bca5ff938b20fb";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2/default.nix
+++ b/distros/iron/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2";
-  version = "2023.1.0-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2/2023.1.0-1.tar.gz";
-    name = "2023.1.0-1.tar.gz";
-    sha256 = "60f97e2d0151be1ad00be60c827c0896f301965ae9362ef1e604d50f7151e494";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "e805536276880a90b984b3c598ba7501b034117b54f46a03db1ec3262c5561a7";
   };
 
   buildType = "ament_python";

--- a/distros/noetic/aques-talk/default.nix
+++ b/distros/noetic/aques-talk/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
+{ lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, rostest, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-aques-talk";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/aques_talk/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "23a718587034dbc0eb16f95cc5c83c892925b5be0f55dffbbb238b4d96c150aa";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/aques_talk/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "f258fe9eed04264021f915dbb599d863beb0174e970d048febafd0c21fa13887";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
+  checkInputs = [ rostest ];
   propagatedBuildInputs = [ kakasi nkf sound-play ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/assimp-devel/default.nix
+++ b/distros/noetic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-noetic-assimp-devel";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/assimp_devel/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "e8e1d96cbd67690f2d08c69cc97bb158f37a5502d2db01d0b19d524ba57a89d3";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/assimp_devel/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "37b99395920abb52017659d1ff642d22274e8b2b38c4b1e3706d6cc42a51b54e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bayesian-belief-networks/default.nix
+++ b/distros/noetic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-noetic-bayesian-belief-networks";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/bayesian_belief_networks/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "2fe668ade379094723382cf451a6c2115ad22fea43586006cee1c0a9d3332f36";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/bayesian_belief_networks/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "87a189fc5812343b7baffd577ab14f1503669f02ef6850fa90cf0de7c857b920";
   };
 
   buildType = "catkin";

--- a/distros/noetic/chaplus-ros/default.nix
+++ b/distros/noetic/chaplus-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-chaplus-ros";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/chaplus_ros/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "ae79ee80c96bbf0e602474b0cb400a1992e7f9507e101daa4545c24fb228d5ef";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/chaplus_ros/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "23c39faa33cde64e39d1ae256f5589d4b26416a35d459f32d342ef1034fb346a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/compass-msgs/default.nix
+++ b/distros/noetic/compass-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-compass-msgs";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/compass/-/archive/release/noetic/compass_msgs/1.0.3-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "22494df8c5ecfefce461afb39bb72a2113354dc729405c4f7129bb341831e88b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages related to compass'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cpr-onav-description/default.nix
+++ b/distros/noetic/cpr-onav-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cpr-onav-description";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "6ae1262faa317d0f8dce5ed0ea757d856f9b1b8db57876f88e04a8c9fdf077f6";
+    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "20a9fa74fde7304c2b8a28a94e02f8e7b9ef5fc908b4864901e9a8e5e4f5a0d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dialogflow-task-executive/default.nix
+++ b/distros/noetic/dialogflow-task-executive/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, catkin-virtualenv, message-generation, message-runtime, roslaunch, rostest, speech-recognition-msgs, std-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-dialogflow-task-executive";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/dialogflow_task_executive/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "30a1325eed964aa1e0d35ad4764ea7b4e3de5e0246b155ae051fc02b3308c35e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/dialogflow_task_executive/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "f56221057407eef4dad3da68038746ac600c8019e70600329dd04a721cf2daa4";
   };
 
   buildType = "catkin";
-  buildInputs = [ actionlib-msgs catkin catkin-virtualenv message-generation roslaunch std-msgs ];
+  buildInputs = [ catkin catkin-virtualenv message-generation roslaunch ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ message-runtime speech-recognition-msgs topic-tools ];
+  propagatedBuildInputs = [ actionlib-msgs message-runtime speech-recognition-msgs std-msgs topic-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dingo-gazebo/default.nix
+++ b/distros/noetic/dingo-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dingo-control, dingo-description, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, ridgeback-gazebo-plugins, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-dingo-gazebo";
-  version = "0.1.2-r1";
+  version = "0.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_gazebo/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "b63a571d75030a17ee122d792496aabb629ebdd2466afea7273238995857d19d";
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_gazebo/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "cf3dfd02314f6ea170a6280d44f7b228f440911cdc0589d6f9a3e2275de78f7e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-simulator/default.nix
+++ b/distros/noetic/dingo-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dingo-gazebo }:
 buildRosPackage {
   pname = "ros-noetic-dingo-simulator";
-  version = "0.1.2-r1";
+  version = "0.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_simulator/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "bb99c8c421dcc03d1f29ea34eec3bf4ac0eb0d62b0a69f30092618baa0591bf6";
+    url = "https://github.com/clearpath-gbp/dingo_simulator-release/archive/release/noetic/dingo_simulator/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "2d52f995c66b75763ea403f372bf3ca721c2b78dd5fee90bbc6ec2b5d6061abb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/downward/default.nix
+++ b/distros/noetic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python3, rostest, time }:
 buildRosPackage {
   pname = "ros-noetic-downward";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/downward/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "43648e97ad5f6998d75ad3f1bfe3769c943944a910dea8e8bd94c5718bf61e6a";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/downward/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "2257bbcc0cef433aeeba2ba8c257d308005ea91a1dd432eda664794de6de5e1d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ff/default.nix
+++ b/distros/noetic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-noetic-ff";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ff/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "49c404fca5d769b971307eadfa407680d56388b4320e7fa57236f41dc1fd91dd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ff/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "174b476e18d9644bd8f93842c084d5469dfd8db90ae99e096701a15fe09cbe52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ffha/default.nix
+++ b/distros/noetic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-noetic-ffha";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ffha/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "c938dded78f6c43202f5b391d53cd396ae45fac99355ee0d4a86c34f6dc9b306";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ffha/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "f41e364293398af80c924dbc218819628785aabe76c31377b9e67ebc2aa6b4f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gdrive-ros/default.nix
+++ b/distros/noetic/gdrive-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime, rospy, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime, roslaunch, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-gdrive-ros";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/gdrive_ros/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "aeb66f26a0526ef1f136b938b1f2c8914e7052230f962d31ff814dda012a851c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/gdrive_ros/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "9d7a30004e5b0a7ea433034bba7458972fb4abd33c1eceec94e2399ae4b47665";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin catkin-virtualenv message-generation std-msgs ];
-  checkInputs = [ rostest ];
+  buildInputs = [ catkin catkin-virtualenv message-generation ];
+  checkInputs = [ roslaunch rostest ];
   propagatedBuildInputs = [ message-runtime rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -470,6 +470,8 @@ self: super: {
 
  common-tutorials = self.callPackage ./common-tutorials {};
 
+ compass-msgs = self.callPackage ./compass-msgs {};
+
  compressed-depth-image-transport = self.callPackage ./compressed-depth-image-transport {};
 
  compressed-image-transport = self.callPackage ./compressed-image-transport {};
@@ -989,8 +991,6 @@ self: super: {
  flatland-server = self.callPackage ./flatland-server {};
 
  flatland-viz = self.callPackage ./flatland-viz {};
-
- flexbe-app = self.callPackage ./flexbe-app {};
 
  flexbe-behavior-engine = self.callPackage ./flexbe-behavior-engine {};
 
@@ -1740,6 +1740,8 @@ self: super: {
 
  magical-ros2-conversion-tool = self.callPackage ./magical-ros2-conversion-tool {};
 
+ magnetometer-compass = self.callPackage ./magnetometer-compass {};
+
  map-laser = self.callPackage ./map-laser {};
 
  map-msgs = self.callPackage ./map-msgs {};
@@ -2282,6 +2284,12 @@ self: super: {
 
  paho-mqtt-cpp = self.callPackage ./paho-mqtt-cpp {};
 
+ pal-carbon-collector = self.callPackage ./pal-carbon-collector {};
+
+ pal-statistics = self.callPackage ./pal-statistics {};
+
+ pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
+
  panda-moveit-config = self.callPackage ./panda-moveit-config {};
 
  parameter-pa = self.callPackage ./parameter-pa {};
@@ -2395,6 +2403,8 @@ self: super: {
  pluginlib = self.callPackage ./pluginlib {};
 
  pluginlib-tutorials = self.callPackage ./pluginlib-tutorials {};
+
+ point-cloud2-filters = self.callPackage ./point-cloud2-filters {};
 
  point-cloud-color = self.callPackage ./point-cloud-color {};
 
@@ -2622,11 +2632,15 @@ self: super: {
 
  qb-hand-hardware-interface = self.callPackage ./qb-hand-hardware-interface {};
 
+ qb-move = self.callPackage ./qb-move {};
+
  qb-move-control = self.callPackage ./qb-move-control {};
 
  qb-move-description = self.callPackage ./qb-move-description {};
 
  qb-move-gazebo = self.callPackage ./qb-move-gazebo {};
+
+ qb-move-hardware-interface = self.callPackage ./qb-move-hardware-interface {};
 
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
 

--- a/distros/noetic/google-chat-ros/default.nix
+++ b/distros/noetic/google-chat-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, dialogflow-task-executive, gdrive-ros, message-generation, message-runtime, python3Packages, rospy, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, catkin-virtualenv, dialogflow-task-executive, gdrive-ros, message-generation, message-runtime, python3Packages, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-google-chat-ros";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/google_chat_ros/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "0fe151f2c055a11ba94868b089abfebb42c52f438dc809b287f728ef1909d431";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/google_chat_ros/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "0b437137997098219f402e1430b50d0de05ac7cf78e0a28d1f6fd6d681d176c3";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin catkin-virtualenv message-generation python3Packages.setuptools ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ dialogflow-task-executive gdrive-ros message-runtime rospy std-msgs ];
+  propagatedBuildInputs = [ actionlib-msgs dialogflow-task-executive gdrive-ros message-runtime rospy std-msgs ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.3.0-r2";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.0-2/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.1-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "df7d5f39149f2cfecc67ff2dc5b89ba18962b85efd872b84209da7eb52978683";
+    sha256 = "e115764e2e571a71aaa1d9146f4c0d795705a701583c952af77e129e2a3fbad9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-3rdparty/default.nix
+++ b/distros/noetic/jsk-3rdparty/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aques-talk, assimp-devel, bayesian-belief-networks, catkin, chaplus-ros, collada-urdf-jsk-patch, dialogflow-task-executive, downward, ff, ffha, google-chat-ros, google-cloud-texttospeech, influxdb-store, julius, julius-ros, libcmt, libsiftfast, lpg-planner, mini-maxwell, nfc-ros, opt-camera, osqp, pgm-learner, respeaker-ros, ros-google-cloud-language, ros-speech-recognition, rospatlite, rosping, rostwitter, sesame-ros, slic, switchbot-ros, voice-text, webrtcvad-ros, zdepth, zdepth-image-transport }:
 buildRosPackage {
   pname = "ros-noetic-jsk-3rdparty";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/jsk_3rdparty/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "fe44d465891fd3a398b0ac54ada77a1ea0a4b40cb3b21c90c11bc1b7a76fadda";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/jsk_3rdparty/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "51296587f93a7d410988829ec46a6cbbc8bcf006007d1ec6efba8587aff62a4a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/julius/default.nix
+++ b/distros/noetic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-noetic-julius";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/julius/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "c463981d736089578a41c410cf6a2096a22ba2a753dd9acfd6d7b67b6306db0b";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/julius/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "2a3fb86c7626925a8af6ff73a65994a3a20a3ed038a2482591a83d44ec75ad6e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libcmt/default.nix
+++ b/distros/noetic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-noetic-libcmt";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libcmt/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "498ae578ab3b3c00c5ed5aac566767570314edbbaef72711e229b8fbee88c783";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libcmt/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "319703faaee89676666f54de600a16c183e7c99881417708584902edafb4871d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/libsiftfast/default.nix
+++ b/distros/noetic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, python3Packages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-noetic-libsiftfast";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libsiftfast/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "22cdd64c7377bb355b22118fc76f59e2c2f9222b4014a145c0a864e6ee51e42c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libsiftfast/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "e3de69185fa469c124e2ba9dde60f712ce91498c71cfa3fb715434278657f120";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lpg-planner/default.nix
+++ b/distros/noetic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk }:
 buildRosPackage {
   pname = "ros-noetic-lpg-planner";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/lpg_planner/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "29427556bb284892013b61603fbef119b214805f5d39f376939e01a89326c6b8";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/lpg_planner/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "7ebb93c2d12a7cd0d2a82be47a9ecc00eb0d36cc48e78e6731b4c37f76f967e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/magnetometer-compass/default.nix
+++ b/distros/noetic/magnetometer-compass/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, compass-msgs, cras-cpp-common, geographiclib, geometry-msgs, imu-transformer, message-filters, nodelet, roscpp, roslib, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-magnetometer-compass";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/compass/-/archive/release/noetic/magnetometer_compass/1.0.3-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "d9ffa71f23124ce98a4954a3467a0b8227f5ea8ef41f66a5277f0cc1adaaf7b8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles catkin cras-cpp-common ];
+  propagatedBuildInputs = [ compass-msgs geographiclib geometry-msgs imu-transformer message-filters nodelet roscpp roslib sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Compass based on a 3-axis magnetometer, attitude readings and possibly also GPS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, git, jq, mavros-msgs, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "81b2cc13a9dc5c626e5d854055363b35a9f9f4629584587d2ec36800801e39e9";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "3cdbef3b972346406a888828be02ff2ba735c0671de488abd24e10be6cf3b1eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "0d0c287141e3f490217c16407a66b23e16fe62ac23cfbfea5f9a170b4477d778";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "948329301561cffbefef14c6e9ba970ff511f5672f5de7bc4c29d890b74c9124";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "9ea4ac07eb79e7727608b4b0f268faf1e07a1e3a8d95e30f9d08e457ccb227c3";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "572674877824c897c19363fea47e0b80026222420f0b541be9264771e3f6ab8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-rqt/default.nix
+++ b/distros/noetic/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rospy, rqt-gui, rqt-gui-py, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-rqt";
-  version = "3.0.1-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "888dfe433d70145864737e645013cc47b7bfe19bafcc9e29017be6540f6be187";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "d4bb0730b51721288ace3de9f6d69b9d1df89a7253c2cc02c4bea54b292f4ee3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mini-maxwell/default.nix
+++ b/distros/noetic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-noetic-mini-maxwell";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/mini_maxwell/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "4f61846b93569fb7d263c36ab2c9aca3ae2360c14793ceacc6a03b960d25daf7";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/mini_maxwell/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "b559c135801bcf04c73614d11c003df0d157ee0c30a275875c64053311ff2566";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nfc-ros/default.nix
+++ b/distros/noetic/nfc-ros/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime }:
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime, rostest }:
 buildRosPackage {
   pname = "ros-noetic-nfc-ros";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/nfc_ros/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "9fb85f5286e639935d7de19ed9b900633b3ef4799cf5522120dbbfbec510afdf";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/nfc_ros/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "8fa2ac33f60bae2c91ab31481b3713c43437030d3caa62809a58377ed3b3ae29";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin catkin-virtualenv ];
+  checkInputs = [ rostest ];
   propagatedBuildInputs = [ message-generation message-runtime ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/opt-camera/default.nix
+++ b/distros/noetic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-opt-camera";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/opt_camera/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "359407843f822ea792aaad63bf30a3b05ecb59d1c9933cbdbf9aa76f6d04f730";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/opt_camera/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "5c330ebf194ef733283d8c6799f6fa64711187179dcfa7c515b5066c8dc2439c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/osqp/default.nix
+++ b/distros/noetic/osqp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-osqp";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/osqp/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "878c82ff8c752a036c41211648eb0fa9b3656f9c4c799808dba894dc88022b74";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/osqp/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "1a53b444089adea24e199f0c9fc7293499a2576c85528d62bfd749cab78b5edb";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pal-carbon-collector/default.nix
+++ b/distros/noetic/pal-carbon-collector/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pal-statistics-msgs, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-pal-carbon-collector";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/noetic/pal_carbon_collector/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "e6f714ba9e78abea0511351d1a73f958ef34cab70026ad1476bc01ca448ecd27";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ pal-statistics-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Node that collects statistics from topics and sends them to carbon'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/pal-statistics-msgs/default.nix
+++ b/distros/noetic/pal-statistics-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pal-statistics-msgs";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/noetic/pal_statistics_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "04c46568123c0aec8dcadd38ead10840ac46060fc41562bd027e51cc6e641b6a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Statistics msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/pal-statistics/default.nix
+++ b/distros/noetic/pal-statistics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gtest, pal-statistics-msgs, python3Packages, rosbag, roscpp, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-pal-statistics";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/noetic/pal_statistics/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "4251cc22f9021178d7895e02bf84bd3d5b59d39f635c57b8d4e21fcf6a7df532";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ gtest rostest ];
+  propagatedBuildInputs = [ boost pal-statistics-msgs python3Packages.future rosbag roscpp rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pal_statistics package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/point-cloud2-filters/default.nix
+++ b/distros/noetic/point-cloud2-filters/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, filters, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-point-cloud2-filters";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ADVRHumanoids/point_cloud2_filters-release/archive/release/noetic/point_cloud2_filters/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "59aca0f3d7358cc45d0218ec59036765ac29219a469e170ef0c01b4c9e054c0b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ filters pcl-conversions pcl-ros pluginlib roscpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Filters for the sensor_msgs/PointCloud2 based on the filters and sensor_filters chains'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/qb-device-bringup/default.nix
+++ b/distros/noetic/qb-device-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-bringup";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_bringup/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "db41bec0a226ffa8bb21c6c980940a0f80aa10992c37aee0e05fd573ce6629fe";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_bringup/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a7672d3dc03525ba4644365a97b9ec2a71885affddaf3523c7cd43f353aa5090";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-control/default.nix
+++ b/distros/noetic/qb-device-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, combined-robot-hw, control-msgs, controller-manager, qb-device-hardware-interface, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-control";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_control/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "691a12d32828349408e9be4a980b0b53b8af72a6d6f72c0ad92a583fc3fa046b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_control/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1800fa231f1de75e8734d683dc086cb00021397476ea9b16479c179d648b1513";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-description/default.nix
+++ b/distros/noetic/qb-device-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-description";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_description/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "a68151a68cfc86d4f1e306273fb96dfafdbedde57f1ba35af6902e90736d09fb";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_description/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "27ba479c6697320bf4305cab1ebcb266801b814e333c897581b057835b2444f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-driver/default.nix
+++ b/distros/noetic/qb-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-srvs, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-driver";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_driver/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "b8890294f705082ae2de41ea0516e5e44d3edb55ea3a7b9f88c93011cdeb0fe3";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ab6f754cc47ba37f06f95a356fb0be3b8996fd1d9d6d581ea03a4cb9e99186f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-gazebo/default.nix
+++ b/distros/noetic/qb-device-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-gazebo";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_gazebo/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "a0a34f61a3958874231aca62adb0b9194bd580a4c1ec1e4f4d46f4e392c811de";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_gazebo/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2ab8b73d1cf2bf599627327e8282278f3f995210091710dfa22ff42db5b4aaee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-hardware-interface/default.nix
+++ b/distros/noetic/qb-device-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-hardware-interface";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_hardware_interface/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "74fae292de09d5a32635c8204274dc6385b392da37d1dffb3c1eabe20cef015b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_hardware_interface/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "bbb06fccd00dda93bb40def70cf4e52b6d138d3223e04fe8d59a1b075dec891f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-msgs/default.nix
+++ b/distros/noetic/qb-device-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-msgs";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_msgs/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "d70728e4aa968557dfeaf830ac8fc7772388600368e5b78dbc46c386f1a7c5ab";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "30130f6acc4eed3ec2b039d3da21b6300fa1b339f7f02f58f79cb2e479399257";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-srvs/default.nix
+++ b/distros/noetic/qb-device-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-device-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-srvs";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_srvs/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "0592f89dce9385bfaa55a6158511183660ef5d9dda77299de4054449d5917087";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_srvs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "23c19e2a441ee45ebdc65fe1f770b51b3420a851b3981d48e9506c33b4b2cf89";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device-utils/default.nix
+++ b/distros/noetic/qb-device-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-device-utils";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_utils/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "11f280e71adc3d63d289896eb50f3f6f6674e7a9b1c4f7e87d1de5fb48afa64d";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device_utils/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "80a2d8429de378c9afb08e890be87f1a5be4b950a8f4a7411dc9a047f0d05052";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-device/default.nix
+++ b/distros/noetic/qb-device/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-gazebo, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs, qb-device-utils }:
 buildRosPackage {
   pname = "ros-noetic-qb-device";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "518d6f733ea9878424eaff30225ae04a6a48d65dd16d721d16d7ad0dc86be9ae";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/noetic/qb_device/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "df2a81ee8441ef7e155bb1b86b80edf8dfc28800c628c0129e9d416f2231a0f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-move-control/default.nix
+++ b/distros/noetic/qb-move-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-move-control";
-  version = "2.2.2-r1";
+  version = "3.0.3-r2";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_control/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "8df244f83363ecece0245591dda13c52c82a66b8d32eed467717c90f5848bce8";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_control/3.0.3-2.tar.gz";
+    name = "3.0.3-2.tar.gz";
+    sha256 = "854bd0da7dde90e565c83ef2c539b8062b00aaee5dd5d440f000b7f1cf90a147";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-move-description/default.nix
+++ b/distros/noetic/qb-move-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-move-description";
-  version = "2.2.2-r1";
+  version = "3.0.3-r2";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_description/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "5e973f773b0b97c1a05d2e968c5a59adc3c6b984a94062dd9a66464746f580db";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_description/3.0.3-2.tar.gz";
+    name = "3.0.3-2.tar.gz";
+    sha256 = "df7cca13c9ed38c67c788529d82208b353f32dcfc5017c9a11c77efe61039b97";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-move-gazebo/default.nix
+++ b/distros/noetic/qb-move-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, qb-device-gazebo, qb-device-hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-move-gazebo";
-  version = "2.2.2-r1";
+  version = "3.0.3-r2";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_gazebo/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "45d54aa657ed48fff70b90970ff8bd6fc84b4bd928a1f52dd422dc13bbfb498f";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_gazebo/3.0.3-2.tar.gz";
+    name = "3.0.3-2.tar.gz";
+    sha256 = "34fe68d505300e511627ba6a0b78a9906d9402dd000b1d84dcb709ea0ce7690d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-move-hardware-interface/default.nix
+++ b/distros/noetic/qb-move-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, interactive-markers, qb-device-hardware-interface, roscpp, tf2, tf2-geometry-msgs, transmission-interface }:
 buildRosPackage {
   pname = "ros-noetic-qb-move-hardware-interface";
-  version = "2.2.2-r1";
+  version = "3.0.3-r2";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_hardware_interface/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "1882f57bb9cde42e67e10bd809e50e5bfb53c285429dbce6092c7296458e2849";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_hardware_interface/3.0.3-2.tar.gz";
+    name = "3.0.3-2.tar.gz";
+    sha256 = "ec44b9258a5e89de49b2f2f50400fe10d1b1ebac26d81da3497e909f2f75c37c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-move/default.nix
+++ b/distros/noetic/qb-move/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-move-control, qb-move-description, qb-move-gazebo, qb-move-hardware-interface }:
 buildRosPackage {
   pname = "ros-noetic-qb-move";
-  version = "2.2.2-r1";
+  version = "3.0.3-r2";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "a7e9a5f34bfe0ccf833e8e1cf6053e2df711750c092cad5abb2c9b071eb03d62";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move/3.0.3-2.tar.gz";
+    name = "3.0.3-2.tar.gz";
+    sha256 = "98ba71f6dcddd99e999f2f6cf0e54fb4bb58d5da1eeee3648c1bafd5972362d9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/respeaker-ros/default.nix
+++ b/distros/noetic/respeaker-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, audio-common-msgs, catkin, catkin-virtualenv, dynamic-reconfigure, flac, geometry-msgs, jsk-tools, python3Packages, speech-recognition-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, angles, audio-common-msgs, catkin, catkin-virtualenv, dynamic-reconfigure, flac, geometry-msgs, jsk-tools, python3Packages, rostest, speech-recognition-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-respeaker-ros";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/respeaker_ros/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "54299b14fb5419c66dd971de0b140e4275eb803ed470627c7e2168544faa6f3b";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/respeaker_ros/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "045b23e9e8be39f82cca6dfff49138c9b8e1f9b28dd364a82afc8eb89fae937a";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin catkin-virtualenv ];
-  checkInputs = [ jsk-tools ];
+  checkInputs = [ jsk-tools rostest ];
   propagatedBuildInputs = [ angles audio-common-msgs dynamic-reconfigure flac geometry-msgs python3Packages.numpy python3Packages.pyaudio speech-recognition-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/robot-body-filter/default.nix
+++ b/distros/noetic/robot-body-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, fcl, filters, geometric-shapes, geometry-msgs, laser-geometry, message-generation, message-runtime, moveit-core, moveit-ros-perception, pcl, pcl-conversions, pkg-config, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, tf2-sensor-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-body-filter";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/robot_body_filter-release/archive/release/noetic/robot_body_filter/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "6cdfb7d4ef7015f91a01b64482d7470612c5ed207f13244e64164b96c0e38d6a";
+    url = "https://github.com/peci1/robot_body_filter-release/archive/release/noetic/robot_body_filter/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "55781f3f7ef2566fa40e3ec086034d192fd28aaaa472ef886f581e60e1c16141";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-google-cloud-language/default.nix
+++ b/distros/noetic/ros-google-cloud-language/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, diagnostic-msgs, message-generation, message-runtime, rospy }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, catkin-virtualenv, diagnostic-msgs, message-generation, message-runtime, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-ros-google-cloud-language";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ros_google_cloud_language/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "a4e4b95e78868a5cfbb7abfd884e073a4b9529b79ea027a25012a7e625f9c335";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/ros_google_cloud_language/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "469237fb1cd61322d5806cb8358223ef75380506cd10f6039fbaeb582c6f7e26";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin catkin-virtualenv message-generation ];
-  propagatedBuildInputs = [ diagnostic-msgs message-runtime rospy ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ actionlib-msgs diagnostic-msgs message-runtime rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.4.7-r1";
+  version = "0.4.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.4.7-1.tar.gz";
-    name = "0.4.7-1.tar.gz";
-    sha256 = "0fcc0d4b2f93845861121abdc922edc22b2af2cff0d01d05cec61e6f73e0d96b";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.4.8-1.tar.gz";
+    name = "0.4.8-1.tar.gz";
+    sha256 = "bf7089cb0ae332eb3d5371e307dfe2f1aa9b863809eb21ccfa010cd4445f9a31";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rospatlite/default.nix
+++ b/distros/noetic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospatlite";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rospatlite/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "5c56f165128c3980917fee6417253fc26a983e9fe9e645ca137bb733b66fc7ff";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rospatlite/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "4ceff1697c85f7d5a9f18d0ed62d899483e8cb311ca8aa0e0bfa83b5c7c4f212";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosping/default.nix
+++ b/distros/noetic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosping";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rosping/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "2c677da1ba00238a88e14c8391c9bee726de9fbe018a75d42a97c6e112311557";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rosping/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "7d493fed4ad1860523560a628846f66e7b6ac5f4b74790eae2ea62ee007bd05a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostwitter/default.nix
+++ b/distros/noetic/rostwitter/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, git, message-generation, message-runtime, mk, python3Packages, rospy, rostest, sound-play, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rostwitter";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rostwitter/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "d079175b1083e07a5a03a15e4f0c0c7cbaeec2a6fdceb102524fdb5c4c22264e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/rostwitter/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "0074c3a683775981ae140c454d5e04625b4296265963b7297937043ec508ae9c";
   };
 
   buildType = "catkin";
-  buildInputs = [ actionlib actionlib-msgs catkin git message-generation mk ];
+  buildInputs = [ actionlib catkin git message-generation mk ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime python3Packages.requests python3Packages.requests_oauthlib python3Packages.simplejson rospy sound-play std-msgs ];
+  propagatedBuildInputs = [ actionlib-msgs dynamic-reconfigure message-runtime python3Packages.requests python3Packages.requests_oauthlib python3Packages.simplejson rospy sound-play std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sesame-ros/default.nix
+++ b/distros/noetic/sesame-ros/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl, rostest }:
 buildRosPackage {
   pname = "ros-noetic-sesame-ros";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/sesame_ros/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "7293e17b217df04f70947b9ec41601496549f1eaa86cc4b0b899f92f0e005177";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/sesame_ros/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "1fa819d4f445510464209b901faf4c71cdc738896c6d9c669b3d1d181b344d87";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin catkin-virtualenv libffi message-generation openssl ];
+  checkInputs = [ rostest ];
   propagatedBuildInputs = [ message-runtime ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/slic/default.nix
+++ b/distros/noetic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv, openssl }:
 buildRosPackage {
   pname = "ros-noetic-slic";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/slic/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "a1e759834fd52662e76d417bc9439887133f0641bac02cde0909e9af740bb15c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/slic/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "6b19a73df1d00ff17ad33119db6fafd6d3df4ca0a1dda42fdbf7d0a2bd323364";
   };
 
   buildType = "cmake";

--- a/distros/noetic/switchbot-ros/default.nix
+++ b/distros/noetic/switchbot-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, python3Packages, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-switchbot-ros";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/switchbot_ros/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "cb8e83c3c40d4f238692b5e9c8ff721cba37d360781b3e516fed4bc9341c4987";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/switchbot_ros/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "3492a4f9bde0984287c665a8dc982d8ac6f79844455e5a0a601ba9beb5794515";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation python3Packages.setuptools ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime python3Packages.requests rospy std-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime python3Packages.requests rospy ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/voice-text/default.nix
+++ b/distros/noetic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-voice-text";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/voice_text/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "bfd97a07a4d42178e42cefac4574681aee3632810e93792cffec5a0b8956a367";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/voice_text/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "3a293807335b216699d5f82d2bd988cf8128f63939805d98e3fbb86d4c15a0b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/zdepth-image-transport/default.nix
+++ b/distros/noetic/zdepth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, image-transport, message-generation, message-runtime, pluginlib, roscpp, sensor-msgs, std-msgs, zdepth }:
 buildRosPackage {
   pname = "ros-noetic-zdepth-image-transport";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth_image_transport/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "e5df7326a2651d97968d72033827823025f3f734d7241dd1dd45a5487062a2b0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth_image_transport/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "79d22d820b58694feed5ed794c92a816c68444bf7d4898f9ee82920725b02bee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/zdepth/default.nix
+++ b/distros/noetic/zdepth/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-zdepth";
-  version = "2.1.26-r1";
+  version = "2.1.28-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth/2.1.26-1.tar.gz";
-    name = "2.1.26-1.tar.gz";
-    sha256 = "b42b58fa5454d032baeec2516fddddf1be41eabe967f8659125d101a09f104b3";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/zdepth/2.1.28-1.tar.gz";
+    name = "2.1.28-1.tar.gz";
+    sha256 = "bbec74f7e1a3cf4b92504378d53de6f9ab84ea9def42b6b469032b9fcc665a48";
   };
 
   buildType = "cmake";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin ros-environment ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "0ca52e7dd702d284bfb72bab9b66c5191e2c97245ffe0cb36d0482871b88b86e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "d258e0dacb291aa43d0f12742791afbc9948dadebe040b7a01caae3be0eebe3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "3b748a72b1ca3510f2666d3520366a107416f6cbb5352f61c0abc42e46df0f01";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "018004576394368ac73495246b27539f4c16ef6cf9be0d0813b01817c2843a46";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "09f34e1ef15f8ad772a22a15be7a4a94fe1ed3c282657d325a4d453eace7c8e2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "b8bd335ba0031a062ea56e61257e6a72579f6624b4f9f9e14b33524dfb98712d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "4.3.0-r1";
+  version = "4.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "d2f2945e18fbdbeab774b2fed8e5eb1f0300a9ff6359b9711d841d6c77aad4cd";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/4.3.0-2.tar.gz";
+    name = "4.3.0-2.tar.gz";
+    sha256 = "4cd29004d4fffe63a3fea275ca9c9e9098d1c44f83954257281b555b71bc7893";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "4.3.0-r1";
+  version = "4.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "95ed9ba73a69dbccf2e3093232f7ba08b34f5180fdb593d636bd5c7ae590dff9";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/4.3.0-2.tar.gz";
+    name = "4.3.0-2.tar.gz";
+    sha256 = "4c3482a8d0188fb8316399d2631c49a1b8abbb77136d737173475f379e6ec99e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/depthimage-to-laserscan/default.nix
+++ b/distros/rolling/depthimage-to-laserscan/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, image-geometry, opencv, rclcpp, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-geometry, opencv, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-depthimage-to-laserscan";
-  version = "2.5.0-r4";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/rolling/depthimage_to_laserscan/2.5.0-4.tar.gz";
-    name = "2.5.0-4.tar.gz";
-    sha256 = "c1f2c09c2d03cb48adc16b12f712f1e6d1cbaa3891b085e9d253128f23228383";
+    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/rolling/depthimage_to_laserscan/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "1904f12af65f9155a4e5f2c2f26f90ea95ca2ff37ae51196b90a918e46569746";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ image-geometry opencv rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "7a9f1f25084e9f1be92305d0f14f93df80521a0c51ef26700cac478ad3da260d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "1a7d8e4cea741f85ce1f5952389bc34a5e4ff9c44ee61b7bac52b76a54b17477";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "1215a5777c65152de06d04e9f5a4034b05070365d9b9f89c0dd6aa2506e970fb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "f8f45fd16bd0f799d77365d2d72ff458ababe23ed8ce2b57d6a57871220aafc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/executive-smach/default.nix
+++ b/distros/rolling/executive-smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, smach, smach-msgs, smach-ros }:
 buildRosPackage {
   pname = "ros-rolling-executive-smach";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/executive_smach/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "f06aac92aa4241a2a919a7ff5b3a54b726e8d9fbccec8e48cec75f1b57088cf2";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/executive_smach/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "932124020892891fcc4ed7d2b5bca5d933b4b5b571996f75730afa3bd91bd3f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastrtps/default.nix
+++ b/distros/rolling/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps";
-  version = "2.11.0-r1";
+  version = "2.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "e3f76ae9c93138021b1bd758ef8b274832b7108c2766d51c5261457fe49e34bb";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.11.1-1.tar.gz";
+    name = "2.11.1-1.tar.gz";
+    sha256 = "03e35dba782990f572ce2901229207d77f0d07fb904b7206e5b41d8a4ab95e4b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "5ab67c00d1542207aff6ad6e6744050de7607449046e4004958638083e25427e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "5b83af5090adf4dbfc4f46b094ae64159e34b6f73e3fffef254827b6803689a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "ce4ad20e3f810ae271f7bc295ccd0f87dc61c2120c3ac24066adcfb316127588";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "1e71d7b9534cee9b6f8378dfd444ecebe77f074c74e69e934adcafab3ceda045";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.6.4-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "9310db0bd64e8ca1526eb942369fbd465fb34372bac019b4c1039b89698b4c27";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "d8fab94c9306bf12d2fe3483637d422121466e2fe796d8d2dd0c5bd1a8aad59d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components rosgraph-msgs zlib ];
+  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/generate-parameter-library-example/default.nix
+++ b/distros/rolling/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-example";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "cf22422e2726ea261ce4399bb058e663e2df035a7ff99d6833472747ae8bb1e2";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "e48f975e1ce20e67be24b354ef0cdb5d804a46af783088b3ccc307e57d33d6ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-library-py/default.nix
+++ b/distros/rolling/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-py";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "13559998e1c545f58870941124d78e1db8002601a982203f049d5f45afef1936";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "3fdde385bc532946bf79cf1ee2c91a058c975d7c12d8bbbbe00f5dc0822a876f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generate-parameter-library/default.nix
+++ b/distros/rolling/generate-parameter-library/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rsl, tcb-span, tl-expected }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "37cb932f698be51b17efc4ca81676c8a560b46db6d7885a0cc52c35a9c9655bb";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "d85ff973da80725e15e432f31aa55126fd39b29db62e942e7e0e3e579137d578";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ fmt generate-parameter-library-py parameter-traits rclcpp rclcpp-lifecycle rsl tcb-span tl-expected ];
-  nativeBuildInputs = [ ament-cmake generate-parameter-library-py ];
+  propagatedBuildInputs = [ fmt generate-parameter-library-py parameter-traits rclcpp rclcpp-lifecycle rclpy rsl tcb-span tl-expected ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python generate-parameter-library-py ];
 
   meta = {
     description = ''CMake to generate ROS parameter library.'';

--- a/distros/rolling/generate-parameter-module-example/default.nix
+++ b/distros/rolling/generate-parameter-module-example/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-rolling-generate-parameter-module-example";
+  version = "0.3.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_module_example/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "deb744855e1f2666c9261d29ae58e0369af12e5e7979ded31bafd03072b7db08";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library for a python module'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -562,6 +562,8 @@ self: super: {
 
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
 
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
+
  geodesy = self.callPackage ./geodesy {};
 
  geographic-info = self.callPackage ./geographic-info {};
@@ -602,6 +604,8 @@ self: super: {
 
  gtsam = self.callPackage ./gtsam {};
 
+ gz-ros2-control-demos = self.callPackage ./gz-ros2-control-demos {};
+
  hardware-interface = self.callPackage ./hardware-interface {};
 
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
@@ -621,8 +625,6 @@ self: super: {
  iceoryx-posh = self.callPackage ./iceoryx-posh {};
 
  ifm3d-core = self.callPackage ./ifm3d-core {};
-
- ign-ros2-control-demos = self.callPackage ./ign-ros2-control-demos {};
 
  ignition-cmake2-vendor = self.callPackage ./ignition-cmake2-vendor {};
 
@@ -694,11 +696,23 @@ self: super: {
 
  kinematics-interface-kdl = self.callPackage ./kinematics-interface-kdl {};
 
+ kinova-gen3-6dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-6dof-robotiq-2f-85-moveit-config {};
+
+ kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
+
  kobuki-core = self.callPackage ./kobuki-core {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
 
  kobuki-velocity-smoother = self.callPackage ./kobuki-velocity-smoother {};
+
+ kortex-api = self.callPackage ./kortex-api {};
+
+ kortex-bringup = self.callPackage ./kortex-bringup {};
+
+ kortex-description = self.callPackage ./kortex-description {};
+
+ kortex-driver = self.callPackage ./kortex-driver {};
 
  lanelet2 = self.callPackage ./lanelet2 {};
 
@@ -1010,6 +1024,10 @@ self: super: {
 
  ouxt-lint-common = self.callPackage ./ouxt-lint-common {};
 
+ pal-statistics = self.callPackage ./pal-statistics {};
+
+ pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
+
  parameter-traits = self.callPackage ./parameter-traits {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
@@ -1061,6 +1079,10 @@ self: super: {
  phidgets-temperature = self.callPackage ./phidgets-temperature {};
 
  picknik-ament-copyright = self.callPackage ./picknik-ament-copyright {};
+
+ picknik-reset-fault-controller = self.callPackage ./picknik-reset-fault-controller {};
+
+ picknik-twist-controller = self.callPackage ./picknik-twist-controller {};
 
  pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
 
@@ -1329,6 +1351,10 @@ self: super: {
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
+
+ robotiq-controllers = self.callPackage ./robotiq-controllers {};
+
+ robotiq-description = self.callPackage ./robotiq-description {};
 
  ros2-control = self.callPackage ./ros2-control {};
 

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "c59ea0ccacd5a0193359140f7d57c690dd7dfb0fe2c961d93c634674cec4fc69";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "eebb32789508b3b6512c96a661da00eba85e3d5225de573db8493ea2e7bba59a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-ros2-control-demos/default.nix
+++ b/distros/rolling/gz-ros2-control-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-gz-ros2-control-demos";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "efecb8f021cd6cb5e1c770ac8cf422d421acd2661eb665adbcd2bb0728d9b227";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-action ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''gz_ros2_control_demos'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "4.3.0-r1";
+  version = "4.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "71ee643621f8f5c0a01908dd8d24eec9e52230a177a4cf71e89dd357d5e48d25";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/4.3.0-2.tar.gz";
+    name = "4.3.0-2.tar.gz";
+    sha256 = "eb456243f87b8d7d06a47a815617ee2969eec49bde7233655ae75da26669fd12";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "4.3.0-r1";
+  version = "4.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "d88cd925e7cfee95486040c66b6241956e5865c890e4790b3568b64af119523e";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/4.3.0-2.tar.gz";
+    name = "4.3.0-2.tar.gz";
+    sha256 = "c31278179ad0534d8e515f7e769a6719b3d0849ad9312c0ff9f9fc2b3c992598";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "6fdf4a628a3ea4a9e81d2fee480675b2ebbe30cc94c6705c65d258dde2f0cf5a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "b1c64bd9eba2676ee586ce824f18cf5c42724df90d311e6556fc6f0da05d03a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "5243e16372b02aae8b69c4822906566e36809dba9a1792c6c54f0a10cc7b28dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "cccdb1add65dfc14a3bb41e925d7ae17539b9c4d17c6124d04e7170004697b21";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "41cd411a8d68977dcb9e4899c319bb063103147ba3f1325aa1c6ff95ae1e2a49";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "1a64f4991e995aa32e3fe753429172c2dff436fe15fd21ce6fe8ec7ad99aaad6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/rolling/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-kinova-gen3-6dof-robotiq-2f-85-moveit-config";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/rolling/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2c28cf73f323e5596a3e3f25c5d53bf718ada20899104c1be64aafbef5aaf8d5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the gen3 with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/rolling/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-kinova-gen3-7dof-robotiq-2f-85-moveit-config";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/rolling/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "cfe2b6ed3b33002055d9cca0864e0d5389c5b34f4e841a3d7a1684e1a8d9049c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the gen3 with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/kortex-api/default.nix
+++ b/distros/rolling/kortex-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-rolling-kortex-api";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/rolling/kortex_api/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "1fc2415d9cd173a7ca936220e4f4b627579153150371742962d5ba2b401190b8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''kortex_api'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/kortex-bringup/default.nix
+++ b/distros/rolling/kortex-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, gazebo-ros2-control, gripper-controllers, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, kortex-description, kortex-driver, launch, launch-ros, rclpy, robotiq-description, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-kortex-bringup";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/rolling/kortex_bringup/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "fd30eee5e3dc1de28d477b1e0823e5d3f4465102c3bd198e6ea1481655b56891";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  propagatedBuildInputs = [ controller-manager gazebo-ros2-control gripper-controllers joint-state-broadcaster joint-state-publisher joint-trajectory-controller kortex-description kortex-driver launch launch-ros rclpy robotiq-description rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Launch file and run-time configurations, e.g. controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/kortex-description/default.nix
+++ b/distros/rolling/kortex-description/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, robotiq-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-rolling-kortex-description";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/rolling/kortex_description/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "dfef58714254beea9c6a6bf3a79222f6543235bbf1d886a79ba655c8386ae3e7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui joint-trajectory-controller picknik-reset-fault-controller picknik-twist-controller robot-state-publisher robotiq-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>URDF and xacro description package for Kortex robots</p>
+    <p>This package contains configuration data, 3D models and launch files
+for Kortex arms and supported grippers</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/kortex-driver/default.nix
+++ b/distros/rolling/kortex-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, hardware-interface, kortex-api, pluginlib, rclcpp }:
+buildRosPackage {
+  pname = "ros-rolling-kortex-driver";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/rolling/kortex_driver/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "858e88a7199fb1919e677d94bbdd3e1f0d58529ffd21080ac9c32287c3449b1e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ hardware-interface kortex-api pluginlib rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver package for the Kinova Robot Hardware.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mcap-vendor/default.nix
+++ b/distros/rolling/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mcap-vendor";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "3c207b8acdcf0607c074354189e7380466ce3ee63016cba23514e600b9f4f029";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "7f16ec152a69f234da43f3dd349f160d8c62cc054ca7b8f6b939c76e9d9b5d57";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-driver/default.nix
+++ b/distros/rolling/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, git, jq, lifecycle-msgs, mavros-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-driver";
-  version = "3.0.1-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/3.0.1-2.tar.gz";
-    name = "3.0.1-2.tar.gz";
-    sha256 = "4a094d0d3354716cd033fbc8633ef01aac9b9d978cb2c475f099dbf4a494205c";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ac5853ad43c4ccf6a9654970c58a3aec819f4f8736cef157328d8ceabd374e37";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-examples/default.nix
+++ b/distros/rolling/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-examples";
-  version = "3.0.1-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/3.0.1-2.tar.gz";
-    name = "3.0.1-2.tar.gz";
-    sha256 = "63659e6f4d25f521c5b311d81e4739339e634afa39db242c3bed8031f125c1fa";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a07ef226bb5013be41afdf8c6c69672bae7c1c1ba0c7cb7594011bc14c424f65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-msgs/default.nix
+++ b/distros/rolling/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-msgs";
-  version = "3.0.1-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/3.0.1-2.tar.gz";
-    name = "3.0.1-2.tar.gz";
-    sha256 = "9b23560b789e3b4590394e4b585568c0ba271e4752571be9a1cc90feef069580";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "629acbfde3b88a6ba990908196fad51c25884d04756760e0daea0ea2ebe28171";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-rqt/default.nix
+++ b/distros/rolling/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-rqt";
-  version = "3.0.1-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/3.0.1-2.tar.gz";
-    name = "3.0.1-2.tar.gz";
-    sha256 = "c53c863d5c283620acdab8f55e7ec07a37bb64849640c67fe39b1da9a327c525";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "388b57066870eb67f64a9ab8a95ff12ad46dabdd7a29d5e6dcafe09917fb2e4f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/pal-statistics-msgs/default.nix
+++ b/distros/rolling/pal-statistics-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-pal-statistics-msgs";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "9b26e68f60417627e378cca066922338008557d03d0ae2cf25db780d60bee958";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Statistics msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/pal-statistics/default.nix
+++ b/distros/rolling/pal-statistics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
+buildRosPackage {
+  pname = "ros-rolling-pal-statistics";
+  version = "2.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "4b414f7def93f04b7c38d0d1baba7073e2c3b0033de228f7e2c902ab85296239";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost pal-statistics-msgs rclcpp rclcpp-lifecycle rclpy ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''The pal_statistics package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/parameter-traits/default.nix
+++ b/distros/rolling/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-parameter-traits";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "c9195aa4ff4ca6c531b174a5aea9751ba50cd8c2bbb7557c64b190644c234a78";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "2d6b184285946811287bc4b42a24934af09d82aa35a273f5fdd1eba459dbfe82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/picknik-reset-fault-controller/default.nix
+++ b/distros/rolling/picknik-reset-fault-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
+buildRosPackage {
+  pname = "ros-rolling-picknik-reset-fault-controller";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/rolling/picknik_reset_fault_controller/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "c9fb3da4b7b80536562dc65c817dbbf193cdd44fa0cfa7e0a7eb3e74b0926a06";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ controller-interface example-interfaces geometry-msgs rclcpp realtime-tools ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS 2 controller that offers a service to clear faults in a hardware interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/picknik-twist-controller/default.nix
+++ b/distros/rolling/picknik-twist-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
+buildRosPackage {
+  pname = "ros-rolling-picknik-twist-controller";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/rolling/picknik_twist_controller/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "8d0fe22b7a7ecd9325f72eda1c94f2d0155d7544f968448b30416abbac772e1d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ controller-interface example-interfaces geometry-msgs rclcpp realtime-tools ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Subscribes to twist msg and forwards to hardware'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "a0f7538c2f99a16de06c2f813f8811eff9a2164cc4d880acf15e555c81b80b30";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "65e965c9450f92d9d313ca77e704f7c2755e395c62742186e22133c21cdf2e65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robotiq-controllers/default.nix
+++ b/distros/rolling/robotiq-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-interface, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-robotiq-controllers";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_robotiq_gripper-release/archive/release/rolling/robotiq_controllers/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "44cc464665cabe88dfb6bdc99a2f7c1e80f18cf0e791afd952ac9e04dd8ee6c4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-interface std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controllers for the Robotiq gripper.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/robotiq-description/default.nix
+++ b/distros/rolling/robotiq-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-ros, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-robotiq-description";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_robotiq_gripper-release/archive/release/rolling/robotiq_description/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "390f1c1f44d7c495e772cf3023bcff63e43ab0306a4b12bb66c98977609a0074";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-ros robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF and xacro description package for the Robotiq gripper.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "b78dfca9f1564d41debbc75e765dbbc0171b8f96bafbbf719978edcfd4184dc2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "143dd1a5af830f7adb4c6b5bfeed7de2fdada7eea4be50fccbb1d6eba5fe2d16";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "6c4232eaed94b12b470d54802df183ae993c360867569c1a0b8f7a1bbacc11ff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "5363887bccbb9a7d1dcad25bf113d80e9b6e8c960985dc5c5b1512fdaef43d2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2bag/default.nix
+++ b/distros/rolling/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2bag";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "803d4aa3886a7a387e1e633be86a670827570029a69eeefd8a2adb55ee6dd270";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "58dcc68507406a50eeae2b3076fc2b9c13c35feb8dc9177d9db4584be2fb04a2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-compression-zstd/default.nix
+++ b/distros/rolling/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression-zstd";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "f6641d669d0da05c5496091a4b942d944b69b707cee1387e5d0d2af7c5806b04";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "917738c0eebffbcd281070fb2efc3d3cb2a7e082b18a9d5ad21b6c78418bb6bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-compression/default.nix
+++ b/distros/rolling/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "51fb4efa545193bc7d61bb1b925ceec19e43ccb6dacd366173abfcdf900bd23c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "73ec61e45de4cb39b6a0cceaacc585fc5969666b16c69540e02ad529c7bd0c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-cpp/default.nix
+++ b/distros/rolling/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-cpp";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "dc839232d7adb125ebde3fb6018a7fedba2ce5503427c9507ed3f5c5a513037f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "841d9a5e447e1393d4b51eab58e1da119ca9b85b1e89584896de4ac2ca6c4d42";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-cpp/default.nix
+++ b/distros/rolling/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-cpp";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "c087daf8ce24fb60c1862b2cc9712858083ab07731564e908b6095b9ebc9f1c2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "77f05d65e6facf9022b712a3b8ea4816f70442acdbf31fa618d5477307ff86c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-py/default.nix
+++ b/distros/rolling/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-py";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "d7b1785ba81022592cc61d88d288e32a1ef33e95474b04c3edd044aaf13e3b7a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "d9a00b57858040761e5c5bd43bccee02f4bf54268951087f293c75a5377c7e21";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-interfaces/default.nix
+++ b/distros/rolling/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-interfaces";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "0b8f1f766af3456a1ea35dfec00ee975805c567376fe15231e458c7237f36478";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "01fc5f7be4813ada1ae7497889ee397bed77785c793b6228622ada5ed1adc4f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking-msgs";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "e8fba6f63b2c3265ba33fa20485219f5c9e3a3490abe738b627d851c3f2b06b2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "a60c2252441b86219383654d55a180cbd602d33aabba4ebee7c578e6022204d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "da532c49b1f73e8c87873a0ee45a51a5bd8aa90f8699b2b7be2117cc4ed0a76b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "1f841bb4710a4cbe43d0dbc9f722252263a8a945782345cf77a3a61d064255f9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common launch-ros ros-testing ros2bag ros2launch rosbag2-storage-default-plugins rosbag2-test-common ];
-  propagatedBuildInputs = [ rclcpp rmw rosbag2-compression rosbag2-cpp rosbag2-performance-benchmarking-msgs rosbag2-storage sensor-msgs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros python3Packages.psutil rclcpp rmw rosbag2-compression rosbag2-cpp rosbag2-performance-benchmarking-msgs rosbag2-py rosbag2-storage sensor-msgs yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-py/default.nix
+++ b/distros/rolling/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-py";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "8fee5a794a36a1f493b085e350e17780a136f6e6f7665c84578ea7e66d85d91e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "91711972338e41184f87a8a23957ac3a99c6e186d6db407c953915d6086e599f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-default-plugins/default.nix
+++ b/distros/rolling/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-default-plugins";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "c5a0105820e3c24ff80ac413da27fd76db7aa648feea98d55fd6c1b5c4506016";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "8a0f353a39c358745c48218bf0f2bb5f72d5f6b79dadf223ac6bcd0360c5b582";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-mcap/default.nix
+++ b/distros/rolling/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-mcap";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "33a05534d386a7e9adb6baf0b9736bd351ba5d8de0bdbf2034a0cf5283c711ee";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "2fa58098eebcec50d71465a427c3eca9026888b084e6dad047354075968d9dff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-sqlite3/default.nix
+++ b/distros/rolling/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-sqlite3";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "99ed7b5d2741c7bf6b78b945cdaea2cff1878cff3a17b3bcc2b017422beafe08";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "d77668f20c81c4036cb519906c60bf26a4ecddc6c049aabe92a49828781981f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage/default.nix
+++ b/distros/rolling/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "f5b5a9200c4a6b43b89fb4bc19fd51f652bcdfd9d2f14c1cb3d689018fa617e6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "94185f8ed856d7957103d4a6844fb40f669ecfab925076a3612b000338d154b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-common/default.nix
+++ b/distros/rolling/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-common";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "67daff9cb02b607e58d7a42774fe86b25dae16d6b6d405566fe0707a09c31f42";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "e27949fd916bc3b31266eaa68376a87c106f82b0f46ecdc5a46c04c76f39eecf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-msgdefs/default.nix
+++ b/distros/rolling/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-msgdefs";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "3b2013dd8f969c2b394efe627582ed2dcaa646949bcc46a6e6154b8eda7dcb05";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "30efd16267565727cfd19a5e341ba1a00b5f04885a9f3e3a653bb62d913fc463";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-tests/default.nix
+++ b/distros/rolling/rosbag2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-tests";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "38bdfdf2e62d36a2cdb1b69a00627675ae3a9772922382ed9805c6222c4cd85a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "5f1ecc232c29f10855ea11fad5ef7535e877dc7e491847baed975c413850486e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp rcpputils ros2bag rosbag2-compression rosbag2-compression-zstd rosbag2-cpp rosbag2-storage rosbag2-storage-default-plugins rosbag2-test-common std-msgs test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp rcpputils ros2bag rosbag2-compression rosbag2-compression-zstd rosbag2-cpp rosbag2-interfaces rosbag2-storage rosbag2-storage-default-plugins rosbag2-test-common std-msgs test-msgs ];
   propagatedBuildInputs = [ ament-index-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/rosbag2-transport/default.nix
+++ b/distros/rolling/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-transport";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "afc1c8e4d0270ae906c0b7d9e5e88ea80d141f05c9cdea74e5eb0d26598d0acd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "93c877074c953697ae0dab75b52fe5ef7721f84c7d9e4fe36295a8714bc42e47";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2/default.nix
+++ b/distros/rolling/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "14df8450f9eb1e9b642066a9a617a55bddca9493ed99c57f6eb8bbb6796e81a2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "dc6d1e74d8b85930490acbff188e6a7e2584b77a6f85d44647005f84e66f9c7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "e863a46c34a2cdfe6360aa4bcfbd2ba4e2f8070f304c4e311ac87b293bf053ae";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "e543067cef7290d854071e26210fe0e46682ce499f28c7ffbc02906ea74aee07";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/septentrio-gnss-driver/default.nix
+++ b/distros/rolling/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-septentrio-gnss-driver";
-  version = "1.2.3-r2";
+  version = "1.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.2.3-2.tar.gz";
-    name = "1.2.3-2.tar.gz";
-    sha256 = "d3ec9f4c08d7b7dbefafeffb70c8765a93d46ff42d440e87c60344552d8387a6";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.3.1-2.tar.gz";
+    name = "1.3.1-2.tar.gz";
+    sha256 = "0e9e87f841b792676ce6b63fccf569520e4d5fa094c016d0762ea12eb7abf5e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shared-queues-vendor/default.nix
+++ b/distros/rolling/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-shared-queues-vendor";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "6946c94b9c7f5bb9714b4cf611fccbc4692c0488a94a0b30e4604a2f34c0cfa3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "3db29216c8bc2be7f345c6c5f63abf6e7eddefbcaffcd7d09d4121bf4d19d753";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/smach-msgs/default.nix
+++ b/distros/rolling/smach-msgs/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-smach-msgs";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/smach_msgs/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "ba069f387c804046e87bd51d24b8d7526b58882bfc6c042b7623a8327c74db04";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/smach_msgs/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "05be9b21f2ff81af7afd7f9f2c21a01bda07cfb1e7720b2149765b8ab84c168c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
-  checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-lint ];
+  buildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-pep257 rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-uncrustify ament-lint ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-pep257 rosidl-default-generators ];
 
   meta = {
     description = ''this package contains a set of messages that are used by the introspection

--- a/distros/rolling/smach-ros/default.nix
+++ b/distros/rolling/smach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, rclpy, smach, smach-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-smach-ros";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/smach_ros/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "8a157dd5f370ed40133465db2dee4bd04e6eaeb96758fe211ac727e63b97a491";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/smach_ros/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "c653299f169d309cb1707daf9cd3cc6dd9706c3631639007d4143eafa730162b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/smach/default.nix
+++ b/distros/rolling/smach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-smach";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/smach/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "3a4be174d9aeffdb196c0d089a8aae5e229c2a9d7c207e044528808dc39d50aa";
+    url = "https://github.com/ros2-gbp/executive_smach-release/archive/release/rolling/smach/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "2284171168073a6472ec3413f4013794e3ec8dc47d13b2fff0463b0df0acf83f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/sqlite3-vendor/default.nix
+++ b/distros/rolling/sqlite3-vendor/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-sqlite3-vendor";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "f0f0b99bfe0e3f509803630db07bf13e99f93971f9729fb03cddcf19323c6d1c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "ede6a05bc542737d5a89a440d8b31b4dee733e44d15209b56be54227ece2d59c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-vendor-package ];
   propagatedBuildInputs = [ sqlite ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
 
   meta = {
     description = ''SQLite 3 vendor package'';

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "4cf6f5c92ff409f19e72bf4d44b89688216ce8e2267188a82ec5812659d75c15";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "0d99a08ad2f302bc40546242771184cdf9a526c54da580a9e6558c3365fa1356";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "d35963a00f7f010eab614364b249f1fc6a293c7233bb1e44ea6c22105ca3becf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "80093415352d08c242ac4b257cc0b6f619ddc53a621ef6418f1e1d3dba60fb67";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "05dc39ef68646cb491e864c8c4c8496dd447ba194cfc90bb39ef1a1d513e98af";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "29997e9d05ffc3bbda18f11df9b498de69cce7cc3220ae64832082833d472159";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "db183510db32a77ed2e4202d759a9d02607956c3441c5f6063c78206fda6bc38";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "a3655e45c5f0bfc106110ae7de12ec8bbbf964f11a0bafaeb6cff053df952b42";
   };
 
   buildType = "cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "3.11.0-r1";
+  version = "3.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.11.0-1.tar.gz";
-    name = "3.11.0-1.tar.gz";
-    sha256 = "9fc3e7fe76e6c3498b49e000af0d19c1b17be546828b27cbe72c05947b33541f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.12.0-1.tar.gz";
+    name = "3.12.0-1.tar.gz";
+    sha256 = "6e6884a27df3491bf6b392e9c31010b3c978688a542dfdbf3feffa7f617cb6ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-control/default.nix
+++ b/distros/rolling/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-control";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "c09b46c2a94aefd0f6343b31a31a39319b453f8ca3abc70a0044e969986aac49";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "3d62feb2d1ed13375baee1d0d9cc16f53dc804a5f8b8a5806509799386579440";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, libyamlcpp, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "f44de9c7eaffce9e34179682850b516a7d2252e38f0886033b6f3b6ae87513db";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "e08c5862aea2434c9bfee7a8add2488a6936c421c6fdecbac6053673109d07e5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs libyamlcpp pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/rolling/webots-ros2-epuck/default.nix
+++ b/distros/rolling/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-epuck";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "b9f481302a33ed279265ad862f2f176c79001d4eadea0fee067e98d5d46fb53f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "1d599445d5a596f358068ae75e696b2d205cc57ab38edfbbbb60afc8e8a3a8ac";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-importer/default.nix
+++ b/distros/rolling/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-importer";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "d271e5c071cf60f1b0edc42ef6984bf2850df981dbcc12439a2b6353dacd4554";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "7eaf4c8304bcda57261b38527c4aefb6a33856b66958c436fed026a13f6454ba";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-mavic/default.nix
+++ b/distros/rolling/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-mavic";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "40ba0c038058d2077f4a292383f2af415e5690e13831f08c2f5e1353b5c05c37";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "740f79cd47689b2d80f8874ab024ecce1c8bf7cd694658e0aa192bb76acad109";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-msgs/default.nix
+++ b/distros/rolling/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-msgs";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "c196cc1beb50bebfa5db1dcea0d14963a2ea77342035d92276a564518aa1d83f";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "a96d4277559ccf4c0678e2e76486eb7c672a2998f4aab82ed7d0e65f933d287c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tesla";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "3b10c65503094a3c73e1dabc3aaf59fbdb81218185114848428d9bb29925cf86";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "9e2b6dc230e952133b944a43c60b78012ea1481b808d504253170b2205bf919b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tests/default.nix
+++ b/distros/rolling/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tests";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "5483f6e94d8d5f8428ce67331e2a11d74ba735ed7bf25911d7a4ba5c597d4923";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "32b257fc18d3450912483e03f336a0079a87cbd8a6ffe2f84161cdfdf1494245";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tiago/default.nix
+++ b/distros/rolling/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tiago";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "3f7eb1b01b104770eca60bcda8705a1e4a01b859fdba68ba5905375f9c708cde";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "7f91e4cdca9f595ed2b4fd7b3640b6e2e7fecba1f27394be824b0f895e40148c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-turtlebot/default.nix
+++ b/distros/rolling/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-turtlebot";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "b11a179c55684a9120af7ec6f417522846b73cc931c262431c6bc8c0ad943568";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "cea3360354ef47e5e8873ac67599bcbd0055293df9e039c45e0bd40e78a1744f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-universal-robot/default.nix
+++ b/distros/rolling/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-universal-robot";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "6fcf2a826f2688982251600f7c18677d9a5387c61fcf59113a1e1d651bb0ecf7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "91ea318dde82123ecf8c7e89d8b3df7631a3aec5b34301e7590e0f38e7f83e5e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2/default.nix
+++ b/distros/rolling/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2";
-  version = "2023.1.1-r1";
+  version = "2023.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.1-1.tar.gz";
-    name = "2023.1.1-1.tar.gz";
-    sha256 = "189f8211d848cfeeb5b522eb7764b66e2c0738984ba17999614e0f3c33b09798";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.1-2.tar.gz";
+    name = "2023.1.1-2.tar.gz";
+    sha256 = "feb90d253252997b68c84c17123703fef3b24f7a5e8eae99fe405d1cda566d69";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/zstd-vendor/default.nix
+++ b/distros/rolling/zstd-vendor/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-vendor";
-  version = "0.23.0-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.23.0-1.tar.gz";
-    name = "0.23.0-1.tar.gz";
-    sha256 = "21996b9a5b4e3733c5c3f46a78200f367e55606166ef7a1c62bb1fc545801b83";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "400fffe663a150cac8411a2764357b38ff030a633b527dac194e57dadbae74dd";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake git ];
+  buildInputs = [ ament-cmake ament-cmake-vendor-package ];
   propagatedBuildInputs = [ zstd ];
-  nativeBuildInputs = [ ament-cmake git ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
 
   meta = {
     description = ''Zstd compression vendor package, providing a dependency for Zstd.'';


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 3205dadcff4e1fbc779ce3962bafcf3e9f3e931b.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Humble Changes:
---------------
* *ament-clang-format 0.12.6-r1 --> 0.12.7-r2*
* *ament-clang-tidy 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-clang-format 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-clang-tidy 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-copyright 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-cppcheck 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-cpplint 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-flake8 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-lint-cmake 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-mypy 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-pclint 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-pep257 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-pycodestyle 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-pyflakes 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-uncrustify 0.12.6-r1 --> 0.12.7-r2*
* *ament-cmake-xmllint 0.12.6-r1 --> 0.12.7-r2*
* *ament-copyright 0.12.6-r1 --> 0.12.7-r2*
* *ament-cppcheck 0.12.6-r1 --> 0.12.7-r2*
* *ament-cpplint 0.12.6-r1 --> 0.12.7-r2*
* *ament-flake8 0.12.6-r1 --> 0.12.7-r2*
* *ament-lint 0.12.6-r1 --> 0.12.7-r2*
* *ament-lint-auto 0.12.6-r1 --> 0.12.7-r2*
* *ament-lint-cmake 0.12.6-r1 --> 0.12.7-r2*
* *ament-lint-common 0.12.6-r1 --> 0.12.7-r2*
* *ament-mypy 0.12.6-r1 --> 0.12.7-r2*
* *ament-pclint 0.12.6-r1 --> 0.12.7-r2*
* *ament-pep257 0.12.6-r1 --> 0.12.7-r2*
* *ament-pycodestyle 0.12.6-r1 --> 0.12.7-r2*
* *ament-pyflakes 0.12.6-r1 --> 0.12.7-r2*
* *ament-uncrustify 0.12.6-r1 --> 0.12.7-r2*
* *ament-xmllint 0.12.6-r1 --> 0.12.7-r2*
* *camera-calibration-parsers 3.1.5-r1 --> 3.1.6-r1*
* *camera-info-manager 3.1.5-r1 --> 3.1.6-r1*
* *clearpath-common 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-config 0.0.3-r1 --> 0.0.4-r1*
* *clearpath-control 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-description 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-generator-common 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-generator-gz 0.0.2-r1 --> 0.0.3-r1*
* *clearpath-gz 0.0.2-r1 --> 0.0.3-r1*
* *clearpath-mounts-description 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-nav2-demos 0.0.1-r1*
* *clearpath-platform 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-platform-description 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-sensors-description 0.0.6-r1 --> 0.0.8-r1*
* *clearpath-simulator 0.0.2-r1 --> 0.0.3-r1*
* *depthimage-to-laserscan 2.5.0-r3 --> 2.5.1-r1*
* *examples-tf2-py 0.25.2-r1 --> 0.25.3-r1*
* *executive-smach 3.0.2-r1 --> 3.0.3-r1*
* *fastrtps-cmake-module 2.2.0-r2 --> 2.2.1-r1*
* *flir-camera-description 2.0.0-r1*
* *flir-camera-msgs 2.0.0-r1*
* *generate-parameter-library 0.3.3-r1 --> 0.3.4-r1*
* *generate-parameter-library-example 0.3.3-r1 --> 0.3.4-r1*
* *generate-parameter-library-py 0.3.3-r1 --> 0.3.4-r1*
* *generate-parameter-module-example 0.3.4-r1*
* *geometry2 0.25.2-r1 --> 0.25.3-r1*
* *google-benchmark-vendor 0.1.1-r2 --> 0.1.2-r1*
* *image-common 3.1.5-r1 --> 3.1.6-r1*
* *image-transport 3.1.5-r1 --> 3.1.6-r1*
* *kinova-gen3-6dof-robotiq-2f-85-moveit-config 0.2.1-r1*
* *kinova-gen3-7dof-robotiq-2f-85-moveit-config 0.2.1-r1*
* *kortex-api 0.2.1-r1*
* *kortex-bringup 0.2.1-r1*
* *kortex-description 0.2.1-r1*
* *kortex-driver 0.2.1-r1*
* *launch-ros 0.19.4-r1 --> 0.19.5-r2*
* *launch-testing-ros 0.19.4-r1 --> 0.19.5-r2*
* *mcap-vendor 0.15.6-r1 --> 0.15.7-r1*
* *microstrain-inertial-driver 3.0.1-r1 --> 3.1.0-r1*
* *microstrain-inertial-examples 3.0.1-r1 --> 3.1.0-r1*
* *microstrain-inertial-msgs 3.0.1-r1 --> 3.1.0-r1*
* *microstrain-inertial-rqt 3.0.1-r1 --> 3.1.0-r1*
* *pal-navigation-cfg 3.0.4-r1 --> 3.0.5-r1*
* *pal-navigation-cfg-bringup 3.0.4-r1 --> 3.0.5-r1*
* *pal-navigation-cfg-params 3.0.4-r1 --> 3.0.5-r1*
* *parameter-traits 0.3.3-r1 --> 0.3.4-r1*
* *picknik-reset-fault-controller 0.0.1-r1 --> 0.0.3-r1*
* *picknik-twist-controller 0.0.1-r1 --> 0.0.3-r1*
* *rcl 5.3.3-r1 --> 5.3.4-r3*
* *rcl-action 5.3.3-r1 --> 5.3.4-r3*
* *rcl-lifecycle 5.3.3-r1 --> 5.3.4-r3*
* *rcl-yaml-param-parser 5.3.3-r1 --> 5.3.4-r3*
* *rclcpp 16.0.4-r2 --> 16.0.5-r2*
* *rclcpp-action 16.0.4-r2 --> 16.0.5-r2*
* *rclcpp-components 16.0.4-r2 --> 16.0.5-r2*
* *rclcpp-lifecycle 16.0.4-r2 --> 16.0.5-r2*
* *rclpy 3.3.8-r2 --> 3.3.9-r1*
* *rmw-connextdds 0.11.1-r2 --> 0.11.2-r1*
* *rmw-connextdds-common 0.11.1-r2 --> 0.11.2-r1*
* *rmw-fastrtps-cpp 6.2.2-r1 --> 6.2.3-r1*
* *rmw-fastrtps-dynamic-cpp 6.2.2-r1 --> 6.2.3-r1*
* *rmw-fastrtps-shared-cpp 6.2.2-r1 --> 6.2.3-r1*
* *robot-upstart 1.0.2-r1 --> 1.0.3-r1*
* *robotiq-controllers 0.0.1-r1*
* *robotiq-description 0.0.1-r1*
* *ros2action 0.18.6-r1 --> 0.18.7-r1*
* *ros2bag 0.15.6-r1 --> 0.15.7-r1*
* *ros2cli 0.18.6-r1 --> 0.18.7-r1*
* *ros2cli-test-interfaces 0.18.6-r1 --> 0.18.7-r1*
* *ros2component 0.18.6-r1 --> 0.18.7-r1*
* *ros2doctor 0.18.6-r1 --> 0.18.7-r1*
* *ros2interface 0.18.6-r1 --> 0.18.7-r1*
* *ros2launch 0.19.4-r1 --> 0.19.5-r2*
* *ros2lifecycle 0.18.6-r1 --> 0.18.7-r1*
* *ros2lifecycle-test-fixtures 0.18.6-r1 --> 0.18.7-r1*
* *ros2multicast 0.18.6-r1 --> 0.18.7-r1*
* *ros2node 0.18.6-r1 --> 0.18.7-r1*
* *ros2param 0.18.6-r1 --> 0.18.7-r1*
* *ros2pkg 0.18.6-r1 --> 0.18.7-r1*
* *ros2run 0.18.6-r1 --> 0.18.7-r1*
* *ros2service 0.18.6-r1 --> 0.18.7-r1*
* *ros2topic 0.18.6-r1 --> 0.18.7-r1*
* *rosbag2 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-compression 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-compression-zstd 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-cpp 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-interfaces 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-performance-benchmarking 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-py 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-storage 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-storage-default-plugins 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-storage-mcap 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-storage-mcap-testdata 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-test-common 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-tests 0.15.6-r1 --> 0.15.7-r1*
* *rosbag2-transport 0.15.6-r1 --> 0.15.7-r1*
* *rosidl-adapter 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-cli 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-cmake 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-generator-c 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-generator-cpp 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-parser 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-runtime-c 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-runtime-cpp 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-typesupport-c 2.0.0-r2 --> 2.0.1-r1*
* *rosidl-typesupport-cpp 2.0.0-r2 --> 2.0.1-r1*
* *rosidl-typesupport-fastrtps-c 2.2.0-r2 --> 2.2.1-r1*
* *rosidl-typesupport-fastrtps-cpp 2.2.0-r2 --> 2.2.1-r1*
* *rosidl-typesupport-interface 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-typesupport-introspection-c 3.1.4-r1 --> 3.1.5-r2*
* *rosidl-typesupport-introspection-cpp 3.1.4-r1 --> 3.1.5-r2*
* *rplidar-ros 2.1.0-r1 --> 2.1.3-r3*
* *rti-connext-dds-cmake-module 0.11.1-r2 --> 0.11.2-r1*
* *rviz-assimp-vendor 11.2.5-r1 --> 11.2.6-r1*
* *rviz-default-plugins 11.2.5-r1 --> 11.2.6-r1*
* *rviz-ogre-vendor 11.2.5-r1 --> 11.2.6-r1*
* *rviz-rendering 11.2.5-r1 --> 11.2.6-r1*
* *rviz-rendering-tests 11.2.5-r1 --> 11.2.6-r1*
* *rviz-visual-testing-framework 11.2.5-r1 --> 11.2.6-r1*
* *rviz2 11.2.5-r1 --> 11.2.6-r1*
* *septentrio-gnss-driver 1.2.3-r1 --> 1.3.1-r1*
* *shared-queues-vendor 0.15.6-r1 --> 0.15.7-r1*
* *smacc2 2.3.8-r1 --> 2.3.18-r1*
* *smacc2-msgs 2.3.8-r1 --> 2.3.18-r1*
* *smach 3.0.2-r1 --> 3.0.3-r1*
* *smach-msgs 3.0.2-r1 --> 3.0.3-r1*
* *smach-ros 3.0.2-r1 --> 3.0.3-r1*
* *spinnaker-camera-driver 2.0.0-r1*
* *sqlite3-vendor 0.15.6-r1 --> 0.15.7-r1*
* *tf2 0.25.2-r1 --> 0.25.3-r1*
* *tf2-bullet 0.25.2-r1 --> 0.25.3-r1*
* *tf2-eigen 0.25.2-r1 --> 0.25.3-r1*
* *tf2-eigen-kdl 0.25.2-r1 --> 0.25.3-r1*
* *tf2-geometry-msgs 0.25.2-r1 --> 0.25.3-r1*
* *tf2-kdl 0.25.2-r1 --> 0.25.3-r1*
* *tf2-msgs 0.25.2-r1 --> 0.25.3-r1*
* *tf2-py 0.25.2-r1 --> 0.25.3-r1*
* *tf2-ros 0.25.2-r1 --> 0.25.3-r1*
* *tf2-ros-py 0.25.2-r1 --> 0.25.3-r1*
* *tf2-sensor-msgs 0.25.2-r1 --> 0.25.3-r1*
* *tf2-tools 0.25.2-r1 --> 0.25.3-r1*
* *webots-ros2 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-control 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-driver 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-epuck 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-importer 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-mavic 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-msgs 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-tesla 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-tests 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-tiago 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-turtlebot 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-universal-robot 2023.1.1-r1 --> 2023.1.1-r2*
* *zstd-vendor 0.15.6-r1 --> 0.15.7-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.11.0-r1 --> 3.12.0-r1*
* *admittance-controller 3.11.0-r1 --> 3.12.0-r1*
* *bicycle-steering-controller 3.11.0-r1 --> 3.12.0-r1*
* *camera-calibration-parsers 4.2.0-r3 --> 4.2.1-r1*
* *camera-info-manager 4.2.0-r3 --> 4.2.1-r1*
* *cascade-lifecycle-msgs 1.0.3-r5 --> 1.0.4-r1*
* *controller-interface 3.15.0-r1 --> 3.16.0-r1*
* *controller-manager 3.15.0-r1 --> 3.16.0-r1*
* *controller-manager-msgs 3.15.0-r1 --> 3.16.0-r1*
* *depthimage-to-laserscan 2.5.0-r5 --> 2.5.1-r1*
* *diff-drive-controller 3.11.0-r1 --> 3.12.0-r1*
* *effort-controllers 3.11.0-r1 --> 3.12.0-r1*
* *executive-smach 3.0.2-r1 --> 3.0.3-r1*
* *force-torque-sensor-broadcaster 3.11.0-r1 --> 3.12.0-r1*
* *forward-command-controller 3.11.0-r1 --> 3.12.0-r1*
* *foxglove-bridge 0.6.4-r1 --> 0.7.0-r1*
* *generate-parameter-library 0.3.3-r2 --> 0.3.4-r1*
* *generate-parameter-library-example 0.3.3-r2 --> 0.3.4-r1*
* *generate-parameter-library-py 0.3.3-r2 --> 0.3.4-r1*
* *generate-parameter-module-example 0.3.4-r1*
* *gripper-controllers 3.11.0-r1 --> 3.12.0-r1*
* *gz-ros2-control-demos 1.1.1-r1*
* *hardware-interface 3.15.0-r1 --> 3.16.0-r1*
* *image-common 4.2.0-r3 --> 4.2.1-r1*
* *image-transport 4.2.0-r3 --> 4.2.1-r1*
* *imu-sensor-broadcaster 3.11.0-r1 --> 3.12.0-r1*
* *joint-limits 3.15.0-r1 --> 3.16.0-r1*
* *joint-state-broadcaster 3.11.0-r1 --> 3.12.0-r1*
* *joint-trajectory-controller 3.11.0-r1 --> 3.12.0-r1*
* *kinova-gen3-6dof-robotiq-2f-85-moveit-config 0.2.1-r1*
* *kinova-gen3-7dof-robotiq-2f-85-moveit-config 0.2.1-r1*
* *kortex-api 0.2.1-r1*
* *kortex-bringup 0.2.1-r1*
* *kortex-description 0.2.1-r1*
* *kortex-driver 0.2.1-r1*
* *microstrain-inertial-driver 3.0.1-r3 --> 3.1.0-r1*
* *microstrain-inertial-examples 3.0.1-r3 --> 3.1.0-r1*
* *microstrain-inertial-msgs 3.0.1-r3 --> 3.1.0-r1*
* *microstrain-inertial-rqt 3.0.1-r3 --> 3.1.0-r1*
* *mrpt2 2.9.4-r1 --> 2.10.0-r1*
* *parameter-traits 0.3.3-r2 --> 0.3.4-r1*
* *picknik-reset-fault-controller 0.0.3-r1*
* *picknik-twist-controller 0.0.3-r1*
* *plansys2-bringup 2.0.10-r1*
* *plansys2-bt-actions 2.0.10-r1*
* *plansys2-core 2.0.10-r1*
* *plansys2-domain-expert 2.0.10-r1*
* *plansys2-executor 2.0.10-r1*
* *plansys2-lifecycle-manager 2.0.10-r1*
* *plansys2-msgs 2.0.10-r1*
* *plansys2-pddl-parser 2.0.10-r1*
* *plansys2-planner 2.0.10-r1*
* *plansys2-popf-plan-solver 2.0.10-r1*
* *plansys2-problem-expert 2.0.10-r1*
* *plansys2-terminal 2.0.10-r1*
* *plansys2-tests 2.0.10-r1*
* *plansys2-tools 2.0.10-r1*
* *popf 0.0.15-r1*
* *position-controllers 3.11.0-r1 --> 3.12.0-r1*
* *rclcpp-cascade-lifecycle 1.0.3-r5 --> 1.0.4-r1*
* *robotiq-controllers 0.0.1-r1*
* *robotiq-description 0.0.1-r1*
* *ros2-control 3.15.0-r1 --> 3.16.0-r1*
* *ros2-control-test-assets 3.15.0-r1 --> 3.16.0-r1*
* *ros2-controllers 3.11.0-r1 --> 3.12.0-r1*
* *ros2-controllers-test-nodes 3.11.0-r1 --> 3.12.0-r1*
* *ros2controlcli 3.15.0-r1 --> 3.16.0-r1*
* *rqt-controller-manager 3.15.0-r1 --> 3.16.0-r1*
* *rqt-joint-trajectory-controller 3.11.0-r1 --> 3.12.0-r1*
* *septentrio-gnss-driver 1.2.3-r3 --> 1.3.1-r3*
* *simple-launch 1.7.0-r3 --> 1.7.1-r1*
* *smach 3.0.2-r1 --> 3.0.3-r1*
* *smach-msgs 3.0.2-r1 --> 3.0.3-r1*
* *smach-ros 3.0.2-r1 --> 3.0.3-r1*
* *steering-controllers-library 3.11.0-r1 --> 3.12.0-r1*
* *transmission-interface 3.15.0-r1 --> 3.16.0-r1*
* *tricycle-controller 3.11.0-r1 --> 3.12.0-r1*
* *tricycle-steering-controller 3.11.0-r1 --> 3.12.0-r1*
* *ur-client-library 1.3.1-r3 --> 1.3.2-r1*
* *velocity-controllers 3.11.0-r1 --> 3.12.0-r1*
* *webots-ros2 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-control 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-driver 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-epuck 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-importer 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-mavic 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-msgs 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-tesla 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-tests 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-tiago 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-turtlebot 2023.1.0-r1 --> 2023.1.1-r2*
* *webots-ros2-universal-robot 2023.1.0-r1 --> 2023.1.1-r2*

Noetic Changes:
---------------
* *aques-talk 2.1.26-r1 --> 2.1.28-r1*
* *assimp-devel 2.1.26-r1 --> 2.1.28-r1*
* *bayesian-belief-networks 2.1.26-r1 --> 2.1.28-r1*
* *chaplus-ros 2.1.26-r1 --> 2.1.28-r1*
* *compass-msgs 1.0.3-r1*
* *cpr-onav-description 0.1.2-r1 --> 0.1.3-r1*
* *dialogflow-task-executive 2.1.26-r1 --> 2.1.28-r1*
* *dingo-gazebo 0.1.2-r1 --> 0.1.2-r2*
* *dingo-simulator 0.1.2-r1 --> 0.1.2-r2*
* *downward 2.1.26-r1 --> 2.1.28-r1*
* *ff 2.1.26-r1 --> 2.1.28-r1*
* *ffha 2.1.26-r1 --> 2.1.28-r1*
* *gdrive-ros 2.1.26-r1 --> 2.1.28-r1*
* *google-chat-ros 2.1.26-r1 --> 2.1.28-r1*
* *image-transport-codecs 2.3.0-r2 --> 2.3.1-r1*
* *jsk-3rdparty 2.1.26-r1 --> 2.1.28-r1*
* *julius 2.1.26-r1 --> 2.1.28-r1*
* *libcmt 2.1.26-r1 --> 2.1.28-r1*
* *libsiftfast 2.1.26-r1 --> 2.1.28-r1*
* *lpg-planner 2.1.26-r1 --> 2.1.28-r1*
* *magnetometer-compass 1.0.3-r1*
* *microstrain-inertial-driver 3.0.1-r1 --> 3.1.0-r1*
* *microstrain-inertial-examples 3.0.1-r1 --> 3.1.0-r1*
* *microstrain-inertial-msgs 3.0.1-r1 --> 3.1.0-r1*
* *microstrain-inertial-rqt 3.0.1-r1 --> 3.1.0-r1*
* *mini-maxwell 2.1.26-r1 --> 2.1.28-r1*
* *nfc-ros 2.1.26-r1 --> 2.1.28-r1*
* *opt-camera 2.1.26-r1 --> 2.1.28-r1*
* *osqp 2.1.26-r1 --> 2.1.28-r1*
* *pal-carbon-collector 1.5.1-r1*
* *pal-statistics 1.5.1-r1*
* *pal-statistics-msgs 1.5.1-r1*
* *point-cloud2-filters 1.0.1-r1*
* *qb-device 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-bringup 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-control 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-description 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-driver 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-gazebo 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-hardware-interface 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-msgs 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-srvs 3.0.5-r1 --> 3.1.0-r1*
* *qb-device-utils 3.0.5-r1 --> 3.1.0-r1*
* *qb-move 2.2.2-r1 --> 3.0.3-r2*
* *qb-move-control 2.2.2-r1 --> 3.0.3-r2*
* *qb-move-description 2.2.2-r1 --> 3.0.3-r2*
* *qb-move-gazebo 2.2.2-r1 --> 3.0.3-r2*
* *qb-move-hardware-interface 2.2.2-r1 --> 3.0.3-r2*
* *respeaker-ros 2.1.26-r1 --> 2.1.28-r1*
* *robot-body-filter 1.3.0-r1 --> 1.3.1-r1*
* *ros-google-cloud-language 2.1.26-r1 --> 2.1.28-r1*
* *ros-industrial-cmake-boilerplate 0.4.7-r1 --> 0.4.8-r1*
* *rospatlite 2.1.26-r1 --> 2.1.28-r1*
* *rosping 2.1.26-r1 --> 2.1.28-r1*
* *rostwitter 2.1.26-r1 --> 2.1.28-r1*
* *sesame-ros 2.1.26-r1 --> 2.1.28-r1*
* *slic 2.1.26-r1 --> 2.1.28-r1*
* *switchbot-ros 2.1.26-r1 --> 2.1.28-r1*
* *voice-text 2.1.26-r1 --> 2.1.28-r1*
* *zdepth 2.1.26-r1 --> 2.1.28-r1*
* *zdepth-image-transport 2.1.26-r1 --> 2.1.28-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 3.11.0-r1 --> 3.12.0-r1*
* *admittance-controller 3.11.0-r1 --> 3.12.0-r1*
* *bicycle-steering-controller 3.11.0-r1 --> 3.12.0-r1*
* *camera-calibration-parsers 4.3.0-r1 --> 4.3.0-r2*
* *camera-info-manager 4.3.0-r1 --> 4.3.0-r2*
* *depthimage-to-laserscan 2.5.0-r4 --> 2.5.1-r1*
* *diff-drive-controller 3.11.0-r1 --> 3.12.0-r1*
* *effort-controllers 3.11.0-r1 --> 3.12.0-r1*
* *executive-smach 3.0.2-r1 --> 3.0.3-r1*
* *fastrtps 2.11.0-r1 --> 2.11.1-r1*
* *force-torque-sensor-broadcaster 3.11.0-r1 --> 3.12.0-r1*
* *forward-command-controller 3.11.0-r1 --> 3.12.0-r1*
* *foxglove-bridge 0.6.4-r1 --> 0.7.0-r1*
* *generate-parameter-library 0.3.3-r1 --> 0.3.4-r1*
* *generate-parameter-library-example 0.3.3-r1 --> 0.3.4-r1*
* *generate-parameter-library-py 0.3.3-r1 --> 0.3.4-r1*
* *generate-parameter-module-example 0.3.4-r1*
* *gripper-controllers 3.11.0-r1 --> 3.12.0-r1*
* *gz-ros2-control-demos 1.1.1-r1*
* *image-common 4.3.0-r1 --> 4.3.0-r2*
* *image-transport 4.3.0-r1 --> 4.3.0-r2*
* *imu-sensor-broadcaster 3.11.0-r1 --> 3.12.0-r1*
* *joint-state-broadcaster 3.11.0-r1 --> 3.12.0-r1*
* *joint-trajectory-controller 3.11.0-r1 --> 3.12.0-r1*
* *kinova-gen3-6dof-robotiq-2f-85-moveit-config 0.2.1-r1*
* *kinova-gen3-7dof-robotiq-2f-85-moveit-config 0.2.1-r1*
* *kortex-api 0.2.1-r1*
* *kortex-bringup 0.2.1-r1*
* *kortex-description 0.2.1-r1*
* *kortex-driver 0.2.1-r1*
* *mcap-vendor 0.23.0-r1 --> 0.24.0-r1*
* *microstrain-inertial-driver 3.0.1-r2 --> 3.1.0-r1*
* *microstrain-inertial-examples 3.0.1-r2 --> 3.1.0-r1*
* *microstrain-inertial-msgs 3.0.1-r2 --> 3.1.0-r1*
* *microstrain-inertial-rqt 3.0.1-r2 --> 3.1.0-r1*
* *pal-statistics 2.1.5-r1*
* *pal-statistics-msgs 2.1.5-r1*
* *parameter-traits 0.3.3-r1 --> 0.3.4-r1*
* *picknik-reset-fault-controller 0.0.3-r1*
* *picknik-twist-controller 0.0.3-r1*
* *position-controllers 3.11.0-r1 --> 3.12.0-r1*
* *robotiq-controllers 0.0.1-r1*
* *robotiq-description 0.0.1-r1*
* *ros2-controllers 3.11.0-r1 --> 3.12.0-r1*
* *ros2-controllers-test-nodes 3.11.0-r1 --> 3.12.0-r1*
* *ros2bag 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-compression 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-compression-zstd 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-cpp 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-examples-cpp 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-examples-py 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-interfaces 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-performance-benchmarking 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-performance-benchmarking-msgs 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-py 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-storage 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-storage-default-plugins 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-storage-mcap 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-storage-sqlite3 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-test-common 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-test-msgdefs 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-tests 0.23.0-r1 --> 0.24.0-r1*
* *rosbag2-transport 0.23.0-r1 --> 0.24.0-r1*
* *rqt-joint-trajectory-controller 3.11.0-r1 --> 3.12.0-r1*
* *septentrio-gnss-driver 1.2.3-r2 --> 1.3.1-r2*
* *shared-queues-vendor 0.23.0-r1 --> 0.24.0-r1*
* *smach 3.0.2-r1 --> 3.0.3-r1*
* *smach-msgs 3.0.2-r1 --> 3.0.3-r1*
* *smach-ros 3.0.2-r1 --> 3.0.3-r1*
* *sqlite3-vendor 0.23.0-r1 --> 0.24.0-r1*
* *steering-controllers-library 3.11.0-r1 --> 3.12.0-r1*
* *tricycle-controller 3.11.0-r1 --> 3.12.0-r1*
* *tricycle-steering-controller 3.11.0-r1 --> 3.12.0-r1*
* *ur-client-library 1.3.1-r2 --> 1.3.2-r1*
* *velocity-controllers 3.11.0-r1 --> 3.12.0-r1*
* *webots-ros2 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-control 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-driver 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-epuck 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-importer 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-mavic 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-msgs 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-tesla 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-tests 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-tiago 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-turtlebot 2023.1.1-r1 --> 2023.1.1-r2*
* *webots-ros2-universal-robot 2023.1.1-r1 --> 2023.1.1-r2*
* *zstd-vendor 0.23.0-r1 --> 0.24.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libqt5-svg
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-vcstool
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote
 * [ ] xsimd
 * [ ] xtensor

