### PR TITLE
rosbridge-library: Use PyMongo for BSON implementation

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -192,6 +192,14 @@ let
       '';
     });
 
+    rosbridge-library = rosSuper.rosbridge-library.override {
+      python3Packages = rosSuper.python3Packages.overrideScope (pySelf: pySuper: {
+        # Use PyMongo for BSON.
+        # https://github.com/RobotWebTools/rosbridge_suite/issues/198
+        bson = pySelf.pymongo;
+      });
+    };
+
     rqt-console = rosSuper.rqt-console.overrideAttrs ({
       nativeBuildInputs ? [], postFixup ? "", ...
     }: {


### PR DESCRIPTION
https://github.com/RobotWebTools/rosbridge_suite/issues/198

```
[rosbridge_websocket-1] Traceback (most recent call last):
[rosbridge_websocket-1]   File "/nix/store/0clz8waa2p2hg4d2v1d43i9wfz1lfr7s-ros-env/lib/python3.10/site-packages/rosbridge_library/util/__init__.py", line 13, in <module>
[rosbridge_websocket-1]     bson.BSON
[rosbridge_websocket-1] AttributeError: module 'bson' has no attribute 'BSON'
[rosbridge_websocket-1] 
[rosbridge_websocket-1] During handling of the above exception, another exception occurred:
[rosbridge_websocket-1] 
[rosbridge_websocket-1] Traceback (most recent call last):
[rosbridge_websocket-1]   File "/nix/store/0clz8waa2p2hg4d2v1d43i9wfz1lfr7s-ros-env/lib/rosbridge_server/rosbridge_websocket", line 41, in <module>
[rosbridge_websocket-1]     from rosbridge_library.capabilities.advertise import Advertise
[rosbridge_websocket-1]   File "/nix/store/0clz8waa2p2hg4d2v1d43i9wfz1lfr7s-ros-env/lib/python3.10/site-packages/rosbridge_library/capabilities/advertise.py", line 37, in <module>
[rosbridge_websocket-1]     from rosbridge_library.internal.publishers import manager
[rosbridge_websocket-1]   File "/nix/store/0clz8waa2p2hg4d2v1d43i9wfz1lfr7s-ros-env/lib/python3.10/site-packages/rosbridge_library/internal/publishers.py", line 38, in <module>
[rosbridge_websocket-1]     from rosbridge_library.internal import message_conversion, ros_loader
[rosbridge_websocket-1]   File "/nix/store/0clz8waa2p2hg4d2v1d43i9wfz1lfr7s-ros-env/lib/python3.10/site-packages/rosbridge_library/internal/message_conversion.py", line 44, in <module>
[rosbridge_websocket-1]     from rosbridge_library.util import bson
[rosbridge_websocket-1]   File "/nix/store/0clz8waa2p2hg4d2v1d43i9wfz1lfr7s-ros-env/lib/python3.10/site-packages/rosbridge_library/util/__init__.py", line 15, in <module>
[rosbridge_websocket-1]     raise Exception(
[rosbridge_websocket-1] Exception: BSON installation does not support all necessary features. Please use the MongoDB BSON implementation. See: https://github.com/RobotWebTools/rosbridge_suite/issues/198
```