### PR TITLE
rosdistro sync, Fri Sep  1 13:18:33 2023

### DIFF
--- a/distros/humble/aruco-opencv/default.nix
+++ b/distros/humble/aruco-opencv/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv4 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "4f05f842c77a4799acdeb231920960c5dab53fbc7886042de3976413383ac6af";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "a4981fdcadc1d3b8dd927289edc271fa6c8e04287afd7cf08d3302bed4dac865";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config-live/default.nix
+++ b/distros/humble/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config-live";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "79e2c412dcca9fbc0b74b05dfa91c48f75b3c31aba203c5666a8e87892148c15";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "71a278e2280ac0829085df272c286fbd0f0a7e7756c6d917bf052bbf5de66323";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "bdd598e7921146d7e46eefce0ceb15a41a594ef274d85af9c1c424e3ba943fdb";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b09ee88fa8c5ea196ceebe0da4de88da9d4f56391e070e3eac234d3feb588d51";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "0e7ff405b8fa2d0ac06f2cf48d4bd3ce3ce1419ff4da7f64c82a294461106c92";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "2930bed323484e57fc256935f192a33d040b9dacbbd742e82f6fa76ffc19b7f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-desktop/default.nix
+++ b/distros/humble/clearpath-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-desktop";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "5be940f2e098e16daf83e27e784cc86b86d8f25cd6ecf22bd8f29407f6b5d08e";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "9cb15b0623a4ea62bb1c6866666a197479b00ecb5d39a5eb3a02cca1020c4a65";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "ea2ba575dabc97d6a3cebdf43034a5df72907d61bc2c9bf3bafbb95c9497456c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "0bab9b04acb1914deffa862fd270fb06036085ba1d56f2ebd850cf6f8eec6b18";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-gz/default.nix
+++ b/distros/humble/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-gz";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "32941e440ba80e308bc27e940f1752a90c9f48289c900b13ed2a14104d1fb922";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "8bf241a2ec1227552862a2d9b442c970d6ca4575be650b91af36b9548259728c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-gz/default.nix
+++ b/distros/humble/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, ign-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-gz";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "68e5d0fd798af6cc9fb4b58b0ecf6cf88831e7ce6df77d3e19d1a8dc08931aa2";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b6fbf39f00d9bf2c196fd4d86b9d69f84278c166b2665a1217ff11e967c8433d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "fb53cf6a90d16ab4d0114dcdd5d38d30d13d44ce76c92e8a9ace158c96004f80";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "25b0a37418ff310c5f80603058a064c9cce9844a1cb3f3ea82d1812d7dfc4474";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "caf5fc8cd8aa72d2a4e4cf8f12bcfa9e42e4d423d161a72147855e7f66ecb732";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "0ab06706c5ff682020a10e90e77000a056df505cec57910e69499fcd7e1c58e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "209e68250bc7526b348b3c70ff9ce9c377c740d268acfdc6ff3c826f90a0fd18";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "cbce1d4079554d21e7e7fda13a8a67237af9a986024b8acd6742b9d4a0c4c49c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "629eba98bd57344882f15bc008425f0bb67bde0ee3333f6600b15d1daa34b190";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "58bda4705e63ea7d92d9ab80fee829637ed60da4ac02354f8f06ffed6ea61ac5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-simulator/default.nix
+++ b/distros/humble/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-simulator";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "9e9b0e0173b09b7629deddc81247932b6202f2723ab27b4a91eee1b0cff8d0a1";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "933673b579b302b0950571642b71d58f0ffdd011e3a49590e69dbe9a67534af9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-viz/default.nix
+++ b/distros/humble/clearpath-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-clearpath-viz";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "6b1e2eedc67cc4435684389f42c76a0bfc0fd1dfbfbeb8cbdbada1d83bce2675";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "175a11f7b587b04e2e692e686d622ef33ee6eea3b66f70dc663d2fe8f83d472b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cv-bridge/default.nix
+++ b/distros/humble/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv3 rcpputils sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv4 rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/humble/ecal/default.nix
+++ b/distros/humble/ecal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, protobuf }:
+buildRosPackage {
+  pname = "ros-humble-ecal";
+  version = "5.12.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ecal-release/archive/release/humble/ecal/5.12.0-1.tar.gz";
+    name = "5.12.0-1.tar.gz";
+    sha256 = "6a9b97cc1d3dc7e9a70454bef30b066e3b598b38e9bb28a13021e84919ecd9c9";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ protobuf ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''eCAL - enhanced Communication Abstraction Layer. A fast publish-subscribe cross-plattform middleware using Shared Memory and UDP.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -524,6 +524,8 @@ self: super: {
 
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
+ ecal = self.callPackage ./ecal {};
+
  ecl-build = self.callPackage ./ecl-build {};
 
  ecl-license = self.callPackage ./ecl-license {};
@@ -1058,6 +1060,10 @@ self: super: {
 
  mod = self.callPackage ./mod {};
 
+ mola-common = self.callPackage ./mola-common {};
+
+ mola-yaml = self.callPackage ./mola-yaml {};
+
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
  moveit = self.callPackage ./moveit {};
@@ -1145,6 +1151,8 @@ self: super: {
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
+
+ mp2p-icp = self.callPackage ./mp2p-icp {};
 
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
 
@@ -2537,6 +2545,8 @@ self: super: {
  webots-ros2-turtlebot = self.callPackage ./webots-ros2-turtlebot {};
 
  webots-ros2-universal-robot = self.callPackage ./webots-ros2-universal-robot {};
+
+ weight-scale-interfaces = self.callPackage ./weight-scale-interfaces {};
 
  wiimote = self.callPackage ./wiimote {};
 

--- a/distros/humble/grid-map-demos/default.nix
+++ b/distros/humble/grid-map-demos/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake grid-map-cmake-helpers ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs grid-map-core grid-map-cv grid-map-filters grid-map-loader grid-map-msgs grid-map-octomap grid-map-ros grid-map-rviz-plugin grid-map-visualization octomap-msgs octomap-rviz-plugins octomap-server python3Packages.opencv3 rclcpp rclpy rviz2 sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs grid-map-core grid-map-cv grid-map-filters grid-map-loader grid-map-msgs grid-map-octomap grid-map-ros grid-map-rviz-plugin grid-map-visualization octomap-msgs octomap-rviz-plugins octomap-server python3Packages.opencv4 rclcpp rclpy rviz2 sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mola-common/default.nix
+++ b/distros/humble/mola-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-humble-mola-common";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_common/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "1fce8091f43db8b368d32a3adddb240f2d881746687ed9c71745f264ba38643f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Common CMake scripts to all MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-yaml";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "818169544b0fe72e8ef1e3de1a635a32faf323ea6ed99092081381cc1d2edd07";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''YAML helper library common to MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mrpt2 }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "3872b33c2ccc8e6555191e346f3c3c485dcad191aa15b2ffcce0761e7a670201";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mp2p_icp/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "bfe472e0e3b7f7d59fa9029758ce615d976e666b65b86c55f68305153b8e45bc";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ mrpt2 ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "a90ec9daaa5be2e8a9246e85b08d5a6a45e2dffa597c70896892c33b157da839";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "1946b15ee214bb6053d9825064113f0a75221a57da61daf462b4fa3d83b6e009";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-msgs/default.nix
+++ b/distros/humble/raspimouse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-msgs";
-  version = "1.1.1-r7";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/humble/raspimouse_msgs/1.1.1-7.tar.gz";
-    name = "1.1.1-7.tar.gz";
-    sha256 = "7bfb427eabf36be186aac43ce3eb3e6f00ce77b452856caf8fbfe59e6f2579ab";
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/humble/raspimouse_msgs/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "4a725f80cbeca31fe01d4106ff9a7aa1e7fce3aae3b661c36dea58bfe74db080";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse/default.nix
+++ b/distros/humble/raspimouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav-msgs, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-raspimouse";
-  version = "1.1.1-r7";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/humble/raspimouse/1.1.1-7.tar.gz";
-    name = "1.1.1-7.tar.gz";
-    sha256 = "0748abc5af4ccf3244d9868b444c654d0a9425c7022790f55d03f6983d7392ce";
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/humble/raspimouse/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c6b5bb71d5ee5bdc9fbd94aa5ce3be1e92bee5c68d62c5f6f7c3e4aec0115cca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rig-reconfigure/default.nix
+++ b/distros/humble/rig-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-rig-reconfigure";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/humble/rig_reconfigure/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "774ca172ef389244354e925b64ff8f8e3705cede0a283e2ca201cb0e3582ca1d";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/humble/rig_reconfigure/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7e05cbfd8760a1246e6526ced1e305d797e8f314d3898f906a400741be8af707";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/stereo-image-proc/default.nix
+++ b/distros/humble/stereo-image-proc/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv3 rclpy ros-testing ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv4 rclpy ros-testing ];
   propagatedBuildInputs = [ cv-bridge image-geometry image-proc image-transport message-filters rclcpp rclcpp-components sensor-msgs stereo-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright pythonPackages.pytest ];
-  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-driver ];
+  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv4 rclpy webots-ros2-driver ];
 
   meta = {
     description = ''Tesla ROS2 interface for Webots.'';

--- a/distros/humble/weight-scale-interfaces/default.nix
+++ b/distros/humble/weight-scale-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-weight-scale-interfaces";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/TechMagicKK/weight_scale_interfaces-release/archive/release/humble/weight_scale_interfaces/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "c23b45efac85df71f7d05f1f3427251eacd80f346714fd1493e68ff8ec29a5ff";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Definition of the interface for weight scale devices'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/aruco-opencv/default.nix
+++ b/distros/iron/aruco-opencv/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv4 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/camera-calibration/default.nix
+++ b/distros/iron/camera-calibration/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.requests pythonPackages.pytest ];
-  propagatedBuildInputs = [ cv-bridge image-geometry message-filters python3Packages.opencv3 rclpy sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ cv-bridge image-geometry message-filters python3Packages.opencv4 rclpy sensor-msgs std-srvs ];
 
   meta = {
     description = ''camera_calibration allows easy calibration of monocular or stereo

--- a/distros/iron/cv-bridge/default.nix
+++ b/distros/iron/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv3 rclcpp rcpputils sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv4 rclcpp rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/iron/ecal/default.nix
+++ b/distros/iron/ecal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, protobuf }:
+buildRosPackage {
+  pname = "ros-iron-ecal";
+  version = "5.12.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ecal-release/archive/release/iron/ecal/5.12.0-1.tar.gz";
+    name = "5.12.0-1.tar.gz";
+    sha256 = "504c795b3ca05f7bcff30dddadc502db1cdf55867ca249cb56d1fca1ad9c8fcc";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ protobuf ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''eCAL - enhanced Communication Abstraction Layer. A fast publish-subscribe cross-plattform middleware using Shared Memory and UDP.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/gazebo-ros2-control-demos/default.nix
+++ b/distros/iron/gazebo-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-iron-gazebo-ros2-control-demos";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control_demos/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "da743cfeda2079140ca85a202256803733b7d8fa45e4240c1419e2b609510de7";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control_demos/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "35972e2f765dba6472c97b8446aadf4b7afc1ca8db3480b710dc6c97e6740617";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gazebo-ros2-control/default.nix
+++ b/distros/iron/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-gazebo-ros2-control";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "57e7498fc189b3a1b9da0403c7b6a54563b02da62fb7a3bb021ec2682ab8aac1";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "80c2e06828b207c3967af235ab90978fac0ed694cee7c8815910e5c6c2da7d56";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -354,6 +354,8 @@ self: super: {
 
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
+ ecal = self.callPackage ./ecal {};
+
  ecl-build = self.callPackage ./ecl-build {};
 
  ecl-command-line = self.callPackage ./ecl-command-line {};
@@ -893,6 +895,10 @@ self: super: {
  microstrain-inertial-rqt = self.callPackage ./microstrain-inertial-rqt {};
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
+
+ mola-common = self.callPackage ./mola-common {};
+
+ mola-yaml = self.callPackage ./mola-yaml {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
@@ -2147,6 +2153,8 @@ self: super: {
  ur-msgs = self.callPackage ./ur-msgs {};
 
  urdf = self.callPackage ./urdf {};
+
+ urdf-launch = self.callPackage ./urdf-launch {};
 
  urdf-parser-plugin = self.callPackage ./urdf-parser-plugin {};
 

--- a/distros/iron/grid-map-demos/default.nix
+++ b/distros/iron/grid-map-demos/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake grid-map-cmake-helpers ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs grid-map-core grid-map-cv grid-map-filters grid-map-loader grid-map-msgs grid-map-octomap grid-map-ros grid-map-rviz-plugin grid-map-visualization octomap-msgs octomap-rviz-plugins octomap-server python3Packages.opencv3 rclcpp rclpy rviz2 sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs grid-map-core grid-map-cv grid-map-filters grid-map-loader grid-map-msgs grid-map-octomap grid-map-ros grid-map-rviz-plugin grid-map-visualization octomap-msgs octomap-rviz-plugins octomap-server python3Packages.opencv4 rclcpp rclpy rviz2 sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/gz-ros2-control-demos/default.nix
+++ b/distros/iron/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-iron-gz-ros2-control-demos";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-controls/gz_ros2_control/archive/release/iron/gz_ros2_control_demos/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "7da3b265dd017964d7865a7072e498c71b2fa647f182b6f6b25868494d10b5ad";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/iron/gz_ros2_control_demos/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "43e3641af4fff973f621485d31e59d57fc36be74bb578ebc9b27922757dce8c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-common/default.nix
+++ b/distros/iron/mola-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-iron-mola-common";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_common/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d055feb72e1f72b4e0b32361387084f447bd1e0ce467b0d8930ffc0a94afc1d4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Common CMake scripts to all MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-yaml";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "f728130a1eabc674aa3cbee1c3eed2f7e3cfe16e608120a2785528cb557a6d76";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''YAML helper library common to MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mrpt2 }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "608efb4608578efc6e40df089c27d578c5fecd6e9149ce57539919ac40402a5c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mp2p_icp/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "8beabb817e756299291b78d3d2c8e5fc961ed3c4b8b4b72479a4ed44dcde4ce4";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ mrpt2 ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/mrpt-msgs/default.nix
+++ b/distros/iron/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mrpt-msgs";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/iron/mrpt_msgs/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "4c16b585adb55f16e0af2713e9fa4eff79a637b975599da48d9bd6580b96e10b";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/iron/mrpt_msgs/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "fa988be6db32a3f9413149839446567570a6c7d629ce0fdc1f0741a69f05b23c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mvsim/default.nix
+++ b/distros/iron/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-iron-mvsim";
-  version = "0.7.2-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "c7d55ce10f0faf90cfe3e01f81ca83b0cf8d71c38cc76184c362673875cc1600";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "c02e109f6e5aabd5edd797da90ed60b0db1b3212c31249839dfeb1e540402b7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ouster-msgs/default.nix
+++ b/distros/iron/ouster-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ouster-msgs";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ouster-lidar/ouster-ros-release/archive/release/iron/ouster_msgs/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "f7801e0b8d34950d3a87f352909b9ef9921b02911405e654d53364437399ae5b";
+    url = "https://github.com/ros2-gbp/ouster-ros-release/archive/release/iron/ouster_msgs/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "c616b21fbefaeeaddbc2ec94086329f703d6f1556cd8bb69fe1861d67041f47b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rig-reconfigure/default.nix
+++ b/distros/iron/rig-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-rig-reconfigure";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/iron/rig_reconfigure/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "71375046e2c7dc61eb42bf6d59d6bbae2f9f410b3c09b8bec2d301b4b95b6638";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/iron/rig_reconfigure/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8f31ea1675e0c96b164e5102cb1b7971af05fcd4d0c1c4cd318d83107b758e7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/stereo-image-proc/default.nix
+++ b/distros/iron/stereo-image-proc/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv3 rclpy ros-testing ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv4 rclpy ros-testing ];
   propagatedBuildInputs = [ cv-bridge image-geometry image-proc image-transport message-filters rclcpp rclcpp-components sensor-msgs stereo-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 

--- a/distros/iron/urdf-launch/default.nix
+++ b/distros/iron/urdf-launch/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, launch-ros, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-iron-urdf-launch";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/urdf_launch-release/archive/release/iron/urdf_launch/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6425356db9bc20b4263edc196f863e748f0e9a46e4ec15d099396f89319e1f62";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui launch-ros robot-state-publisher rviz-common rviz-default-plugins rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch files for common URDF operations'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/iron/webots-ros2-tesla/default.nix
+++ b/distros/iron/webots-ros2-tesla/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright pythonPackages.pytest ];
-  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-driver ];
+  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv4 rclpy webots-ros2-driver ];
 
   meta = {
     description = ''Tesla ROS2 interface for Webots.'';

--- a/distros/noetic/aruco-opencv/default.nix
+++ b/distros/noetic/aruco-opencv/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ aruco-opencv-msgs catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport nodelet python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 roscpp tf2-geometry-msgs tf2-ros yaml-cpp ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-transport nodelet python39Packages.img2pdf python3Packages.numpy python3Packages.opencv4 roscpp tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/cpr-onav-description/default.nix
+++ b/distros/noetic/cpr-onav-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cpr-onav-description";
-  version = "0.1.5-r2";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.5-2.tar.gz";
-    name = "0.1.5-2.tar.gz";
-    sha256 = "366a5322a28d66f3218bbf3ce47b4fe91c71534081171264d98783c906a257d3";
+    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "b32d01b91837aa662bba83bb90dbdfaa96400c893359947b029673bc254f2f6c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cv-bridge/default.nix
+++ b/distros/noetic/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ python3Packages.numpy rostest ];
-  propagatedBuildInputs = [ boost opencv python3 python3Packages.opencv3 rosconsole sensor-msgs ];
+  propagatedBuildInputs = [ boost opencv python3 python3Packages.opencv4 rosconsole sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/jsk-topic-tools/default.nix
+++ b/distros/noetic/jsk-topic-tools/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin message-generation rostest ];
   checkInputs = [ roscpp-tutorials roslint ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet python3Packages.numpy python3Packages.opencv3 python3Packages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools unixtools.ping ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet python3Packages.numpy python3Packages.opencv4 python3Packages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools unixtools.ping ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/movie-publisher/default.nix
+++ b/distros/noetic/movie-publisher/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cv-bridge ffmpeg python3Packages.imageio python3Packages.opencv3 rosbash-params rospy sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg python3Packages.imageio python3Packages.opencv4 rosbash-params rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/turtlebot3-autorace-camera/default.nix
+++ b/distros/noetic/turtlebot3-autorace-camera/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure python3Packages.opencv3 pythonPackages.enum34 pythonPackages.numpy rospy sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure python3Packages.opencv4 pythonPackages.enum34 pythonPackages.numpy rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/turtlebot3-autorace-detect/default.nix
+++ b/distros/noetic/turtlebot3-autorace-detect/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs python3Packages.opencv3 pythonPackages.enum34 pythonPackages.numpy rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs python3Packages.opencv4 pythonPackages.enum34 pythonPackages.numpy rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/rolling/aruco-opencv/default.nix
+++ b/distros/rolling/aruco-opencv/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport python39Packages.img2pdf python3Packages.numpy python3Packages.opencv4 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/camera-calibration/default.nix
+++ b/distros/rolling/camera-calibration/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.requests pythonPackages.pytest ];
-  propagatedBuildInputs = [ cv-bridge image-geometry message-filters python3Packages.opencv3 rclpy sensor-msgs std-srvs ];
+  propagatedBuildInputs = [ cv-bridge image-geometry message-filters python3Packages.opencv4 rclpy sensor-msgs std-srvs ];
 
   meta = {
     description = ''camera_calibration allows easy calibration of monocular or stereo

--- a/distros/rolling/cv-bridge/default.nix
+++ b/distros/rolling/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv3 rclcpp rcpputils sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv4 rclcpp rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/rolling/ecal/default.nix
+++ b/distros/rolling/ecal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, protobuf }:
+buildRosPackage {
+  pname = "ros-rolling-ecal";
+  version = "5.12.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ecal-release/archive/release/rolling/ecal/5.12.0-1.tar.gz";
+    name = "5.12.0-1.tar.gz";
+    sha256 = "64d4b22451f502a9363d6d069cc6be695f83e63becd092768a44778f2ae104c2";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ protobuf ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''eCAL - enhanced Communication Abstraction Layer. A fast publish-subscribe cross-plattform middleware using Shared Memory and UDP.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -362,6 +362,8 @@ self: super: {
 
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
+ ecal = self.callPackage ./ecal {};
+
  ecl-build = self.callPackage ./ecl-build {};
 
  ecl-command-line = self.callPackage ./ecl-command-line {};
@@ -804,6 +806,12 @@ self: super: {
 
  map-msgs = self.callPackage ./map-msgs {};
 
+ mapviz = self.callPackage ./mapviz {};
+
+ mapviz-interfaces = self.callPackage ./mapviz-interfaces {};
+
+ mapviz-plugins = self.callPackage ./mapviz-plugins {};
+
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
@@ -855,6 +863,10 @@ self: super: {
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
+
+ mola-common = self.callPackage ./mola-common {};
+
+ mola-yaml = self.callPackage ./mola-yaml {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
@@ -948,6 +960,8 @@ self: super: {
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
+ mp2p-icp = self.callPackage ./mp2p-icp {};
+
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
 
  mrpt2 = self.callPackage ./mrpt2 {};
@@ -957,6 +971,8 @@ self: super: {
  mrpt-path-planning = self.callPackage ./mrpt-path-planning {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
+ multires-image = self.callPackage ./multires-image {};
 
  mvsim = self.callPackage ./mvsim {};
 
@@ -1857,6 +1873,8 @@ self: super: {
  tf-transformations = self.callPackage ./tf-transformations {};
 
  theora-image-transport = self.callPackage ./theora-image-transport {};
+
+ tile-map = self.callPackage ./tile-map {};
 
  tinyspline-vendor = self.callPackage ./tinyspline-vendor {};
 

--- a/distros/rolling/mapviz-interfaces/default.nix
+++ b/distros/rolling/mapviz-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-mapviz-interfaces";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_interfaces/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "720fe28afb37d3135b99b9b833bcee03518e46bbdad7e6d555fd7ab6e4bc200b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ builtin-interfaces marti-common-msgs rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS interfaces used by Mapviz'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mapviz-plugins/default.nix
+++ b/distros/rolling/mapviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-mapviz-plugins";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_plugins/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "5cdea3974e2d38cd43538ae0076f314e3995796544b32065a46ea69ba4e1635f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  propagatedBuildInputs = [ ament-index-cpp cv-bridge gps-msgs image-transport map-msgs mapviz marti-common-msgs marti-nav-msgs marti-sensor-msgs marti-visualization-msgs nav-msgs pluginlib qt5.qtbase rclcpp rclcpp-action sensor-msgs std-msgs stereo-msgs swri-image-util swri-math-util swri-route-util swri-transform-util tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''Common plugins for the Mapviz visualization tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mapviz/default.nix
+++ b/distros/rolling/mapviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-rolling-mapviz";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "f5ec921105fe4f3434a78edccfac91f024b8df8a8f58bb202cb688032ad3a300";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake pkg-config ros-environment ];
+  propagatedBuildInputs = [ cv-bridge freeglut geometry-msgs glew image-transport mapviz-interfaces marti-common-msgs pluginlib qt5.qtbase rclcpp rqt-gui rqt-gui-cpp std-srvs swri-math-util swri-transform-util tf2 tf2-geometry-msgs tf2-ros xorg.libXi xorg.libXmu yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake pkg-config qt5.qtbase ];
+
+  meta = {
+    description = ''mapviz'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mola-common/default.nix
+++ b/distros/rolling/mola-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-rolling-mola-common";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_common/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "bbfa18e2e65eb54af149a1e0b627a8efd60edeee5a3c67859cf6b80769f4d1f3";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Common CMake scripts to all MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-yaml";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "b2a9954be64a5a4e7732f5038b227b0258e2611220cb80133938410178c3de9a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''YAML helper library common to MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mrpt2 }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "8de115b2eefabbf22f67c0e9df510cb1a95beb2ea329a6b6e5102bd4c2d482de";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mp2p_icp/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "1e261574579a9964c741a8424a20a05e6a0740429426a95aca42b072b9fa6643";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ mrpt2 ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/multires-image/default.nix
+++ b/distros/rolling/multires-image/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, gps-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
+buildRosPackage {
+  pname = "ros-rolling-multires-image";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/multires_image/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "d328050f566885160e1f2b4cf4a04ec0e8701155c52baf3a7864a55e08b0a54a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs gps-msgs mapviz pluginlib qt5.qtbase rclcpp rclpy swri-math-util swri-transform-util tf2 ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''multires_image'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "abe08e693e2f66216b86897c514759272fd5a5cfb70a3b2ad7ec7a10529b6df3";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "9248611a3ceef6f8866e472a2700fb7e94baf1e8ea8c280ca018662c25205938";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rig-reconfigure/default.nix
+++ b/distros/rolling/rig-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rig-reconfigure";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/rolling/rig_reconfigure/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "d34237a9577d038320104e0c559b01a3317c3b620658526a0bbe2f41e410324e";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/rolling/rig_reconfigure/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "2689e42f5786b8bd1277846e5b20aca19124c709af52753167b39c76c9a30463";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-adapter-python/default.nix
+++ b/distros/rolling/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter-python";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "13442c94ad282d31ec16061964b5db4e62f81869e22bb68cde693dd4c633389a";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "9f635edb3f88a8905da29330612d92ef8dc5f69a7d785fb22c5b17c2fba4c721";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-adapter/default.nix
+++ b/distros/rolling/rmf-fleet-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "e3347171f2009ac57873352290b85d4f7dc20115e23b2db76ca12b307383b642";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "bdec13fc67d39f33f2c1f7b7caf3eb08d5305e7fa960165fa179eb9537d74a2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-task-ros2/default.nix
+++ b/distros/rolling/rmf-task-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-ros2";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "6e7797bb11bd35e2f38cb24bfe7a83f4c384c6039aad6908a1553459b94304c9";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "5a2854723e9a185d2cd67c0bcb776a3440498b919ff4e06a2abe3e1d9c85c25d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-traffic-ros2/default.nix
+++ b/distros/rolling/rmf-traffic-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-ros2";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "bfed7023a249e6d1f847f499c5cca20295c50b8d53ad8fb1247c4b32eca2a267";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "2ca41c75d3825d82abef7e1af7d3534ac0b755fde6686c5fec3fd74bcc6c731a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-building-systems/default.nix
+++ b/distros/rolling/rmf-visualization-building-systems/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rmf-building-map-msgs, rmf-door-msgs, rmf-lift-msgs, rmf-visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-building-systems";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_building_systems/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6a00bb92f72ad540877522aa08a1dc9e462810a7c2d31d0ee127024844074045";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_building_systems/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9a4460a21041332e376b445b94d77c341730fe547f673ce0e1bd6a26f4f6f763";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-visualization-fleet-states/default.nix
+++ b/distros/rolling/rmf-visualization-fleet-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rmf-fleet-msgs, rmf-utils, rmf-visualization-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-fleet-states";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_fleet_states/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e5ff9299a2faca145089f71dc8a2ead6757d088a95ed3adedf83e6735f05b941";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_fleet_states/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "664c4684963d429a1f4d405c290f1c18c3b510eb841e3fa9f1f3c89edf1fc786";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-floorplans/default.nix
+++ b/distros/rolling/rmf-visualization-floorplans/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, opencv, rclcpp, rclcpp-components, rmf-building-map-msgs, rmf-utils, rmf-visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-floorplans";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_floorplans/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0753441c3ad8244cace574c4204361878964dfabed8e04b61cb9288e23a446d1";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_floorplans/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "7b6401789b0e401f0c5371b19d96b952ce7f6a5c5e2cd5158849d166ddd534b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-navgraphs/default.nix
+++ b/distros/rolling/rmf-visualization-navgraphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, rclcpp-components, rmf-building-map-msgs, rmf-fleet-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-navgraphs";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d11922b8ee333f27fe31d33624b25a9b71d1704877311fab6b522b18c0c6ca38";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "56da9f79f4c6d30c0900052477d4ade1f7744922a75fb02c1987a896e8c47ed4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-obstacles/default.nix
+++ b/distros/rolling/rmf-visualization-obstacles/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, geometry-msgs, rclcpp, rclcpp-components, rmf-obstacle-msgs, rmf-utils, rmf-visualization-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-obstacles";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_obstacles/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d60c9f46c1a80540ac2c94a6bd436734317942ce7efa82299cc4bdc144996887";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_obstacles/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "f69613a9b19f0f56c3202933772b789352567ee99c0a81e87cf6bd904c9a370a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
+++ b/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, eigen, pluginlib, qt5, rclcpp, resource-retriever, rmf-door-msgs, rmf-lift-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rviz-common, rviz-default-plugins, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-rviz2-plugins";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "b8aac09412243fda618babde253bfed98fe73e601a64918fcd380b7dfbeae03e";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d94bb9cda183897c6cc1a038bbf32d48594b647b2a4392bbd9bf036b5e6fe835";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-schedule/default.nix
+++ b/distros/rolling/rmf-visualization-schedule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, eigen, geometry-msgs, openssl, rclcpp, rclcpp-components, rmf-traffic, rmf-traffic-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rosidl-default-generators, visualization-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-schedule";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "7f593ff5bf89d75a46021346fda05380f35307e9ebc35629efc204fa56598f73";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ba06e9f52e7c6adfc8502c1e8498f7dab7dbe00e2307335b1f66b75a850c8472";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization/default.nix
+++ b/distros/rolling/rmf-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-xml, rmf-visualization-building-systems, rmf-visualization-fleet-states, rmf-visualization-floorplans, rmf-visualization-navgraphs, rmf-visualization-obstacles, rmf-visualization-rviz2-plugins, rmf-visualization-schedule }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "3db552fff830df88cc7c8f7fb92981ae9d3b8cb61533126419e27d091de77487";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "35fd3f3080bca7b539517cc60ea719dd620d77387bca745fff4dccd9c4c77f67";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-websocket/default.nix
+++ b/distros/rolling/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-websocket";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "5686eedf37d7e86c2feff5cdd3af3594747de7991b19ce8d4cee809980501a10";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "dfef8deb934a3223c6adde3b02c676d1849b1e76317dce7e1a7cafe0c2f76604";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-image-proc/default.nix
+++ b/distros/rolling/stereo-image-proc/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv3 rclpy ros-testing ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv4 rclpy ros-testing ];
   propagatedBuildInputs = [ cv-bridge image-geometry image-proc image-transport message-filters rclcpp rclcpp-components sensor-msgs stereo-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 

--- a/distros/rolling/tile-map/default.nix
+++ b/distros/rolling/tile-map/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-rolling-tile-map";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/tile_map/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "be0625743e4ef0cf5668a7350fd9b67349463fe51f173b00698bba54674e8795";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ glew jsoncpp mapviz pluginlib qt5.qtbase rclcpp swri-math-util swri-transform-util tf2 yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake qt5.qtbase ];
+
+  meta = {
+    description = ''Tile map provides a slippy map style interface for visualizing 
+     OpenStreetMap and GoogleMap tiles.  A mapviz visualization plug-in is also
+     implemented'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f5666097352cd26aeffa428970638119c1231181edbef80bcf6bbfb72b8a95c5";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c1cf908d973bfd5ee08d8ff90a85cb793739c03c92ed593d18d6873f77bdbcdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "94d5c462584caddfe1f83837472f7c463d57a0fe07ff119a48047fa08ec4ea25";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "2dc87b6e6b1c075404f0bfc7bfdfa889d3817f772ae3ee22492d85754ff86a43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "6fe3069adc6e7b92656613c9deb3472e364b63daf40f037a5f27524deb1630f2";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "d6c5271f52a6d3ecfcbf3ce66035d423f3455be263df8ee1705b2a490f4169f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-description/default.nix
+++ b/distros/rolling/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-description";
-  version = "2.1.0-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "e3d96d26ec90ab2d5d961ddc3b7613f2a5441158a09f1a002b41930015c75d97";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2a247bb535119049695b4c563f8a4e03ee35e8435f08dcca8dd2842ca74ad5d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "4efde8b4eb51ee24bca183ef82ade2384c0234aca2177d2570bac25d0dce6dbd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5a3a23d01d9d20137143f91e82b810cb9d725327f7b8ec1eb39bf8d221654305";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "c47198f018849b0f424b25331959c8bfd679730453a7ee8e944b3f22c3572b89";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "bdb870a3945da5c2bebf8f836c6353624a72369039d7d2791c21118bf1dd146b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright pythonPackages.pytest ];
-  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-driver ];
+  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv4 rclpy webots-ros2-driver ];
 
   meta = {
     description = ''Tesla ROS2 interface for Webots.'';


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 4c0baef357f0d0c84502202d75a69c496feb433e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-config-live 0.0.2-r1 --> 0.1.0-r1*
* *clearpath-control 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-description 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-desktop 0.0.2-r1 --> 0.1.0-r1*
* *clearpath-generator-common 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-generator-gz 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-gz 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-mounts-description 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-platform 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-platform-description 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-sensors-description 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-simulator 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-viz 0.0.2-r1 --> 0.1.0-r1*
* *ecal 5.12.0-r1*
* *mola-common 0.2.0-r1*
* *mola-yaml 0.2.0-r1*
* *mp2p-icp 0.1.0-r1 --> 0.2.0-r1*
* *mvsim 0.7.3-r1 --> 0.7.4-r1*
* *raspimouse 1.1.1-r7 --> 1.1.2-r1*
* *raspimouse-msgs 1.1.1-r7 --> 1.1.2-r1*
* *rig-reconfigure 1.2.0-r1 --> 1.3.0-r1*
* *weight-scale-interfaces 0.0.1-r1*

Iron Changes:
-------------
* *ecal 5.12.0-r1*
* *gazebo-ros2-control 0.6.1-r1 --> 0.6.2-r1*
* *gazebo-ros2-control-demos 0.6.1-r1 --> 0.6.2-r1*
* *gz-ros2-control-demos 1.1.1-r1 --> 1.1.2-r1*
* *mola-common 0.2.0-r1*
* *mola-yaml 0.2.0-r1*
* *mp2p-icp 0.1.0-r1 --> 0.2.0-r1*
* *mrpt-msgs 0.4.6-r1 --> 0.4.7-r1*
* *mvsim 0.7.2-r1 --> 0.7.4-r1*
* *ouster-msgs 0.10.3-r1 --> 0.10.4-r1*
* *rig-reconfigure 1.2.0-r1 --> 1.3.0-r1*
* *urdf-launch 0.1.0-r1*

Noetic Changes:
---------------
* *cpr-onav-description 0.1.5-r2 --> 0.1.6-r1*

Rolling Changes:
----------------
* *ecal 5.12.0-r1*
* *mapviz 2.3.0-r1*
* *mapviz-interfaces 2.3.0-r1*
* *mapviz-plugins 2.3.0-r1*
* *mola-common 0.2.0-r1*
* *mola-yaml 0.2.0-r1*
* *mp2p-icp 0.1.0-r1 --> 0.2.0-r1*
* *multires-image 2.3.0-r1*
* *mvsim 0.7.3-r1 --> 0.7.4-r1*
* *rig-reconfigure 1.2.0-r1 --> 1.3.0-r1*
* *rmf-fleet-adapter 2.3.1-r1 --> 2.3.2-r1*
* *rmf-fleet-adapter-python 2.3.1-r1 --> 2.3.2-r1*
* *rmf-task-ros2 2.3.1-r1 --> 2.3.2-r1*
* *rmf-traffic-ros2 2.3.1-r1 --> 2.3.2-r1*
* *rmf-visualization 2.2.0-r1 --> 2.2.1-r1*
* *rmf-visualization-building-systems 2.2.0-r1 --> 2.2.1-r1*
* *rmf-visualization-fleet-states 2.2.0-r1 --> 2.2.1-r1*
* *rmf-visualization-floorplans 2.2.0-r1 --> 2.2.1-r1*
* *rmf-visualization-navgraphs 2.2.0-r1 --> 2.2.1-r1*
* *rmf-visualization-obstacles 2.2.0-r1 --> 2.2.1-r1*
* *rmf-visualization-rviz2-plugins 2.2.0-r1 --> 2.2.1-r1*
* *rmf-visualization-schedule 2.2.0-r1 --> 2.2.1-r1*
* *rmf-websocket 2.3.1-r1 --> 2.3.2-r1*
* *tile-map 2.3.0-r1*
* *ur 2.3.2-r1 --> 2.4.0-r1*
* *ur-calibration 2.3.2-r1 --> 2.4.0-r1*
* *ur-controllers 2.3.2-r1 --> 2.4.0-r1*
* *ur-dashboard-msgs 2.3.2-r1 --> 2.4.0-r1*
* *ur-description 2.1.0-r2 --> 2.2.0-r1*
* *ur-moveit-config 2.3.2-r1 --> 2.4.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] hdf5-tools
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

