### PR TITLE
rosdistro sync, Fri Aug  4 19:59:18 2023

### DIFF
--- a/distros/humble/ament-cmake-vendor-package/default.nix
+++ b/distros/humble/ament-cmake-vendor-package/default.nix
@@ -4,13 +4,13 @@
 
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
-  pname = "ros-iron-ament-cmake-vendor-package";
-  version = "2.0.3-r1";
+  pname = "ros-humble-ament-cmake-vendor-package";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_vendor_package/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "e3a0039ca358d245e6021bbb91e7261c793a93533142b12c2f6a16b7046cda42";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_vendor_package/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "d6173555eeb64eb83d31cc44e92702e068b09c141c912cde44f100c9bfaa8269";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -112,6 +112,8 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
+ ament-cmake-vendor-package = self.callPackage ./ament-cmake-vendor-package {};
+
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
@@ -1036,8 +1038,6 @@ self: super: {
 
  message-tf-frame-transformer = self.callPackage ./message-tf-frame-transformer {};
 
- metavision-driver = self.callPackage ./metavision-driver {};
-
  micro-ros-diagnostic-bridge = self.callPackage ./micro-ros-diagnostic-bridge {};
 
  micro-ros-diagnostic-msgs = self.callPackage ./micro-ros-diagnostic-msgs {};
@@ -1507,6 +1507,8 @@ self: super: {
  raspimouse-description = self.callPackage ./raspimouse-description {};
 
  raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
+
+ raspimouse-ros2-examples = self.callPackage ./raspimouse-ros2-examples {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -2011,6 +2013,8 @@ self: super: {
  rviz-2d-overlay-plugins = self.callPackage ./rviz-2d-overlay-plugins {};
 
  rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
+
+ rviz-common = self.callPackage ./rviz-common {};
 
  rviz-default-plugins = self.callPackage ./rviz-default-plugins {};
 

--- a/distros/humble/raspimouse-ros2-examples/default.nix
+++ b/distros/humble/raspimouse-ros2-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, v4l-utils }:
+buildRosPackage {
+  pname = "ros-humble-raspimouse-ros2-examples";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/humble/raspimouse_ros2_examples/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d17f48b74fd8e1b8babfdcb2fd6a41f41d5bf20b5e7e8d47ec6d47bfb19cdad7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs v4l-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Raspberry Pi Mouse examples'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.5-r1";
+  version = "11.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.5-1.tar.gz";
-    name = "11.2.5-1.tar.gz";
-    sha256 = "4f5eb768c59919ff132e7f4aababeb5ebd299db451d3b85c62010cccadbd763b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.7-1.tar.gz";
+    name = "11.2.7-1.tar.gz";
+    sha256 = "c6e0d36ebf10882ae9c61b39807f3b7ba815d884abaa13eb8ee8e12574fc9e8b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt5.qtbase rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros tinyxml2-vendor urdf yaml-cpp-vendor ];
+  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt5.qtbase qt5.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros tinyxml2-vendor urdf yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -102,6 +102,8 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
+ ament-cmake-vendor-package = self.callPackage ./ament-cmake-vendor-package {};
+
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
@@ -1765,6 +1767,8 @@ self: super: {
  rviz-2d-overlay-plugins = self.callPackage ./rviz-2d-overlay-plugins {};
 
  rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
+
+ rviz-common = self.callPackage ./rviz-common {};
 
  rviz-default-plugins = self.callPackage ./rviz-default-plugins {};
 

--- a/distros/iron/rviz-common/default.nix
+++ b/distros/iron/rviz-common/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-common";
-  version = "12.4.0-r2";
+  version = "12.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.0-2.tar.gz";
-    name = "12.4.0-2.tar.gz";
-    sha256 = "594698b65060a80a3bee90281ffa6e81b5394d8fc09e596b36ae2fc37f1761f0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.2-1.tar.gz";
+    name = "12.4.2-1.tar.gz";
+    sha256 = "8134a4548fa9b4daad3156ee63dbf73f5e1b169f88b955e302ba1f82a6e70076";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt5.qtbase rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros tinyxml2-vendor urdf yaml-cpp-vendor ];
+  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt5.qtbase qt5.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros tinyxml2-vendor urdf yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -2642,6 +2642,24 @@ self: super: {
 
  qb-move-hardware-interface = self.callPackage ./qb-move-hardware-interface {};
 
+ qb-softhand-industry = self.callPackage ./qb-softhand-industry {};
+
+ qb-softhand-industry-bringup = self.callPackage ./qb-softhand-industry-bringup {};
+
+ qb-softhand-industry-control = self.callPackage ./qb-softhand-industry-control {};
+
+ qb-softhand-industry-description = self.callPackage ./qb-softhand-industry-description {};
+
+ qb-softhand-industry-driver = self.callPackage ./qb-softhand-industry-driver {};
+
+ qb-softhand-industry-hardware-interface = self.callPackage ./qb-softhand-industry-hardware-interface {};
+
+ qb-softhand-industry-msgs = self.callPackage ./qb-softhand-industry-msgs {};
+
+ qb-softhand-industry-srvs = self.callPackage ./qb-softhand-industry-srvs {};
+
+ qb-softhand-industry-utils = self.callPackage ./qb-softhand-industry-utils {};
+
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
 
  qt-dotgraph = self.callPackage ./qt-dotgraph {};

--- a/distros/noetic/qb-softhand-industry-bringup/default.nix
+++ b/distros/noetic/qb-softhand-industry-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-bringup";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_bringup/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "fcf381a6f89df099e48bbdcd20c65fc446d9a4b739109314bcd217d273197ba5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains bringup utilities for qbrobotics® SoftHand Industry.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry-control/default.nix
+++ b/distros/noetic/qb-softhand-industry-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, qb-softhand-industry-hardware-interface, qb-softhand-industry-utils, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-control";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_control/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "66ea8d028817dc932afa0033028168773f44f35c8b572d48d0ee306f50250e62";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ combined-robot-hw controller-manager qb-softhand-industry-hardware-interface qb-softhand-industry-utils roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS control node for qbrobotics® SoftHand INdustry device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry-description/default.nix
+++ b/distros/noetic/qb-softhand-industry-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-description";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_description/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "91dcb24363564b11140bc07844b3c8d6c9acbf9c3ced3378672e330cb6c7d72a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS description for qbrobotics® SoftHand INdustry device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry-driver/default.nix
+++ b/distros/noetic/qb-softhand-industry-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qb-softhand-industry-srvs, qb-softhand-industry-utils, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-driver";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_driver/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "eeaf81137095e5e50a6f60d6a2dee1aa13814331a84d5884503b7288bd3f9556";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ qb-softhand-industry-srvs qb-softhand-industry-utils roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains communication interface for qbrobotics® SoftHand Industry.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry-hardware-interface/default.nix
+++ b/distros/noetic/qb-softhand-industry-hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, joint-limits-interface, qb-softhand-industry-msgs, qb-softhand-industry-srvs, roscpp, transmission-interface }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-hardware-interface";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_hardware_interface/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "283c6f5eaff8648bbfc5504297a8de5a562888a16a3393bf1eb29b72b6eb9847";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ control-toolbox hardware-interface joint-limits-interface qb-softhand-industry-msgs qb-softhand-industry-srvs roscpp transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the hardware interface for qbrobotics® SoftHand INdustry device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry-msgs/default.nix
+++ b/distros/noetic/qb-softhand-industry-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-msgs";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_msgs/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "7a93da3d20a36be7fd9273386f8ba0308969ad48584077ab5a147523fc435a56";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS messages for qbrobotics® SoftHand Industry.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry-srvs/default.nix
+++ b/distros/noetic/qb-softhand-industry-srvs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-softhand-industry-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-srvs";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_srvs/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "71162fc3f7929b4955bb55ae724dde8f8402b5bf1276dcffaf0ad6963799a4c6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ message-runtime qb-softhand-industry-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS services for qbrobotics® SoftHand Industry.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry-utils/default.nix
+++ b/distros/noetic/qb-softhand-industry-utils/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry-utils";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_utils/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "10d10faabf08997ecde9c0c2ba8a8b97d07d7376311cd7c0a5cd13c5c56849f9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains some utility functions for qbrobotics® SoftHand INdustry device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/qb-softhand-industry/default.nix
+++ b/distros/noetic/qb-softhand-industry/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qb-softhand-industry-control, qb-softhand-industry-description, qb-softhand-industry-hardware-interface, qb-softhand-industry-utils }:
+buildRosPackage {
+  pname = "ros-noetic-qb-softhand-industry";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "50ccae1b5840fa471232eadda461943143cd8479ef4b441a21b5d3764a9a2de6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ qb-softhand-industry-control qb-softhand-industry-description qb-softhand-industry-hardware-interface qb-softhand-industry-utils ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS interface for qbrobotics® SoftHand INdustry device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/ament-cmake-vendor-package/default.nix
+++ b/distros/rolling/ament-cmake-vendor-package/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, git }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-vendor-package";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "70394e6c53e781c962410bda2c59b10a9617c2f267e25935058930d70b742331";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "808a80dc54178802d8641bff6ac20c16ab739d29d11f9e9b8dbba482aeb5750d";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-test ];
-  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git ];
+  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
 
   meta = {
     description = ''Macros for maintaining a 'vendor' package.'';

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -102,6 +102,8 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
+ ament-cmake-vendor-package = self.callPackage ./ament-cmake-vendor-package {};
+
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
@@ -1651,6 +1653,8 @@ self: super: {
  rviz-2d-overlay-plugins = self.callPackage ./rviz-2d-overlay-plugins {};
 
  rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
+
+ rviz-common = self.callPackage ./rviz-common {};
 
  rviz-default-plugins = self.callPackage ./rviz-default-plugins {};
 

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "12.5.0-r2";
+  version = "12.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/12.5.0-2.tar.gz";
-    name = "12.5.0-2.tar.gz";
-    sha256 = "31f31364d439f243b490ad822e688072e35cacc89c96b4ba1993c07baf18af8b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/12.8.0-1.tar.gz";
+    name = "12.8.0-1.tar.gz";
+    sha256 = "f230d133553b7855d37b8d0bdd69bea9f46ff51d97a90f13df0e1b22a32f92c7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt5.qtbase rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros tinyxml2-vendor urdf yaml-cpp-vendor ];
+  propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt5.qtbase qt5.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros tinyxml2-vendor urdf yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 359c1c87608709cfa1c3e6a0bb6d5f0701ba82f6.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ament-cmake-vendor-package 1.3.5-r1*
* *raspimouse-ros2-examples 2.0.0-r1*
* *rviz-common 11.2.5-r1 --> 11.2.7-r1*

Iron Changes:
-------------
* *ament-cmake-vendor-package 2.0.2-r2 --> 2.0.3-r1*
* *rviz-common 12.4.0-r2 --> 12.4.2-r1*

Noetic Changes:
---------------
* *qb-softhand-industry 1.0.8-r3*
* *qb-softhand-industry-bringup 1.0.8-r3*
* *qb-softhand-industry-control 1.0.8-r3*
* *qb-softhand-industry-description 1.0.8-r3*
* *qb-softhand-industry-driver 1.0.8-r3*
* *qb-softhand-industry-hardware-interface 1.0.8-r3*
* *qb-softhand-industry-msgs 1.0.8-r3*
* *qb-softhand-industry-srvs 1.0.8-r3*
* *qb-softhand-industry-utils 1.0.8-r3*

Rolling Changes:
----------------
* *ament-cmake-vendor-package 2.2.0-r1 --> 2.2.1-r1*
* *rviz-common 12.5.0-r2 --> 12.8.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] hdf5-tools
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopencv-imgproc-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote
 * [ ] xsimd
 * [ ] xtensor

