### PR TITLE
rosdistro sync, Tue Aug  8 19:06:13 2023

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "69b0c02c92aa096136dd2a1d8be141dd46c65cc53901fb6a197e8ec0977ea782";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "e6055d5efb122d8f400f93155713811c42828ec416311f82b85e52b6f955b9f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "c3161873517a1475d08b058c93864eca9f8da95cf4b11a5f6f35a67e0cee5777";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "4d8ab20e64d9a52d41b1ecb631dd663d8a1b744b7f2949a425bdd4a660096e85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/aruco-opencv/default.nix
+++ b/distros/humble/aruco-opencv/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, libyamlcpp, python39Packages, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, python39Packages, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-aruco-opencv";
   version = "2.1.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport libyamlcpp python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-core/default.nix
+++ b/distros/humble/as2-core/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, libyamlcpp, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-core";
   version = "1.0.0-r2";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ];
-  propagatedBuildInputs = [ ament-cmake as2-msgs cv-bridge eigen geographic-msgs geographiclib geometry-msgs image-transport libyamlcpp nav-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-cmake as2-msgs cv-bridge eigen geographic-msgs geographiclib geometry-msgs image-transport nav-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-motion-controller/default.nix
+++ b/distros/humble/as2-motion-controller/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, libyamlcpp, pluginlib, rclcpp, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, tf2-geometry-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-controller";
   version = "1.0.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
-  propagatedBuildInputs = [ as2-core as2-motion-reference-handlers as2-msgs eigen gbenchmark geometry-msgs libyamlcpp pluginlib rclcpp tf2-geometry-msgs ];
+  propagatedBuildInputs = [ as2-core as2-motion-reference-handlers as2-msgs eigen gbenchmark geometry-msgs pluginlib rclcpp tf2-geometry-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "55b3726c2ee334d8f6d97a15b5c4f6850c71b7d127ec22c2ee69f87e702c0864";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "ef67abceaf223e005601021e676459d306e2cb1f3b1d11ce9afa57423567c630";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "18283f67abbd248fdfb75fdb635280d733bfeeaee538290478e9941d74fe69fc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "5fa99e2a6d585289a3fd4b06d8a516260933be54f198824c80a62406ba772b57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "786dd56f2c6d3eec21a8b9af2628bce54eaf49a256339d8450a44b077e4e78f5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "354914a5bce645dc89a7873acba36bdf7f70edad2056a25e283e290d60cb9ac1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/domain-bridge/default.nix
+++ b/distros/humble/domain-bridge/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, libyamlcpp, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, zstd-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, yaml-cpp, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-domain-bridge";
   version = "0.5.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common example-interfaces launch launch-testing launch-testing-ament-cmake rmw-connextdds rmw-cyclonedds-cpp rmw-fastrtps-cpp rmw-implementation-cmake rosgraph-msgs test-msgs ];
-  propagatedBuildInputs = [ libyamlcpp rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp zstd-vendor ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp yaml-cpp zstd-vendor ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "bcead1d719abea2400bdc6e73f23899ea0320a8dcf9c7084cde8dfd0b7f5e95b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "6764a5c52d07b2be1713e22f737e015b9abfe470087a9e41c7f76820823066a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "a5bc665e5d3fcb1bceb1dc3bea69639f9abc11c26ed760040a12342ed9e2bb5d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "e81d75506130f315473d1163561e4b4338c2165165cf5c9dc275fe0822a9c828";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "7501261e764859262248f186a4697dc709f05156364037e7187391b9f5398fa2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "6e2659eb8c6612390370d72640545be7756b4173d8dac65e8dc445b67afe1dc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "f493f82a2d10765c5f55022215a796c051721cfd34bff4df427d6adae35e2aa8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "688c1922245d62d360709d09b0341eada8c198805efec8b7eb3e5c5b1b30d452";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "15531cb1ae22f434bc76078cc63c9defffd492d0748db28b0ddd341e15e1cdaf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "90f3591761ea654c56ad314bf7f985750ebe4410266e8f6b2b66c4a2decfc2ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fastrtps";
-  version = "2.6.5-r1";
+  version = "2.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.5-1.tar.gz";
-    name = "2.6.5-1.tar.gz";
-    sha256 = "98990243a4732532b1f1b08d86b836c002c2c5ba6747560638d19c20fad97fed";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.6-1.tar.gz";
+    name = "2.6.6-1.tar.gz";
+    sha256 = "68ce3661e22ba7eaf48e0a276b3054fb3e7e59a386d978766b046eca6db23c40";
   };
 
   buildType = "cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "d0b9d3b4b518493aed96c73cb56dddf37f6737931f217e18818f6c59726fa3dd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "5aa86f25bddadcbd72e80262d5c25bb29741277ac6bb756642692df671f1f1cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "e7edd61313415f610c952790d4ad260b75b6a5b8675309f99ee4250c5a2729f0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "066ab413a8aca7e5f4ce5e81b68cb3e636a0d4578d67a68ee123dff680258a9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1508,7 +1508,13 @@ self: super: {
 
  raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
 
+ raspimouse-navigation = self.callPackage ./raspimouse-navigation {};
+
  raspimouse-ros2-examples = self.callPackage ./raspimouse-ros2-examples {};
+
+ raspimouse-slam = self.callPackage ./raspimouse-slam {};
+
+ raspimouse-slam-navigation = self.callPackage ./raspimouse-slam-navigation {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -2223,6 +2229,8 @@ self: super: {
  tf2-tools = self.callPackage ./tf2-tools {};
 
  tf-transformations = self.callPackage ./tf-transformations {};
+
+ theora-image-transport = self.callPackage ./theora-image-transport {};
 
  tiago-2dnav = self.callPackage ./tiago-2dnav {};
 

--- a/distros/humble/grid-map-pcl/default.nix
+++ b/distros/humble/grid-map-pcl/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, libyamlcpp, pcl, rclcpp, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pcl, rclcpp, rcutils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-grid-map-pcl";
   version = "2.0.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake grid-map-cmake-helpers ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros libyamlcpp pcl rclcpp rcutils ];
+  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros pcl rclcpp rcutils yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "53eb03a3b958e18b6fdc3cb701191643001a066423fb5ebef2cd8028e77a1350";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "172de240fea425eea6fb57d076a3a5abfd716819fb4b59a8eacdd3fa6b797e6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "92e68499b85fcadf2fc9bd9f0800639c893fe4db5be0bfa8da262813ca43c8c1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "941720d8ccaed1b221189f42dcc5c9aa94877912d2a46fe3be46f687dd78c39c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "16a11c007f8af33982364326c42d53e7ce294f4711f65311d0b21b5a97fddb9d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "0f04f00245fdb3e17d4b244dfab3a756e91adebd7d66ecd8aa56fcd7d6273f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-publisher-gui/default.nix
+++ b/distros/humble/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
 buildRosPackage {
   pname = "ros-humble-joint-state-publisher-gui";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/humble/joint_state_publisher_gui/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "63ced7d5e798e6ff8b3b61093cedbe80bd929c6ba2134a116681585cd92d03d4";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/humble/joint_state_publisher_gui/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "0ac35a2eb30efd52c2b5c8b6191df47c25d1757ea04478e70afbc272cb388c8c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/joint-state-publisher/default.nix
+++ b/distros/humble/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2topic, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-publisher";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/humble/joint_state_publisher/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f07ad473af6619aaafbdc59348da557ed6498cfbdb9a26e65a1987dbcbb270ee";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/humble/joint_state_publisher/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "e1389359bbe896208b525f5df096985bb18af8277e004b91688d4c98b092d225";
   };
 
   buildType = "ament_python";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "c7e44fb8a37de1209f7f13db75d241ffea500f23fb57948b4cc5340ff524ef61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "12230e32ee2f21ba2e0be2fd2da69a01c3a6ce0920680c2ed60af4bf78cc8333";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-fw/default.nix
+++ b/distros/humble/leo-fw/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, geometry-msgs, leo-msgs, libyamlcpp, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-leo-fw";
   version = "1.3.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python libyamlcpp ];
+  buildInputs = [ ament-cmake ament-cmake-python yaml-cpp ];
   propagatedBuildInputs = [ ament-index-python geometry-msgs leo-msgs nav-msgs python3Packages.dbus-python python3Packages.pyyaml python3Packages.whichcraft rclcpp rclcpp-components rclpy ros2cli sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/mapviz/default.nix
+++ b/distros/humble/mapviz/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, launch-xml, libyamlcpp, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, launch-xml, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-mapviz";
   version = "2.2.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config ];
-  propagatedBuildInputs = [ cv-bridge freeglut geometry-msgs glew image-transport launch-xml libyamlcpp mapviz-interfaces marti-common-msgs pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros xorg.libXi xorg.libXmu ];
+  propagatedBuildInputs = [ cv-bridge freeglut geometry-msgs glew image-transport launch-xml mapviz-interfaces marti-common-msgs pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros xorg.libXi xorg.libXmu yaml-cpp ];
   nativeBuildInputs = [ ament-cmake pkg-config qt5.qtbase ];
 
   meta = {

--- a/distros/humble/mavros-extras/default.nix
+++ b/distros/humble/mavros-extras/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-mavros-extras";
   version = "2.5.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python angles ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn libyamlcpp mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
 
   meta = {

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "58ff5c33f5fc87457324c215669b1f66f273ea026837ddbd582c4ea35b58ff99";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "4772d385f2f19e44175cc17a0ef3dea207987bcbac5404ad61e6bbd23f0131ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "0bcb864d5acdd03191795c4e4dbd70c7d3ab26c36698d3fd99ed1db5d0a9b166";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "5c20e6453e724ebdb677dfbbdd8b9795684c0d46f072f83902bf2cdb0b7e43b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "12edb43d3f4da9123864248d63654487e40c0ae07322c5a3110e29fa6c8614eb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "4934da1403d7d20baa1baba5884b0d0e7c6b22038001d0e95ed0b1ed74aecb62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "f3cf93144b7295c6f89169199580f552bd2c9d6a38829e84f1744fa2ec3e6d18";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "dff106028c99cf27e0a4d22ff790238aa948bc75fc307745948a9a5fe99ee238";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "b22cec9f161b1ea76a1d66ea3d69e8ba13533ebef7b432f510a4cc72525d73e9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "8c744c19538fb858eb83d908bdb8f8d3339d14945b4631a544d1bf573d402819";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "c4f3323259fed44144cb5db6798ee766685026a01cdbe8f1f225a2fb8a6699ba";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "0683ab82e71433ef64bfcc5676009698207fe73c41b9a8e0c86adede90336216";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "142aea73e3fa5a3955c882c2958a1bd1b03dd553d8d453ddcfe3c970285e1ca6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "75a01d866e23fc6fdc5ae0a6e55b69875786d65d889a2062008bc0314ae798fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "81719f709a06bae22de7f95d7f3c7902a32d3118edd545f9375c2f3d308a0324";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "5e1069dddebe908cd4827fd64936c465b4bb36ce2414bc090d13beceec3de81b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "d631beb5937a9822a7d36299fdd1548fdb2c8240551f51434038e53dc5d6a5ee";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "7afe57787817b32c2345b2772d0da17d06d6aab94d6573669a4ca17417f4608d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "1cf7e74f87e78c72b7825bee1073f837bcc7b3f91f78b9f238d758048f95bb97";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "e4cebb590924fae49146ad5adbac761c76c42fa3e076a6d88a05ac4ab2c2c0d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "7f691c6fe45846d9fa41374c717398b17f67d356e0c987843af2873e078670f5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "52d22123419993e735aaf6f69fdbe65cc3e0c6f5e12dd7f2148389881e7f4e48";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "a5c97c0117862acada5b2c39b719fe54a514ac760b63b6aca5cf4c8b800d305d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "41aac50d11d8769a875196694bc467bcf96cf2ec84e029eb3d0ed6ffb99b45e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "359810688bb6f5502b5fde55267d39e7d2d3287be5d0f34ef6464a270bd96b77";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "0727415d479fc6e03f7224f6109c7a47b87449c62a8ffe3e7dd85136d1668481";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "de633bc517bcffac84cddc5f60eba7c81072632209061e26670467ea05fca30f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d56af0acd4e036e464030873d6999daf164396879a7992e2dec2cc2eca2b0831";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "80caeae46edf6669ff2e6005a3cbe4d512fd8a08c5c958d28ed5a8da39f3e72d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d15d45ac4617ef1b822800dc7ba45d0168d093431bac1fa62b8e7159ee28c1d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "55596a49aa322347b2d595db566acabc119c3126583aa75caa5afcf3dfde7744";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "367ccb91bca1d5bb0d3913da3a4a8cdd665583ffcff4d8ac3251ba4badc8797f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "c6e5194c08dedc65c0028008b18defe750503f063ab4ca19e0622a7c1c63998e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "cba087c6295bfae89055b60fbec79f0c9ab61cc55ab06133f2babc9018f8c2ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "9fb4ac4d69c89e050ba15a0ea7b4e905ba4c8846532d16411b70f89021c7769c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "73e1566ca9fda8007a02fe308d6d631b8bd03f5f5f657457012f0ac4b14b4e06";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "d289b425ce5f7bc1e3ea1405031c881a739506dc4a6dc9d534587aa9cc1c7d65";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "f5f391cce895d8f9394ff80ae9cf966c7e1e8dc370087bdd398ae98fc995979e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "fe66aabdc36346956210eca8be2edd5be13f7147394844a8ed8247ea8ee8b9d5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "abe6ac60ceb647bbff6e3cf4bddbcf93b5a0e65d6b3048864c1d41eabc19e48c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "f9e839d1aa3d98ae0a178b9ac3d2b45d7ee3d9b15006bfb8cd445a2bbd84af50";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "076ae7691483c128f0925d3e1911df88ad892380a3757bfea701bb9306d93063";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "da48e98fc4d7b82c5388cf8ec85cfe8ab5674b2f2cf14804d15aa05f888eccef";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "b4c2cd6521ca8362cafdf21f46fce4cca07102dde2d3bed84e3b57b865c5ab51";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "27bf09aab1ceb475bdaa5bff9465b49889e5def79464a6cb676891c3fee7477d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "b986789db6c0022f658a3c7ad07ec9ae1b81d6439874db05bc452888c3728007";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "b9b5be3401d94d992d5fad6a30dd2fa0db46b37407233b315182566d44ca96a1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "aa065427f7c54455816e84e744fcaaaf10043bfcfeb89cc8dc73816f44a28199";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "c2595417b9b8f86a28fb7c50654bde157f36ed383a3ef8edc565fa53ebbef197";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "b1ba033a7ea93969f0b1614dfbf84936d670051fdf8ba65a6f86f90c13857401";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "ea54a42aaa2a302e287b98e21ba3b16ab6543ea3b0beec5116089798fcf1d423";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "0959eaf13b13a0a89d10c3ed42de35c4a9570994c3dbf66b439affdf653eaa60";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "1a099a226353b2c03febe1ab961f5ab5d0eab605f1096e7d8af559684322eba7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "21e1214813f50fb5b0d8e40364319776ff6e90dc8cf68dc9d4fce903cb887046";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "207055653a32f7a387e5ba2314b055cd8846f378681c448d26569bcb60135a82";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d00b110eb21f5bf764941f6046f458bdacdd4044c673bdd500ec0e705cfbca53";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "c638c153e1019d650fa5118cdb5a7d85634ecc6cf94bd73a30438e3ec5d2dde8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d7eefbc887593142db036784887251520155307111825aa14d9fcaa4fbdee897";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "35001662df8e6b42dba77f809aaa098a6bf6fdf3835a7a2ffcbb19b85a64912f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "37071cb91876a4120b5525d449cc96d4f362fafcd1ce59f37738f99c9e0e51a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "f807622da572d2f9d76851ade481137a32fd4a0083ebf8451c8c00aa3f334102";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "cb192af3c391326c909453dffc590b52c7aa687ce56cc779849a0fd8a0f3b065";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.8-r2";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.8-2.tar.gz";
-    name = "1.1.8-2.tar.gz";
-    sha256 = "9c7fed8b7567eca8f8aa8195897fd823b8dc3744a0f58bce8208a453e21f8668";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "a260342e79cd62407cff3b81f15f676ffe9db41f6f2d98e0ab4aca60afcdee59";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "84bf703ad51ff3b356f29631c6168d5365ec582353aafd16762e96da84e9525c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "e96012fc71356a2a93a1890efa3ea7a8c0e0e16499fb3bc205d98e30a1e992a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-navigation/default.nix
+++ b/distros/humble/raspimouse-navigation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, nav2-bringup, raspimouse, raspimouse-slam, rplidar-ros, rviz2, urg-node }:
+buildRosPackage {
+  pname = "ros-humble-raspimouse-navigation";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_navigation/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "346741fbad99e1bb73faaa57836685d9b075bc2d3498dd51e2d627d6d9507246";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hls-lfcd-lds-driver nav2-bringup raspimouse raspimouse-slam rplidar-ros rviz2 urg-node ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Navigation package for Raspberry Pi Mouse'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/raspimouse-slam-navigation/default.nix
+++ b/distros/humble/raspimouse-slam-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, raspimouse-navigation, raspimouse-slam }:
+buildRosPackage {
+  pname = "ros-humble-raspimouse-slam-navigation";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam_navigation/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "5a9489190a4b66b2ae957c592212ef587707e2cb170b0653f9214ff69ec5bd36";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ raspimouse-navigation raspimouse-slam ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''SLAM and navigation packages for Raspberry Pi Mouse V3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/raspimouse-slam/default.nix
+++ b/distros/humble/raspimouse-slam/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, joint-state-publisher, joy-linux, nav2-map-server, raspimouse, raspimouse-description, raspimouse-ros2-examples, robot-state-publisher, rplidar-ros, rviz2, slam-toolbox, urg-node, xacro }:
+buildRosPackage {
+  pname = "ros-humble-raspimouse-slam";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8bffec08cfe0808dbb3eea36d7393381628e1c0be7a4d32a23fbb5592c240d3d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hls-lfcd-lds-driver joint-state-publisher joy-linux nav2-map-server raspimouse raspimouse-description raspimouse-ros2-examples robot-state-publisher rplidar-ros rviz2 slam-toolbox urg-node xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''SLAM package for Raspberry Pi Mouse'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rmf-fleet-adapter/default.nix
+++ b/distros/humble/rmf-fleet-adapter/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, libyamlcpp, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-rmf-fleet-adapter";
   version = "2.1.6-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake eigen libyamlcpp ];
+  buildInputs = [ ament-cmake eigen yaml-cpp ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
   propagatedBuildInputs = [ nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/humble/rmf-traffic-editor/default.nix
+++ b/distros/humble/rmf-traffic-editor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, libyamlcpp, proj, qt5, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, proj, qt5, rmf-utils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-rmf-traffic-editor";
   version = "1.6.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-index-cpp eigen libyamlcpp qt5.qtbase rmf-utils ];
+  buildInputs = [ ament-cmake ament-index-cpp eigen qt5.qtbase rmf-utils yaml-cpp ];
   checkInputs = [ ament-cmake-uncrustify ];
   propagatedBuildInputs = [ ceres-solver glog proj ];
 

--- a/distros/humble/rmf-traffic-ros2/default.nix
+++ b/distros/humble/rmf-traffic-ros2/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, libyamlcpp, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-rmf-traffic-ros2";
   version = "2.1.6-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ libyamlcpp nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux zlib ];
+  propagatedBuildInputs = [ nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/robot-calibration/default.nix
+++ b/distros/humble/robot-calibration/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, libyamlcpp, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-robot-calibration";
   version = "0.8.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser libyamlcpp moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "4a671f30edb2cb51950bf8c7bd3ce759d3085f6691773bb08fe81257e401343e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "e6edc2db08ce6d7f6a573de699f23886cd2e56ff84a73d8f18458105c6f17d75";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "f0f56d4d39a4866b433682311c9bdfba6ecd4db376ae27594442c67d3f6321fe";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "9623d065161bcace655ae561a78db243a1bf66add3b921ee00c7880b42da40aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "b218af48461504d1cfc0b725e44917b4a77e7770567d46caee0a74c9a5009f42";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "99632a14354c4a83ab876b7b81af2aea4c3a4df25cf67f8ecaecb06ba47d274f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rt-manipulators-cpp/default.nix
+++ b/distros/humble/rt-manipulators-cpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, libyamlcpp, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rt-manipulators-cpp";
   version = "1.0.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module libyamlcpp yaml-cpp-vendor ];
+  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module yaml-cpp yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/slam-toolbox/default.nix
+++ b/distros/humble/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-slam-toolbox";
-  version = "2.6.4-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "347a14b83e8e5c073f244ba0daf4b3d0d9927e2d964310e49040da53a1213df9";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "b2b6dbec2cf653dd25c892a81085a1984d54ed1eedc0ae55a24e0679c0a162e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "5f6cf93e53322fa66db3299aaa4235cda0b4e8fcd31a4b8ac338101d32d8b664";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "a1dcd92a525ba7f728a403e67abef3be9bca98b1038e6c5795ce1eba92b5c774";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-transform-util/default.nix
+++ b/distros/humble/swri-transform-util/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-swri-transform-util";
   version = "3.5.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geometry-msgs geos gps-msgs launch-xml marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/humble/theora-image-transport/default.nix
+++ b/distros/humble/theora-image-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-theora-image-transport";
+  version = "2.5.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/humble/theora_image_transport/2.5.0-2.tar.gz";
+    name = "2.5.0-2.tar.gz";
+    sha256 = "11dbfec1d9cce078465bc135c2ffd1d33b46b672a3265691eb364b5f3d7053a6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-transport libogg libtheora opencv pluginlib rclcpp rcutils rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
+
+  meta = {
+    description = ''Theora_image_transport provides a plugin to image_transport for
+    transparently sending an image stream encoded with the Theora codec.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/tile-map/default.nix
+++ b/distros/humble/tile-map/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, libyamlcpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-tile-map";
   version = "2.2.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ glew jsoncpp libyamlcpp mapviz pluginlib qt5.qtbase rclcpp swri-math-util swri-transform-util tf2 ];
+  propagatedBuildInputs = [ glew jsoncpp mapviz pluginlib qt5.qtbase rclcpp swri-math-util swri-transform-util tf2 yaml-cpp ];
   nativeBuildInputs = [ ament-cmake qt5.qtbase ];
 
   meta = {

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "af511fa747531dea1ce67b0e7840acf3343c81daf5d3d989fd29554dbfd8d0d1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "7f1ffed8a1728ebfcf864681b1fb4a3940c725e528396d7d5e891eaf290a788c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "b57b95ee5d5cd517c403ad3239167da0171c8983df98283c7cf1e40a5d1ed528";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "89bb8f91cfec74690a34b78a6970e133761a7fd79f4a484b976714786f5f0396";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
   version = "2.2.8-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen libyamlcpp rclcpp ur-client-library ur-robot-driver ];
+  propagatedBuildInputs = [ eigen rclcpp ur-client-library ur-robot-driver yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "9220d2e9f6649faff7b7e05d5ea129bd5840afeb2c3e31665193f40ff4d556fc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "7c187d53ff225a9aad0b4dc96c2b9335c46f3fea22380731d952ce85ae82e9a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velodyne-pointcloud/default.nix
+++ b/distros/humble/velodyne-pointcloud/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-velodyne-pointcloud";
   version = "2.4.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, libyamlcpp, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
   version = "2023.1.1-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs libyamlcpp pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/humble/yaml-cpp-vendor/default.nix
+++ b/distros/humble/yaml-cpp-vendor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libyamlcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-yaml-cpp-vendor";
   version = "8.0.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ libyamlcpp ];
+  propagatedBuildInputs = [ yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "94990e50a5b4b8377e1c811ab6b00313499019d7edd48bd83266f9ca69d24d03";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "0d4feddb2340d2aa11347e8db2e6283ee55ab8a0e73a84b4eda7066281390b15";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "ba7a2ce140a88eaaccadb7b55e63e609838271147a6dd6f60352cfb14083540a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "5d7aab90b038fce510a6a8baab5e6727deed1f4505a8cbf6a432a4693b1e2461";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/aruco-opencv/default.nix
+++ b/distros/iron/aruco-opencv/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, libyamlcpp, python39Packages, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, python39Packages, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-aruco-opencv";
   version = "5.0.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport libyamlcpp python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "86e72a7b063b6404d1ee8c817f6cada77f9bc65738724e09bb8b6e7bf53ea7c8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "446667f1536e06fcafe49c6b13fa870d88e0e2a0dafd5b55f25f8b56bd11586f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "b24e7bec3d7f1cdc0e8bb793d493253c12e6191835b06c1512b4afafcea830e9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "2de688c5421d35ebda1e9948a5a6508f44f8e004ce804eb3b9bd124de08eafb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "a1d8555fe12c3c22ab20bc99f99130d75d2a5b2313345a2e052dea68068d9cec";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "519ef339276d92a8c01ffbd2658f00f8cfffbd8c2d66d19574eaaa9ee09b1eea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "7c3ac0d4142567587a376f2633616678197b7693b2a16ee2491b6e6b3a9b32a7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "10567f81d58edd6f29ff5393be274c9b97a8c0c3f7a32fe39139de308c18848a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/costmap-queue/default.nix
+++ b/distros/iron/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-costmap-queue";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/costmap_queue/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "736caea67194e1990884f470d4459d4500dfcdd86a524f6c6fc2624c313961cc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/costmap_queue/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "c4c4413831414bb1b613bed512ca90ebe0cdad829f322c3e0443ddfbcf8d00c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "149eb8f6f9215e5d48b65291c8111b9442f78057610fd45322f6b4bb607b6c5e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "4e648f5b50ad3f6ac83d4d258eb4deba2c9490498271cd52d50992dbcea75ae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/domain-bridge/default.nix
+++ b/distros/iron/domain-bridge/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, libyamlcpp, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, zstd-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, yaml-cpp, zstd-vendor }:
 buildRosPackage {
   pname = "ros-iron-domain-bridge";
   version = "0.5.0-r4";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common example-interfaces launch launch-testing launch-testing-ament-cmake rmw-connextdds rmw-cyclonedds-cpp rmw-fastrtps-cpp rmw-implementation-cmake rosgraph-msgs test-msgs ];
-  propagatedBuildInputs = [ libyamlcpp rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp zstd-vendor ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp yaml-cpp zstd-vendor ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/iron/dwb-core/default.nix
+++ b/distros/iron/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-core";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_core/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "6182d42909d223b21798d5610fb4cab79e9a55f8552f02dfd8562a399d6dc206";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_core/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "904bb2ee45b387bae807ffa125a477604d1f11a4356258484dc5e387f1ee19a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-critics/default.nix
+++ b/distros/iron/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-critics";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_critics/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "1f7f7b98bef1b41a71dde25f7fc85f329619249c506574082a10054d91bf6495";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_critics/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "05097b233ae7127b7daffd7ffbcdefecf25d113418ead00eee52ec0333cbbe34";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-msgs/default.nix
+++ b/distros/iron/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "384e9273f161d2719765c7d1c3c755737f8653b32d287fab38cc57bccb009bf9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "53f60bfaea5ab021e63790480fcb571fdd5eef15ba841336d6d986b39fddc093";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-plugins/default.nix
+++ b/distros/iron/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-dwb-plugins";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_plugins/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "72173d91c1a8744db82ecece5d114d382b6627fc792e522d3a42efbe199c9406";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_plugins/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "62980b6788a21ac090130f781fabb6fc262de0c0abd786ca5218906b6dfe4687";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "482554839ec3fab5a48e276bd71c536606441519b26ff079d33836cafe49395f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "65b737a8cac3e003b6949b64cb227515feadd23d5cac5e8bddff2b6f6cdcf531";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "6f26903f3f9a16d3a24d6f2f34e5c7102f357a4ad23d7e479d0730d3666cb9c0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "61304512a1782dc511728b8b66c1e603c88d80fa175e0a23ee492ee4a9337f9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "2726d1a47b592923a21332cbdfb6dc95d3da9144458a466f0b53439af90f0608";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "ab06c0298273e9e8e843bd1c6684665b6559ba5678c616bfebca686acf062895";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -1752,6 +1752,34 @@ self: super: {
 
  rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
 
+ rtabmap = self.callPackage ./rtabmap {};
+
+ rtabmap-conversions = self.callPackage ./rtabmap-conversions {};
+
+ rtabmap-demos = self.callPackage ./rtabmap-demos {};
+
+ rtabmap-examples = self.callPackage ./rtabmap-examples {};
+
+ rtabmap-launch = self.callPackage ./rtabmap-launch {};
+
+ rtabmap-msgs = self.callPackage ./rtabmap-msgs {};
+
+ rtabmap-odom = self.callPackage ./rtabmap-odom {};
+
+ rtabmap-python = self.callPackage ./rtabmap-python {};
+
+ rtabmap-ros = self.callPackage ./rtabmap-ros {};
+
+ rtabmap-rviz-plugins = self.callPackage ./rtabmap-rviz-plugins {};
+
+ rtabmap-slam = self.callPackage ./rtabmap-slam {};
+
+ rtabmap-sync = self.callPackage ./rtabmap-sync {};
+
+ rtabmap-util = self.callPackage ./rtabmap-util {};
+
+ rtabmap-viz = self.callPackage ./rtabmap-viz {};
+
  rtcm-msgs = self.callPackage ./rtcm-msgs {};
 
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
@@ -1971,6 +1999,8 @@ self: super: {
  tf2-tools = self.callPackage ./tf2-tools {};
 
  tf-transformations = self.callPackage ./tf-transformations {};
+
+ theora-image-transport = self.callPackage ./theora-image-transport {};
 
  tile-map = self.callPackage ./tile-map {};
 

--- a/distros/iron/grid-map-pcl/default.nix
+++ b/distros/iron/grid-map-pcl/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, libyamlcpp, pcl, rclcpp, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pcl, rclcpp, rcutils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-grid-map-pcl";
   version = "2.1.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake grid-map-cmake-helpers ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros libyamlcpp pcl rclcpp rcutils ];
+  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros pcl rclcpp rcutils yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "db14590f2783b48ce970f3c22801dd32badb99caec429e6a4a8a07edb68db4dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "6120b0ebcb49b4c887032618a8e2a8eb662c31e85ee801a24c9dc4dfe93290ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "74e8cb630c7aa6fd4b23af62ea2eeb77d46d46bbeda03315562abdf3ee6bc3bc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "b8889de1596089bb404260fb61fc87b57b9f63d4612e7b3344a2e0e011bbd26b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "a73733a271259816da7afc934f68953be1c3291bea7c7801586e148ec145ffac";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "54278ca62cee5e4dbaf03f47796b60cfbb2e96dc4cfcbe3902064466743c6425";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "ea5c38f36ab73399ce0a4cdca21a81000f32f1e42306389fcef90c6866bae850";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "cc72a700c049db8aea42bebb281d6f8769fdcd387263f8f4f78b137e2685a9b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "169dd1c91b96f470ea1f7426461c10e5ce60d9fbf26376befbd0f28ab7da466d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "45d72a26cddab7a47847078c4c01a822f9bac1e1e1fc3ceed19e0c34811c7eaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-publisher-gui/default.nix
+++ b/distros/iron/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
 buildRosPackage {
   pname = "ros-iron-joint-state-publisher-gui";
-  version = "2.3.0-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/iron/joint_state_publisher_gui/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "01c6f1bd6844b5d3f58f8f479fc05abb2e55ba728ddc49edc21703ec4e25f6aa";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/iron/joint_state_publisher_gui/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a8b897728b8b102576978ec80e7cfddac657ab6d3314b38c57462e1392832101";
   };
 
   buildType = "ament_python";

--- a/distros/iron/joint-state-publisher/default.nix
+++ b/distros/iron/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2topic, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-publisher";
-  version = "2.3.0-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/iron/joint_state_publisher/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "b0afefb75839a250355afc8baeee1412fba687a8d977357f560cd7faf568a11f";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/iron/joint_state_publisher/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "b2ae780da6ca9be6bdf7181f8cf863990f97f50a3091fea01e3c297137b0cc7e";
   };
 
   buildType = "ament_python";

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "acfdea3d3e1361bb2f08bc75e644f1d008408ef4b92f4a6ef6bd161d86b54710";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "081fa98c92ef0aae831a7136365a5bcba1fc72a870b0d1a96dd4f6d0776e45cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mapviz/default.nix
+++ b/distros/iron/mapviz/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, launch-xml, libyamlcpp, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, launch-xml, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-mapviz";
   version = "2.2.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config ros-environment ];
-  propagatedBuildInputs = [ cv-bridge freeglut geometry-msgs glew image-transport launch-xml libyamlcpp mapviz-interfaces marti-common-msgs pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros xorg.libXi xorg.libXmu ];
+  propagatedBuildInputs = [ cv-bridge freeglut geometry-msgs glew image-transport launch-xml mapviz-interfaces marti-common-msgs pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros xorg.libXi xorg.libXmu yaml-cpp ];
   nativeBuildInputs = [ ament-cmake pkg-config qt5.qtbase ];
 
   meta = {

--- a/distros/iron/mavros-extras/default.nix
+++ b/distros/iron/mavros-extras/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-mavros-extras";
   version = "2.5.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python angles ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn libyamlcpp mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
 
   meta = {

--- a/distros/iron/nav-2d-msgs/default.nix
+++ b/distros/iron/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav-2d-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "43b1d5bfc1d7b0d8ef5e856e1e4f3cfceee0963e678971f2c63a5028707e44a3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "a25abba3e769df4e82dd25d3d4a8746bcb1c75a472fe5affbcd208d1274e2789";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav-2d-utils/default.nix
+++ b/distros/iron/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav-2d-utils";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_utils/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "16f4dacb6c8f5a473fd28fadfa3fc2de60bc76ce9d00293ddb373f864bbdb690";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_utils/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "d9c31cb7e13ab25861fdbcbfdb2d818e052ca9b53fa3b92e46635fa8d5b6ddf1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-amcl/default.nix
+++ b/distros/iron/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-amcl";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_amcl/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "6b8b2752464574e20c35bfd5736558049bf5bf06d69c3056688fe41d456b4de5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_amcl/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "00918cc3af6c9facf33add665e12ac4ab3e10194f760ac422856ca4761ad66f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-behavior-tree/default.nix
+++ b/distros/iron/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-behavior-tree";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behavior_tree/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "c02271a0e8134d724163b3288c76dff20383353fb794a13c5d347a43daa0cbc4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behavior_tree/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "d615c37facd1758012d1f0d8635284dd0d732e1b9ba4a8ca7392719ab0bc50fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-behaviors/default.nix
+++ b/distros/iron/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-behaviors";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behaviors/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "982f084a08c6dc6ba7f7d05e4de5b4c5ae6e6d9584212ddba03bf518834f89f4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behaviors/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "1be74fbb0630c71dbbf7d70bd1f710cbb6eca037a69d70494cb49846bbed7ddf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-bringup/default.nix
+++ b/distros/iron/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-iron-nav2-bringup";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bringup/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "55cb13586344d94a9d78e76e99cbe7bd4c58aab234ae092d030ea0f8d271a8d5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bringup/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "9f4476b1be269caf56ff78673a62ede11fbeb9e9a9292601c7471e360f2f2aca";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-bt-navigator/default.nix
+++ b/distros/iron/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-bt-navigator";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bt_navigator/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "d9a23ebb11a2977906a4c524718bbbcce90cbdf4cf0e504734b8aff57cd3bd4b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bt_navigator/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "daef8c59c393b968497b183afb67855ab885921882c2d99f0aae95a79233b7f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-collision-monitor/default.nix
+++ b/distros/iron/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-msgs, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-collision-monitor";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_collision_monitor/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "7ee3bd6fd23d315127127db27b17fab854f94d5abc74596593713ae6ea15f351";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_collision_monitor/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "c973395d3ce953fda85491647a292117f98fd30d7155b1990265d50d552bf40c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-common/default.nix
+++ b/distros/iron/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-nav2-common";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_common/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "815aff42a2ce70adee53131392ae9d8e0560c5aceab2a7d26bf3fc6a5849a213";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_common/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "190b103ebe93d2e4ed0b2cc7a3d7df01cf24e3daf28012559d88cd6c670b2d21";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-constrained-smoother/default.nix
+++ b/distros/iron/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-nav2-constrained-smoother";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_constrained_smoother/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "73d2fb720d53be37fd117e5edaa3870b21d4944e0ea5d8aa35a967f343670704";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_constrained_smoother/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "fec6b701812c9b3b68f0ab36c343c8304803f918c616c46bf531842f9b73dbc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-controller/default.nix
+++ b/distros/iron/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-controller";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_controller/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "93066c34f833b8397ee8fde9b2abb32a85b61f5ae893c5c0703b6f096819dd01";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_controller/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "a3c7ef34b374c56fa963c59509479b5457b2f6a87c8d2d1da52d8b0a4436af65";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-core/default.nix
+++ b/distros/iron/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-behavior-tree, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-core";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_core/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "1579366140a2a95ea2a22d2f21eafb39dc7741e127ddacf6f4185bfce580de02";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_core/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "249e1c3e392bb04b9e4b500c579296c62b3ceadef0bc87f7c9aa9d0dce287f6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-costmap-2d/default.nix
+++ b/distros/iron/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-costmap-2d";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_costmap_2d/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "f9f49fd705ac7534a2a70506c5c7d6e03fa819b1d8f7444c638cd757770887bf";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_costmap_2d/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "23589cdac2161c85ee067dce64cf4002c2a955eb86f22b027f808725082993d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-dwb-controller/default.nix
+++ b/distros/iron/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-iron-nav2-dwb-controller";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_dwb_controller/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "02de48a4ce20f3065697ff68d4181b67231d59e8087a846a33fc63c2004724bd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_dwb_controller/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "6d7aac05341052695e868e0959f8d0771b41b9fd0df15bd81aa9fa6e2bc5bb26";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-lifecycle-manager/default.nix
+++ b/distros/iron/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-lifecycle-manager";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_lifecycle_manager/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "7702fd6f497025e474ba6a16b4dc3b5a7fb45075963582906f7bbff128f25772";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_lifecycle_manager/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "0f8832c3823f02b3a2234981ced3f8ba811f7eb8515e70f83345660ea550f1d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-map-server/default.nix
+++ b/distros/iron/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-nav2-map-server";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_map_server/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "c00088b500215fd106e4fc4b474716f3355591c21ac270eed96ab7585260e308";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_map_server/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "74cc996b89f3cf25d4313cc728110bcb22c4c68f82092a80932d7cb8a76a94fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-msgs/default.nix
+++ b/distros/iron/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-msgs";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_msgs/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "6e446a90b28786c4832cf5395085bd1c120f8a39acd6d543c10e0567ec9c396a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_msgs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "84e56fdd926920ecae0584c29a7abc16bd2520415599ecf326558422c7451d95";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-navfn-planner/default.nix
+++ b/distros/iron/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-navfn-planner";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_navfn_planner/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "8b201ba89e1336261622b96c2906feedd4ceff93b49c972a2fc278313b814851";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_navfn_planner/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "32217bac520439f0c1600038761fb3b510207810480e8f3f8963265ba8349592";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-planner/default.nix
+++ b/distros/iron/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-planner";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_planner/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "1a6424e5064c462ff16a064914c9d535be0eb967fca3b08669c10a4930c718de";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_planner/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "dcc344dab6fa980f88eb906845a112737947c2dda9195e1506888f8d927f43e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/iron/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-regulated-pure-pursuit-controller";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_regulated_pure_pursuit_controller/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "c5293d7b6594900c2361a6a4eda3fe851123ad1caeb168fbf2179d05a1673406";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_regulated_pure_pursuit_controller/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "c84b78992603a0116444bff20819f6cbfe630bb3a9aa5bf9784f3e1c2b1485ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-rotation-shim-controller/default.nix
+++ b/distros/iron/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-iron-nav2-rotation-shim-controller";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rotation_shim_controller/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "b99955aad2bba8d2a4b9d613ff208c2218c941680c9ecacc7b3b50da703469af";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rotation_shim_controller/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e30070a8977297c4bb8a51734dda498eb0495ee9a1796cbc9947f91350afdf83";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-rviz-plugins/default.nix
+++ b/distros/iron/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-nav2-rviz-plugins";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rviz_plugins/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "4c9689cf0c885d43e7ca041decb9f364829b474fec5f6ad541382d16394afc27";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rviz_plugins/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e10cf4e8881c4083a8a798c19e1939b4bf1e120664ac0352d2356231f04fdd6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-simple-commander/default.nix
+++ b/distros/iron/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-nav2-simple-commander";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_simple_commander/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "d35d993e0525a51afa0fcb917251e38f94c258bec101c06af92b8b07c79fe8ce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_simple_commander/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "eaffbb3534c9f33ec9b3e45e4efbd133eda0f6ec2ff0a1e41461e7743ea0870d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/nav2-smac-planner/default.nix
+++ b/distros/iron/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-smac-planner";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smac_planner/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "a017aaea01610cb0289a6005967079f366be28d2f1649432c93e8f67efe83f80";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smac_planner/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "78013dea740b972dbbd73b6748263c5f883a64aeb29e34738502fab7bee4a072";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-smoother/default.nix
+++ b/distros/iron/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-smoother";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smoother/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "254c47c53b0ec6631d48f57ac0e03cb54210db0e8ae3f7808025b91d60554be2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smoother/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "8805d3576257e1a1214ce40311efd0fd20d337bfe60548ba4180f93046d5bfa9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-system-tests/default.nix
+++ b/distros/iron/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-system-tests";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_system_tests/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "00ecfe227d4ca538b7af14521baf91e77f3a126c842695f82d9c79f46a7685ae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_system_tests/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "330439b89b6ed8acce9a19c98c0e6fc4094f5148652eba7adcf7302d558b43cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-theta-star-planner/default.nix
+++ b/distros/iron/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-theta-star-planner";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_theta_star_planner/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "cb2db1b323cac212c43e8e675da941fe13f2fa33fc8ece80f7539185f6a47da4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_theta_star_planner/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "d61151b7e7f1b357ee059977d5501195f33b178b4195bfd0a12b03d40151e01a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-util/default.nix
+++ b/distros/iron/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-util";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_util/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "be954b6049a3bb6010b53ffa946894688eb67448d6cf3342fbacf1cb0b22a225";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_util/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "267cf9734abe2721c67f63a03437b166076d78e763aa022ad5a6d266c01444d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-velocity-smoother/default.nix
+++ b/distros/iron/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-nav2-velocity-smoother";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_velocity_smoother/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "21b4598e42704c6140c647fc47cc80804a6b180ccd901c5bc45b96486ea310d4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_velocity_smoother/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "038a443fe7062155f6fbd61a2c37f9cf6a9ef5b11a884af8b4253560d9d56717";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-voxel-grid/default.nix
+++ b/distros/iron/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-nav2-voxel-grid";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_voxel_grid/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "112e95bf42826e5f29c59d65129f73a09dbbd44b9a2647ded8743b40f017314a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_voxel_grid/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "7f462c428216122b22df60cb28adf5f2221779bfb59e755cb1705831546051bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-waypoint-follower/default.nix
+++ b/distros/iron/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-waypoint-follower";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_waypoint_follower/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "d8ff99a2e9ad82562d926e1e6e62fc9e632473bce4f1196fde2d938961b69747";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_waypoint_follower/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "55a2907b0783c3eadc4864567f63e614f3588594583b60eaf8eb4e6d09b56c9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/navigation2/default.nix
+++ b/distros/iron/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-iron-navigation2";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/navigation2/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "d04956c2f3aec0db4a3329ca8954b36ce003ea3caec49b082a6ffab660f7e491";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/navigation2/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e01343fd78ecaa08a341a5f03020e3992c229b565fb87e75ab1dc828c1656055";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "7de8ce3a12906f6ccaab6e09f7bc792a5f01e95146e4445c2e7c235cdaae5fe7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "c17004f113ac6b6de483acbb5320c6c55aaaaec92cd794afd90f2cdb8f23d5a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-fleet-adapter/default.nix
+++ b/distros/iron/rmf-fleet-adapter/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, libyamlcpp, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-fleet-adapter";
   version = "2.2.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake eigen libyamlcpp ];
+  buildInputs = [ ament-cmake eigen yaml-cpp ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
   propagatedBuildInputs = [ nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/iron/rmf-traffic-editor/default.nix
+++ b/distros/iron/rmf-traffic-editor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, libyamlcpp, proj, qt5, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, proj, qt5, rmf-utils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-editor";
   version = "1.7.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-index-cpp eigen libyamlcpp qt5.qtbase rmf-utils ];
+  buildInputs = [ ament-cmake ament-index-cpp eigen qt5.qtbase rmf-utils yaml-cpp ];
   checkInputs = [ ament-cmake-uncrustify ];
   propagatedBuildInputs = [ ceres-solver glog proj ];
 

--- a/distros/iron/rmf-traffic-ros2/default.nix
+++ b/distros/iron/rmf-traffic-ros2/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, libyamlcpp, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-ros2";
   version = "2.2.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ libyamlcpp nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux zlib ];
+  propagatedBuildInputs = [ nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/robot-calibration/default.nix
+++ b/distros/iron/robot-calibration/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, libyamlcpp, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-robot-calibration";
   version = "0.8.0-r3";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser libyamlcpp moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "80da42dcbda988372f67be21e32fb8ec4f0ba53821d0704da14b3aedfcf52b87";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "b95ded3c99c08f6692728344cae189393ba8098f8ed13c69e112e06142e5ba7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "c297c52eaa33fe729d63e49db37292475c35ea683a9977111bd11698d534e9df";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "87738ac367c44a5791110286864ca008a09626c0cc5b019bad2f73d1b4bb1f7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "59652ddfcb7a73adcf80c332cb66c03b6bcac89de263de8dd5821d53d1909300";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "924a541f1b1b11b224e2d02feab51dba6735583a8786ae54ef94515e3fc782ac";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "0682ddc0263ba5e904704b0a2acdaa13928536746c0c60742e714f90a74d58aa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "71af93022fcb321baebf5f43ea91d40307229af7dbe2ae3d3288bda03ca27a91";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "c22ab30166a1c50dd93ed0224ea79e8fea44ea079a3bd3f2c062bf9a8f2acd6f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "9cd96c428c0419e0f56471a3277d6cd3c628cc819f1ec87dddde8e820643a971";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "1b333d4c8a916ce701a9c98388cf91c332243970d0fcfc29c1fd686a44490e2d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "0891f2c20765560fbff229554daf34745069592b20703552ad41f8e1fe5cfca1";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "1fe58e805a193057de4e51d1513e1bf7bea72de564fb635ba80c100a1098f8f2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "98a2e1804bb6073da20a8d066556367fb982af06f140417d39709c167a94a681";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rt-manipulators-cpp/default.nix
+++ b/distros/iron/rt-manipulators-cpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, libyamlcpp, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rt-manipulators-cpp";
   version = "1.0.0-r3";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module libyamlcpp yaml-cpp-vendor ];
+  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module yaml-cpp yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/rtabmap-conversions/default.nix
+++ b/distros/iron/rtabmap-conversions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-conversions";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_conversions/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "9cc7e26a4e98e6808a5594adaec28ade9536bb1c394aab2bb1981c83a91a05fc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry laser-geometry pcl-conversions rclcpp rclcpp-components rtabmap rtabmap-msgs sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map's conversions package. This package can be used to convert rtabmap_msgs's msgs into RTAB-Map's library objects.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-demos/default.nix
+++ b/distros/iron/rtabmap-demos/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, turtlebot3-gazebo }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-demos";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_demos/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "8d696440d50119a36e3f4174aad5f091b4b85de3ad22b670bf377f6cd14a8212";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav2-bringup rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz turtlebot3-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map's demo launch files.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-examples/default.nix
+++ b/distros/iron/rtabmap-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, realsense2-camera, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros, velodyne }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-examples";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_examples/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "198aaa5dc4ef07eeee1f4139668073871b0e21f63e26ad75d6f8af0a8ce68ea8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ imu-filter-madgwick realsense2-camera rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz tf2-ros velodyne ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map's example launch files.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-launch/default.nix
+++ b/distros/iron/rtabmap-launch/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-launch";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_launch/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "8c5055b3f0ce266db49b7c9539b956f9f93a793b2abe2d7d98405bec99cd11f0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rtabmap-msgs rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map's main launch files.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-msgs/default.nix
+++ b/distros/iron/rtabmap-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-msgs";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_msgs/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "e0b8974cbed255bb26dfe5be71ba18fda0996b6a3e60ea7d3b9b28678fdd7205";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map's msgs package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-odom/default.nix
+++ b/distros/iron/rtabmap-odom/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, rtabmap-util, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-odom";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_odom/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "0e755c140a7d5502c52ec78bf8a7d8b8007c695c5a92931f4e460eb484983e14";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ cv-bridge image-geometry laser-geometry message-filters nav-msgs pcl-conversions pcl-ros pluginlib rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs rtabmap-util sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''RTAB-Map's odometry package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-python/default.nix
+++ b/distros/iron/rtabmap-python/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-python";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_python/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "a89c0903fa1cccce7df6cdf4bfc6832b8645ac3d755ec20f8d63379722f87c1e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+
+  meta = {
+    description = ''RTAB-Map's python package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-ros/default.nix
+++ b/distros/iron/rtabmap-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-ros";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_ros/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "1df65ef355659e34bf0e30e000d0854829e30e3a12646dc4ed5e2ff67ff81f31";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rtabmap-conversions rtabmap-demos rtabmap-examples rtabmap-launch rtabmap-msgs rtabmap-odom rtabmap-python rtabmap-rviz-plugins rtabmap-slam rtabmap-sync rtabmap-util rtabmap-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map Stack'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-rviz-plugins/default.nix
+++ b/distros/iron/rtabmap-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-rviz-plugins";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_rviz_plugins/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "c2662b8d9d5da92399bddba0bb89479efae4c27e71081cadddb60d34524c821e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ pcl-conversions pluginlib rclcpp rtabmap-conversions rtabmap-msgs rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''RTAB-Map's rviz plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-slam/default.nix
+++ b/distros/iron/rtabmap-slam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, nav2-msgs, rclcpp, rclcpp-components, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-slam";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_slam/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "49e47b95f468c11c2493fe6d7e6920eb30fc2881c3d851ccfea082275f4f8daf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs nav-msgs nav2-msgs rclcpp rclcpp-components rtabmap-msgs rtabmap-sync rtabmap-util sensor-msgs std-msgs std-srvs tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''RTAB-Map's SLAM package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-sync/default.nix
+++ b/distros/iron/rtabmap-sync/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-sync";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_sync/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "684610be5be0d0341f0f76aa6f625790fdaa8eed9fd91f8ec0c0061f7c0aaf72";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ cv-bridge image-transport message-filters nav-msgs rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''RTAB-Map's synchronization package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-util/default.nix
+++ b/distros/iron/rtabmap-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-util";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_util/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "1f1666b1f6fbbdcd190ed39ebedb9949e6304f065aabe594d04e22b1f0964d20";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cv-bridge image-transport laser-geometry message-filters nav-msgs octomap-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rtabmap-conversions rtabmap-msgs sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RTAB-Map's various useful nodes and nodelets.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap-viz/default.nix
+++ b/distros/iron/rtabmap-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap-viz";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_viz/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "591003c02ce57dc8bcf04884012f22115eac41e4fd9fc0c63247e630be354543";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs nav-msgs rclcpp rtabmap-msgs rtabmap-sync std-msgs std-srvs tf2 ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''RTAB-Map's visualization package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/rtabmap/default.nix
+++ b/distros/iron/rtabmap/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, cv-bridge, libg2o, libpointmatcher, octomap, pcl, proj, qt-gui-cpp, sqlite, zlib }:
+buildRosPackage {
+  pname = "ros-iron-rtabmap";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/iron/rtabmap/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "951d2768fb44aab80941dd84744274e9cd592df5dc2dea17b62f288a976b96b7";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake proj ];
+  propagatedBuildInputs = [ cv-bridge libg2o libpointmatcher octomap pcl qt-gui-cpp sqlite zlib ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''RTAB-Map's standalone library. RTAB-Map is a RGB-D SLAM approach with real-time constraints.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/slam-toolbox/default.nix
+++ b/distros/iron/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-slam-toolbox";
-  version = "2.7.0-r2";
+  version = "2.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/iron/slam_toolbox/2.7.0-2.tar.gz";
-    name = "2.7.0-2.tar.gz";
-    sha256 = "1da8853d1aa295de2085cac3a88ba7b450785d6360676c40a603ef7e16ecf0d8";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/iron/slam_toolbox/2.7.1-1.tar.gz";
+    name = "2.7.1-1.tar.gz";
+    sha256 = "5c6ff242385682ab0706b0dde1557818e0686417a47751842852e4087dfd875d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "089a6ce6084df8dfeaaff3b619fe00a310da485781e06233c45b96ed6a89840f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "3cedac70c14bd4a5899aecbea5dfd3238f2ad14ab8c3614d7ee1e6ece2c7fe10";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-transform-util/default.nix
+++ b/distros/iron/swri-transform-util/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-swri-transform-util";
   version = "3.5.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geometry-msgs geos gps-msgs launch-xml marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/iron/theora-image-transport/default.nix
+++ b/distros/iron/theora-image-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-theora-image-transport";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/iron/theora_image_transport/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b537772e5354059a5e35c94549018acb086e7b8ea144a7797dccdbbac00c1935";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-transport libogg libtheora opencv pluginlib rclcpp rcutils rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
+
+  meta = {
+    description = ''Theora_image_transport provides a plugin to image_transport for
+    transparently sending an image stream encoded with the Theora codec.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/tile-map/default.nix
+++ b/distros/iron/tile-map/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, libyamlcpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-tile-map";
   version = "2.2.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ glew jsoncpp libyamlcpp mapviz pluginlib qt5.qtbase rclcpp swri-math-util swri-transform-util tf2 ];
+  propagatedBuildInputs = [ glew jsoncpp mapviz pluginlib qt5.qtbase rclcpp swri-math-util swri-transform-util tf2 yaml-cpp ];
   nativeBuildInputs = [ ament-cmake qt5.qtbase ];
 
   meta = {

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "b79c0ba449e0f22798e4cfe99653d94ce868b41e812d6e61bf90aa37bfa51ccd";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "a1a3798088c188f0f03c5f9ce174f7d2c10138781be387466f3cff143bd6f5d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "b869bcfb91bb10d3d450f5ef24766a627359f2fba0018aa0888608474963233d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "83d7791b5e920578b54caac854fb75f937193885d7a9793d09c3afb962d78ab6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "d2a2af5333a62e39d1da2315542f03d5d6433a476d0eaae59c06023e63dc8b75";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "dfe6563478d1746e490d634e8fca61eca74993815eecf3b790154186867b9dad";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-calibration/default.nix
+++ b/distros/iron/ur-calibration/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-ur-calibration";
   version = "2.3.2-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen libyamlcpp rclcpp ur-client-library ur-robot-driver ];
+  propagatedBuildInputs = [ eigen rclcpp ur-client-library ur-robot-driver yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "cb61ce70460d95f8cce6c2e175420d16a76d59c92470c0d168ea22608ba8566d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "dfb142f7d3031ab394833aa48395437edc75f9e803723e525b20b5235a4edf65";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/velodyne-pointcloud/default.nix
+++ b/distros/iron/velodyne-pointcloud/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-velodyne-pointcloud";
   version = "2.3.0-r3";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/webots-ros2-driver/default.nix
+++ b/distros/iron/webots-ros2-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, libyamlcpp, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-driver";
   version = "2023.1.1-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs libyamlcpp pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/iron/yaml-cpp-vendor/default.nix
+++ b/distros/iron/yaml-cpp-vendor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libyamlcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-yaml-cpp-vendor";
   version = "8.1.2-r3";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ libyamlcpp ];
+  propagatedBuildInputs = [ yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/noetic/aruco-opencv/default.nix
+++ b/distros/noetic/aruco-opencv/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aruco-opencv-msgs, catkin, cv-bridge, dynamic-reconfigure, image-transport, libyamlcpp, nodelet, python39Packages, python3Packages, roscpp, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, aruco-opencv-msgs, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, python39Packages, python3Packages, roscpp, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-aruco-opencv";
   version = "0.3.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ aruco-opencv-msgs catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport libyamlcpp nodelet python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 roscpp tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport nodelet python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 roscpp tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/camera-calibration-parsers/default.nix
+++ b/distros/noetic/camera-calibration-parsers/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config, rosbash, rosconsole, roscpp, roscpp-serialization, rosunit, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, pkg-config, rosbash, rosconsole, roscpp, roscpp-serialization, rosunit, sensor-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-camera-calibration-parsers";
   version = "1.12.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin pkg-config rosconsole ];
   checkInputs = [ rosbash rosunit ];
-  propagatedBuildInputs = [ boost libyamlcpp roscpp roscpp-serialization sensor-msgs ];
+  propagatedBuildInputs = [ boost roscpp roscpp-serialization sensor-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dynamixel-workbench-controllers/default.nix
+++ b/distros/noetic/dynamixel-workbench-controllers/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamixel-workbench-msgs, dynamixel-workbench-toolbox, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamixel-workbench-msgs, dynamixel-workbench-toolbox, eigen, geometry-msgs, roscpp, sensor-msgs, trajectory-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-dynamixel-workbench-controllers";
   version = "2.2.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cmake-modules dynamixel-workbench-msgs dynamixel-workbench-toolbox eigen geometry-msgs libyamlcpp roscpp sensor-msgs trajectory-msgs ];
+  propagatedBuildInputs = [ cmake-modules dynamixel-workbench-msgs dynamixel-workbench-toolbox eigen geometry-msgs roscpp sensor-msgs trajectory-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dynamixel-workbench-operators/default.nix
+++ b/distros/noetic/dynamixel-workbench-operators/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, std-srvs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, roscpp, sensor-msgs, std-srvs, trajectory-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-dynamixel-workbench-operators";
   version = "2.2.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cmake-modules geometry-msgs libyamlcpp roscpp sensor-msgs std-srvs trajectory-msgs ];
+  propagatedBuildInputs = [ cmake-modules geometry-msgs roscpp sensor-msgs std-srvs trajectory-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/end-effector/default.nix
+++ b/distros/noetic/end-effector/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, gtest, joint-state-publisher-gui, kdl-parser, libyamlcpp, message-runtime, moveit-ros-planning-interface, muparser, roscpp, rosee-msg, rospy, srdfdom }:
+{ lib, buildRosPackage, fetchurl, catkin, gtest, joint-state-publisher-gui, kdl-parser, message-runtime, moveit-ros-planning-interface, muparser, roscpp, rosee-msg, rospy, srdfdom, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-end-effector";
   version = "1.0.6-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ joint-state-publisher-gui kdl-parser libyamlcpp message-runtime moveit-ros-planning-interface muparser roscpp rosee-msg rospy srdfdom ];
+  propagatedBuildInputs = [ joint-state-publisher-gui kdl-parser message-runtime moveit-ros-planning-interface muparser roscpp rosee-msg rospy srdfdom yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/euscollada/default.nix
+++ b/distros/noetic/euscollada/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, libyamlcpp, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom }:
+{ lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-euscollada";
   version = "0.4.4-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules mk rosboost-cfg rosbuild ];
   checkInputs = [ openhrp3 pr2-description roseus ];
-  propagatedBuildInputs = [ assimp-devel collada-dom collada-parser collada-urdf libyamlcpp qhull resource-retriever roscpp rospack rostest tf urdf urdfdom ];
+  propagatedBuildInputs = [ assimp-devel collada-dom collada-parser collada-urdf qhull resource-retriever roscpp rospack rostest tf urdf urdfdom yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/face-detector/default.nix
+++ b/distros/noetic/face-detector/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, libyamlcpp, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-face-detector";
   version = "1.4.2-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
   checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport libyamlcpp message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/fetch-drivers/default.nix
+++ b/distros/noetic/fetch-drivers/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, curl, diagnostic-msgs, fetch-auto-dock-msgs, fetch-driver-msgs, libyamlcpp, mk, nav-msgs, power-msgs, python3, robot-calibration-msgs, robot-controllers, robot-controllers-interface, rosconsole, roscpp, roscpp-serialization, rospack, rostime, sensor-msgs, urdf, urdfdom }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, curl, diagnostic-msgs, fetch-auto-dock-msgs, fetch-driver-msgs, mk, nav-msgs, power-msgs, python3, robot-calibration-msgs, robot-controllers, robot-controllers-interface, rosconsole, roscpp, roscpp-serialization, rospack, rostime, sensor-msgs, urdf, urdfdom, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-fetch-drivers";
   version = "0.9.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin mk rospack ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs boost curl diagnostic-msgs fetch-auto-dock-msgs fetch-driver-msgs libyamlcpp nav-msgs power-msgs python3 robot-calibration-msgs robot-controllers robot-controllers-interface rosconsole roscpp roscpp-serialization rostime sensor-msgs urdf urdfdom ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs boost curl diagnostic-msgs fetch-auto-dock-msgs fetch-driver-msgs nav-msgs power-msgs python3 robot-calibration-msgs robot-controllers robot-controllers-interface rosconsole roscpp roscpp-serialization rostime sensor-msgs urdf urdfdom yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/flatland-plugins/default.nix
+++ b/distros/noetic/flatland-plugins/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, flatland-msgs, flatland-server, libyamlcpp, nav-msgs, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, flatland-msgs, flatland-server, nav-msgs, pluginlib, roscpp, sensor-msgs, std-msgs, tf, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-flatland-plugins";
   version = "1.3.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cmake-modules flatland-msgs flatland-server libyamlcpp nav-msgs pluginlib roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cmake-modules flatland-msgs flatland-server nav-msgs pluginlib roscpp sensor-msgs std-msgs tf yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/flatland-server/default.nix
+++ b/distros/noetic/flatland-server/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, flatland-msgs, geometry-msgs, interactive-markers, libyamlcpp, lua, opencv, pluginlib, roscpp, std-msgs, std-srvs, tf2, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, flatland-msgs, geometry-msgs, interactive-markers, lua, opencv, pluginlib, roscpp, std-msgs, std-srvs, tf2, tf2-geometry-msgs, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-flatland-server";
   version = "1.3.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules ];
-  propagatedBuildInputs = [ flatland-msgs geometry-msgs interactive-markers libyamlcpp lua opencv pluginlib roscpp std-msgs std-srvs tf2 tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ flatland-msgs geometry-msgs interactive-markers lua opencv pluginlib roscpp std-msgs std-srvs tf2 tf2-geometry-msgs visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/gazebo-video-monitor-plugins/default.nix
+++ b/distros/noetic/gazebo-video-monitor-plugins/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, gazebo-video-monitor-msgs, libyamlcpp, opencv, roscpp, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, gazebo-video-monitor-msgs, opencv, roscpp, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-video-monitor-plugins";
   version = "0.7.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin libyamlcpp ];
+  buildInputs = [ catkin yaml-cpp ];
   propagatedBuildInputs = [ gazebo-ros gazebo-video-monitor-msgs opencv roscpp std-srvs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -2642,17 +2642,11 @@ self: super: {
 
  qb-move-hardware-interface = self.callPackage ./qb-move-hardware-interface {};
 
- qb-softhand-industry = self.callPackage ./qb-softhand-industry {};
-
  qb-softhand-industry-bringup = self.callPackage ./qb-softhand-industry-bringup {};
-
- qb-softhand-industry-control = self.callPackage ./qb-softhand-industry-control {};
 
  qb-softhand-industry-description = self.callPackage ./qb-softhand-industry-description {};
 
  qb-softhand-industry-driver = self.callPackage ./qb-softhand-industry-driver {};
-
- qb-softhand-industry-hardware-interface = self.callPackage ./qb-softhand-industry-hardware-interface {};
 
  qb-softhand-industry-msgs = self.callPackage ./qb-softhand-industry-msgs {};
 

--- a/distros/noetic/global-planner-tests/default.nix
+++ b/distros/noetic/global-planner-tests/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, map-server, nav-core2, nav-msgs, pluginlib, roscpp, roslint }:
+{ lib, buildRosPackage, fetchurl, catkin, map-server, nav-core2, nav-msgs, pluginlib, roscpp, roslint, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-global-planner-tests";
   version = "0.3.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ roslint ];
-  propagatedBuildInputs = [ libyamlcpp map-server nav-core2 nav-msgs pluginlib roscpp ];
+  propagatedBuildInputs = [ map-server nav-core2 nav-msgs pluginlib roscpp yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/grid-map-pcl/default.nix
+++ b/distros/noetic/grid-map-pcl/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, grid-map-core, grid-map-msgs, grid-map-ros, gtest, libyamlcpp, pcl, pcl-ros, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, grid-map-core, grid-map-msgs, grid-map-ros, gtest, pcl, pcl-ros, roscpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-grid-map-pcl";
   version = "1.6.4-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros libyamlcpp pcl pcl-ros roscpp ];
+  propagatedBuildInputs = [ grid-map-core grid-map-msgs grid-map-ros pcl pcl-ros roscpp yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/iris-lama-ros/default.nix
+++ b/distros/noetic/iris-lama-ros/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, iris-lama, libyamlcpp, message-filters, nav-msgs, rosbag, rosbag-storage, roscpp, std-srvs, tf, tf-conversions, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, iris-lama, message-filters, nav-msgs, rosbag, rosbag-storage, roscpp, std-srvs, tf, tf-conversions, tf2-geometry-msgs, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-iris-lama-ros";
   version = "1.3.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ geometry-msgs iris-lama libyamlcpp message-filters nav-msgs rosbag rosbag-storage roscpp std-srvs tf tf-conversions tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs iris-lama message-filters nav-msgs rosbag rosbag-storage roscpp std-srvs tf tf-conversions tf2-geometry-msgs visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/jsk-interactive-marker/default.nix
+++ b/distros/noetic/jsk-interactive-marker/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-jsk-interactive-marker";
   version = "2.1.8-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules message-generation mk rosbuild ];
-  propagatedBuildInputs = [ actionlib dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs interactive-markers jsk-footstep-msgs jsk-recognition-msgs jsk-recognition-utils jsk-rviz-plugins jsk-topic-tools libyamlcpp message-filters message-runtime moveit-msgs roscpp roslib rviz sensor-msgs tf tf-conversions tinyxml urdf visualization-msgs ];
+  propagatedBuildInputs = [ actionlib dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs interactive-markers jsk-footstep-msgs jsk-recognition-msgs jsk-recognition-utils jsk-rviz-plugins jsk-topic-tools message-filters message-runtime moveit-msgs roscpp roslib rviz sensor-msgs tf tf-conversions tinyxml urdf visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/jsk-recognition-utils/default.nix
+++ b/distros/noetic/jsk-recognition-utils/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen-conversions, geometry-msgs, image-geometry, image-view, jsk-recognition-msgs, jsk-tools, jsk-topic-tools, libyamlcpp, message-generation, message-runtime, pcl-msgs, pcl-ros, python3Packages, pythonPackages, qt5, sensor-msgs, std-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen-conversions, geometry-msgs, image-geometry, image-view, jsk-recognition-msgs, jsk-tools, jsk-topic-tools, message-generation, message-runtime, pcl-msgs, pcl-ros, python3Packages, pythonPackages, qt5, sensor-msgs, std-msgs, tf, tf-conversions, tf2-ros, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-jsk-recognition-utils";
   version = "1.2.15-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin dynamic-reconfigure message-generation python3Packages.setuptools pythonPackages.cython qt5.qtbase ];
   checkInputs = [ jsk-tools ];
-  propagatedBuildInputs = [ eigen-conversions geometry-msgs image-geometry image-view jsk-recognition-msgs jsk-topic-tools libyamlcpp message-runtime pcl-msgs pcl-ros python3Packages.scikitimage pythonPackages.chainer sensor-msgs std-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ eigen-conversions geometry-msgs image-geometry image-view jsk-recognition-msgs jsk-topic-tools message-runtime pcl-msgs pcl-ros python3Packages.scikitimage pythonPackages.chainer sensor-msgs std-msgs tf tf-conversions tf2-ros visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, leo-msgs, libyamlcpp, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, leo-msgs, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-leo-fw";
   version = "2.3.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin python3Packages.setuptools ];
-  propagatedBuildInputs = [ leo-msgs libyamlcpp nav-msgs python3Packages.numpy python3Packages.rospkg python3Packages.whichcraft roscpp rosgraph rosmon-msgs rosnode rospy rosservice sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ leo-msgs nav-msgs python3Packages.numpy python3Packages.rospkg python3Packages.whichcraft roscpp rosgraph rosmon-msgs rosnode rospy rosservice sensor-msgs std-srvs yaml-cpp ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/map-server/default.nix
+++ b/distros/noetic/map-server/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, SDL, SDL_image, bullet, catkin, libyamlcpp, nav-msgs, roscpp, roslib, rospy, rostest, rosunit, tf2 }:
+{ lib, buildRosPackage, fetchurl, SDL, SDL_image, bullet, catkin, nav-msgs, roscpp, roslib, rospy, rostest, rosunit, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-map-server";
   version = "1.17.3-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ roslib rospy rostest rosunit ];
-  propagatedBuildInputs = [ SDL SDL_image bullet libyamlcpp nav-msgs roscpp tf2 ];
+  propagatedBuildInputs = [ SDL SDL_image bullet nav-msgs roscpp tf2 yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
   version = "1.1.13-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ogre1_9 ompl qt5.qtbase ];
   checkInputs = [ moveit-resources-panda-moveit-config rosunit ];
-  propagatedBuildInputs = [ libyamlcpp moveit-core moveit-ros-planning moveit-ros-visualization rosconsole roscpp rviz srdfdom urdf xacro ];
+  propagatedBuildInputs = [ moveit-core moveit-ros-planning moveit-ros-visualization rosconsole roscpp rviz srdfdom urdf xacro yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/multi-map-server/default.nix
+++ b/distros/noetic/multi-map-server/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, SDL_image, catkin, jsk-tools, libyamlcpp, map-server, nav-msgs, python3Packages, pythonPackages, rosconsole, roscpp, rosmake, rospy, tf }:
+{ lib, buildRosPackage, fetchurl, SDL_image, catkin, jsk-tools, map-server, nav-msgs, python3Packages, pythonPackages, rosconsole, roscpp, rosmake, rospy, tf, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-multi-map-server";
   version = "2.2.12-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin jsk-tools python3Packages.pyyaml pythonPackages.pillow rosmake ];
-  propagatedBuildInputs = [ SDL_image libyamlcpp map-server nav-msgs rosconsole roscpp rospy tf ];
+  propagatedBuildInputs = [ SDL_image map-server nav-msgs rosconsole roscpp rospy tf yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/multisense-ros/default.nix
+++ b/distros/noetic/multisense-ros/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, cv-bridge, dynamic-reconfigure, genmsg, geometry-msgs, image-geometry, image-transport, libjpeg_turbo, libyamlcpp, message-generation, message-runtime, multisense-lib, rosbag, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, cv-bridge, dynamic-reconfigure, genmsg, geometry-msgs, image-geometry, image-transport, libjpeg_turbo, message-generation, message-runtime, multisense-lib, rosbag, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-multisense-ros";
   version = "4.0.5-r1";
@@ -14,9 +14,9 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin libyamlcpp ];
+  buildInputs = [ catkin yaml-cpp ];
   propagatedBuildInputs = [ angles cv-bridge dynamic-reconfigure genmsg geometry-msgs image-geometry image-transport libjpeg_turbo message-generation message-runtime multisense-lib rosbag roscpp sensor-msgs std-msgs stereo-msgs tf ];
-  nativeBuildInputs = [ catkin libyamlcpp ];
+  nativeBuildInputs = [ catkin yaml-cpp ];
 
   meta = {
     description = ''multisense_ros'';

--- a/distros/noetic/picovoice-driver/default.nix
+++ b/distros/noetic/picovoice-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, libyamlcpp, picovoice-msgs, roscpp, roslib }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, picovoice-msgs, roscpp, roslib, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-driver";
   version = "1.0.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile libyamlcpp picovoice-msgs roscpp roslib ];
+  propagatedBuildInputs = [ actionlib ddynamic-reconfigure libsndfile picovoice-msgs roscpp roslib yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/points-preprocessor/default.nix
+++ b/distros/noetic/points-preprocessor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, autoware-config-msgs, catkin, cv-bridge, gtest, libyamlcpp, message-filters, pcl-conversions, pcl-ros, qt5, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros, velodyne-pcl }:
+{ lib, buildRosPackage, fetchurl, autoware-config-msgs, catkin, cv-bridge, gtest, message-filters, pcl-conversions, pcl-ros, qt5, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros, velodyne-pcl, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-points-preprocessor";
   version = "1.14.14-r3";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ autoware-config-msgs cv-bridge gtest libyamlcpp message-filters pcl-conversions pcl-ros qt5.qtbase roscpp roslint rostest sensor-msgs std-msgs tf tf2 tf2-eigen tf2-ros velodyne-pcl ];
+  propagatedBuildInputs = [ autoware-config-msgs cv-bridge gtest message-filters pcl-conversions pcl-ros qt5.qtbase roscpp roslint rostest sensor-msgs std-msgs tf tf2 tf2-eigen tf2-ros velodyne-pcl yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
   version = "2.7.4-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin message-generation python3Packages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ angles cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ angles cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rosmon-core/default.nix
+++ b/distros/noetic/rosmon-core/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, libyamlcpp, ncurses, python3, python3Packages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml }:
+{ lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, ncurses, python3, python3Packages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-rosmon-core";
   version = "2.5.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin python3 ];
   checkInputs = [ catch-ros python3Packages.rospkg rostest ];
-  propagatedBuildInputs = [ boost cmake-modules diagnostic-msgs libyamlcpp ncurses rosbash roscpp rosfmt roslib rosmon-msgs rospack std-msgs tinyxml ];
+  propagatedBuildInputs = [ boost cmake-modules diagnostic-msgs ncurses rosbash roscpp rosfmt roslib rosmon-msgs rospack std-msgs tinyxml yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rslidar-sdk/default.nix
+++ b/distros/noetic/rslidar-sdk/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libpcap, libyamlcpp, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, libpcap, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-rslidar-sdk";
   version = "1.3.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ libpcap libyamlcpp pcl pcl-conversions pcl-ros roscpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ libpcap pcl pcl-conversions pcl-ros roscpp sensor-msgs std-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
   version = "1.14.20-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules eigen message-generation urdfdom urdfdom-headers ];
   checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-ros tinyxml-2 urdf visualization-msgs ];
+  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-ros tinyxml-2 urdf visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sr-hand-detector/default.nix
+++ b/distros/noetic/sr-hand-detector/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, roscpp, roslib, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, roslib, rostest, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-sr-hand-detector";
   version = "0.0.9-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ libyamlcpp roscpp roslib ];
+  propagatedBuildInputs = [ roscpp roslib yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/swri-roscpp/default.nix
+++ b/distros/noetic/swri-roscpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, marti-introspection-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, marti-common-msgs, marti-introspection-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-swri-roscpp";
   version = "2.15.2-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin pkg-config ];
   checkInputs = [ gtest message-generation message-runtime rostest rosunit ];
-  propagatedBuildInputs = [ boost diagnostic-updater dynamic-reconfigure libyamlcpp marti-common-msgs marti-introspection-msgs nav-msgs roscpp std-msgs std-srvs ];
+  propagatedBuildInputs = [ boost diagnostic-updater dynamic-reconfigure marti-common-msgs marti-introspection-msgs nav-msgs roscpp std-msgs std-srvs yaml-cpp ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/noetic/swri-transform-util/default.nix
+++ b/distros/noetic/swri-transform-util/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, genpy, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, python3Packages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, genpy, geographic-msgs, geometry-msgs, geos, gps-common, marti-nav-msgs, nodelet, pkg-config, proj, python3Packages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-swri-transform-util";
   version = "2.15.2-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin pkg-config python3Packages.setuptools ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs genpy geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj python3Packages.numpy roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs genpy geographic-msgs geometry-msgs geos gps-common marti-nav-msgs nodelet proj python3Packages.numpy roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools yaml-cpp ];
   nativeBuildInputs = [ catkin pkg-config python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/swri-yaml-util/default.nix
+++ b/distros/noetic/swri-yaml-util/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config, roscpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, pkg-config, roscpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-swri-yaml-util";
   version = "2.15.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin pkg-config ];
-  propagatedBuildInputs = [ boost libyamlcpp roscpp ];
+  propagatedBuildInputs = [ boost roscpp yaml-cpp ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/noetic/tesseract-collision/default.nix
+++ b/distros/noetic/tesseract-collision/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
+{ lib, buildRosPackage, fetchurl, boost, bullet, cmake, console-bridge, eigen, fcl, gbenchmark, gtest, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-collision";
   version = "0.18.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "cmake";
   buildInputs = [ cmake ros-industrial-cmake-boilerplate ];
   checkInputs = [ gbenchmark gtest tesseract-scene-graph ];
-  propagatedBuildInputs = [ boost bullet console-bridge eigen fcl libyamlcpp tesseract-common tesseract-geometry tesseract-support ];
+  propagatedBuildInputs = [ boost bullet console-bridge eigen fcl tesseract-common tesseract-geometry tesseract-support yaml-cpp ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, libyamlcpp, ros-industrial-cmake-boilerplate, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, ros-industrial-cmake-boilerplate, tinyxml-2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
   version = "0.18.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "cmake";
   buildInputs = [ cmake ros-industrial-cmake-boilerplate ];
   checkInputs = [ clang gtest lcov ];
-  propagatedBuildInputs = [ boost console-bridge eigen libyamlcpp tinyxml-2 ];
+  propagatedBuildInputs = [ boost console-bridge eigen tinyxml-2 yaml-cpp ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, liblapack, libyamlcpp, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, liblapack, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-state-solver, tesseract-support, tesseract-urdf, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
   version = "0.18.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "cmake";
   buildInputs = [ cmake ros-industrial-cmake-boilerplate ];
   checkInputs = [ gtest liblapack tesseract-support tesseract-urdf ];
-  propagatedBuildInputs = [ console-bridge eigen libyamlcpp opw-kinematics orocos-kdl tesseract-common tesseract-scene-graph tesseract-state-solver ];
+  propagatedBuildInputs = [ console-bridge eigen opw-kinematics orocos-kdl tesseract-common tesseract-scene-graph tesseract-state-solver yaml-cpp ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, libyamlcpp, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
   version = "0.18.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "cmake";
   buildInputs = [ cmake ros-industrial-cmake-boilerplate ];
   checkInputs = [ gtest tesseract-support ];
-  propagatedBuildInputs = [ console-bridge eigen libyamlcpp tesseract-common tesseract-scene-graph ];
+  propagatedBuildInputs = [ console-bridge eigen tesseract-common tesseract-scene-graph yaml-cpp ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/ur-calibration/default.nix
+++ b/distros/noetic/ur-calibration/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, libyamlcpp, roscpp, rosunit, ur-client-library, ur-robot-driver }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, rosunit, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-ur-calibration";
   version = "2.1.2-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ eigen libyamlcpp roscpp ur-client-library ur-robot-driver ];
+  propagatedBuildInputs = [ eigen roscpp ur-client-library ur-robot-driver yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/velodyne-pointcloud/default.nix
+++ b/distros/noetic/velodyne-pointcloud/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-updater, dynamic-reconfigure, eigen, libyamlcpp, nodelet, roscpp, roslaunch, roslib, roslint, rostest, rosunit, sensor-msgs, tf2-ros, velodyne-driver, velodyne-laserscan, velodyne-msgs }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-updater, dynamic-reconfigure, eigen, nodelet, roscpp, roslaunch, roslib, roslint, rostest, rosunit, sensor-msgs, tf2-ros, velodyne-driver, velodyne-laserscan, velodyne-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pointcloud";
   version = "1.7.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin roslint ];
   checkInputs = [ roslaunch rostest rosunit tf2-ros ];
-  propagatedBuildInputs = [ angles diagnostic-updater dynamic-reconfigure eigen libyamlcpp nodelet roscpp roslib sensor-msgs tf2-ros velodyne-driver velodyne-laserscan velodyne-msgs ];
+  propagatedBuildInputs = [ angles diagnostic-updater dynamic-reconfigure eigen nodelet roscpp roslib sensor-msgs tf2-ros velodyne-driver velodyne-laserscan velodyne-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "d258e0dacb291aa43d0f12742791afbc9948dadebe040b7a01caae3be0eebe3d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "cff875547134148525564c67fb90562f795c4aa59d14ce73449c197005602c56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "018004576394368ac73495246b27539f4c16ef6cf9be0d0813b01817c2843a46";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "45cef7e7bbf820ec707c7c0ef3cbaa52effc7227a80f1eed80f9939fdc189d86";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/aruco-opencv/default.nix
+++ b/distros/rolling/aruco-opencv/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, libyamlcpp, python39Packages, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, python39Packages, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-aruco-opencv";
   version = "4.1.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport libyamlcpp python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "b8bd335ba0031a062ea56e61257e6a72579f6624b4f9f9e14b33524dfb98712d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "b25755a14f6247e0175ea3683130ddf630330952879507940c4273b1ca6c7c1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "61d89a0ee1721f8f770a238a88c3c28e49dfb36c918368a3c21fba28c28a1a30";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "1348ac407e314465b6c920343528c3d0544b2f57c9fffdb29449220158592e42";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "2a3aba6d8f4722f9ac3fe77b3c2296c9f6f0b1f4d06f9a45a784d8bec49b2e77";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "23dd72316833b9b2903fdf4b993a9fa50d13762c1bdd887fecdf9eb92d7ecbd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "f336ab28e3838eddc113d495420eca193a3365e35f2a4b9694b361c8c49e27bc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "c4711021a4d273596e6dfff6c98ad1998ca9c112acd7af69a7e2b392a95d0613";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "1a7d8e4cea741f85ce1f5952389bc34a5e4ff9c44ee61b7bac52b76a54b17477";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "33926f704071f4afffb230038ab3c430c54cb8a67323af3428335b86c6ab74b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/domain-bridge/default.nix
+++ b/distros/rolling/domain-bridge/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, libyamlcpp, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, zstd-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-testing, launch-testing-ament-cmake, rclcpp, rclcpp-components, rcutils, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rosbag2-cpp, rosgraph-msgs, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp, test-msgs, yaml-cpp, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-domain-bridge";
   version = "0.5.0-r3";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common example-interfaces launch launch-testing launch-testing-ament-cmake rmw-connextdds rmw-cyclonedds-cpp rmw-fastrtps-cpp rmw-implementation-cmake rosgraph-msgs test-msgs ];
-  propagatedBuildInputs = [ libyamlcpp rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp zstd-vendor ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rcutils rosbag2-cpp rosidl-default-runtime rosidl-typesupport-cpp yaml-cpp zstd-vendor ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "f8f45fd16bd0f799d77365d2d72ff458ababe23ed8ce2b57d6a57871220aafc8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "cab4cc4d6531baf30e0c1a89c707d142dfef17c07c5061c9eea447e702e3d349";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "5b83af5090adf4dbfc4f46b094ae64159e34b6f73e3fffef254827b6803689a1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "8ee1779aa5240d8d3025d3a4a13b3b703af81fece29a8eb52463c2bdb64b50fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "1e71d7b9534cee9b6f8378dfd444ecebe77f074c74e69e934adcafab3ceda045";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "d43c47e4b6dff3b1186228164032a8ffadd7c9c7d6a25b3d25654a28b5199f75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -1848,6 +1848,8 @@ self: super: {
 
  tf-transformations = self.callPackage ./tf-transformations {};
 
+ theora-image-transport = self.callPackage ./theora-image-transport {};
+
  tinyspline-vendor = self.callPackage ./tinyspline-vendor {};
 
  tinyxml2-vendor = self.callPackage ./tinyxml2-vendor {};

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "eebb32789508b3b6512c96a661da00eba85e3d5225de573db8493ea2e7bba59a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "5d97fe3abff0639d4cd57638a087c4a0151201773885064051c61770534ef968";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "160653b1eab04e7d6387e222565b2d63da21982141d6987ad85f590766ee5a50";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "f51646e99d834d2c322181a932785ecfb2697b0a2144dc5cef09df3ee05490f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "b1c64bd9eba2676ee586ce824f18cf5c42724df90d311e6556fc6f0da05d03a2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "4855d7f82a03245a99f50598c67add8fbe6cacf9a8eda50c4964fa4782268fae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "8be36da71fc8ee5236d9b956620d470592024ee9cb20aae720e606f52624e015";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "ef2db556b1bacfb41a74dbed3060df1495ede19e0685c9ef7f9f7b972689cc29";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "cccdb1add65dfc14a3bb41e925d7ae17539b9c4d17c6124d04e7170004697b21";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "a43f18c3a2709043f9c4a53ff2a408dc463010105f895f3b9a5e37f038d67c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-publisher-gui/default.nix
+++ b/distros/rolling/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-publisher-gui";
-  version = "2.3.0-r2";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher_gui/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "255b331da0aec234a32fb38242469bb22dc62d04e57d255dfa8c2703ec61c8a6";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher_gui/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "1b4f6e48533750430f1d79762a45b4504f8ba2b520bd17237334333c3619fc25";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/joint-state-publisher/default.nix
+++ b/distros/rolling/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2topic, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-publisher";
-  version = "2.3.0-r2";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "2d48d5c1fe8c43b9cf56bc078c111637a57f99d271890a5cbc536b60466c0669";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/rolling/joint_state_publisher/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5c9aa39c5a2f163a7904ba146579bd42e913158a2b2d2ab717c94204b59c4273";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "1a64f4991e995aa32e3fe753429172c2dff436fe15fd21ce6fe8ec7ad99aaad6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "75bcf78d6e45342a0f03e5eea90980b82df1ff1d7907b7426694b31fdaad8929";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-extras/default.nix
+++ b/distros/rolling/mavros-extras/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, libyamlcpp, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mavros-extras";
   version = "2.4.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python angles ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common gtest ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn libyamlcpp mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros mavros-msgs message-filters nav-msgs pluginlib rclcpp rclcpp-components rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs urdf visualization-msgs yaml-cpp yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
 
   meta = {

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "65e965c9450f92d9d313ca77e704f7c2755e395c62742186e22133c21cdf2e65";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "85757bb8fc965cc485dd1bd85ed37aee64a46a4b9f27cbf332a82f45a1516653";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-adapter/default.nix
+++ b/distros/rolling/rmf-fleet-adapter/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, libyamlcpp, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter";
   version = "2.3.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake eigen libyamlcpp ];
+  buildInputs = [ ament-cmake eigen yaml-cpp ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
   propagatedBuildInputs = [ nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/rolling/rmf-traffic-editor/default.nix
+++ b/distros/rolling/rmf-traffic-editor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, libyamlcpp, proj, qt5, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, proj, qt5, rmf-utils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-editor";
   version = "1.8.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-index-cpp eigen libyamlcpp qt5.qtbase rmf-utils ];
+  buildInputs = [ ament-cmake ament-index-cpp eigen qt5.qtbase rmf-utils yaml-cpp ];
   checkInputs = [ ament-cmake-uncrustify ];
   propagatedBuildInputs = [ ceres-solver glog proj ];
 

--- a/distros/rolling/rmf-traffic-ros2/default.nix
+++ b/distros/rolling/rmf-traffic-ros2/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, libyamlcpp, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-ros2";
   version = "2.3.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ libyamlcpp nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux zlib ];
+  propagatedBuildInputs = [ nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/robot-calibration/default.nix
+++ b/distros/rolling/robot-calibration/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, libyamlcpp, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-robot-calibration";
   version = "0.8.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser libyamlcpp moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "f4bb86891b445ff2d89d4f98cc3dc2e2d262d0b7512736c908fe5d7df41b2037";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "49531cef225f1ffffb8402e726c88407080713f93b44c6b3c77059eeb26afd3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "f64f54f930f623a4516eb8e940562738928d8f60ea908de91fe041a31cf1f251";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "7ac96af3e77774162cbaf4bcb03bfbc3c100179e1df55c84672251613595df08";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "143dd1a5af830f7adb4c6b5bfeed7de2fdada7eea4be50fccbb1d6eba5fe2d16";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "f12c23740db0fe70fe40b38cd651af3fc94b6d24888a61b8e60ba0ddbbdbc963";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "5363887bccbb9a7d1dcad25bf113d80e9b6e8c960985dc5c5b1512fdaef43d2c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "817127f59486187da26a8bb097135db2c0e33eea8328ed394d6d4c3d2f7acdc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "b3bae9e60a9d7067e01a24cf258b7d0297084af8bc52f7f68867cf2fcacef470";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "4072da36b6a9540b1a7c2c9b8b9d08dccf4ed6440219e4ea737558b536e8b1dd";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "63912e05a3d37a0f202b3087da77d7686483d42b2ee52df05321e878e263dd90";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "ef0b1c35a1c5bd04a433df322d2a62f1674945cae877c5964a9c5b05371964a1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "e543067cef7290d854071e26210fe0e46682ce499f28c7ffbc02906ea74aee07";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "61e70a2095559d6b5433977ec7ffd1036cf39c7af514525affcf929c4a11e4ad";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rt-manipulators-cpp/default.nix
+++ b/distros/rolling/rt-manipulators-cpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, libyamlcpp, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, eigen, eigen3-cmake-module, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rt-manipulators-cpp";
   version = "1.0.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module libyamlcpp yaml-cpp-vendor ];
+  propagatedBuildInputs = [ dynamixel-sdk eigen eigen3-cmake-module yaml-cpp yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "0d99a08ad2f302bc40546242771184cdf9a526c54da580a9e6558c3365fa1356";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "1a686797974a9ddaa3221abdcfacb4d0e2462cfba6b5095ae3aad598c24e3936";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-transform-util/default.nix
+++ b/distros/rolling/swri-transform-util/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-transform-util";
   version = "3.5.0-r2";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geometry-msgs geos gps-msgs launch-xml marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/rolling/theora-image-transport/default.nix
+++ b/distros/rolling/theora-image-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-theora-image-transport";
+  version = "3.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/theora_image_transport/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "e640b2d579f31755425412d9d28adf11da09f0bbaf6d953cee184c1fb336cdbb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-transport libogg libtheora opencv pluginlib rclcpp rcutils rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
+
+  meta = {
+    description = ''Theora_image_transport provides a plugin to image_transport for
+    transparently sending an image stream encoded with the Theora codec.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "d3de0c85641cafb43db1789d532e9e12a43b748fe2a4611e4c356778d7ac26d4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "7aceb3dae91743310b473eaa9db98f3bdb5b5c033a3922928466b9c8cb9d976b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "80093415352d08c242ac4b257cc0b6f619ddc53a621ef6418f1e1d3dba60fb67";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "126304509c404516d0277a335b27eec8c92b9798a8d279ab491e71f641123fb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "29997e9d05ffc3bbda18f11df9b498de69cce7cc3220ae64832082833d472159";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "e8bc1e34c94403a34661abb081ec7c709fabc4ae7468cbe44969471d1255a0a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, libyamlcpp, rclcpp, ur-client-library, ur-robot-driver }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
   version = "2.3.2-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen libyamlcpp rclcpp ur-client-library ur-robot-driver ];
+  propagatedBuildInputs = [ eigen rclcpp ur-client-library ur-robot-driver yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "3.12.0-r1";
+  version = "3.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.12.0-1.tar.gz";
-    name = "3.12.0-1.tar.gz";
-    sha256 = "6e6884a27df3491bf6b392e9c31010b3c978688a542dfdbf3feffa7f617cb6ee";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.13.0-1.tar.gz";
+    name = "3.13.0-1.tar.gz";
+    sha256 = "9ce7f20cb6a082b4ea1233ec74693c257d873db6cafd655aa3b5a89684dc1874";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velodyne-pointcloud/default.nix
+++ b/distros/rolling/velodyne-pointcloud/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-velodyne-pointcloud";
   version = "2.3.0-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, libyamlcpp, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
   version = "2023.1.1-r2";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs libyamlcpp pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs pluginlib rclcpp rclpy sensor-msgs std-msgs tf2-geometry-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-importer webots-ros2-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {

--- a/distros/rolling/yaml-cpp-vendor/default.nix
+++ b/distros/rolling/yaml-cpp-vendor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, libyamlcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-yaml-cpp-vendor";
   version = "8.3.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-vendor-package ];
-  propagatedBuildInputs = [ libyamlcpp ];
+  propagatedBuildInputs = [ yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 069e4c017542e1ea1de8ba5b77b507985b3a0e69.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.23.0-r1 --> 2.24.0-r1*
* *admittance-controller 2.23.0-r1 --> 2.24.0-r1*
* *bicycle-steering-controller 2.23.0-r1 --> 2.24.0-r1*
* *costmap-queue 1.1.8-r2 --> 1.1.9-r1*
* *diff-drive-controller 2.23.0-r1 --> 2.24.0-r1*
* *dwb-core 1.1.8-r2 --> 1.1.9-r1*
* *dwb-critics 1.1.8-r2 --> 1.1.9-r1*
* *dwb-msgs 1.1.8-r2 --> 1.1.9-r1*
* *dwb-plugins 1.1.8-r2 --> 1.1.9-r1*
* *effort-controllers 2.23.0-r1 --> 2.24.0-r1*
* *fastrtps 2.6.5-r1 --> 2.6.6-r1*
* *force-torque-sensor-broadcaster 2.23.0-r1 --> 2.24.0-r1*
* *forward-command-controller 2.23.0-r1 --> 2.24.0-r1*
* *gripper-controllers 2.23.0-r1 --> 2.24.0-r1*
* *imu-sensor-broadcaster 2.23.0-r1 --> 2.24.0-r1*
* *joint-state-broadcaster 2.23.0-r1 --> 2.24.0-r1*
* *joint-state-publisher 2.3.0-r1 --> 2.4.0-r1*
* *joint-state-publisher-gui 2.3.0-r1 --> 2.4.0-r1*
* *joint-trajectory-controller 2.23.0-r1 --> 2.24.0-r1*
* *nav-2d-msgs 1.1.8-r2 --> 1.1.9-r1*
* *nav-2d-utils 1.1.8-r2 --> 1.1.9-r1*
* *nav2-amcl 1.1.8-r2 --> 1.1.9-r1*
* *nav2-behavior-tree 1.1.8-r2 --> 1.1.9-r1*
* *nav2-behaviors 1.1.8-r2 --> 1.1.9-r1*
* *nav2-bringup 1.1.8-r2 --> 1.1.9-r1*
* *nav2-bt-navigator 1.1.8-r2 --> 1.1.9-r1*
* *nav2-collision-monitor 1.1.8-r2 --> 1.1.9-r1*
* *nav2-common 1.1.8-r2 --> 1.1.9-r1*
* *nav2-constrained-smoother 1.1.8-r2 --> 1.1.9-r1*
* *nav2-controller 1.1.8-r2 --> 1.1.9-r1*
* *nav2-core 1.1.8-r2 --> 1.1.9-r1*
* *nav2-costmap-2d 1.1.8-r2 --> 1.1.9-r1*
* *nav2-dwb-controller 1.1.8-r2 --> 1.1.9-r1*
* *nav2-lifecycle-manager 1.1.8-r2 --> 1.1.9-r1*
* *nav2-map-server 1.1.8-r2 --> 1.1.9-r1*
* *nav2-msgs 1.1.8-r2 --> 1.1.9-r1*
* *nav2-navfn-planner 1.1.8-r2 --> 1.1.9-r1*
* *nav2-planner 1.1.8-r2 --> 1.1.9-r1*
* *nav2-regulated-pure-pursuit-controller 1.1.8-r2 --> 1.1.9-r1*
* *nav2-rotation-shim-controller 1.1.8-r2 --> 1.1.9-r1*
* *nav2-rviz-plugins 1.1.8-r2 --> 1.1.9-r1*
* *nav2-simple-commander 1.1.8-r2 --> 1.1.9-r1*
* *nav2-smac-planner 1.1.8-r2 --> 1.1.9-r1*
* *nav2-smoother 1.1.8-r2 --> 1.1.9-r1*
* *nav2-system-tests 1.1.8-r2 --> 1.1.9-r1*
* *nav2-theta-star-planner 1.1.8-r2 --> 1.1.9-r1*
* *nav2-util 1.1.8-r2 --> 1.1.9-r1*
* *nav2-velocity-smoother 1.1.8-r2 --> 1.1.9-r1*
* *nav2-voxel-grid 1.1.8-r2 --> 1.1.9-r1*
* *nav2-waypoint-follower 1.1.8-r2 --> 1.1.9-r1*
* *navigation2 1.1.8-r2 --> 1.1.9-r1*
* *position-controllers 2.23.0-r1 --> 2.24.0-r1*
* *raspimouse-navigation 2.0.0-r1*
* *raspimouse-slam 2.0.0-r1*
* *raspimouse-slam-navigation 2.0.0-r1*
* *ros2-controllers 2.23.0-r1 --> 2.24.0-r1*
* *ros2-controllers-test-nodes 2.23.0-r1 --> 2.24.0-r1*
* *rqt-joint-trajectory-controller 2.23.0-r1 --> 2.24.0-r1*
* *slam-toolbox 2.6.4-r1 --> 2.6.5-r1*
* *steering-controllers-library 2.23.0-r1 --> 2.24.0-r1*
* *theora-image-transport 2.5.0-r2*
* *tricycle-controller 2.23.0-r1 --> 2.24.0-r1*
* *tricycle-steering-controller 2.23.0-r1 --> 2.24.0-r1*
* *velocity-controllers 2.23.0-r1 --> 2.24.0-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.12.0-r1 --> 3.13.0-r1*
* *admittance-controller 3.12.0-r1 --> 3.13.0-r1*
* *bicycle-steering-controller 3.12.0-r1 --> 3.13.0-r1*
* *controller-interface 3.16.0-r1 --> 3.17.0-r1*
* *controller-manager 3.16.0-r1 --> 3.17.0-r1*
* *controller-manager-msgs 3.16.0-r1 --> 3.17.0-r1*
* *costmap-queue 1.2.1-r1 --> 1.2.2-r1*
* *diff-drive-controller 3.12.0-r1 --> 3.13.0-r1*
* *dwb-core 1.2.1-r1 --> 1.2.2-r1*
* *dwb-critics 1.2.1-r1 --> 1.2.2-r1*
* *dwb-msgs 1.2.1-r1 --> 1.2.2-r1*
* *dwb-plugins 1.2.1-r1 --> 1.2.2-r1*
* *effort-controllers 3.12.0-r1 --> 3.13.0-r1*
* *force-torque-sensor-broadcaster 3.12.0-r1 --> 3.13.0-r1*
* *forward-command-controller 3.12.0-r1 --> 3.13.0-r1*
* *gripper-controllers 3.12.0-r1 --> 3.13.0-r1*
* *hardware-interface 3.16.0-r1 --> 3.17.0-r1*
* *imu-sensor-broadcaster 3.12.0-r1 --> 3.13.0-r1*
* *joint-limits 3.16.0-r1 --> 3.17.0-r1*
* *joint-state-broadcaster 3.12.0-r1 --> 3.13.0-r1*
* *joint-state-publisher 2.3.0-r3 --> 2.4.0-r1*
* *joint-state-publisher-gui 2.3.0-r3 --> 2.4.0-r1*
* *joint-trajectory-controller 3.12.0-r1 --> 3.13.0-r1*
* *nav-2d-msgs 1.2.1-r1 --> 1.2.2-r1*
* *nav-2d-utils 1.2.1-r1 --> 1.2.2-r1*
* *nav2-amcl 1.2.1-r1 --> 1.2.2-r1*
* *nav2-behavior-tree 1.2.1-r1 --> 1.2.2-r1*
* *nav2-behaviors 1.2.1-r1 --> 1.2.2-r1*
* *nav2-bringup 1.2.1-r1 --> 1.2.2-r1*
* *nav2-bt-navigator 1.2.1-r1 --> 1.2.2-r1*
* *nav2-collision-monitor 1.2.1-r1 --> 1.2.2-r1*
* *nav2-common 1.2.1-r1 --> 1.2.2-r1*
* *nav2-constrained-smoother 1.2.1-r1 --> 1.2.2-r1*
* *nav2-controller 1.2.1-r1 --> 1.2.2-r1*
* *nav2-core 1.2.1-r1 --> 1.2.2-r1*
* *nav2-costmap-2d 1.2.1-r1 --> 1.2.2-r1*
* *nav2-dwb-controller 1.2.1-r1 --> 1.2.2-r1*
* *nav2-lifecycle-manager 1.2.1-r1 --> 1.2.2-r1*
* *nav2-map-server 1.2.1-r1 --> 1.2.2-r1*
* *nav2-msgs 1.2.1-r1 --> 1.2.2-r1*
* *nav2-navfn-planner 1.2.1-r1 --> 1.2.2-r1*
* *nav2-planner 1.2.1-r1 --> 1.2.2-r1*
* *nav2-regulated-pure-pursuit-controller 1.2.1-r1 --> 1.2.2-r1*
* *nav2-rotation-shim-controller 1.2.1-r1 --> 1.2.2-r1*
* *nav2-rviz-plugins 1.2.1-r1 --> 1.2.2-r1*
* *nav2-simple-commander 1.2.1-r1 --> 1.2.2-r1*
* *nav2-smac-planner 1.2.1-r1 --> 1.2.2-r1*
* *nav2-smoother 1.2.1-r1 --> 1.2.2-r1*
* *nav2-system-tests 1.2.1-r1 --> 1.2.2-r1*
* *nav2-theta-star-planner 1.2.1-r1 --> 1.2.2-r1*
* *nav2-util 1.2.1-r1 --> 1.2.2-r1*
* *nav2-velocity-smoother 1.2.1-r1 --> 1.2.2-r1*
* *nav2-voxel-grid 1.2.1-r1 --> 1.2.2-r1*
* *nav2-waypoint-follower 1.2.1-r1 --> 1.2.2-r1*
* *navigation2 1.2.1-r1 --> 1.2.2-r1*
* *position-controllers 3.12.0-r1 --> 3.13.0-r1*
* *ros2-control 3.16.0-r1 --> 3.17.0-r1*
* *ros2-control-test-assets 3.16.0-r1 --> 3.17.0-r1*
* *ros2-controllers 3.12.0-r1 --> 3.13.0-r1*
* *ros2-controllers-test-nodes 3.12.0-r1 --> 3.13.0-r1*
* *ros2controlcli 3.16.0-r1 --> 3.17.0-r1*
* *rqt-controller-manager 3.16.0-r1 --> 3.17.0-r1*
* *rqt-joint-trajectory-controller 3.12.0-r1 --> 3.13.0-r1*
* *rtabmap 0.21.2-r1*
* *rtabmap-conversions 0.21.2-r1*
* *rtabmap-demos 0.21.2-r1*
* *rtabmap-examples 0.21.2-r1*
* *rtabmap-launch 0.21.2-r1*
* *rtabmap-msgs 0.21.2-r1*
* *rtabmap-odom 0.21.2-r1*
* *rtabmap-python 0.21.2-r1*
* *rtabmap-ros 0.21.2-r1*
* *rtabmap-rviz-plugins 0.21.2-r1*
* *rtabmap-slam 0.21.2-r1*
* *rtabmap-sync 0.21.2-r1*
* *rtabmap-util 0.21.2-r1*
* *rtabmap-viz 0.21.2-r1*
* *slam-toolbox 2.7.0-r2 --> 2.7.1-r1*
* *steering-controllers-library 3.12.0-r1 --> 3.13.0-r1*
* *theora-image-transport 3.1.0-r1*
* *transmission-interface 3.16.0-r1 --> 3.17.0-r1*
* *tricycle-controller 3.12.0-r1 --> 3.13.0-r1*
* *tricycle-steering-controller 3.12.0-r1 --> 3.13.0-r1*
* *velocity-controllers 3.12.0-r1 --> 3.13.0-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 3.12.0-r1 --> 3.13.0-r1*
* *admittance-controller 3.12.0-r1 --> 3.13.0-r1*
* *bicycle-steering-controller 3.12.0-r1 --> 3.13.0-r1*
* *controller-interface 3.16.0-r1 --> 3.17.0-r1*
* *controller-manager 3.16.0-r1 --> 3.17.0-r1*
* *controller-manager-msgs 3.16.0-r1 --> 3.17.0-r1*
* *diff-drive-controller 3.12.0-r1 --> 3.13.0-r1*
* *effort-controllers 3.12.0-r1 --> 3.13.0-r1*
* *force-torque-sensor-broadcaster 3.12.0-r1 --> 3.13.0-r1*
* *forward-command-controller 3.12.0-r1 --> 3.13.0-r1*
* *gripper-controllers 3.12.0-r1 --> 3.13.0-r1*
* *hardware-interface 3.16.0-r1 --> 3.17.0-r1*
* *imu-sensor-broadcaster 3.12.0-r1 --> 3.13.0-r1*
* *joint-limits 3.16.0-r1 --> 3.17.0-r1*
* *joint-state-broadcaster 3.12.0-r1 --> 3.13.0-r1*
* *joint-state-publisher 2.3.0-r2 --> 2.4.0-r1*
* *joint-state-publisher-gui 2.3.0-r2 --> 2.4.0-r1*
* *joint-trajectory-controller 3.12.0-r1 --> 3.13.0-r1*
* *position-controllers 3.12.0-r1 --> 3.13.0-r1*
* *ros2-control 3.16.0-r1 --> 3.17.0-r1*
* *ros2-control-test-assets 3.16.0-r1 --> 3.17.0-r1*
* *ros2-controllers 3.12.0-r1 --> 3.13.0-r1*
* *ros2-controllers-test-nodes 3.12.0-r1 --> 3.13.0-r1*
* *ros2controlcli 3.16.0-r1 --> 3.17.0-r1*
* *rqt-controller-manager 3.16.0-r1 --> 3.17.0-r1*
* *rqt-joint-trajectory-controller 3.12.0-r1 --> 3.13.0-r1*
* *steering-controllers-library 3.12.0-r1 --> 3.13.0-r1*
* *theora-image-transport 3.2.0-r1*
* *transmission-interface 3.16.0-r1 --> 3.17.0-r1*
* *tricycle-controller 3.12.0-r1 --> 3.13.0-r1*
* *tricycle-steering-controller 3.12.0-r1 --> 3.13.0-r1*
* *velocity-controllers 3.12.0-r1 --> 3.13.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] hdf5-tools
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote
 * [ ] xsimd

