### PR TITLE
rosdistro sync, Fri Aug  4 13:31:57 2023

### DIFF
--- a/distros/default.nix
+++ b/distros/default.nix
@@ -1,7 +1,7 @@
 # Define all supported ROS distros
 
 self: super: {
-  rosPackages = rec {
+  rosPackages = self.lib.warn "nix-ros-overlay staging branch has been renamed to develop, use it instead" rec {
     recurseForDerivations = true;
     lib = super.lib // import ../lib { inherit lib self; };
 

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "0a2b1123f675920b026b4e89f312546f33d73e26f9e81b6577e74b1e3f83a157";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "e64880412f42ce46ef910531fbd6dd431d97d4b709cdf033a4d9714166338d81";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "b7742e7b29a3e41b7c35718e8770fd213afef97b0a8cab87b06b1a1c5f7030a2";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "7b81d8ba26e57f04ce07642cf4331b8bd43668cc152721e79bc2931f169235dd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "5d49b66149517124a2a1c92af05687bf57251a955f426e4e4cedbe0e1b69d8d2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "1cc43a20b862dc3b30ea1c19988bf915bda26ae58ba63e17a0c13ed43d012a66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "8e5ea2f00c6f04676af7da84c92b258a914b45c5f23104eaf00bfb0f201966f6";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "03f0b0b865528503f994ddfa5757b8b42d8381d18fa87f919abd44b3b927f184";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "e84a637016c2a92298389de01b78f33c7707e98299014ec7f7a79888602190cf";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "f543d31080879b13a9d167736d743b18bde3c8d29bc9288f268930a2537162ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "a831a04cf625396994aef385abfd1ac7686d683441d76178d03404062c3c785c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "8462fe96b7e573d26a56b3897b27b2b1008ae145214b80211df363661dd8375c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-nav2-demos/default.nix
+++ b/distros/humble/clearpath-nav2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, nav2-bringup, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-clearpath-nav2-demos";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/humble/clearpath_nav2_demos/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "0e0d3e550de48b33a15917451d3d81dce7c5d04715979a197c068ade5d00c423";
+    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/humble/clearpath_nav2_demos/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "296e5408d7d0018f0e79d726148b721700c1979c297a37e3919de281d1d49f1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "034fdca21e9161c32ca26f9b96af440bb399fea9f6b7949d04aa33c0cf0a2925";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "f7ea4812030f04dadf49a31631185a2541857334c4cf176c3484ca80c194dba1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "348c2c3df687888b9bea52a353821ebfda3b57f50d88926abda8907f2055fe54";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "e8a5c954564d16245ea4e76aff14cf1b940a5bce5e0f47d41b076d36823e9a7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "eb5e984753feccb386ea62a51ae2fc132aaa23619a0cbbc22d1f34a6e5d136f4";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "a151d51b44ae8d7003e631eb2041e00d429dffa164e8db021e6463e0f411e77e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/crane-plus-control/default.nix
+++ b/distros/humble/crane-plus-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, crane-plus-description, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, ros2-controllers, ros2controlcli, xacro }:
+buildRosPackage {
+  pname = "ros-humble-crane-plus-control";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/humble/crane_plus_control/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "0bbfa300fa64bd366df8761a5348af142cab613eb46ae7a54c16298d89f706ff";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager crane-plus-description dynamixel-sdk hardware-interface pluginlib rclcpp ros2-controllers ros2controlcli xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+ V2 control package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/crane-plus-description/default.nix
+++ b/distros/humble/crane-plus-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-ros2-control, ign-ros2-control, joint-state-publisher-gui, launch, robot-state-publisher, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-humble-crane-plus-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/humble/crane_plus_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "48f76bb303af532f42fd60e6e6439df98014ed40bc94b8d4695d4a6335b0fd91";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gazebo-ros2-control ign-ros2-control joint-state-publisher-gui launch robot-state-publisher rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''CRANE+ V2 description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/crane-plus-examples/default.nix
+++ b/distros/humble/crane-plus-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, crane-plus-control, crane-plus-description, crane-plus-moveit-config, cv-bridge, geometry-msgs, image-geometry, moveit-ros-planning-interface, opencv, rclcpp, tf2-geometry-msgs, usb-cam }:
+buildRosPackage {
+  pname = "ros-humble-crane-plus-examples";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/humble/crane_plus_examples/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c89d8b881a67aa6a3b477f11be90a7e35d283d8c9d392b60768b6f232c066d2b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-moveit-config cv-bridge geometry-msgs image-geometry moveit-ros-planning-interface opencv rclcpp tf2-geometry-msgs usb-cam ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+ V2 examples package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/crane-plus-gazebo/default.nix
+++ b/distros/humble/crane-plus-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, crane-plus-description, crane-plus-moveit-config, gripper-controllers, robot-state-publisher, ros-gz, ros2-controllers }:
+buildRosPackage {
+  pname = "ros-humble-crane-plus-gazebo";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/humble/crane_plus_gazebo/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "4b0e7bb079cacd9f337e8474f5aa31b1e31fe2b8c45634c3c4488b293caf0e85";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager crane-plus-description crane-plus-moveit-config gripper-controllers robot-state-publisher ros-gz ros2-controllers ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+ V2 gazebo simulation package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/crane-plus-moveit-config/default.nix
+++ b/distros/humble/crane-plus-moveit-config/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit, robot-state-publisher, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-humble-crane-plus-moveit-config";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/humble/crane_plus_moveit_config/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "397049ce66242ebf2530761f4904ee347832510e2b44b92e29868df106e45fcd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit robot-state-publisher rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''CRANE+ V2 move_group config package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/crane-plus/default.nix
+++ b/distros/humble/crane-plus/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, crane-plus-control, crane-plus-description, crane-plus-examples, crane-plus-gazebo, crane-plus-moveit-config }:
+buildRosPackage {
+  pname = "ros-humble-crane-plus";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/humble/crane_plus/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8970cb60e5203f1c8a2ed608d7812ec152f97a8461c979a06ddf937574f5d1ab";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-examples crane-plus-gazebo crane-plus-moveit-config ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 package suite of CRANE+ V2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/event-camera-msgs/default.nix
+++ b/distros/humble/event-camera-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-event-camera-msgs";
+  version = "1.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_msgs-release/archive/release/humble/event_camera_msgs/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "83d1d4dd82b4ba311e06152075ab04116312e1f7dc7f8065a4db8a85392a3b02";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = ''messages for event based cameras'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/humble/flexbe-behavior-engine/default.nix
+++ b/distros/humble/flexbe-behavior-engine/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-behavior-engine";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_behavior_engine/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "3dc858ec3d726f388ca319845b8333531bb8b5be577824d0d224e9d5e3a86bfa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ flexbe-core flexbe-input flexbe-mirror flexbe-msgs flexbe-onboard flexbe-states flexbe-testing flexbe-widget ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A meta-package to aggregate all the FlexBE packages'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-core/default.nix
+++ b/distros/humble/flexbe-core/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-msgs, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs, std-srvs, tf2-ros-py }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-core";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_core/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "8ef39c4f019dbe6cdfeb45767312e3453ba6e9f5e4236d9fe98a0d3f701f8d72";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-ros launch-testing pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-msgs rclpy std-msgs std-srvs tf2-ros-py ];
+
+  meta = {
+    description = ''flexbe_core provides the core components for the FlexBE behavior engine.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-input/default.nix
+++ b/distros/humble/flexbe-input/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-input";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_input/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "041bc878980e1a557f4ac70c18f2e3d72ac61afba7555e2d6e7da03a0710bd08";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rclpy ];
+
+  meta = {
+    description = ''flexbe_input enables to send data to onboard behavior when required.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-mirror/default.nix
+++ b/distros/humble/flexbe-mirror/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-mirror";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_mirror/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "19d1001fed4b4a2efbb7ac131e0cfedaaf35a8472349c4ec99e1e0ad520f3571";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rclpy ];
+
+  meta = {
+    description = ''flexbe_mirror implements functionality to remotely mirror an executed behavior.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-msgs/default.nix
+++ b/distros/humble/flexbe-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-msgs";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "3d0d36c5e5567b7cbb55ade223470b380f7bb5034151ca7a0b4b61d95c8ff3a6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-generators rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''flexbe_msgs provides the messages used by FlexBE.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-onboard/default.nix
+++ b/distros/humble/flexbe-onboard/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-states, launch-ros, launch-testing, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-onboard";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_onboard/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "cb469c3bcab3fa0aafc554431e800c2e38a3cd210eb8cc5684ea04c8cb8b5181";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-testing pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-states launch-ros rclpy ];
+
+  meta = {
+    description = ''flexbe_onboard implements the robot-side of the behavior engine from where all behaviors are started.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-states/default.nix
+++ b/distros/humble/flexbe-states/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-states";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_states/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "104baa5b0ccd7a0fde26ffa7678367dc88a8a97fac6db64eb8996468bf949d5a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-testing rclpy ];
+
+  meta = {
+    description = ''flexbe_states provides a collection of common generic predefined states.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-testing/default.nix
+++ b/distros/humble/flexbe-testing/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-testing";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_testing/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "d56c6dd9eb32da4e2b95ab4bcf0305e1f6f12e006c7b0f067c48f3e34937c65c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 launch-testing pythonPackages.pytest std-msgs ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs launch-ros rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''flexbe_testing provides a framework for unit testing states.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flexbe-widget/default.nix
+++ b/distros/humble/flexbe-widget/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-flexbe-widget";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_widget/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "04207dc42d19affdf6c341d3e996d348a9ac55bad93cd7904383dfecbb3ed366";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard launch-ros rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''flexbe_widget implements some smaller scripts for the behavior engine.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.0-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8201bdeba40fd3c63ba85693475ae3d0899695d46aecf800a444106afac2900c";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "95d918cefb62226eb9a7abb383097a31723edc80a6f40c206a8f4a751584aaf6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "e3482c62b1df16fd2def73034a19f62d333b647c593da086720e97692520ab5a";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "3d64202e112d71a6fd2c3fa2c6638c4053257106de50cd58fadf0d9689088010";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-example/default.nix
+++ b/distros/humble/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-example";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "9b39413bcb6a7ea845200b0a22e2686c060dcd47048ac81eecbf09910ebaf0b7";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "9b723972cc752894f1999f6389b1a5b5de5907315dacd02ee81cf1e44390640c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-py/default.nix
+++ b/distros/humble/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-py";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "b24e2832a0270de8af3c684f6c380230c6408af030b001970a0780d16d703476";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "c0125951cfaf3626d8e59049160260c95e9d43c203226edae97e00d0c52c0344";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "207143bd2c5449a5e69c802d064440eaea75266db5bfd822ea066226cfffb165";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "38154b812eef62c20526e487164a552bd33959b95bcd97d4081856576abcf7ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-module-example/default.nix
+++ b/distros/humble/generate-parameter-module-example/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-module-example";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "9aa8e179024fe60427f8c6a35296b72cd0f9bb3b3815892357ae80ce94930c43";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "541046c0c70cf5df383818d08a08bcc5e3f220d6058e9e71c7c2a47d0bb159c5";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  propagatedBuildInputs = [ generate-parameter-library generate-parameter-library-py rclpy ];
 
   meta = {
     description = ''Example usage of generate_parameter_library for a python module'';

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -356,6 +356,18 @@ self: super: {
 
  costmap-queue = self.callPackage ./costmap-queue {};
 
+ crane-plus = self.callPackage ./crane-plus {};
+
+ crane-plus-control = self.callPackage ./crane-plus-control {};
+
+ crane-plus-description = self.callPackage ./crane-plus-description {};
+
+ crane-plus-examples = self.callPackage ./crane-plus-examples {};
+
+ crane-plus-gazebo = self.callPackage ./crane-plus-gazebo {};
+
+ crane-plus-moveit-config = self.callPackage ./crane-plus-moveit-config {};
+
  create-bringup = self.callPackage ./create-bringup {};
 
  create-description = self.callPackage ./create-description {};
@@ -524,6 +536,8 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ event-camera-msgs = self.callPackage ./event-camera-msgs {};
+
  example-interfaces = self.callPackage ./example-interfaces {};
 
  examples-rclcpp-async-client = self.callPackage ./examples-rclcpp-async-client {};
@@ -581,6 +595,24 @@ self: super: {
  filters = self.callPackage ./filters {};
 
  find-object-2d = self.callPackage ./find-object-2d {};
+
+ flexbe-behavior-engine = self.callPackage ./flexbe-behavior-engine {};
+
+ flexbe-core = self.callPackage ./flexbe-core {};
+
+ flexbe-input = self.callPackage ./flexbe-input {};
+
+ flexbe-mirror = self.callPackage ./flexbe-mirror {};
+
+ flexbe-msgs = self.callPackage ./flexbe-msgs {};
+
+ flexbe-onboard = self.callPackage ./flexbe-onboard {};
+
+ flexbe-states = self.callPackage ./flexbe-states {};
+
+ flexbe-testing = self.callPackage ./flexbe-testing {};
+
+ flexbe-widget = self.callPackage ./flexbe-widget {};
 
  flir-camera-description = self.callPackage ./flir-camera-description {};
 
@@ -1003,6 +1035,8 @@ self: super: {
  message-filters = self.callPackage ./message-filters {};
 
  message-tf-frame-transformer = self.callPackage ./message-tf-frame-transformer {};
+
+ metavision-driver = self.callPackage ./metavision-driver {};
 
  micro-ros-diagnostic-bridge = self.callPackage ./micro-ros-diagnostic-bridge {};
 

--- a/distros/humble/laser-filters/default.nix
+++ b/distros/humble/laser-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, message-filters, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-laser-filters";
-  version = "2.0.6-r2";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/humble/laser_filters/2.0.6-2.tar.gz";
-    name = "2.0.6-2.tar.gz";
-    sha256 = "8e7f0cc631cc9fa356b7d993fd98ae3ad7fc3e7d35c84633a4c5e7cae3c82050";
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/humble/laser_filters/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "618be07750d25db351859f760ef35553bc7753e8fbe7ca230c805b7ae394c9c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/metavision-driver/default.nix
+++ b/distros/humble/metavision-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, event-camera-msgs, rclcpp, rclcpp-components, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-metavision-driver";
+  version = "1.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/humble/metavision_driver/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "b62b8c79e93216ea3db78a616d7a3dfa1e9cd959614dcad201ff9e83b7e61795";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ event-camera-msgs rclcpp rclcpp-components std-srvs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''ROS1 and ROS2 drivers for metavision based event cameras'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-parameter-traits";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "60284c63b0bcbd189029d78553e822e67d3e3bef96d0d917ce68f0688ac37a5d";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "df756f89e426e6e1d4a4e137c447fa2b84e3cce19ffe49518c8cfc70a54a3923";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.6-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.6-1.tar.gz";
-    name = "11.2.6-1.tar.gz";
-    sha256 = "c2427ef8df263dc6b129c14acb0ff34fbec5ad855797518a90ee4e2dd1ffaa86";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "ad63d8d977ae5e3f02baf586cea9cb6547430cfa3ed7410be1cdf136ed456b80";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.6-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.6-1.tar.gz";
-    name = "11.2.6-1.tar.gz";
-    sha256 = "79c23d24c9a09be1580f0341ae1f112f52eb9c952941e186d942b073b5362cfb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "85a30a20bcbdfd3ada32f132c18a43ce738a725a7ca5557d3e982f7b6d0e5e1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.6-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.6-1.tar.gz";
-    name = "11.2.6-1.tar.gz";
-    sha256 = "32b323ae80ecbf26600785a406d8d4edaeb5a849711634393e4aec27bdf25553";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "2593ef85dc2d47577345246ea77449257d20480774ff34bef4f5e7ed67778954";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.6-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.6-1.tar.gz";
-    name = "11.2.6-1.tar.gz";
-    sha256 = "66cc1398a449945ad9b99f245194523415bbbd797a10bb013204e4731bd53003";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "11e0125bb6650dcbadd37ba486fda4a0c4e8037beb2491d44e4e13ea29058ccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.6-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.6-1.tar.gz";
-    name = "11.2.6-1.tar.gz";
-    sha256 = "e0d265fe8eb313bbe60cdbed728f54149787d55bb7307a725eb3252051deb26e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "36ecbca42b0a23e23fa2c6785f6efef94336caaabfcd6ca36c4b10eea1e182fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.6-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.6-1.tar.gz";
-    name = "11.2.6-1.tar.gz";
-    sha256 = "d190ce743d4f7f6e5f2f1c568f83fd5787bc3a3ce2af6f5df4d22bdc5ffc49a3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "98ca7deb3d1f605627335e93eedfbc86eff62b657026967e02852fa33238db30";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.6-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.6-1.tar.gz";
-    name = "11.2.6-1.tar.gz";
-    sha256 = "34b179cdf3f6455819166c40e83b7de1b80bdfab01d4c6931ac0f5400ba57851";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "e46a66cce6cb2606a09d10644db99a4ab44a64023e48086df471aa9d7bbc53c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, flir-camera-msgs, image-transport, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.0-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "3f920f77e4e7ea8604179e704d67c41f85332711e7eb2f2021fe0bc704c89df2";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c58dfe42d5a2fe2a1aa6e3c2b0e5146771daef8762fe6f260051c8138725eb50";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake curl dpkg python3Packages.distro ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ camera-info-manager flir-camera-msgs image-transport rclcpp rclcpp-components sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ camera-info-manager flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/generate-parameter-library-example/default.nix
+++ b/distros/iron/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-example";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "c59570915f1c71cb708c8ad0578538d0ef520e7cece6732220162d251d837217";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "3170753249cde8bcbe014651292b45965f71a2eadd1637aac24e5fd50accc940";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generate-parameter-library-py/default.nix
+++ b/distros/iron/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-py";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "331eb017c89114b191a43b12a264040a5c150f5fd0d9afd75fe1083927fab580";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "28b7b6b491ddf2f711f338d24e6ccb90d1f5c3e58cf004d3e3676a15094db509";
   };
 
   buildType = "ament_python";

--- a/distros/iron/generate-parameter-library/default.nix
+++ b/distros/iron/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "896f4ef98f7d8a29302bd2d24c7c1055cd9ec684acc23b9494e7d4180fe5f5a6";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "9d058b1710709c92b8107f509d9a7a5984e63c20e82b593dc2d195f3c5311e7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generate-parameter-module-example/default.nix
+++ b/distros/iron/generate-parameter-module-example/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-module-example";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_module_example/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "0091e7d3be0820fd322706ea37ea96a58bee7e808e16bf0d54cee0e79a1ca509";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_module_example/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "72475cf5472ce06e4f391a2a601e8bfe55adafa28bb1b5aec03e08770a2e72c8";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  propagatedBuildInputs = [ generate-parameter-library generate-parameter-library-py rclpy ];
 
   meta = {
     description = ''Example usage of generate_parameter_library for a python module'';

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -1802,6 +1802,12 @@ self: super: {
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
 
+ sick-safetyscanners2 = self.callPackage ./sick-safetyscanners2 {};
+
+ sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};
+
+ sick-safetyscanners-base = self.callPackage ./sick-safetyscanners-base {};
+
  simple-actions = self.callPackage ./simple-actions {};
 
  simple-launch = self.callPackage ./simple-launch {};

--- a/distros/iron/laser-filters/default.nix
+++ b/distros/iron/laser-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, message-filters, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-laser-filters";
-  version = "2.0.6-r4";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/iron/laser_filters/2.0.6-4.tar.gz";
-    name = "2.0.6-4.tar.gz";
-    sha256 = "e6039bb00dcbe4ffb40095b455ec18f64a9b3ac37d1189415ecafac2acf159a5";
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/iron/laser_filters/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "3b2e5a94d00cf35904d82ea05bd57cd84c78127c611a02996f87583831242787";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/parameter-traits/default.nix
+++ b/distros/iron/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-parameter-traits";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "85a414a5a5bfe223d8e45e64e29281b924c96eaa6c5b2a6a13a1bab63905aa0e";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "d2b26fe850c77d8fff19f626e4f876eef3e5489daffa7bb79900761bd44cafd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-bringup/default.nix
+++ b/distros/iron/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-plansys2-bringup";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_bringup/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "289ca01aa856e839ee243101a937e21377837e37093947d09b877c33234d1af2";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_bringup/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "927bdbdee37b318cad0f392d6c1bf22a02f2a4eeaa27569d9dfe2b8f6973b115";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-bt-actions/default.nix
+++ b/distros/iron/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-plansys2-bt-actions";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_bt_actions/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "ce33f97ae9b5275409d171cfadb48c7cf24802477d5fa50c5cc041f04fd7e21c";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_bt_actions/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "87531e07322ee85d31ecf4cb0f399ea0b2b03ae2ff1ffe5265c9063ec0ccf42e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-core/default.nix
+++ b/distros/iron/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-plansys2-core";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_core/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "0cb8a01cd8583d39ee75f4900351f6d70cdbecd852a23cacd2dc63fc8975895a";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_core/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "0dd3e30bd84b5b69725040acf5515d8380cd2423e89a59bf5c524e322798fefe";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-domain-expert/default.nix
+++ b/distros/iron/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-plansys2-domain-expert";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_domain_expert/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "cc4dec20eb764b51ab98b44a678b931ed71f84abb98a27b2487edb8b03adb562";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_domain_expert/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "896508e829c1fcddac05af53db8bdcbd4c3ea1dfaec565ad929cfeea66e8b59a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-executor/default.nix
+++ b/distros/iron/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, pluginlib, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-plansys2-executor";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_executor/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "5ddbc3d808bfd04e1d240d2bab53012a6f022075b70176f693065acaa8dcdfb1";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_executor/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "70a178e88444303458144b4461919539267406c4ba2de507ffd5c37e62b7b990";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-lifecycle-manager/default.nix
+++ b/distros/iron/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-plansys2-lifecycle-manager";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_lifecycle_manager/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "b173b88225355cf64fb9ea33e593dcc875e8b193acf6ba289459965ed93f0f41";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_lifecycle_manager/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "50d785dc3ddd7674a1d7f524e6505f951be037015875e4126e6c8a0765668f0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-msgs/default.nix
+++ b/distros/iron/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-plansys2-msgs";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_msgs/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "67fffe446b14bf2523aa88a4534eafdcb983e6a64f94b7c081905b25d40a621d";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_msgs/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "957841ffa743c85fe3df16da52e94afa81bcd1bf1d1407a2fbee740201858ed8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-pddl-parser/default.nix
+++ b/distros/iron/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-plansys2-pddl-parser";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_pddl_parser/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "506665575fea2ca48b4136b1bdff58bad64211a2d5d6299b1d48f08a5a8fdca8";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_pddl_parser/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "a12e27cf2b90a766500496fb20687128a409841d12404127dd97533964f0ff13";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-planner/default.nix
+++ b/distros/iron/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-plansys2-planner";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_planner/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "13e57dd4db97ae47928b29e372a1c81f5ddd46c2a69cf2353c08d1ab0cbe6f37";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_planner/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "bdd59dae73c83f53388b5e53dfbfa75d856322c522aac5f893a51f5e920ee36a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-popf-plan-solver/default.nix
+++ b/distros/iron/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-iron-plansys2-popf-plan-solver";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_popf_plan_solver/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "c6a8caeb7dc5bc2de38ab45874c0ed4edc1fd3a5c253e850ae0956e8702395cd";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_popf_plan_solver/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "5a3015aa06b5a027e7a091c0eed5851e96898f96b6e450e6fe01f4debed8255a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-problem-expert/default.nix
+++ b/distros/iron/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, qt5, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-plansys2-problem-expert";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_problem_expert/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "74bba957c59ecf2d8a385c5222809a715a775303de7ccabeb145ce77b3211374";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_problem_expert/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "085d31fa82d9e715a72a2ab7f4ff5e5c118bb7958e60103ba0b9545859dc506b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-terminal/default.nix
+++ b/distros/iron/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-iron-plansys2-terminal";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_terminal/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "597542d9dfb568f0fa35e8fd102a9644eaaccb9e6da69e75b689ba7799d3fefc";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_terminal/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "a37ba6b2dac431b68621fd7c8e75e23edeccba80cd470774d29776bf56068cfd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-tests/default.nix
+++ b/distros/iron/plansys2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-plansys2-tests";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_tests/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "0fc76f0618ef6258a07e7f067549206b4b889477cd54e0d8362ba2970707f918";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_tests/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "1a59e8a4f9b440683fd29fbbd48da68084f90fc84d7702fe21e392edd402984f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plansys2-tools/default.nix
+++ b/distros/iron/plansys2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, qt5, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
 buildRosPackage {
   pname = "ros-iron-plansys2-tools";
-  version = "2.0.10-r1";
+  version = "2.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_tools/2.0.10-1.tar.gz";
-    name = "2.0.10-1.tar.gz";
-    sha256 = "f0ebb4d1cbcae3807f7536a8d0ce076c6f9c5f9459bce9981470cf98165bd793";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/iron/plansys2_tools/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "d11d5da69309261039d25f2df79c433b6c4791492ac7a0fd4ce3aaeb6a8173f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-assimp-vendor/default.nix
+++ b/distros/iron/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-iron-rviz-assimp-vendor";
-  version = "12.4.1-r1";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.1-1.tar.gz";
-    name = "12.4.1-1.tar.gz";
-    sha256 = "a6657401a740cfb552f81a9fd79cf31c00ab96e3c084e973baba753a8d1aaee8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "0fba733c5d70d007b7828bba0aef5b922385d4a1a7c557335e6495a3a068c883";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-default-plugins/default.nix
+++ b/distros/iron/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz-default-plugins";
-  version = "12.4.1-r1";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.1-1.tar.gz";
-    name = "12.4.1-1.tar.gz";
-    sha256 = "b99d64827f466962c0e54a72ea8e8d0c6f484c16f36800f8439dc30c91593114";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "bd5bd746ed8b77e7e8353570724cc992b079e5e29d354f3987fa1b28e61b67c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-ogre-vendor/default.nix
+++ b/distros/iron/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-iron-rviz-ogre-vendor";
-  version = "12.4.1-r1";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.1-1.tar.gz";
-    name = "12.4.1-1.tar.gz";
-    sha256 = "c038d7c8cf4e069fc8b886cba54388fa4c042d945782e900db3d67733023a053";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "22dffea3ad690bba525a8a87bb7b17419f966c54c36d25c47d39a5331a77a7ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering-tests/default.nix
+++ b/distros/iron/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering-tests";
-  version = "12.4.1-r1";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.1-1.tar.gz";
-    name = "12.4.1-1.tar.gz";
-    sha256 = "07d55d65fcb7bc75bf818de550d2fe1a7da1d8cc5e73a574b53f42c39bdddda0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "cb11f6db54f7374f13789c5f038b6c7cdf86a77ed70c07baeffc4759e6de0e29";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering/default.nix
+++ b/distros/iron/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering";
-  version = "12.4.1-r1";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.1-1.tar.gz";
-    name = "12.4.1-1.tar.gz";
-    sha256 = "83bc1089f6cb0a679594e1f9ce57d321560edbab7bf02bdb3d44c52a7948c109";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "98ebbccc724e9ea8efa133df05cddcdba230dc0939272e3920442724a078b099";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-visual-testing-framework/default.nix
+++ b/distros/iron/rviz-visual-testing-framework/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rviz-visual-testing-framework";
-  version = "12.4.1-r1";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.1-1.tar.gz";
-    name = "12.4.1-1.tar.gz";
-    sha256 = "1609a66ef1fbb6cb6b955cc1300c1783163f4c2b0341ea1b29a50472c9c5ffba";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "17d6955636f4fcfaae7991cf6a0e0ee08544b650b56d8abf715f9afd2865624d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake qt5.qtbase ];
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-cmake-gtest rcutils rviz-common ];
+  propagatedBuildInputs = [ ament-cmake-gtest geometry-msgs rclcpp rcutils rviz-common rviz-ogre-vendor rviz-rendering std-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/rviz2/default.nix
+++ b/distros/iron/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz2";
-  version = "12.4.1-r1";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.1-1.tar.gz";
-    name = "12.4.1-1.tar.gz";
-    sha256 = "3ad749483b981a7f75b529a4e49e12c6127851fb9c37534d06bb6c740bc22dcd";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "d33d1faa3b34d7a22e18200a3c6d12b21b7612070f37a2fc58f34b60836b0d11";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/sick-safetyscanners-base/default.nix
+++ b/distros/iron/sick-safetyscanners-base/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake }:
+buildRosPackage {
+  pname = "ros-iron-sick-safetyscanners-base";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/iron/sick_safetyscanners_base/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d1483b618ec1cfacb14af9ac89d5c50b0d0aa9da72420359da7b8581b2b1cb13";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Provides an Interface to read the sensor output of a SICK
+  Safety Scanner'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/iron/sick-safetyscanners2-interfaces/default.nix
+++ b/distros/iron/sick-safetyscanners2-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-iron-sick-safetyscanners2-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners2_interfaces-release/archive/release/iron/sick_safetyscanners2_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "102ec87fbc99cfd7f44ec444d21d09f403eedc64f7ea6d73977985ae136363b0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces for the sick_safetyscanners ros2 driver'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/iron/sick-safetyscanners2/default.nix
+++ b/distros/iron/sick-safetyscanners2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
+buildRosPackage {
+  pname = "ros-iron-sick-safetyscanners2";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/iron/sick_safetyscanners2/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "cce7051dcb2755066e5d70632839029dceed97456c26ae6f854db60193224894";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle sensor-msgs sick-safetyscanners-base sick-safetyscanners2-interfaces ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 Driver for the SICK safetyscanners'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "6ca2eeb9810839f50b1765660449b64241187e0915ef394d51af53ad25dc7ac1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "04d37e79fbfcc9e4d0d06f86ad78c0ed1ac3f9c94d9995c8e663362516c27d1b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "90e22b7cadfb6624a31bcd20604981d4e6071ba363bc9961a17fe376f11ee186";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "94ebec519ac5d8a172ad4c198c6e77b04cbc24a98195918cff8647e93baf9d8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-desktop/default.nix
+++ b/distros/noetic/dingo-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dingo-msgs, dingo-viz }:
 buildRosPackage {
   pname = "ros-noetic-dingo-desktop";
-  version = "0.1.2-r1";
+  version = "0.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/noetic/dingo_desktop/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "3dddb3f00733090f01f5f1cac43ff8e59dabdbad721894f2f075a03f44eed25c";
+    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/noetic/dingo_desktop/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "c09ce513a52ee854f6790b82aa2e941de03440fd007fa6b965c6f2e8a380fcc0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dingo-viz/default.nix
+++ b/distros/noetic/dingo-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dingo-description, joint-state-publisher-gui, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz }:
 buildRosPackage {
   pname = "ros-noetic-dingo-viz";
-  version = "0.1.2-r1";
+  version = "0.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/noetic/dingo_viz/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "497d7e7ee12c26a89bf1920f491b05d4321c0076525cb1a857c19d47836aec4c";
+    url = "https://github.com/clearpath-gbp/dingo_desktop-release/archive/release/noetic/dingo_viz/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "ff0e2dcf9179732c86e27f3a8b74aada8f4dcd1e18f4e828a405d7684f46be74";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "0798b96d22daf10fbc1c795c31479268faddb4bcb626be42364d1058ac2c74e0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "e4a919e9c2fdb4b87f615c011c31b5af88baab46bce4e41cdf2a6db347cd4a9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "4b25f1a4dbdfcc559d46c0f3e021aefb58bf5b4e2b04b330df2513b965748ecd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "8c2129cd8b8c0aec4a0a1d4088fdaa78beb4073f0a6a6e32256feb146b9e263d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "94e8b5e31cee69dc078f1703a7fe29601243784662e96b716f7726c5bccb2504";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "9e5dc2d748df703a199f05c1d90ad4173c2d0638454fa072626822167c85b355";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-catkin, python3, random-numbers, rosconsole, roslib, rostest, rostime, rosunit, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "e6141ce68aeeed737436f67254df4be1b6298542a77c766b727b5233053de1da";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "3166135415758d89ee8c4b84fd260a4b1a5ba1e20db918758645022ccf5bf442";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "78b2892a232ac6cc3a8d72af9f69102db10795cf04873396ab465b5b50e6edb2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "9c721596c68bc12cc0d9d905f97a09ac3c76cd97eefb5ddf5def64dc0666253a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "c63d9b2d34fd0b4c5f432e1f03d3a8526676f145f663e3d565d3d045085e4c83";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "5d12ebbb87b9d588290005476be1f2e006ec13033f77f1930495558d1f68ef7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "c07133b525023e0c5e543a19f12696b5e2874a44d02c185b13189823a5845222";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "fa949c1492881d5fa4e672536497d8c52d4fdfed08bd25ea548fcb0b516142c6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "5df31783cf14f5de8ab083b7ac1d7a366fd5c8e0be15e0d80b2c2edf759e5527";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "6085e3f4be3e4d49cb4af50b0c7e72b82d203cad6ae578d7709904107e851175";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "ee829e7aca898e73571b6eb8c9468946643dcff0ca7fcfc595d76bccc19c1742";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "63e45aff83cf851f55f20b867a55ed80b7b1083d4e43d31b29df6074ffbdce33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "d8c01b07f7b788ff56838498bed0ea512297ceaad604608f5ce6e757d4bf107d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "d8c23e36e12037ee22783ba0ff92a9112c2e75f73b8403977325b854c9cbcc7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "e9d143b063ea2f397a57e74ee1979d281402a37101e825b11525472951fd30d8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "2636f701c961f9b98b189deceb478d8aefdb783628351ea061d28103d1c89b10";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "e9d5a74b0dc4dba5d9f02444924c8db143cb16d79d27246e2ce34101f7c2abac";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "cb05644c51f5bd99bf65faa821afe49a395bd16a20230fc4745daadcfb5fc3c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "3b435aa6ad2cbe3b9aa4d63c6812a00ec8d54048464acfe588e3e03e538f33f4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "7bad3318fe200027350fe4b231a3a717b9de4269bd2eaf4aa35aa6190abcfd09";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "d41d4c0e239af3d983acec5bf39d7fbacfcfdb575472ebcfc55136e5dec2ee6c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "b4a488434e3ad1851a6a1e880b0135d90d060f9f1084e23c8716bb508a68621d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "a685e02b437ccd64244888e9c5c55737bc5e823c12d3379a95f84e7551d8cf59";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "65e2406c545734e7fd7e498a9fe76dd389ecc4003b066dfcc8a688b8dfd0b322";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-perception/default.nix
+++ b/distros/noetic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, nodelet, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-perception";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "a36e3443e81864176d88f3f9b4c92845c4086783694fc6858a58176f2f082c0e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "43bd545086e7b40b023e4a9b8904f5721954f512e8c717b2880625d9b7c74790";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "9acddac2b367120928943b095df60428a3b122002f0ff6a202880866f3efe45a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "f0e89173397d5b54923aaa3fb3e8b1c088fb3e538d2578d68b1a37d278effb18";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "1bcd9e5258ecc13f6965dbd1ca53e3e058f42f8755db4f37101d3d1e4af3b973";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "02aa01b73edaa7e4f581eed6587943c741c3b4e4b49e2d128fe178c5ee61213c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "b94e045f40c5cd9d93465f1a58be9f8af34696515954a7b81e02fb627784318d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "389ae8f5a83c9a27f805a505143651fe12f3ebb4854c02210a5d0b19614ae45b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "43768c7ee83871f8579be698b080b6fe04b9ceb1a9f21a5647750f93759092ee";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "e6ff67d377553263f126e09ec72990e7ffc5d59113b76a693ea3d7778a3cf291";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "4fc09a8b1c3ce8fadf34bb6c719eb566edf60fb8396efcbc3128f39d95a3cc35";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "c3420c99bc18d944ff39767020c511d4ea9c8a7f519404dc46bd07bc60f74b8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "0694e1e25380187785570df4873a56a400011dce06c966260e8c5c4480d3a3f5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "36af6c0c03d70de7a5b5a7a3d131dad57e966b0e516666d23fea6210f5fff894";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "6b20b45ff8080417524b0b04f72755e348a681161eeab7aca1a4d3fc328af9cc";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "9af173dc4807ea6084904370c5b7de64ce34df69fe81941550ab873758df141d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "c93c93b31c91b18d7f35182ab85e3f97f225e35b60364c03138979ada6fdbd44";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "dbbd29928415b6e5b0e5617d60036d231fd517fe66083e924992a375b16127e9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "4c9d55e0c48fbef68e050ad385888510352b79c79b4ff8b4940afe2e2f4fb12c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "a484660bd4e5fcd57ae16ea0729394091b329da7867ea5e94f2a30393ede27cc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "90f97b91cece0995eff38c894a148a4fb2d94d956da61d8e8a33a0705521739a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "bc535da9324f3ea700aaf2ebc11835fc4c4a69a0a7865b6af1381353c55fd2bd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "218c1e4c99fe785d4f01327f6955ab0bb45336cfdf1d80a76a67fc4a0d527541";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "f0b253d2e8634f3e65f58ec2da8712fbb368f942634f977a51b87cdd4e986803";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-2d";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "e222dadc83d2e91a6381850ab86ecc007a6f3f378a0c7a81188d7db13d7f6f6c";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "b238ee5edf8d0fb460d5901b47582c88a5e558d7717400e7a509af5edfc94f41";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-3d";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "8231c478387606b623e797662496f28e95c422e880bba8f65d2147636414d174";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "45fb658de4d254e72b5d8166f1455fb4e8cfbed8b0b9387c19a0baf130316a0e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-graphslam-2d/default.nix
+++ b/distros/noetic/mrpt-graphslam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-graphslam-2d";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "06961b4f93c3809ed67f77cc46e2446d77f06d4c9f5c20b2a73f196842b9eaff";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "b4e3f94b04b943a132a13de09c63bd25df0c5cfc965139ef08584e1180d1b499";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-icp-slam-2d/default.nix
+++ b/distros/noetic/mrpt-icp-slam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-icp-slam-2d";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "b5f5d8f1bd741174a4c172086c478e55b6c8f8913879e8b9d4f47b3e07e2b814";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "4a822f533518a530cc0a1930a8dbd0a47fb98f4ce7cee532cba5b3f83072c5b9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-rbpf-slam/default.nix
+++ b/distros/noetic/mrpt-rbpf-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rbpf-slam";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "c8231aba6b29528a3a00a05441bb2c84b53f79d95a1d70aa73e4b5bda3ad0bb1";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "3f550d49fc10db0a71c8b0dc230162e2675135397ce3b1b61fe1a764845ca267";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-slam/default.nix
+++ b/distros/noetic/mrpt-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-slam";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "3bd24356f9004e958fd934815c2412a5e6952a0ab7c993f7f951b2ee49398e08";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "03cd37d2b4de1dc86713b1718c95e56a5be89f8fda631f93403d0582fdd13b24";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "dacf7d79f4a1c1ad6de62ad2db641242f1d076ac7a708f46901049011d8fd411";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "9e7e3d82aa0a76bb1987634ea746ed0d9a985f5f5eadcc561a146beb4fa7ad27";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "a8fdfd364b33f3853e342b8e2e2c92fd6ee39b8c89e3cef00438ba65c39ef5c8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "4a16be83340fdbbabe91eaddfc174c3097c2802334c8250d64de028503f19b1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "01c44f44ce7cc94f24b5e224821dc5b98aa56cd1f2819b9812eb0dcb82acba9e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "c0d023de47115acfb4382e50ce1f37b9904630b5c6c4631bd47f7b57ee4c7b1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "7799f375c193351cf59f227fbcde9eda9c8ceab162622aaf35a3f96025e3f058";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "0ad032bd5e2c1377dae874d7d78114cc311472ee5cc1def7006798b8badb01ef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "7481b1f88ed042ca1978d26a97d79e1dcdd1aa549a64ad21e280eda87014aae2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "3f072f485b1ee8e8d6b83d7eb557e7063def2376f28768bd654e0344f9d40e66";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner";
-  version = "1.1.12-r1";
+  version = "1.1.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.12-1.tar.gz";
-    name = "1.1.12-1.tar.gz";
-    sha256 = "7ab87e93f40ac97d26f1c910757540df2caf2aff661f37085d659c8c83e2fe1b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.13-2.tar.gz";
+    name = "1.1.13-2.tar.gz";
+    sha256 = "48409e4ba19c70b7f374b70f9e780d602617fe25a46a9e80c63ce00a1edb0e4a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "b429b9cd79a8ced1cb20b4f7a686d82a46ef74d76b736e38b3354743c6efffac";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "3cd589c6d5c17737b2677e381fad8e15402bfcb9fa272ae51a047cd441a91501";
   };
 
   buildType = "catkin";

--- a/distros/noetic/point-cloud2-filters/default.nix
+++ b/distros/noetic/point-cloud2-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, filters, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-point-cloud2-filters";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ADVRHumanoids/point_cloud2_filters-release/archive/release/noetic/point_cloud2_filters/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "59aca0f3d7358cc45d0218ec59036765ac29219a469e170ef0c01b4c9e054c0b";
+    url = "https://github.com/ADVRHumanoids/point_cloud2_filters-release/archive/release/noetic/point_cloud2_filters/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "2d850891e224b1416a67e4087e55302cadfd6928eedfd99385ddccd59e5c8cd4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-hand-control/default.nix
+++ b/distros/noetic/qb-hand-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-hand-control";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_control/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "98835f987ad007fa4bc682d1c8db4e6c7b1f1808893c6d2a4b9e04138816a676";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_control/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "358b66e1b565cd3b2c956184973595dc8a2791f21a09eafc27005be363df3217";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-hand-description/default.nix
+++ b/distros/noetic/qb-hand-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-hand-description";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_description/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "238565902edb69c79a2cfd59a536f570c2fc1103cc8562d2d8dfea5ac3fad114";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_description/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "ca55da147352f5eacad5cf2f80c4ed082fa8b8dbcb68d8077dd00d89e671bcfe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-hand-gazebo/default.nix
+++ b/distros/noetic/qb-hand-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, qb-device-gazebo, qb-device-hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-hand-gazebo";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_gazebo/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "b45e409b6786b345281ed396d76e4fdd1976fbe9beab46d98dfe02b9a4416214";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_gazebo/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "abb679af37693a40dbdb1e0a359dd3d695683571066fa751c4cce1eed2f4aebb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-hand-hardware-interface/default.nix
+++ b/distros/noetic/qb-hand-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, qb-device-hardware-interface, roscpp, transmission-interface }:
 buildRosPackage {
   pname = "ros-noetic-qb-hand-hardware-interface";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_hardware_interface/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "a91b53d027cfa0364a66cb84b19d7a0dacaea02967ecf59517031b0c7d43d13a";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand_hardware_interface/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "28f9763028d6a5f79e3a16f7b50a730dbb635f6cb740e2bb57fec42090784030";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-hand/default.nix
+++ b/distros/noetic/qb-hand/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-hand-control, qb-hand-description, qb-hand-gazebo, qb-hand-hardware-interface }:
 buildRosPackage {
   pname = "ros-noetic-qb-hand";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "347e138a200c4edad413c86a64153b027e71616c6f90e65bd238fd8a6c034bb7";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/noetic/qb_hand/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "53b09e175a8947e65300f51a4d69cb44ec4570ebfa28b0f7719ae3ed716361a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "c6b11e4dbbf098b764196ee63bd6d99c052b42a1da8575caa8549ee5964cb18f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "692d195266ae18d8b5135fcee7e263f8c081a36cef168a00c6a57aaafc47f965";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "f879ad3bd027e3f19fb80aa6fbbcb41ff3ba19d4ce6a2bc1b948221f1b242648";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "c06c9901c705131b2ac9e23f95045909e2f08d8805d1cc44a150a44a8cb4526e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.14.1-r1";
+  version = "0.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "5ad37173dd4a8526f7cfcdb54b68bcb1478145c4618608712db67bef0d673c88";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "522a45c629455ea2198212718ffc7f6f1d122a7974ea45eef1936f32a4b42c2f";
   };
 
   buildType = "catkin";

--- a/distros/rolling/event-camera-msgs/default.nix
+++ b/distros/rolling/event-camera-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-event-camera-msgs";
+  version = "1.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_msgs-release/archive/release/rolling/event_camera_msgs/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "69cd21779d220d9f22921b6eee6c396074772e1fb996d86fb0c84b4a9b16b5e7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = ''messages for event based cameras'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/rolling/generate-parameter-library-example/default.nix
+++ b/distros/rolling/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-example";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "e48f975e1ce20e67be24b354ef0cdb5d804a46af783088b3ccc307e57d33d6ee";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "9ab0b0d9763442d0c6a384c60a2021d0f83f014267c7c5702aa51fc9e6763ce8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-library-py/default.nix
+++ b/distros/rolling/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-py";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "3fdde385bc532946bf79cf1ee2c91a058c975d7c12d8bbbbe00f5dc0822a876f";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "34bd8c1faf74e409029cf1ad46606026353c6b2c65aef8c427c317531a3bd2b9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generate-parameter-library/default.nix
+++ b/distros/rolling/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "d85ff973da80725e15e432f31aa55126fd39b29db62e942e7e0e3e579137d578";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "68c6b0bf40199ab2f4620458a6be56cc02a36bc58fd11d9c45be166838372bd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-module-example/default.nix
+++ b/distros/rolling/generate-parameter-module-example/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-module-example";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_module_example/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "deb744855e1f2666c9261d29ae58e0369af12e5e7979ded31bafd03072b7db08";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_module_example/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "44e0beed2cd6bcee023dcfd8bbf6c79f19670775d65e08abe42ef04aabdc5d73";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  propagatedBuildInputs = [ generate-parameter-library generate-parameter-library-py rclpy ];
 
   meta = {
     description = ''Example usage of generate_parameter_library for a python module'';

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -436,6 +436,8 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ event-camera-msgs = self.callPackage ./event-camera-msgs {};
+
  example-interfaces = self.callPackage ./example-interfaces {};
 
  examples-rclcpp-async-client = self.callPackage ./examples-rclcpp-async-client {};
@@ -957,6 +959,14 @@ self: super: {
  nao-command-msgs = self.callPackage ./nao-command-msgs {};
 
  nao-lola = self.callPackage ./nao-lola {};
+
+ nao-lola-client = self.callPackage ./nao-lola-client {};
+
+ nao-lola-command-msgs = self.callPackage ./nao-lola-command-msgs {};
+
+ nao-lola-conversion = self.callPackage ./nao-lola-conversion {};
+
+ nao-lola-sensor-msgs = self.callPackage ./nao-lola-sensor-msgs {};
 
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
 

--- a/distros/rolling/laser-filters/default.nix
+++ b/distros/rolling/laser-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, message-filters, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-laser-filters";
-  version = "2.0.6-r3";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/rolling/laser_filters/2.0.6-3.tar.gz";
-    name = "2.0.6-3.tar.gz";
-    sha256 = "1e49d5fee03a08e758f2a53ee06dfec245115b5f100dcb1ae6822cd389e8aded";
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/rolling/laser_filters/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "2c5dc97727bd88484c993a288136e6e66a7f1feafe31aae13c6835a220427df0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nao-button-sim/default.nix
+++ b/distros/rolling/nao-button-sim/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, nao-sensor-msgs, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, nao-lola-sensor-msgs, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-nao-button-sim";
-  version = "0.1.1-r4";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_button_sim-release/archive/release/rolling/nao_button_sim/0.1.1-4.tar.gz";
-    name = "0.1.1-4.tar.gz";
-    sha256 = "3b815d3335333cda164deacf7208b4ea367e98e125844d4a832dbcbe4c8b3bc0";
+    url = "https://github.com/ros2-gbp/nao_button_sim-release/archive/release/rolling/nao_button_sim/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fcce4aedc76b057cce39fe6350429e16218438b40f5cfea44a13b42596ffeae1";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ nao-sensor-msgs ];
+  propagatedBuildInputs = [ nao-lola-sensor-msgs ];
 
   meta = {
     description = ''Allows simulating button presses through command line interface'';

--- a/distros/rolling/nao-command-msgs/default.nix
+++ b/distros/rolling/nao-command-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nao-command-msgs";
-  version = "0.0.4-r3";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_interfaces-release/archive/release/rolling/nao_command_msgs/0.0.4-3.tar.gz";
-    name = "0.0.4-3.tar.gz";
-    sha256 = "5ed07e8b7e65364fd36fe9d9925a440e618d9c667ad087657824619b4bdb3346";
+    url = "https://github.com/ros2-gbp/nao_interfaces-release/archive/release/rolling/nao_command_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "07c284423eb2d71675650db77f2f1efd9ee5a2b252f93553bebe14d48aaef8ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nao-lola-client/default.nix
+++ b/distros/rolling/nao-lola-client/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-lola-command-msgs, nao-lola-sensor-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-rolling-nao-lola-client";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_client/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "6609c54654e6b33ed42e10d23871a0740f5713005a3ae2409871505021df9524";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost nao-lola-command-msgs nao-lola-sensor-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Packages that allow communicating with the NAO's Lola middle-ware.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/nao-lola-command-msgs/default.nix
+++ b/distros/rolling/nao-lola-command-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-nao-lola-command-msgs";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_command_msgs/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "e0c45f9d2769ef8806400d88624fabc00b23cfbeff270f3ee40a43acc317763f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package defining command msgs to be sent to NAO robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/nao-lola-conversion/default.nix
+++ b/distros/rolling/nao-lola-conversion/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, message-filters, nao-lola-sensor-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-nao-lola-conversion";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_conversion/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "3eb1d5c930e1c11454a41654effc5126fcc17a6a5633006a4d8d0363c93ac7a5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ message-filters nao-lola-sensor-msgs rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A package that converts Nao Lola messages to / from common ROS interfaces'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/nao-lola-sensor-msgs/default.nix
+++ b/distros/rolling/nao-lola-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-nao-lola-sensor-msgs";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_sensor_msgs/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "aaeada4360aa23a916046001c7cb4842bdf9a18e07403910483ddfac47597dbc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package defining sensor msgs to be received from NAO robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/nao-lola/default.nix
+++ b/distros/rolling/nao-lola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-nao-lola";
-  version = "0.3.1-r1";
+  version = "1.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "1cb69731328dda40eea84ccfc9c046a8fc8ff91788811975100846805fe03e97";
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "171fccbd4272d8645fe9a25dec4cd8538f46dc28f2c422a6b6a36290575461dd";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Packages that allow communicating with the NAO’s Lola middle-ware.'';
+    description = ''Packages that allow communicating with the NAO's Lola middle-ware.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/rolling/nao-sensor-msgs/default.nix
+++ b/distros/rolling/nao-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-nao-sensor-msgs";
-  version = "0.0.4-r3";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_interfaces-release/archive/release/rolling/nao_sensor_msgs/0.0.4-3.tar.gz";
-    name = "0.0.4-3.tar.gz";
-    sha256 = "759b9727be6f8e3d75def5a3c5e52e55f44ab792f01ca4fe75b9e2dd77bc40d6";
+    url = "https://github.com/ros2-gbp/nao_interfaces-release/archive/release/rolling/nao_sensor_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f2031e8b701c5ea62a538c9da9201e81550d25e366cc8a12aca9261f7ef71ffa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parameter-traits/default.nix
+++ b/distros/rolling/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-parameter-traits";
-  version = "0.3.4-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "2d6b184285946811287bc4b42a24934af09d82aa35a273f5fdd1eba459dbfe82";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "4e07975da1767a6709db9bb1793df3ff649b49e8ecc8b8f3585eba9dcde76528";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcss3d-nao/default.nix
+++ b/distros/rolling/rcss3d-nao/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nao-command-msgs, nao-sensor-msgs, rclcpp-components, rcss3d-agent, rcss3d-agent-msgs-to-soccer-interfaces, soccer-vision-3d-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nao-lola-command-msgs, nao-lola-sensor-msgs, rclcpp-components, rcss3d-agent, rcss3d-agent-msgs-to-soccer-interfaces, soccer-vision-3d-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcss3d-nao";
-  version = "0.1.1-r2";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_nao-release/archive/release/rolling/rcss3d_nao/0.1.1-2.tar.gz";
-    name = "0.1.1-2.tar.gz";
-    sha256 = "15be650adc9f4a2f5acf3455517fb622f57928728ec105f8d46800f623c53775";
+    url = "https://github.com/ros2-gbp/rcss3d_nao-release/archive/release/rolling/rcss3d_nao/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a6c0946b4247bddfa2cf288b75fa7592cb8a04095686ea728f16a05d602c2807";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs nao-command-msgs nao-sensor-msgs rclcpp-components rcss3d-agent rcss3d-agent-msgs-to-soccer-interfaces soccer-vision-3d-msgs ];
+  propagatedBuildInputs = [ geometry-msgs nao-lola-command-msgs nao-lola-sensor-msgs rclcpp-components rcss3d-agent rcss3d-agent-msgs-to-soccer-interfaces soccer-vision-3d-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "12.7.0-r1";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/12.7.0-1.tar.gz";
-    name = "12.7.0-1.tar.gz";
-    sha256 = "465328ee3a74c21680e2710302fa9f6952f1b326df968b7da5a94c2dfb2b6876";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "cc0ba36fffc91178a5359e1a198edc18a93768ae96b6d8970428f8ee444a20b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "12.7.0-r1";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/12.7.0-1.tar.gz";
-    name = "12.7.0-1.tar.gz";
-    sha256 = "7418230f8399d3d2ce140efd6582ba1358497ad26316af5b771291f187e534b4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "1419b649a448b1a7791ee4105d86995f79794e26519bc5992e3ab10156f3d2c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "12.7.0-r1";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/12.7.0-1.tar.gz";
-    name = "12.7.0-1.tar.gz";
-    sha256 = "3de4b4527499256c25c1d470a2fb761ba7437bbf758f8e305115ee3a044c11ed";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "77b097fdf77d7f19288f0881dce70638606453d0bebd43f0039e1b55141bfd27";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "12.7.0-r1";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/12.7.0-1.tar.gz";
-    name = "12.7.0-1.tar.gz";
-    sha256 = "6a5660e63ae723b454559cb8755c1f37737243f37dfad03b4b32061b65eb462e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "d93800ae1705644fc8fd45886b6764588508d2602fe645add62d3052484b7d43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "12.7.0-r1";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/12.7.0-1.tar.gz";
-    name = "12.7.0-1.tar.gz";
-    sha256 = "507dd4aeb48acbdb4916770712aa500fb1ea042f1874394a8ff6654855df90c1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "72ddd6e9dfa555aaa6be2a6b16f9ed2fadfda8aac87822d1370b9426b9fefad0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "12.7.0-r1";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/12.7.0-1.tar.gz";
-    name = "12.7.0-1.tar.gz";
-    sha256 = "0aa88179b3986619021e1c209f32224c507c05ce613d921073cb5ef0789a431a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "6062a5b061cf29824d9a8d8a9ae4e8004b3a3d41e0d930faa278132540bae456";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "12.7.0-r1";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/12.7.0-1.tar.gz";
-    name = "12.7.0-1.tar.gz";
-    sha256 = "c4f5910d94d1c4a9db7cc74b96276eccec306fec0536257319d1446ad090268b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "34c2f4ca720c9b1256f0f4c4af46c2a817d02482e2376098d91e85cd9e653060";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit c89eed8b34d2947c851df29c09c1cb444282b63e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 0.0.8-r1 --> 0.0.9-r1*
* *clearpath-config 0.0.4-r1 --> 0.0.5-r1*
* *clearpath-control 0.0.8-r1 --> 0.0.9-r1*
* *clearpath-description 0.0.8-r1 --> 0.0.9-r1*
* *clearpath-generator-common 0.0.8-r1 --> 0.0.9-r1*
* *clearpath-mounts-description 0.0.8-r1 --> 0.0.9-r1*
* *clearpath-nav2-demos 0.0.1-r1 --> 0.0.2-r1*
* *clearpath-platform 0.0.8-r1 --> 0.0.9-r1*
* *clearpath-platform-description 0.0.8-r1 --> 0.0.9-r1*
* *clearpath-sensors-description 0.0.8-r1 --> 0.0.9-r1*
* *crane-plus 2.0.0-r1*
* *crane-plus-control 2.0.0-r1*
* *crane-plus-description 2.0.0-r1*
* *crane-plus-examples 2.0.0-r1*
* *crane-plus-gazebo 2.0.0-r1*
* *crane-plus-moveit-config 2.0.0-r1*
* *event-camera-msgs 1.1.4-r1*
* *flexbe-behavior-engine 2.3.2-r1*
* *flexbe-core 2.3.2-r1*
* *flexbe-input 2.3.2-r1*
* *flexbe-mirror 2.3.2-r1*
* *flexbe-msgs 2.3.2-r1*
* *flexbe-onboard 2.3.2-r1*
* *flexbe-states 2.3.2-r1*
* *flexbe-testing 2.3.2-r1*
* *flexbe-widget 2.3.2-r1*
* *flir-camera-description 2.0.0-r1 --> 2.0.3-r1*
* *flir-camera-msgs 2.0.0-r1 --> 2.0.3-r1*
* *generate-parameter-library 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-library-example 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-library-py 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-module-example 0.3.4-r1 --> 0.3.6-r1*
* *laser-filters 2.0.6-r2 --> 2.0.7-r1*
* *metavision-driver 1.0.1-r2*
* *parameter-traits 0.3.4-r1 --> 0.3.6-r1*
* *rviz-assimp-vendor 11.2.6-r1 --> 11.2.7-r1*
* *rviz-default-plugins 11.2.6-r1 --> 11.2.7-r1*
* *rviz-ogre-vendor 11.2.6-r1 --> 11.2.7-r1*
* *rviz-rendering 11.2.6-r1 --> 11.2.7-r1*
* *rviz-rendering-tests 11.2.6-r1 --> 11.2.7-r1*
* *rviz-visual-testing-framework 11.2.6-r1 --> 11.2.7-r1*
* *rviz2 11.2.6-r1 --> 11.2.7-r1*
* *spinnaker-camera-driver 2.0.0-r1 --> 2.0.3-r1*

Iron Changes:
-------------
* *generate-parameter-library 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-library-example 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-library-py 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-module-example 0.3.4-r1 --> 0.3.6-r1*
* *laser-filters 2.0.6-r4 --> 2.0.7-r1*
* *parameter-traits 0.3.4-r1 --> 0.3.6-r1*
* *plansys2-bringup 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-bt-actions 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-core 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-domain-expert 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-executor 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-lifecycle-manager 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-msgs 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-pddl-parser 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-planner 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-popf-plan-solver 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-problem-expert 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-terminal 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-tests 2.0.10-r1 --> 2.0.11-r1*
* *plansys2-tools 2.0.10-r1 --> 2.0.11-r1*
* *rviz-assimp-vendor 12.4.1-r1 --> 12.4.2-r1*
* *rviz-default-plugins 12.4.1-r1 --> 12.4.2-r1*
* *rviz-ogre-vendor 12.4.1-r1 --> 12.4.2-r1*
* *rviz-rendering 12.4.1-r1 --> 12.4.2-r1*
* *rviz-rendering-tests 12.4.1-r1 --> 12.4.2-r1*
* *rviz-visual-testing-framework 12.4.1-r1 --> 12.4.2-r1*
* *rviz2 12.4.1-r1 --> 12.4.2-r1*
* *sick-safetyscanners-base 1.0.2-r1*
* *sick-safetyscanners2 1.0.3-r1*
* *sick-safetyscanners2-interfaces 1.0.0-r1*

Noetic Changes:
---------------
* *chomp-motion-planner 1.1.12-r1 --> 1.1.13-r2*
* *costmap-cspace 0.14.1-r1 --> 0.14.2-r1*
* *dingo-desktop 0.1.2-r1 --> 0.1.2-r2*
* *dingo-viz 0.1.2-r1 --> 0.1.2-r2*
* *joystick-interrupt 0.14.1-r1 --> 0.14.2-r1*
* *map-organizer 0.14.1-r1 --> 0.14.2-r1*
* *moveit 1.1.12-r1 --> 1.1.13-r2*
* *moveit-chomp-optimizer-adapter 1.1.12-r1 --> 1.1.13-r2*
* *moveit-core 1.1.12-r1 --> 1.1.13-r2*
* *moveit-fake-controller-manager 1.1.12-r1 --> 1.1.13-r2*
* *moveit-kinematics 1.1.12-r1 --> 1.1.13-r2*
* *moveit-planners 1.1.12-r1 --> 1.1.13-r2*
* *moveit-planners-chomp 1.1.12-r1 --> 1.1.13-r2*
* *moveit-planners-ompl 1.1.12-r1 --> 1.1.13-r2*
* *moveit-plugins 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-benchmarks 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-control-interface 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-manipulation 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-move-group 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-occupancy-map-monitor 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-perception 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-planning 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-planning-interface 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-robot-interaction 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-visualization 1.1.12-r1 --> 1.1.13-r2*
* *moveit-ros-warehouse 1.1.12-r1 --> 1.1.13-r2*
* *moveit-runtime 1.1.12-r1 --> 1.1.13-r2*
* *moveit-servo 1.1.12-r1 --> 1.1.13-r2*
* *moveit-setup-assistant 1.1.12-r1 --> 1.1.13-r2*
* *moveit-simple-controller-manager 1.1.12-r1 --> 1.1.13-r2*
* *mrpt-ekf-slam-2d 0.1.14-r1 --> 0.1.15-r1*
* *mrpt-ekf-slam-3d 0.1.14-r1 --> 0.1.15-r1*
* *mrpt-graphslam-2d 0.1.14-r1 --> 0.1.15-r1*
* *mrpt-icp-slam-2d 0.1.14-r1 --> 0.1.15-r1*
* *mrpt-rbpf-slam 0.1.14-r1 --> 0.1.15-r1*
* *mrpt-slam 0.1.14-r1 --> 0.1.15-r1*
* *neonavigation 0.14.1-r1 --> 0.14.2-r1*
* *neonavigation-common 0.14.1-r1 --> 0.14.2-r1*
* *neonavigation-launch 0.14.1-r1 --> 0.14.2-r1*
* *obj-to-pointcloud 0.14.1-r1 --> 0.14.2-r1*
* *pilz-industrial-motion-planner 1.1.12-r1 --> 1.1.13-r2*
* *pilz-industrial-motion-planner-testutils 1.1.12-r1 --> 1.1.13-r2*
* *planner-cspace 0.14.1-r1 --> 0.14.2-r1*
* *point-cloud2-filters 1.0.1-r1 --> 1.0.2-r1*
* *qb-hand 3.0.2-r1 --> 3.0.3-r1*
* *qb-hand-control 3.0.2-r1 --> 3.0.3-r1*
* *qb-hand-description 3.0.2-r1 --> 3.0.3-r1*
* *qb-hand-gazebo 3.0.2-r1 --> 3.0.3-r1*
* *qb-hand-hardware-interface 3.0.2-r1 --> 3.0.3-r1*
* *safety-limiter 0.14.1-r1 --> 0.14.2-r1*
* *track-odometry 0.14.1-r1 --> 0.14.2-r1*
* *trajectory-tracker 0.14.1-r1 --> 0.14.2-r1*

Rolling Changes:
----------------
* *event-camera-msgs 1.1.4-r1*
* *generate-parameter-library 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-library-example 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-library-py 0.3.4-r1 --> 0.3.6-r1*
* *generate-parameter-module-example 0.3.4-r1 --> 0.3.6-r1*
* *laser-filters 2.0.6-r3 --> 2.0.7-r1*
* *nao-button-sim 0.1.1-r4 --> 1.0.0-r1*
* *nao-command-msgs 0.0.4-r3 --> 1.0.0-r1*
* *nao-lola 0.3.1-r1 --> 1.1.0-r2*
* *nao-lola-client 1.1.0-r2*
* *nao-lola-command-msgs 1.1.0-r2*
* *nao-lola-conversion 1.1.0-r2*
* *nao-lola-sensor-msgs 1.1.0-r2*
* *nao-sensor-msgs 0.0.4-r3 --> 1.0.0-r1*
* *parameter-traits 0.3.4-r1 --> 0.3.6-r1*
* *rcss3d-nao 0.1.1-r2 --> 1.0.0-r1*
* *rviz-assimp-vendor 12.7.0-r1 --> 12.8.0-r1*
* *rviz-default-plugins 12.7.0-r1 --> 12.8.0-r1*
* *rviz-ogre-vendor 12.7.0-r1 --> 12.8.0-r1*
* *rviz-rendering 12.7.0-r1 --> 12.8.0-r1*
* *rviz-rendering-tests 12.7.0-r1 --> 12.8.0-r1*
* *rviz-visual-testing-framework 12.7.0-r1 --> 12.8.0-r1*
* *rviz2 12.7.0-r1 --> 12.8.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] hdf5-tools
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libqt5-svg
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-vcstool
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote
 * [ ] xsimd
 * [ ] xtensor

