### PR TITLE
rosdistro sync, Fri Aug 18 18:31:53 2023

### DIFF
--- a/distros/humble/aws-sdk-cpp-vendor/default.nix
+++ b/distros/humble/aws-sdk-cpp-vendor/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl, zlib }:
 buildRosPackage {
   pname = "ros-humble-aws-sdk-cpp-vendor";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/humble/aws_sdk_cpp_vendor/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "38df12f48b53e34a65afc79ceb5d41ab16336f029ce61f728ae9a4b7083211b2";
+    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/humble/aws_sdk_cpp_vendor/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "f98659d79e692a49d2324b3798d77b74fae43b739f9e6e11bc76f4cc165ee3b5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ openssl ];
+  propagatedBuildInputs = [ openssl zlib ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
 
   meta = {

--- a/distros/humble/behaviortree-cpp-v3/default.nix
+++ b/distros/humble/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, cppzmq, ncurses, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp-v3";
-  version = "3.8.4-r1";
+  version = "3.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/humble/behaviortree_cpp_v3/3.8.4-1.tar.gz";
-    name = "3.8.4-1.tar.gz";
-    sha256 = "70c51085c57641ce4a7362b6d8a2da2b043301fd8f87ffaeb9b1271d2a543b63";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/humble/behaviortree_cpp_v3/3.8.5-1.tar.gz";
+    name = "3.8.5-1.tar.gz";
+    sha256 = "7fc53e76961607b6275725de420746141ec8890100893f1fd4a59ba53cd41e66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.3.3-r1";
+  version = "4.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.3-1.tar.gz";
-    name = "4.3.3-1.tar.gz";
-    sha256 = "c53ab0be9e09e17f064124619222c88c6499057c7ef5a35ab4a0fef0a4706899";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.5-1.tar.gz";
+    name = "4.3.5-1.tar.gz";
+    sha256 = "e83189693a869733f02e154e36d0e7e4da466bc89792180f951f2ebe1e66d06b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-calibration-parsers/default.nix
+++ b/distros/humble/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration-parsers";
-  version = "3.1.6-r1";
+  version = "3.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.6-1.tar.gz";
-    name = "3.1.6-1.tar.gz";
-    sha256 = "4331d663f56f6a3018abc5026755e73db8667bf1d5e943578136611a531744ed";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.7-1.tar.gz";
+    name = "3.1.7-1.tar.gz";
+    sha256 = "dc0609ae321cec0a32997d6439b01742fea6bd5b89e4cbb0c8124b98429ddef9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-info-manager/default.nix
+++ b/distros/humble/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager";
-  version = "3.1.6-r1";
+  version = "3.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.6-1.tar.gz";
-    name = "3.1.6-1.tar.gz";
-    sha256 = "30e7b7abdc640a5f46911219afdced165d2c0d69ced5734a3f18c5771371bcf8";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.7-1.tar.gz";
+    name = "3.1.7-1.tar.gz";
+    sha256 = "dc45050caf301b4bf47dd850f06ffff3e9edff57a96a2ff23517f049197e5b7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "ff5f20ebc0244b4a818ec5798a3dcf7066f6ec63ba29a70adee92b0f3563533f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "164685b56969acd412f60aac384b19b18cf54bc9163150a05b91ffc13816a6bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "d55804444519b111e02ce4f23b4083f3c56a4ee5f764afaca3f52f130248becc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "ba47348d8af2cc8aceed826c57c5bb99c1611e5c3c8d6f2eabab2c33ae688d39";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "38b518c320acc6854fdb423f4a70adf87125c3d1d0e603d5b28aff50fc673433";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "053072d4d77d1fd5d00d817eaa7f9c98b902f7d3c27b7f97e7a2dd81181ae56c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "b439516d3e9f9b1ce3df8eeaf956b00058aa9e0785e978f502983e781db04c4f";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "c8ae449923b95e0f77767cb1555987f9ecc171a7c289dc8c0c3702572d928cf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "84a18cfa1f5f60b0b3a0e8562b6bde1e4a8d504c047deee384e36567c033b9ac";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "071857c4edf87b92f5110845d87a305d77607a82ddf090c0c22ec8c351e24ddc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -2156,8 +2156,6 @@ self: super: {
 
  stubborn-buddies-msgs = self.callPackage ./stubborn-buddies-msgs {};
 
- swri-cli-tools = self.callPackage ./swri-cli-tools {};
-
  swri-console = self.callPackage ./swri-console {};
 
  swri-console-util = self.callPackage ./swri-console-util {};

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "8f736c20047fb099a4c5fcce3f5228d045e5cf85f5138ca0e9a39042f792aa67";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "7cc908dd2c28d41f5cf5e8af5ad663cf5280fdb7fe514aba1a168e036e958942";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-common/default.nix
+++ b/distros/humble/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-common";
-  version = "3.1.6-r1";
+  version = "3.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.6-1.tar.gz";
-    name = "3.1.6-1.tar.gz";
-    sha256 = "351fb492a563575850a31bdcbd8385a0075bbd916bc917c11226c0824000cc7d";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.7-1.tar.gz";
+    name = "3.1.7-1.tar.gz";
+    sha256 = "7103a20e71ef3bb7a827940050ba6cdd24d7edcdbb7133bd3d32f3a2b6da02e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-transport/default.nix
+++ b/distros/humble/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-transport";
-  version = "3.1.6-r1";
+  version = "3.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.6-1.tar.gz";
-    name = "3.1.6-1.tar.gz";
-    sha256 = "707798757458816b9fb50febd5981d96544cd1e7b72fa98b729a32f6640807cb";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.7-1.tar.gz";
+    name = "3.1.7-1.tar.gz";
+    sha256 = "82b39688809bf4e276393ef9c15da9c8c1389c07f18dd391c15b9a0ae6ef5d40";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "dc19d8f1df5474bfd626153a6ada09ff054a9a4baa253489394decfa0631d35f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "85d136bf02cf8db2e87a2850f79ec7a0abb4b45ad964684a8fe06a886dc8082d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "f00e00e4687a4437593d582bc7fb183ddc892083e59a4b078dac67339849cbcc";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "d9629f71c92bfd4820fd11cd55c05645c80e9460258f881ec807bdba2ad96b65";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "7cfc9a3f9f7a949cf3ebc81b345d8014fc572f38936987739262a6737f060819";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "542d0259dc5e89e9f5b8777f39c93a8a5fffd48b20c4f4919f3c20f348c1e4b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "5145ff799266809bc6f173af96d8ce34fc570eca2d82eff132ec1af881d63aaa";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "4a480a69cafcbd8d74057d123682ce77dc12e3c8b8d4beedf3dd1c4f10a6c9fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "38a13960e50cbbb2159c28d53179b06ec0b6183a5d9549a956e4be7c49851efa";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "8ab12bf64e58d1d4668a527f0200e6cf19fc1672730e3c1f630981d455c36414";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "32b86696f16b223a0a4350b47b0c1b62948d8cb3ac42075c1479d59d6a181ae2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "e1eaeb5f3e058c849a5265a38d9fe9c7b3d5eb67e76a02f76cb10b1f20a60c1a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "f21ebd51091bd6f4824c7b8a9201ba868fa5bc8f37f10fe3684cc44e0bcbe78f";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "80ab117dcb8b1cb3c16ef5628ae8c9061a84a80fcfea9e864f3228ce9045724d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-console-util/default.nix
+++ b/distros/humble/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-console-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "1467d6cf9836cd08ecd7b23536cc37368143f8a0a8746b37f8577de07fa2bf50";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "1caeb007781050cf04ab2ee53a5bb2c125a29e02d85b5dcf73c4f7a77ad1926f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-dbw-interface/default.nix
+++ b/distros/humble/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-swri-dbw-interface";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "dceaaaf634ff9a9c19a6555d12d498fe6f3895b05ca1ce087c935b73b999797e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "8badda81cd24bb38e5847d2e7a492d8e2927ac5cf17a228dbf628a47025845fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-geometry-util/default.nix
+++ b/distros/humble/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-geometry-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "98a3133b40a46b80bc7effc9c42e2795f6f30eb66c0b75ecd21e4bf2d6c8fb6a";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "3681d3862936c30eb1b572b788e88423367c62234f11691fd96d455c7a70cf4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-image-util/default.nix
+++ b/distros/humble/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-image-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "6c9acdccc39eab866c1b022820c8b4698f4270397d533cd8647f540f1508419c";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "e571ae5a85d89387478addc93371f61f67b39cf797f16b6a4b92f5f68e884f12";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-math-util/default.nix
+++ b/distros/humble/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-math-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "84131b6f1e23cf4d1aa3b10b48a4d65af248135bf0c09fe46f8dca498631def8";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "eb3d13b68c2b9030543058d99c56e415f1bcdf941496d904808b3691bb313f20";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-opencv-util/default.nix
+++ b/distros/humble/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-humble-swri-opencv-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "be6bee4b796eb46660d6cb0ba8f0b72eb0166dded0d968bbd8fd8886721dd9d4";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "66390b6b879b21faa3c134325fc1b607e0c36728315575d1d3f7299457e34d37";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-prefix-tools/default.nix
+++ b/distros/humble/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-swri-prefix-tools";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_prefix_tools/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "611518ec0b3a7de7dece8430466bcd0688c2ca94be79a5cd389b5bf252387c03";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_prefix_tools/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "d60f3057b57e23f8338b9866d51d24fea1c866fe42c4200a5ddfa27c6eb0a68d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-roscpp/default.nix
+++ b/distros/humble/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-swri-roscpp";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "51e6b13e346b96c6b5d2a62f52883b8fefaa6f30d245279c6464ded215c2bd3e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "2140b29e67afe33740842aa31d842fb7149d873b7a45af5fe2addfec1ecbdc2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-route-util/default.nix
+++ b/distros/humble/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-swri-route-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "184807e4b12861b72c1ee8d40d1849e0485f42e10576efca0636aaeb181e1b5b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "9676d299953eb46851349db39820639e30b62c4ed7861ee39a1a8ecb505d7db6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-serial-util/default.nix
+++ b/distros/humble/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-humble-swri-serial-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "aa9ca1cb5bcdf3dcf8070c0baf1453c95e200d5edf8efe2fcd0a7a1f8c4e116f";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "070233818d40aa62727c2a4c343f1eb46c37939e50666221d2e245665f9a8530";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-system-util/default.nix
+++ b/distros/humble/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-system-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_system_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "719b6bf04b302465d03e0bb27c764d0d8de4b29960bbd7f46f25266d8be8badf";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_system_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "7e7d715006189b74d90650b233482b36809aea1754c946def494fdf414fde9bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-transform-util/default.nix
+++ b/distros/humble/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-swri-transform-util";
-  version = "3.5.2-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.5.2-1.tar.gz";
-    name = "3.5.2-1.tar.gz";
-    sha256 = "1c05f86ae143447d17713936d8caf545850b53458f099213ce3323dc2b4b733d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "90c617a1fe190f1f1980b18ca7a2d93004f4a86d345ee35f8575c2b940d3bb8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "6bc099cc644bd6dd1404f1110ebe78ef8aeb5772aa390c3bd79ccbb6a4402b2a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "5d8e001fd5ac84cb37f8d61872b447514905f868cbe0ab425207d42a2c6c013e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/aws-sdk-cpp-vendor/default.nix
+++ b/distros/iron/aws-sdk-cpp-vendor/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl, zlib }:
 buildRosPackage {
   pname = "ros-iron-aws-sdk-cpp-vendor";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/iron/aws_sdk_cpp_vendor/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "ef2dfbce2f3efe0aba47e345c47b5ebe97c5865a8c9b85349d0d8486c0839434";
+    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/iron/aws_sdk_cpp_vendor/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "d684e1829eea7de31132685dd7f37eee45094faf5192a2c95092de90ba2b2103";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ openssl ];
+  propagatedBuildInputs = [ openssl zlib ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package curl ];
 
   meta = {

--- a/distros/iron/behaviortree-cpp-v3/default.nix
+++ b/distros/iron/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, cppzmq, ncurses, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp-v3";
-  version = "3.8.4-r1";
+  version = "3.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/iron/behaviortree_cpp_v3/3.8.4-1.tar.gz";
-    name = "3.8.4-1.tar.gz";
-    sha256 = "f7f6c031e931c0e7d0d03dc3d1dcadbe7ed7ae03ffa55c6f881caf2d4ebe1ee8";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp-release/archive/release/iron/behaviortree_cpp_v3/3.8.5-1.tar.gz";
+    name = "3.8.5-1.tar.gz";
+    sha256 = "23fbe097a42e24a0a6ecafc783c032975491ee81667f31bb428b5da8abf5f805";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.3.3-r1";
+  version = "4.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.3-1.tar.gz";
-    name = "4.3.3-1.tar.gz";
-    sha256 = "21dc1f3bdfbda93dac45c060c2d98d5693484568bd90c0fe56a349e23036499b";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.5-1.tar.gz";
+    name = "4.3.5-1.tar.gz";
+    sha256 = "aab822b5f21adb51bcda53c9b6d2f943013f410826bcec794f14dbc0c1ee8d28";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/camera-calibration-parsers/default.nix
+++ b/distros/iron/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-camera-calibration-parsers";
-  version = "4.2.1-r1";
+  version = "4.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "4e1d474d3cc9169f364812f5f1b56ed75498f822c3195a31af751a83ac6e25a3";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "b43efff4061ddb17efd96ef35fd9e9898d7baa76937ed179f5294f60935df7f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/camera-info-manager/default.nix
+++ b/distros/iron/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-camera-info-manager";
-  version = "4.2.1-r1";
+  version = "4.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "1853ad846e4fa3e6fc3f8965bec0155aa8198f74d28c9270ca7d52679ff89016";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "4a08d3e0bc3cc438afe56174d26def4ca66af38146f7fb29ab61a05c1187bf2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -1900,6 +1900,10 @@ self: super: {
 
  soccer-vision-attribute-msgs = self.callPackage ./soccer-vision-attribute-msgs {};
 
+ social-nav-msgs = self.callPackage ./social-nav-msgs {};
+
+ social-nav-util = self.callPackage ./social-nav-util {};
+
  sol-vendor = self.callPackage ./sol-vendor {};
 
  sophus = self.callPackage ./sophus {};

--- a/distros/iron/heaphook/default.nix
+++ b/distros/iron/heaphook/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, tlsf }:
 buildRosPackage {
   pname = "ros-iron-heaphook";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/heaphook-release/archive/release/iron/heaphook/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "1f4918f9d803840995e80d07f9c6d80f96e05a86c8b7512421204b3734d991e9";
+    url = "https://github.com/ros2-gbp/heaphook-release/archive/release/iron/heaphook/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "4b48120f9fb28de1a36d0e5d75af7192d9eadcf301cdc9e829df694053eb5e40";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-common/default.nix
+++ b/distros/iron/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-iron-image-common";
-  version = "4.2.1-r1";
+  version = "4.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "887c6d4339794cca465578a1f7984f64d6999b96c99bff92d62613112e43ea99";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "fc7ec16630f5349c9bcc8a290ccc2d378f8878efd82fe12da3dfdc9dab3a4a1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-transport/default.nix
+++ b/distros/iron/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-image-transport";
-  version = "4.2.1-r1";
+  version = "4.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "19d9b91552a8916d0db86e4bad967ff618b29c6de46212eaee0c329680dd0b75";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "700d51e00158168ffaeab55729290a769a0a0d317de1a690d5b956f0256e4839";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mvsim/default.nix
+++ b/distros/iron/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-iron-mvsim";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "02dd04b2c592f1c2ce033f1ca3f94969258617a3dd392dcca3b5a879da9d1a93";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "c7d55ce10f0faf90cfe3e01f81ca83b0cf8d71c38cc76184c362673875cc1600";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/social-nav-msgs/default.nix
+++ b/distros/iron/social-nav-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-2d-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-social-nav-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/social_nav_ros-release/archive/release/iron/social_nav_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "2f458a60e8171e724ee7188df612f8373c9f48970406d6d4b078c89f0ccfb89b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS interfaces for social navigation'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/iron/social-nav-util/default.nix
+++ b/distros/iron/social-nav-util/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rclpy, social-nav-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-iron-social-nav-util";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/social_nav_ros-release/archive/release/iron/social_nav_util/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "b4b0fd36f65c077d852e0e19bfa4b6baec9940d2144d194776fb3e648f157d3c";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs rclpy social-nav-msgs visualization-msgs ];
+
+  meta = {
+    description = ''Utilities for social navigation work'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/iron/swri-console-util/default.nix
+++ b/distros/iron/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-swri-console-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_console_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "6449d0ac809181b866d0a37063ad2d58f8bd8cb649c3f92dce64aaf473b70d17";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_console_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "e3ac1afb3b3ff7115873805112a632e59dafdaf781bb3fcd53f097731a9e374a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-dbw-interface/default.nix
+++ b/distros/iron/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-swri-dbw-interface";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_dbw_interface/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "f103f1d462763ec0fde39344c54136f9365b96da715e7e82a5681b0346e0c2e5";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_dbw_interface/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "b5901875c2ac349189e857b128214e2b4c2d421afa74f17ae659d3da8706ef50";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-geometry-util/default.nix
+++ b/distros/iron/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-iron-swri-geometry-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_geometry_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "f279e0d519aa4dd46f1b1cbfba9373fb95b68b06558869605f0666e705d7e5cd";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_geometry_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "6d2692722bcc2008ab83cef847060ec8dac33b9dce4e245445e804e082a71fbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-image-util/default.nix
+++ b/distros/iron/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-iron-swri-image-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_image_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "9c8db1872364b658dc4f849d7e19ffe225dbb4fcbd50689686dfbbb71e23a5a1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_image_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "c8344fb841d1f6e666f35dc395ba2c4898a846ba14434a19af67c9c66fa4ca05";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-math-util/default.nix
+++ b/distros/iron/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-swri-math-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_math_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "dcfa13134cf514ac127f64a068d96518de7d46413e163c1f67771d220bd039e1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_math_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "ec1f33bdff583785f0290aacf52835658e7fe2d3faa87d2177b7ae0e90146403";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-opencv-util/default.nix
+++ b/distros/iron/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-iron-swri-opencv-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_opencv_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "ed0036f69ce700cb57cbf23884d9336e9d49fbbd7be0bc67cb01bbc08f1e36ba";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_opencv_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "3df32c10847d62f751ddf321e15ce7efb424bf74fc12389e08f06902d5ec62b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-prefix-tools/default.nix
+++ b/distros/iron/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-swri-prefix-tools";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_prefix_tools/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "cc322b1fdc5bce096de19cdfcbc50674bc2d6cad7d10820b0d5544e4608fbf7e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_prefix_tools/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "8e5152ef6e521db75c1c8db02527a7e096a552b2064f61725be4183a248112b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-roscpp/default.nix
+++ b/distros/iron/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-swri-roscpp";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_roscpp/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "e592a5f97f5e4a5fbfe670a9c649c29a9fcbe336698ba17cec9b77bb613d991d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_roscpp/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "aef1e55fef44196fe4bd827d964da67a08d8ea0c54ce01367597bd407aed5de4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-route-util/default.nix
+++ b/distros/iron/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-swri-route-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_route_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "72fcd3befb446c4a368c1474c3f4fe6b0db0e8a24d024cf5b0356d605da91e72";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_route_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "1a0fb2a7bfc458a40f0cda384d96aa6e9e4cfe0e146057be118c198997939dc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-serial-util/default.nix
+++ b/distros/iron/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-iron-swri-serial-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_serial_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "cd6beebd58f2720a67de69906c5a8c1df8e373b4944dda2a2c2a9b50058649cc";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_serial_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "98ca0362247cdcd4b122508621d654354288aed7335809db5d8f6f942a33f0bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-system-util/default.nix
+++ b/distros/iron/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-swri-system-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_system_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "241c7859f4d8b73a0b8c8c7c83b1eca753279c7c43d4b81d93108c082fa0f918";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_system_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "64051bcaa23d89493291d002166d9aee236a7276bdc7eca5d63eb7409d0628ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-transform-util/default.nix
+++ b/distros/iron/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-swri-transform-util";
-  version = "3.5.3-r1";
+  version = "3.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_transform_util/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "e231c69965a0da8e88851a4814e4a6c312cc0313cf759e87bc0bc2e72375b6dd";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_transform_util/3.5.4-1.tar.gz";
+    name = "3.5.4-1.tar.gz";
+    sha256 = "64689c83a75fc01325d82133323fdc20f3b90c6a50072a3e4859d00b6a66784b";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/behaviortree-cpp-v3/default.nix
+++ b/distros/noetic/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cppzmq, ncurses, ros-environment, roslib }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp-v3";
-  version = "3.8.4-r1";
+  version = "3.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/noetic/behaviortree_cpp_v3/3.8.4-1.tar.gz";
-    name = "3.8.4-1.tar.gz";
-    sha256 = "3ecdcc33c5dd26e1a77c4d7d3e22c756ebdd9080dafdd919cf2582a9cbe87a6e";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/noetic/behaviortree_cpp_v3/3.8.5-1.tar.gz";
+    name = "3.8.5-1.tar.gz";
+    sha256 = "f5afa436d6d868e1641bc0cada428c144646c78815f64c6b71733f41e7630c3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/behaviortree-cpp/default.nix
+++ b/distros/noetic/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ros-environment, roslib, sqlite }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp";
-  version = "4.2.1-r1";
+  version = "4.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.2.1-1.tar.gz";
-    name = "4.2.1-1.tar.gz";
-    sha256 = "6a002e66fb87170aa9005a12a4a293409727e95d948324af3698a1c7fbf07b54";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.3.5-1.tar.gz";
+    name = "4.3.5-1.tar.gz";
+    sha256 = "82873d422154d4b51eda7c24134cd284a2d784a7358d6984c047ee7fa8454612";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-can-msgs/default.nix
+++ b/distros/noetic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-can-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "babb64d0980f74a1fb67a3cf8ad983f6fbe758a16f3dc0aa9de22088fef9ad45";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "c85494e6ea49e4df87ef293e785c8af8435618360ed9c296fb8801b8fc13352c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-common-msgs/default.nix
+++ b/distros/noetic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-common-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "38e5ad3a372eb954c413d2fc26f114a933779a82b1f0b3dce70743d5071c5e2b";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "9fc86c18d72ec62ad2daad72dfc4501fae361fdb193f8d3314119b735889c122";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-dbw-msgs/default.nix
+++ b/distros/noetic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-dbw-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_dbw_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "176be07b25ce1ad4e6cbfe8812797d1848b25d42880657c7bce29808f50ecc2e";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_dbw_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "295f4d74dfbada272d44d69483ffe5686d3c0477c3d55c23d898dae1035588b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-introspection-msgs/default.nix
+++ b/distros/noetic/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-introspection-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_introspection_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "14b01f49d4c7e7dc1a8222fc3ca5c59f9601d36f6bbf4999130b69456e81cf0d";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_introspection_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "29f3355d38d33e9ac358f16bc2f0847ac6989601c0903157b696982a4ed62068";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-nav-msgs/default.nix
+++ b/distros/noetic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-nav-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "627500b5a3c69d00602711b61539bd702377189cf529c2d6e6a94699e5a1a1b1";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "8552a557452a9482a2e5aa00527acabc84128c58f58d499688f93a0619754b66";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-perception-msgs/default.nix
+++ b/distros/noetic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-perception-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "8b4d5f2e4791ee54f675c83203deb0df09fd6b2c70729f334e78480c82461961";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "8d077ba57afe640ac5e3ae355b8884f0fa38ea21eb2af9df0f93e803c756c24d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-sensor-msgs/default.nix
+++ b/distros/noetic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-sensor-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "7b78aebe19a212b2e6d22dd7181dd376173adb82b8f74f6a228d658c3d91f290";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "db233b36db9e7baed6b6a157fafac76692085b2dc87036d612479daab3bf129e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-status-msgs/default.nix
+++ b/distros/noetic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-status-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "34816e459b00b84a94b060aa87ed3da13500e9a20a04df80ce26094f3da85621";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "841f58e5c0c542fca1d834d8f82d646a2cc498939f0fa69cb5c4e42c909082f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-visualization-msgs/default.nix
+++ b/distros/noetic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-visualization-msgs";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "729340251387b7c85d1e1143eb90c6978ad90202521033a6fd98403ff541d499";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "2c898e21e5a27b6dcb02ef304a7a73a024e7d5b9cbefc894d491b5853ea54da6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "fa5ba6d5323880249c1594e2a6e6a4651124dda7a0db6321dcda4440df1908be";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "3d82d21f21a1b9e7f760cf5b81f5c52b3897b1794c29d90fadaa353fdbd76e11";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit b923476c0a96d0a13991b22c9b61c180e3df4b6f.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aws-sdk-cpp-vendor 0.1.0-r1 --> 0.1.1-r1*
* *behaviortree-cpp 4.3.3-r1 --> 4.3.5-r1*
* *behaviortree-cpp-v3 3.8.4-r1 --> 3.8.5-r1*
* *camera-calibration-parsers 3.1.6-r1 --> 3.1.7-r1*
* *camera-info-manager 3.1.6-r1 --> 3.1.7-r1*
* *controller-interface 2.29.0-r1 --> 2.30.0-r1*
* *controller-manager 2.29.0-r1 --> 2.30.0-r1*
* *controller-manager-msgs 2.29.0-r1 --> 2.30.0-r1*
* *flir-camera-description 2.0.5-r1 --> 2.0.6-r1*
* *flir-camera-msgs 2.0.5-r1 --> 2.0.6-r1*
* *hardware-interface 2.29.0-r1 --> 2.30.0-r1*
* *image-common 3.1.6-r1 --> 3.1.7-r1*
* *image-transport 3.1.6-r1 --> 3.1.7-r1*
* *joint-limits 2.29.0-r1 --> 2.30.0-r1*
* *mvsim 0.7.1-r1 --> 0.7.2-r1*
* *ros2-control 2.29.0-r1 --> 2.30.0-r1*
* *ros2-control-test-assets 2.29.0-r1 --> 2.30.0-r1*
* *ros2controlcli 2.29.0-r1 --> 2.30.0-r1*
* *rqt-controller-manager 2.29.0-r1 --> 2.30.0-r1*
* *spinnaker-camera-driver 2.0.5-r1 --> 2.0.6-r1*
* *swri-console-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-dbw-interface 3.5.2-r1 --> 3.5.4-r1*
* *swri-geometry-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-image-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-math-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-opencv-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-prefix-tools 3.5.2-r1 --> 3.5.4-r1*
* *swri-roscpp 3.5.2-r1 --> 3.5.4-r1*
* *swri-route-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-serial-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-system-util 3.5.2-r1 --> 3.5.4-r1*
* *swri-transform-util 3.5.2-r1 --> 3.5.4-r1*
* *transmission-interface 2.29.0-r1 --> 2.30.0-r1*

Iron Changes:
-------------
* *aws-sdk-cpp-vendor 0.1.0-r1 --> 0.1.1-r1*
* *behaviortree-cpp 4.3.3-r1 --> 4.3.5-r1*
* *behaviortree-cpp-v3 3.8.4-r1 --> 3.8.5-r1*
* *camera-calibration-parsers 4.2.1-r1 --> 4.2.2-r1*
* *camera-info-manager 4.2.1-r1 --> 4.2.2-r1*
* *heaphook 0.1.0-r1 --> 0.1.1-r1*
* *image-common 4.2.1-r1 --> 4.2.2-r1*
* *image-transport 4.2.1-r1 --> 4.2.2-r1*
* *mvsim 0.7.1-r1 --> 0.7.2-r1*
* *social-nav-msgs 0.1.0-r1*
* *social-nav-util 0.1.0-r1*
* *swri-console-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-dbw-interface 3.5.3-r1 --> 3.5.4-r1*
* *swri-geometry-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-image-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-math-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-opencv-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-prefix-tools 3.5.3-r1 --> 3.5.4-r1*
* *swri-roscpp 3.5.3-r1 --> 3.5.4-r1*
* *swri-route-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-serial-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-system-util 3.5.3-r1 --> 3.5.4-r1*
* *swri-transform-util 3.5.3-r1 --> 3.5.4-r1*

Noetic Changes:
---------------
* *behaviortree-cpp 4.2.1-r1 --> 4.3.5-r1*
* *behaviortree-cpp-v3 3.8.4-r1 --> 3.8.5-r1*
* *marti-can-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-common-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-dbw-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-introspection-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-nav-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-perception-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-sensor-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-status-msgs 0.11.0-r1 --> 0.12.0-r1*
* *marti-visualization-msgs 0.11.0-r1 --> 0.12.0-r1*
* *mvsim 0.7.1-r1 --> 0.7.2-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] hdf5-tools
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] range-v3
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

