### PR TITLE
rosdistro sync, Sat Aug 12 01:44:44 2023

### DIFF
--- a/distros/humble/aws-sdk-cpp-vendor/default.nix
+++ b/distros/humble/aws-sdk-cpp-vendor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl }:
+buildRosPackage {
+  pname = "ros-humble-aws-sdk-cpp-vendor";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/humble/aws_sdk_cpp_vendor/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "38df12f48b53e34a65afc79ceb5d41ab16336f029ce61f728ae9a4b7083211b2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ openssl ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
+
+  meta = {
+    description = ''A vendor package for aws-sdk-cpp'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "7b81d8ba26e57f04ce07642cf4331b8bd43668cc152721e79bc2931f169235dd";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "23f6d3d08a3b0dcfbecacb7a84056b8d26cdb5a6a624b3589720b1a38fe0d81c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "15294191d0b8d31562d94c7bc81e9abbcdaa0620c3b50495ef1316a387d2ff94";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "bdfeccec3fe7fa8c5468e4b1ed0932106e41d85682a5487d02f4dab00fbb5cd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "e267f01c35e48df9c32a904db6d1487c7979278ef98d42c2882353189a66c6ff";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "31c05b56808a6459e28dcd6b9c6c610e8c1494600b5fcfdc67d3d40bca8e46cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "1665abd5a3803ec1eb16c24c2c13c1566dc1adbca430942bea99b2342779d8fc";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "d5b64f9486dc90178eaee7a114ab212fcf6c3384fbf2a84396cdbba430ad1d0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "6fa5276652635d72eddd4eae5b35fddf82b177f1b12c12403d489de71ab5118e";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "8bb238dcc7cd8e8c24f2f3ec3674ac8a9cfa9f373c0075f3c12656bf9c8cf63b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "aa1c888e0c6f8c044df7e5c281b74366a0e918de57bfcb7d946d4ac9e7728a9a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "9336fdd440cb6c4a8bc52f067e4cbfd8f1e0e2e7754d83462ea2c573a6259939";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "d505201c868c9ed903fd9b4962ba677dcd230104a61ef57b989a29f2d8c0019c";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "38aca13d29b50e7ed862f679b3f6f36bddfef9f0612ccd615d17056c21c01b83";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "4b835ef958d73fc9b5a8ddd086a90718546faf9474c4a0fe71c6678bca226052";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "282c90940081008cbb15720c6f30770c0c414c9888ac8581578184fe72af0819";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flexbe-behavior-engine/default.nix
+++ b/distros/humble/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-humble-flexbe-behavior-engine";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_behavior_engine/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "3dc858ec3d726f388ca319845b8333531bb8b5be577824d0d224e9d5e3a86bfa";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_behavior_engine/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "f465f4f1a1445f8210a3fb3cf3bd37a89f5fe7074b4f9027aa5ee15940824ada";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flexbe-core/default.nix
+++ b/distros/humble/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-msgs, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs, std-srvs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-flexbe-core";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_core/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "8ef39c4f019dbe6cdfeb45767312e3453ba6e9f5e4236d9fe98a0d3f701f8d72";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_core/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "789512ca53f2db6e6840c0e84b6bd2da737f2ca92bc90c0a3924e92731f24147";
   };
 
   buildType = "ament_python";

--- a/distros/humble/flexbe-input/default.nix
+++ b/distros/humble/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-flexbe-input";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_input/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "041bc878980e1a557f4ac70c18f2e3d72ac61afba7555e2d6e7da03a0710bd08";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_input/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "645ee6f26ea60ddee96adec014fef3ccc77990834cea2f74c3e492ae9f48fe86";
   };
 
   buildType = "ament_python";

--- a/distros/humble/flexbe-mirror/default.nix
+++ b/distros/humble/flexbe-mirror/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-flexbe-mirror";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_mirror/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "19d1001fed4b4a2efbb7ac131e0cfedaaf35a8472349c4ec99e1e0ad520f3571";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_mirror/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "69008887d8042363603014f99955ef696809e9ea218db2c1eff1fd1fdd16c87d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/flexbe-msgs/default.nix
+++ b/distros/humble/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flexbe-msgs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_msgs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "3d0d36c5e5567b7cbb55ade223470b380f7bb5034151ca7a0b4b61d95c8ff3a6";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "43f72cff3105576e3ee373da45f3613284a0f6534e642c9d078da0de89f0cbc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flexbe-onboard/default.nix
+++ b/distros/humble/flexbe-onboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-states, launch-ros, launch-testing, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-flexbe-onboard";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_onboard/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "cb469c3bcab3fa0aafc554431e800c2e38a3cd210eb8cc5684ea04c8cb8b5181";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_onboard/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5ddd23dc86b32df5a0757242e1b97e9fff09d2771144ea2f610b32a8c6d5ffbe";
   };
 
   buildType = "ament_python";

--- a/distros/humble/flexbe-states/default.nix
+++ b/distros/humble/flexbe-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-flexbe-states";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_states/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "104baa5b0ccd7a0fde26ffa7678367dc88a8a97fac6db64eb8996468bf949d5a";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_states/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "79177732dd7b624d53d78599d9a8e2dfd0a9b6b928695019d9ab71032a53a7f2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/flexbe-testing/default.nix
+++ b/distros/humble/flexbe-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flexbe-testing";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_testing/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "d56c6dd9eb32da4e2b95ab4bcf0305e1f6f12e006c7b0f067c48f3e34937c65c";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_testing/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "6bef0d3e1ed64a6da10823acffe05d91225e6e0c5f353b2d18f6e2bebb802622";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flexbe-widget/default.nix
+++ b/distros/humble/flexbe-widget/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-flexbe-widget";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_widget/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "04207dc42d19affdf6c341d3e996d348a9ac55bad93cd7904383dfecbb3ed366";
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/humble/flexbe_widget/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "ffde273f20bb222289b411ff45cff648daf1a7c467b39c453948569dec6b6c0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "95d918cefb62226eb9a7abb383097a31723edc80a6f40c206a8f4a751584aaf6";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "b439516d3e9f9b1ce3df8eeaf956b00058aa9e0785e978f502983e781db04c4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "3d64202e112d71a6fd2c3fa2c6638c4053257106de50cd58fadf0d9689088010";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "84a18cfa1f5f60b0b3a0e8562b6bde1e4a8d504c047deee384e36567c033b9ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -242,6 +242,8 @@ self: super: {
 
  aws-robomaker-small-warehouse-world = self.callPackage ./aws-robomaker-small-warehouse-world {};
 
+ aws-sdk-cpp-vendor = self.callPackage ./aws-sdk-cpp-vendor {};
+
  backward-ros = self.callPackage ./backward-ros {};
 
  bag2-to-image = self.callPackage ./bag2-to-image {};
@@ -1198,6 +1200,8 @@ self: super: {
 
  nav2-map-server = self.callPackage ./nav2-map-server {};
 
+ nav2-mppi-controller = self.callPackage ./nav2-mppi-controller {};
+
  nav2-msgs = self.callPackage ./nav2-msgs {};
 
  nav2-navfn-planner = self.callPackage ./nav2-navfn-planner {};
@@ -2107,6 +2111,10 @@ self: super: {
  soccer-vision-3d-msgs = self.callPackage ./soccer-vision-3d-msgs {};
 
  soccer-vision-attribute-msgs = self.callPackage ./soccer-vision-attribute-msgs {};
+
+ social-nav-msgs = self.callPackage ./social-nav-msgs {};
+
+ social-nav-util = self.callPackage ./social-nav-util {};
 
  sol-vendor = self.callPackage ./sol-vendor {};
 

--- a/distros/humble/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/humble/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-kinova-gen3-6dof-robotiq-2f-85-moveit-config";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "045fd2a30e01e1f8141cef782247887fbcd04015ceb1f529ce096f6547a0a69c";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "126785b070e2678b563a0f24db6079fefd6779d46d12ebecd8db48e4aa8ca556";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/humble/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-kinova-gen3-7dof-robotiq-2f-85-moveit-config";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "8cfa36b0ae2c34d782c829264aae7a941f7aa0684d41465740809d0541b4d2d7";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "253daaa8e2f523d38951d6ff0f67496bcc0b877a87c601d8a1947bb8de71d8ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kortex-api/default.nix
+++ b/distros/humble/kortex-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-kortex-api";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_api/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "a2215b09bae7687b8d02ee71775033d219ecd15afb96b7aa519ce32574cc6768";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_api/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "b57e60cf16e5373ff7ee2c095f60d007df753c745c487f06de2246e4062ee4bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kortex-bringup/default.nix
+++ b/distros/humble/kortex-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, gazebo-ros2-control, gripper-controllers, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, kortex-description, kortex-driver, launch, launch-ros, rclpy, robotiq-description, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-kortex-bringup";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_bringup/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "236374ddcbe72dd98900913fef3609663f58c909786120ba3be0590eb8f62deb";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_bringup/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "3412c424e8723353791ab5acfa51d845a313ed27c0ec45abaf5750404bba1e50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kortex-description/default.nix
+++ b/distros/humble/kortex-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, robotiq-description, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-kortex-description";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_description/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "b32072a36491874256a68765cb4e829647df5e35cf9c3526ca060328606f6a24";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_description/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "e3f435aa09fd39732151c98ccdd22c88bd92412fd1f3f5923b6627802c2c5b6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kortex-driver/default.nix
+++ b/distros/humble/kortex-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, hardware-interface, kortex-api, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-kortex-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "53a5047576cbb737a4bb2534bdc23aa2d226117484562dd59e9437cc71ad6867";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "789bcb19f13e9f90e0bcc59a47f8e676296e8bf50fd398ca865cc43f6170704e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-mppi-controller/default.nix
+++ b/distros/humble/nav2-mppi-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
+buildRosPackage {
+  pname = "ros-humble-nav2-mppi-controller";
+  version = "1.1.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "bec31d66625fbd3f8610d56fa3149e950b73813d9f7c227b56ae984cb63accc9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gbenchmark geometry-msgs llvmPackages.openmp nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros visualization-msgs xsimd xtensor ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+
+  meta = {
+    description = ''nav2_mppi_controller'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/rig-reconfigure/default.nix
+++ b/distros/humble/rig-reconfigure/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, git, glfw3, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-rig-reconfigure";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/humble/rig_reconfigure/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "5f84c98403f23072d9d3c08d7d5d2257dbd5a938bf1d64402315a4c51c4cd9a7";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/humble/rig_reconfigure/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "774ca172ef389244354e925b64ff8f8e3705cede0a283e2ca201cb0e3582ca1d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake git ];
-  propagatedBuildInputs = [ glfw3 rclcpp ];
+  propagatedBuildInputs = [ ament-index-cpp glfw3 rclcpp ];
   nativeBuildInputs = [ ament-cmake git ];
 
   meta = {

--- a/distros/humble/rmf-fleet-adapter-python/default.nix
+++ b/distros/humble/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-humble-rmf-fleet-adapter-python";
-  version = "2.1.6-r1";
+  version = "2.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_fleet_adapter_python/2.1.6-1.tar.gz";
-    name = "2.1.6-1.tar.gz";
-    sha256 = "3b4cedaeac1444dacc9e8558a1ea235b8865762355387ac3e23b76a946b41ff7";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_fleet_adapter_python/2.1.7-1.tar.gz";
+    name = "2.1.7-1.tar.gz";
+    sha256 = "3c7717b2234ad5d42b0e9a6fab8430046daeef3c60985b095205a9e606038ea6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-fleet-adapter/default.nix
+++ b/distros/humble/rmf-fleet-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-rmf-fleet-adapter";
-  version = "2.1.6-r1";
+  version = "2.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_fleet_adapter/2.1.6-1.tar.gz";
-    name = "2.1.6-1.tar.gz";
-    sha256 = "f92f1e9664480a79f77d94b62cfa2415da550aa5a2ef1d75458dab8a2231c32f";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_fleet_adapter/2.1.7-1.tar.gz";
+    name = "2.1.7-1.tar.gz";
+    sha256 = "628a50be5887850402532fca326ab80bc9aed0b37e2e86f3be3d72f8adb64569";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-task-ros2/default.nix
+++ b/distros/humble/rmf-task-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-humble-rmf-task-ros2";
-  version = "2.1.6-r1";
+  version = "2.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_task_ros2/2.1.6-1.tar.gz";
-    name = "2.1.6-1.tar.gz";
-    sha256 = "6e9df8495557a99ac7088e008da59508a35f21dd8557abc7c10383e161f9f465";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_task_ros2/2.1.7-1.tar.gz";
+    name = "2.1.7-1.tar.gz";
+    sha256 = "b6043959d3a25a8dc4cecbddef5bf61bbaf5165c9705a5410364ffe2793b0648";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-task-sequence/default.nix
+++ b/distros/humble/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-humble-rmf-task-sequence";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task_sequence/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "1a519e80ea68c495673c704e076c40c28d2a8c4f2fb23b7d6941142aee386f24";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task_sequence/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "d1628099694ac05f07aebb1b922e679f6d34dbe74c7c8254b4b04512ea4de578";
   };
 
   buildType = "cmake";

--- a/distros/humble/rmf-task/default.nix
+++ b/distros/humble/rmf-task/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-humble-rmf-task";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "83c4cc097590d96c971310ff791249cf4ea694348eec2e78fde90184589518db";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/humble/rmf_task/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "c21c1ecc28e89cbc26ab41a7ed1d730d360e2f5902e0789e19f8968a8919c37f";
   };
 
   buildType = "cmake";

--- a/distros/humble/rmf-traffic-editor-assets/default.nix
+++ b/distros/humble/rmf-traffic-editor-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-humble-rmf-traffic-editor-assets";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/humble/rmf_traffic_editor_assets/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "a6d5fd3100459b022606d8630d8b3240d9780bcc52c873c97c240f63a5f6fba5";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/humble/rmf_traffic_editor_assets/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "478f806b54a7149f5312a4cc335566bfd33368cba562ddacf1e36e0035fe2ea9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rmf-traffic-editor-test-maps/default.nix
+++ b/distros/humble/rmf-traffic-editor-test-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-humble-rmf-traffic-editor-test-maps";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/humble/rmf_traffic_editor_test_maps/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "54efdfc9cb0fcdf551f1d2994da31c099e7b775a9f860896885ad9338ec37903";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/humble/rmf_traffic_editor_test_maps/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "9d3bac5398c840205855e1a557853c400e1ac188243fbb9932c8cdaeeee196b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-traffic-editor/default.nix
+++ b/distros/humble/rmf-traffic-editor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, proj, qt5, rmf-utils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-rmf-traffic-editor";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/humble/rmf_traffic_editor/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "e790760e33d674bca376cc71251bc01f3450c41a0152715bd431df9b4ea16f22";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/humble/rmf_traffic_editor/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "1bac08da58607592866dacc526df53c7910cc3f78a371e6214fc3f3da3f25956";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-traffic-ros2/default.nix
+++ b/distros/humble/rmf-traffic-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-rmf-traffic-ros2";
-  version = "2.1.6-r1";
+  version = "2.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_traffic_ros2/2.1.6-1.tar.gz";
-    name = "2.1.6-1.tar.gz";
-    sha256 = "f0c8a62489e99897a9b6dd429572b78aa465aa5ecad62fd8ef76a807b4071107";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_traffic_ros2/2.1.7-1.tar.gz";
+    name = "2.1.7-1.tar.gz";
+    sha256 = "2b2dfd1350a7e4adf642bf72ba3e8cd0ceccc44537d7b7f71e188ba33f6ca7f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmf-websocket/default.nix
+++ b/distros/humble/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-humble-rmf-websocket";
-  version = "2.1.6-r1";
+  version = "2.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_websocket/2.1.6-1.tar.gz";
-    name = "2.1.6-1.tar.gz";
-    sha256 = "0b0f8bc9583adddbeb6e3718ca05499de4ab781b8fc08bb1fd8049a5c57277f3";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/humble/rmf_websocket/2.1.7-1.tar.gz";
+    name = "2.1.7-1.tar.gz";
+    sha256 = "4a74e3ebeee386f78f97e65cb805651fcb0ff756e926958fc3f010951a4f8fb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/social-nav-msgs/default.nix
+++ b/distros/humble/social-nav-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-2d-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-social-nav-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/social_nav_ros-release/archive/release/humble/social_nav_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "57241f25b32b515f3e34f2ef1cdd4362f160df538b028d7dd74c654e0bd23221";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS interfaces for social navigation'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/humble/social-nav-util/default.nix
+++ b/distros/humble/social-nav-util/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rclpy, social-nav-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-social-nav-util";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/social_nav_ros-release/archive/release/humble/social_nav_util/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "d5a5498d0154ae39f5df313f236ae47c73abe588d29ea3a86a25a370fae8fae1";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs rclpy social-nav-msgs visualization-msgs ];
+
+  meta = {
+    description = ''Utilities for social navigation work'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "c58dfe42d5a2fe2a1aa6e3c2b0e5146771daef8762fe6f260051c8138725eb50";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "f21ebd51091bd6f4824c7b8a9201ba868fa5bc8f37f10fe3684cc44e0bcbe78f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake curl dpkg python3Packages.distro ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ camera-info-manager flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/aws-sdk-cpp-vendor/default.nix
+++ b/distros/iron/aws-sdk-cpp-vendor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl }:
+buildRosPackage {
+  pname = "ros-iron-aws-sdk-cpp-vendor";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/iron/aws_sdk_cpp_vendor/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "ef2dfbce2f3efe0aba47e345c47b5ebe97c5865a8c9b85349d0d8486c0839434";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ openssl ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
+
+  meta = {
+    description = ''A vendor package for aws-sdk-cpp'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/depthai-bridge/default.nix
+++ b/distros/iron/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-bridge";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "51151ff829029b0c95268d8d7d69d521bf2cfeb83f9d321f389c192ac8e46839";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "bdde2a256bef68e1eba669ac544a6baf0f58036857414921f86fae94ccaa1021";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-descriptions/default.nix
+++ b/distros/iron/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-descriptions";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "cce712ba28452cbf1545d37a8bd184cfaeab23ddeda949d3266fca06c2ab65ba";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "19388b5e5e8586c05c83084b1d6dae9177545a339f4faafcffb2558295c28460";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-examples/default.nix
+++ b/distros/iron/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-examples";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "50de152f3bd11e4f27c95ab128547f9157fb2e12a1d30fd5ebc82789f676ad55";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "293c96ee36750585f42b0e9876996a453fc8ae79320c4eeeeb7b8eb413629c7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-filters/default.nix
+++ b/distros/iron/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-filters";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "d417b3017f25107f4c2e4364169c80b249726fa8047a04f7c0c0dc55cb5a2b70";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "90c4cde1e3da5c1d517775d50cbef5293afff2ec833c9868015b509e28ffcbd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-driver/default.nix
+++ b/distros/iron/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-driver";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "816239e760be7aac51243d42f4851234bb5ad30f6d418469302412c54d2cfebd";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "d48a4955446c8a2dd6fe8c2df82496bb37cbfa8fe39cf46817d39ef49033fc33";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-msgs/default.nix
+++ b/distros/iron/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-msgs";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "46b2fab39083631eef909bd302b7d360646466fad5fffbd045fed07109c3f5c3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "a609a9413a164aba2add59abebd86142c507afdccb6347569421a1c66150f6a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros/default.nix
+++ b/distros/iron/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "e5c1f3699f4ddf3f6e062bfd27c38386f5c906ec2a57f32a95196a707ea23fb8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "090d45debfa8e67ca31b749a5a8bc216b0e8d58a55ffe7fe04993847ef507088";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/flexbe-behavior-engine/default.nix
+++ b/distros/iron/flexbe-behavior-engine/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-behavior-engine";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_behavior_engine/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "b8788784cc97b389d54b6e472e5094e56a7345e52c3e3419cd7f5c59b00974fb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ flexbe-core flexbe-input flexbe-mirror flexbe-msgs flexbe-onboard flexbe-states flexbe-testing flexbe-widget ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A meta-package to aggregate all the FlexBE packages'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-core/default.nix
+++ b/distros/iron/flexbe-core/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-msgs, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs, std-srvs, tf2-ros-py }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-core";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_core/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c81c3c03bf8690d4e737455a14faad721523b826bf5b2de026fd4144571bfab1";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-ros launch-testing pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-msgs rclpy std-msgs std-srvs tf2-ros-py ];
+
+  meta = {
+    description = ''flexbe_core provides the core components for the FlexBE behavior engine.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-input/default.nix
+++ b/distros/iron/flexbe-input/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-input";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_input/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "3167b7b638542c3991a3bc49d0463992431966790f9cff57e32ce3e6bcb128df";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rclpy ];
+
+  meta = {
+    description = ''flexbe_input enables to send data to onboard behavior when required.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-mirror/default.nix
+++ b/distros/iron/flexbe-mirror/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-mirror";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_mirror/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5d099242522218ab4ebba12236b422ca078522cbe80c38cc105bb638a1a0d97f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rclpy ];
+
+  meta = {
+    description = ''flexbe_mirror implements functionality to remotely mirror an executed behavior.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-msgs/default.nix
+++ b/distros/iron/flexbe-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-msgs";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "8ce0bfe2f2d19d31d2932fe86e35eb0b442f22639568657d207de5db0c5cc11f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-generators rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''flexbe_msgs provides the messages used by FlexBE.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-onboard/default.nix
+++ b/distros/iron/flexbe-onboard/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-states, launch-ros, launch-testing, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-onboard";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_onboard/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "d3742fbc69714c840dbfb5716288c5913799efacbc67a20f2cdb277e11af50c0";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-testing pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-states launch-ros rclpy ];
+
+  meta = {
+    description = ''flexbe_onboard implements the robot-side of the behavior engine from where all behaviors are started.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-states/default.nix
+++ b/distros/iron/flexbe-states/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-states";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_states/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "aa6d0ec9aea6ea5df2a1ab8e13eaacc633ebe885c7bad50f8670ca25b212eb4c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-testing rclpy ];
+
+  meta = {
+    description = ''flexbe_states provides a collection of common generic predefined states.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-testing/default.nix
+++ b/distros/iron/flexbe-testing/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-msgs, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-testing";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_testing/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "0201de58974139be54ec0617ab3d7776d12fb0f0209e732e28f2991f871b7f14";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-copyright ament-flake8 ament-pep257 launch-testing pythonPackages.pytest std-msgs ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs launch-ros rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''flexbe_testing provides a framework for unit testing states.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flexbe-widget/default.nix
+++ b/distros/iron/flexbe-widget/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, launch-ros, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-flexbe-widget";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/flexbe_behavior_engine-release/archive/release/iron/flexbe_widget/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "2a30eea087e69cb603a4d593fa925456f1d1294e572cf7074e51dedbee28c66f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard launch-ros rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''flexbe_widget implements some smaller scripts for the behavior engine.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -182,6 +182,8 @@ self: super: {
 
  aws-robomaker-small-warehouse-world = self.callPackage ./aws-robomaker-small-warehouse-world {};
 
+ aws-sdk-cpp-vendor = self.callPackage ./aws-sdk-cpp-vendor {};
+
  backward-ros = self.callPackage ./backward-ros {};
 
  bag2-to-image = self.callPackage ./bag2-to-image {};
@@ -489,6 +491,24 @@ self: super: {
  filters = self.callPackage ./filters {};
 
  find-object-2d = self.callPackage ./find-object-2d {};
+
+ flexbe-behavior-engine = self.callPackage ./flexbe-behavior-engine {};
+
+ flexbe-core = self.callPackage ./flexbe-core {};
+
+ flexbe-input = self.callPackage ./flexbe-input {};
+
+ flexbe-mirror = self.callPackage ./flexbe-mirror {};
+
+ flexbe-msgs = self.callPackage ./flexbe-msgs {};
+
+ flexbe-onboard = self.callPackage ./flexbe-onboard {};
+
+ flexbe-states = self.callPackage ./flexbe-states {};
+
+ flexbe-testing = self.callPackage ./flexbe-testing {};
+
+ flexbe-widget = self.callPackage ./flexbe-widget {};
 
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
@@ -1017,6 +1037,8 @@ self: super: {
  nav2-lifecycle-manager = self.callPackage ./nav2-lifecycle-manager {};
 
  nav2-map-server = self.callPackage ./nav2-map-server {};
+
+ nav2-mppi-controller = self.callPackage ./nav2-mppi-controller {};
 
  nav2-msgs = self.callPackage ./nav2-msgs {};
 

--- a/distros/iron/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/iron/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-iron-kinova-gen3-6dof-robotiq-2f-85-moveit-config";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "bcdd9c83e1bd11aca58bafaebc5d62838a1cb21d7dc424b8a834b3e63e13576c";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d934f4b2cacaa08da8f79a3253855439fe807dc2e06ca766c161bcc11f47d325";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/iron/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-iron-kinova-gen3-7dof-robotiq-2f-85-moveit-config";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "7d0d466c1d4cfe991afa6b9bbedd391f4cb9034ff4f1c906143b3c6254a931a3";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "c53cff8ff6d1b5874ce7b2aaf267f0a758debf46057784ccebf4ac49a9d1ffbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kortex-api/default.nix
+++ b/distros/iron/kortex-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-kortex-api";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_api/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "59201ee61a5167c7ba2e695e91f2a30f4be95d27232202e0ade6f99a49ba4662";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_api/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "494a6b10dc4609c22546e22b276ba90f2a88da82d402560cb5de39d408d7eea5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kortex-bringup/default.nix
+++ b/distros/iron/kortex-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, gazebo-ros2-control, gripper-controllers, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, kortex-description, kortex-driver, launch, launch-ros, rclpy, robotiq-description, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-iron-kortex-bringup";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_bringup/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "245626ecf6eaf80091f36665bd8f4dfe1b00eb78f1d9ffcb1c7cad5f430b26b4";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_bringup/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "7fea8b96990a8404cbbc209664e2ca846c25670c27c6dcd0c155cfe9454e81ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kortex-description/default.nix
+++ b/distros/iron/kortex-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, robotiq-description, rviz2 }:
 buildRosPackage {
   pname = "ros-iron-kortex-description";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_description/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "c86a19e2b49905e4239260e4adae9e11bac1dcbdebe4ea92c80de2b8009320db";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_description/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "5894dc1258da238675ea62284661dd827b973e9e26a295f5545cd8b35ed515fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kortex-driver/default.nix
+++ b/distros/iron/kortex-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, hardware-interface, kortex-api, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-kortex-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "2a1f0e97a297f050db11527616371bce1d51bbbd4a35008bd28ec8744e4e94e9";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/iron/kortex_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "ff12e92db7852bc73aa623f1551ff300da24dfffe75e37172e757bc0a93f0f82";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-mppi-controller/default.nix
+++ b/distros/iron/nav2-mppi-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
+buildRosPackage {
+  pname = "ros-iron-nav2-mppi-controller";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_mppi_controller/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "a913a626213164c5a366fa5f759501c08b9319346f6e6f7e0cb38b76a8a8ff29";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gbenchmark geometry-msgs llvmPackages.openmp nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros visualization-msgs xsimd xtensor ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+
+  meta = {
+    description = ''nav2_mppi_controller'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/rig-reconfigure/default.nix
+++ b/distros/iron/rig-reconfigure/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, git, glfw3, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-rig-reconfigure";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/iron/rig_reconfigure/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1ebaff0aeecdebd82fde14b52ad6a6cf8c6b64b01030c51fdeab8b702f7f5e1a";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/iron/rig_reconfigure/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "71375046e2c7dc61eb42bf6d59d6bbae2f9f410b3c09b8bec2d301b4b95b6638";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake git ];
-  propagatedBuildInputs = [ glfw3 rclcpp ];
+  propagatedBuildInputs = [ ament-index-cpp glfw3 rclcpp ];
   nativeBuildInputs = [ ament-cmake git ];
 
   meta = {

--- a/distros/iron/rmf-fleet-adapter-python/default.nix
+++ b/distros/iron/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-iron-rmf-fleet-adapter-python";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter_python/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "9a39c9e761387d1101d9352a84a5a4ab6311c3962f292d27d9335ee495774938";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter_python/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ec344f4b4328683f9e294acf6f9e4923b25663f012e570aba2ddce01718c4e1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-fleet-adapter/default.nix
+++ b/distros/iron/rmf-fleet-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-fleet-adapter";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "98f41c9cddb3121fb85b9be805c639845143606a97a7a96707dc6bbb1e3754ee";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a7eb6bf605b98aaaba713843091bcef7c2f99c83e3dccc637d3d55c743b8da13";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-task-ros2/default.nix
+++ b/distros/iron/rmf-task-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-iron-rmf-task-ros2";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_task_ros2/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "c987b8c1a465b3cd2b93b56aa1a7d7faeb62971556659962f831a7232bf0f24d";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_task_ros2/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "80593dbb4523fec5706f4004ab6fedb9df6ec69077272b9a0801af88e808d2ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-task-sequence/default.nix
+++ b/distros/iron/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-iron-rmf-task-sequence";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task_sequence/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "43fc6c646910664d69e9b97cffe034760b8d2288142d3aafd63a6ac15f9f41db";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task_sequence/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "71dcf34028aea12e01c9891b917c4f28c07dd27d085edd13835b26ed6ed82e0d";
   };
 
   buildType = "cmake";

--- a/distros/iron/rmf-task/default.nix
+++ b/distros/iron/rmf-task/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-iron-rmf-task";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "68c66032b5891a4a5095ea5630ce78133523122fd1b299bb9c65097b90560123";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/iron/rmf_task/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "64aeee7812200dfe86ed08fd59de183486c41d715dcc927d67dc7099cd70320c";
   };
 
   buildType = "cmake";

--- a/distros/iron/rmf-traffic-editor-assets/default.nix
+++ b/distros/iron/rmf-traffic-editor-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-editor-assets";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/iron/rmf_traffic_editor_assets/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "156674115699309bd1695df2acf8091049e6f7469b9b18bbb67c3569e79d8917";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/iron/rmf_traffic_editor_assets/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "8169544af2de6d3ee7fc7aa6d2d41b0243f2efa4093834e37883b67e79825335";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rmf-traffic-editor-test-maps/default.nix
+++ b/distros/iron/rmf-traffic-editor-test-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-editor-test-maps";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/iron/rmf_traffic_editor_test_maps/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "6ba11cd75451462391a9020cbea674786f58bd31f60a14407944e9b696e364e7";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/iron/rmf_traffic_editor_test_maps/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "b645062833c46d1a4d8d6d77cc40bc5e4f61233556299c1e0c3de27759d5dc63";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-traffic-editor/default.nix
+++ b/distros/iron/rmf-traffic-editor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, proj, qt5, rmf-utils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-editor";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/iron/rmf_traffic_editor/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "78245dca8c75f6820a4334afed7c6c91357e32fd18be6ecca4a240e2b475cd35";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/iron/rmf_traffic_editor/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "b9c5e4efedecd112528d086e7796f1233382f85feeedd955ef0cf6c4086d44cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-traffic-ros2/default.nix
+++ b/distros/iron/rmf-traffic-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-ros2";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_traffic_ros2/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "661972dccf6082598b03a9b9bb3fd2e748328fedc38d36b8213c401bb67f8a63";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_traffic_ros2/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ba7996db7bf60b46a4d1a838f181384143ad6fc5ce6ac3d90ddacaab997c191c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-websocket/default.nix
+++ b/distros/iron/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-websocket";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_websocket/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "1433f12069ebe0c169a75aabc82227aa91285123c82adf63f2e126f27a7f249d";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_websocket/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "5659aa6bea4ef57132770471d70be347a0c57f20ea7e66041026363eaa964f02";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/cpr-onav-description/default.nix
+++ b/distros/noetic/cpr-onav-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cpr-onav-description";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "20a9fa74fde7304c2b8a28a94e02f8e7b9ef5fc908b4864901e9a8e5e4f5a0d6";
+    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "21d8ab41c544cc5aa44b3b55541665570a02685ab554530f930d324bc16c86fe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "4f9aa89e9b83caa3fe8a8297526a294e7ab5f39162b549e8fa7c720238a5143a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "ec486e648cd5644c9ce7d1e01925e7274e03dd1272ea6a3c87c14e63a266ae20";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "2074fba81fc8018daaa44f430bbca7410de2d0ea0465b3f2e192424635ea3ce6";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "6c8ddb82a3e633ce18390b2beed00e578dbc0a3a53874e1b1aefd2da680bc9d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "1a4c52c6e6d0979ca585ae8d7395a534954d09ffb21a3fad98921dab560880ef";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "9ad512bc1dcf8b8e117bd2db307b5990ec423e1d508125684fcb8a8dd2313b26";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "5548bf677e5bae757c24c04c4a4022bc5e63dc998ed0378f739a1ac7e780218e";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "42b1d29e4d36fb7736ac3ed26bd27027505a67efc3d83531c03d31627a622b21";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "ed7a3691475891139088b3b4244cc3e80e44ad5bc6b0c95dc6284b577cf97692";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "7b08d58cb927a921d22ae7e71886a63005dcb6842db1a52f1f1f8d0f66fdd309";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "704be1d24026515a283644fe81cbff3581c3fd5bae0a4960c4a21d6ab252f4c5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "92b20dec4fb844011addf19165818e432e0b6d74651fecbf40abdb2c0cf16a1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "0833152b64b72262c4e6ab4e84840ddadd736e0051ff2f41151632de4cdd1bcd";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "d3cd2f8ddaa7fb96bf05074871582c0f2650c8d52c39d2d39a12c47875e3ca11";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit c0d446436c86b6f52ae04bdc9059fbfe1580030a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aws-sdk-cpp-vendor 0.1.0-r1*
* *clearpath-config 0.0.5-r1 --> 0.0.6-r1*
* *depthai-bridge 2.7.4-r1 --> 2.7.5-r1*
* *depthai-descriptions 2.7.4-r1 --> 2.7.5-r1*
* *depthai-examples 2.7.4-r1 --> 2.7.5-r1*
* *depthai-filters 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros-driver 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros-msgs 2.7.4-r1 --> 2.7.5-r1*
* *flexbe-behavior-engine 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-core 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-input 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-mirror 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-msgs 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-onboard 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-states 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-testing 2.3.2-r1 --> 2.3.3-r1*
* *flexbe-widget 2.3.2-r1 --> 2.3.3-r1*
* *flir-camera-description 2.0.3-r1 --> 2.0.5-r1*
* *flir-camera-msgs 2.0.3-r1 --> 2.0.5-r1*
* *kinova-gen3-6dof-robotiq-2f-85-moveit-config 0.2.1-r1 --> 0.2.2-r1*
* *kinova-gen3-7dof-robotiq-2f-85-moveit-config 0.2.1-r1 --> 0.2.2-r1*
* *kortex-api 0.2.1-r1 --> 0.2.2-r1*
* *kortex-bringup 0.2.1-r1 --> 0.2.2-r1*
* *kortex-description 0.2.1-r1 --> 0.2.2-r1*
* *kortex-driver 0.2.1-r1 --> 0.2.2-r1*
* *nav2-mppi-controller 1.1.9-r1*
* *rig-reconfigure 1.1.0-r1 --> 1.2.0-r1*
* *rmf-fleet-adapter 2.1.6-r1 --> 2.1.7-r1*
* *rmf-fleet-adapter-python 2.1.6-r1 --> 2.1.7-r1*
* *rmf-task 2.1.5-r1 --> 2.1.6-r1*
* *rmf-task-ros2 2.1.6-r1 --> 2.1.7-r1*
* *rmf-task-sequence 2.1.5-r1 --> 2.1.6-r1*
* *rmf-traffic-editor 1.6.1-r1 --> 1.6.2-r1*
* *rmf-traffic-editor-assets 1.6.1-r1 --> 1.6.2-r1*
* *rmf-traffic-editor-test-maps 1.6.1-r1 --> 1.6.2-r1*
* *rmf-traffic-ros2 2.1.6-r1 --> 2.1.7-r1*
* *rmf-websocket 2.1.6-r1 --> 2.1.7-r1*
* *social-nav-msgs 0.1.0-r1*
* *social-nav-util 0.1.0-r1*
* *spinnaker-camera-driver 2.0.3-r1 --> 2.0.5-r1*

Iron Changes:
-------------
* *aws-sdk-cpp-vendor 0.1.0-r1*
* *depthai-bridge 2.7.4-r1 --> 2.7.5-r1*
* *depthai-descriptions 2.7.4-r1 --> 2.7.5-r1*
* *depthai-examples 2.7.4-r1 --> 2.7.5-r1*
* *depthai-filters 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros-driver 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros-msgs 2.7.4-r1 --> 2.7.5-r1*
* *flexbe-behavior-engine 2.3.3-r1*
* *flexbe-core 2.3.3-r1*
* *flexbe-input 2.3.3-r1*
* *flexbe-mirror 2.3.3-r1*
* *flexbe-msgs 2.3.3-r1*
* *flexbe-onboard 2.3.3-r1*
* *flexbe-states 2.3.3-r1*
* *flexbe-testing 2.3.3-r1*
* *flexbe-widget 2.3.3-r1*
* *kinova-gen3-6dof-robotiq-2f-85-moveit-config 0.2.1-r1 --> 0.2.2-r1*
* *kinova-gen3-7dof-robotiq-2f-85-moveit-config 0.2.1-r1 --> 0.2.2-r1*
* *kortex-api 0.2.1-r1 --> 0.2.2-r1*
* *kortex-bringup 0.2.1-r1 --> 0.2.2-r1*
* *kortex-description 0.2.1-r1 --> 0.2.2-r1*
* *kortex-driver 0.2.1-r1 --> 0.2.2-r1*
* *nav2-mppi-controller 1.2.2-r1*
* *rig-reconfigure 1.1.0-r1 --> 1.2.0-r1*
* *rmf-fleet-adapter 2.2.0-r1 --> 2.2.1-r1*
* *rmf-fleet-adapter-python 2.2.0-r1 --> 2.2.1-r1*
* *rmf-task 2.2.1-r1 --> 2.2.2-r1*
* *rmf-task-ros2 2.2.0-r1 --> 2.2.1-r1*
* *rmf-task-sequence 2.2.1-r1 --> 2.2.2-r1*
* *rmf-traffic-editor 1.7.0-r1 --> 1.7.1-r1*
* *rmf-traffic-editor-assets 1.7.0-r1 --> 1.7.1-r1*
* *rmf-traffic-editor-test-maps 1.7.0-r1 --> 1.7.1-r1*
* *rmf-traffic-ros2 2.2.0-r1 --> 2.2.1-r1*
* *rmf-websocket 2.2.0-r1 --> 2.2.1-r1*

Noetic Changes:
---------------
* *cpr-onav-description 0.1.3-r1 --> 0.1.4-r1*
* *depthai-bridge 2.7.4-r1 --> 2.7.5-r1*
* *depthai-descriptions 2.7.4-r1 --> 2.7.5-r1*
* *depthai-examples 2.7.4-r1 --> 2.7.5-r1*
* *depthai-filters 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros-driver 2.7.4-r1 --> 2.7.5-r1*
* *depthai-ros-msgs 2.7.4-r1 --> 2.7.5-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] hdf5-tools
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

