### PR TITLE
Patch vendor git in rig_reconfigure

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -111,6 +111,14 @@ rosSelf: rosSuper: with rosSelf.lib; {
     ];
   });
 
+  rig-reconfigure = patchVendorGit rosSuper.rig-reconfigure {
+    url = "https://github.com/ocornut/imgui.git";
+    fetchgitArgs = {
+      rev = "3ea0fad204e994d669f79ed29dcaf61cd5cb571d";
+      sha256 = "sha256-v9FP9zJvul+2zRGaIugNDBCR9xZqCY8U90Dfe6fXpJM=";
+    };
+  };
+
   rmw-implementation = rosSuper.rmw-implementation.overrideAttrs ({
     propagatedBuildInputs ? [], ...
   }: {


### PR DESCRIPTION
Without this, the build fails.

See [this code in their CMakeLists.txt](https://github.com/teamspatzenhirn/rig_reconfigure/blob/b25483eff7e1dfe935fe5836386964b45500e83a/CMakeLists.txt#L13-L14).