### PR TITLE
Wrap plotjuggler with Qt wrapper

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -166,6 +166,9 @@ let
     }: {
       dontWrapQtApps = false;
       nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
+      postFixup = ''
+        wrapQtApp "$out/lib/plotjuggler/plotjuggler"
+      '';
     });
 
     pr2-tilt-laser-interface = patchBoostSignals rosSuper.pr2-tilt-laser-interface;


### PR DESCRIPTION
Without this, running `ros2 run plotjuggler plotjuggler` results in:

    qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
    qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
    This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

    Stack trace (most recent call last):
    #13   Object "[0xffffffffffffffff]", at 0xffffffffffffffff, in
    #12   Object "/nix/store/g7mcg164p44hzgra9sp653a34d276vw2-ros-humble-plotjuggler-3.7.1-r1/lib/plotjuggler/plotjuggler", at 0x473b04, in
    #11   Object "/nix/store/1x4ijm9r1a88qk7zcmbbfza324gx1aac-glibc-2.37-8/lib/libc.so.6", at 0x7f512523db88, in __libc_start_main
    #10   Object "/nix/store/1x4ijm9r1a88qk7zcmbbfza324gx1aac-glibc-2.37-8/lib/libc.so.6", at 0x7f512523dacd, in
    #9    Object "/nix/store/g7mcg164p44hzgra9sp653a34d276vw2-ros-humble-plotjuggler-3.7.1-r1/lib/plotjuggler/plotjuggler", at 0x4711af, in
    #8    Object "/nix/store/b085hafh1ph7alj1nnbzmz29znni4v5w-qtbase-5.15.9/lib/libQt5Widgets.so.5", at 0x7f51263765b8, in QApplicationPrivate::init()
    #7    Object "/nix/store/b085hafh1ph7alj1nnbzmz29znni4v5w-qtbase-5.15.9/lib/libQt5Gui.so.5", at 0x7f5125b29cdb, in QGuiApplicationPrivate::init()
    #6    Object "/nix/store/b085hafh1ph7alj1nnbzmz29znni4v5w-qtbase-5.15.9/lib/libQt5Core.so.5", at 0x7f51256d13b4, in QCoreApplicationPrivate::init()
    #5    Object "/nix/store/b085hafh1ph7alj1nnbzmz29znni4v5w-qtbase-5.15.9/lib/libQt5Gui.so.5", at 0x7f5125b26e3f, in QGuiApplicationPrivate::createEventDispatcher()
    #4    Object "/nix/store/b085hafh1ph7alj1nnbzmz29znni4v5w-qtbase-5.15.9/lib/libQt5Gui.so.5", at 0x7f5125b2686a, in QGuiApplicationPrivate::createPlatformIntegration()
    #3    Object "/nix/store/b085hafh1ph7alj1nnbzmz29znni4v5w-qtbase-5.15.9/lib/libQt5Core.so.5", at 0x7f5125499cc0, in QMessageLogger::fatal(char const*, ...) const
    #2    Object "/nix/store/1x4ijm9r1a88qk7zcmbbfza324gx1aac-glibc-2.37-8/lib/libc.so.6", at 0x7f512523c8b9, in abort
    #1    Object "/nix/store/1x4ijm9r1a88qk7zcmbbfza324gx1aac-glibc-2.37-8/lib/libc.so.6", at 0x7f5125252c85, in gsignal
    #0    Object "/nix/store/1x4ijm9r1a88qk7zcmbbfza324gx1aac-glibc-2.37-8/lib/libc.so.6", at 0x7f51252a1a8c, in
    Aborted (Signal sent by tkill() 2090297 1000)