### PR TITLE
rosdistro sync, Fri Sep  8 13:49:36 2023

### DIFF
--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.3.5-r1";
+  version = "4.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.5-1.tar.gz";
-    name = "4.3.5-1.tar.gz";
-    sha256 = "e83189693a869733f02e154e36d0e7e4da466bc89792180f951f2ebe1e66d06b";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.6-1.tar.gz";
+    name = "4.3.6-1.tar.gz";
+    sha256 = "153c9db82db641f3f11e0e70dc864dea8d62b7cf8631806becd29afff5718ca6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/boost-plugin-loader/default.nix
+++ b/distros/humble/boost-plugin-loader/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, gtest, ros-industrial-cmake-boilerplate }:
+buildRosPackage {
+  pname = "ros-humble-boost-plugin-loader";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tesseract-robotics-release/boost_plugin_loader-release/archive/release/humble/boost_plugin_loader/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "5464e5b2049c8f2281a4ea8e1dc418166c03c8714dec3f429d517fde8e6dc293";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Boost plugin loader implementation'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.0.6-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "23f6d3d08a3b0dcfbecacb7a84056b8d26cdb5a6a624b3589720b1a38fe0d81c";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "7b202e7d533ebac41399892568bf770bd5b962b99249a8c149fe84b24956a869";
   };
 
   buildType = "ament_python";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "bdfeccec3fe7fa8c5468e4b1ed0932106e41d85682a5487d02f4dab00fbb5cd2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "d91fa8463553e5cb2431bdf38b88c79e231a53db82259974dc3e7394e57470d2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ boost camera-info-manager cv-bridge depthai depthai-ros-msgs image-transport opencv rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs vision-msgs xacro ];
+  propagatedBuildInputs = [ boost camera-info-manager cv-bridge depthai depthai-ros-msgs image-transport opencv rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs tf2-ros vision-msgs xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "31c05b56808a6459e28dcd6b9c6c610e8c1494600b5fcfdc67d3d40bca8e46cb";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "0502e3504ff4e8dac15e3608cd44efcd590de5b4c6b439c70c9b8fbf4b14ecd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "d5b64f9486dc90178eaee7a114ab212fcf6c3384fbf2a84396cdbba430ad1d0a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "62984a93eec4acc019c80ed59705bba399d464be703ac615f28b1b7d37c5934b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "8bb238dcc7cd8e8c24f2f3ec3674ac8a9cfa9f373c0075f3c12656bf9c8cf63b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "c7fcb0bb77c65294b49d778e5c1cc392763ee13ef566b334f9a81aee4a9df658";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  propagatedBuildInputs = [ cv-bridge image-transport message-filters opencv rclcpp rclcpp-components sensor-msgs vision-msgs visualization-msgs ];
+  propagatedBuildInputs = [ cv-bridge depthai-ros-msgs image-transport message-filters opencv rclcpp rclcpp-components sensor-msgs vision-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "9336fdd440cb6c4a8bc52f067e4cbfd8f1e0e2e7754d83462ea2c573a6259939";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "a94b5320167b9ae80e3c18aa29c0b4e652dd8f363fe10fb9dc87396243bd9a76";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs image-pipeline image-transport image-transport-plugins pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ ament-cmake-auto camera-calibration cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs diagnostic-updater image-pipeline image-transport image-transport-plugins pluginlib rclcpp rclcpp-components sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "38aca13d29b50e7ed862f679b3f6f36bddfef9f0612ccd615d17056c21c01b83";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "c4985f22702b3109f0d69cb8e93e926be308655e820238cf19d2f4a543c63a63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-driver, depthai-ros-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "282c90940081008cbb15720c6f30770c0c414c9888ac8581578184fe72af0819";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "44ecc50da290733b3461a159ff033ff720285c3cc3d64ee0a3fc4081fad21f51";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-driver depthai-ros-msgs ];
+  propagatedBuildInputs = [ depthai depthai-bridge depthai-descriptions depthai-examples depthai-filters depthai-ros-driver depthai-ros-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ecal/default.nix
+++ b/distros/humble/ecal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, protobuf }:
 buildRosPackage {
   pname = "ros-humble-ecal";
-  version = "5.12.0-r1";
+  version = "5.12.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ecal-release/archive/release/humble/ecal/5.12.0-1.tar.gz";
-    name = "5.12.0-1.tar.gz";
-    sha256 = "6a9b97cc1d3dc7e9a70454bef30b066e3b598b38e9bb28a13021e84919ecd9c9";
+    url = "https://github.com/ros2-gbp/ecal-release/archive/release/humble/ecal/5.12.0-2.tar.gz";
+    name = "5.12.0-2.tar.gz";
+    sha256 = "e4fcbb77ab8c5101b1a9c6a50d88f30ac0eb8b0dc9543822dda884cb98fa1457";
   };
 
   buildType = "cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -262,6 +262,8 @@ self: super: {
 
  boost-geometry-util = self.callPackage ./boost-geometry-util {};
 
+ boost-plugin-loader = self.callPackage ./boost-plugin-loader {};
+
  bosch-locator-bridge = self.callPackage ./bosch-locator-bridge {};
 
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
@@ -1062,6 +1064,12 @@ self: super: {
 
  mola-common = self.callPackage ./mola-common {};
 
+ mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
+
+ mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
+
+ mola-kernel = self.callPackage ./mola-kernel {};
+
  mola-yaml = self.callPackage ./mola-yaml {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
@@ -1255,6 +1263,8 @@ self: super: {
  nmea-hardware-interface = self.callPackage ./nmea-hardware-interface {};
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
+
+ nmea-navsat-driver = self.callPackage ./nmea-navsat-driver {};
 
  nodl-python = self.callPackage ./nodl-python {};
 

--- a/distros/humble/gps-msgs/default.nix
+++ b/distros/humble/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-gps-msgs";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_msgs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "14dabb8fb5ce2767fcc68397be71f45cce3c8ca19a4dedb54316a15a6a29aff1";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "c194677da0afa403b695dcb89545afb481a3982e1d99bb6de677eb1c8314dbdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gps-tools/default.nix
+++ b/distros/humble/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-gps-tools";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_tools/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "f60e2d6c7bd2a0e70355a1794fbfdea194f2a52578d1205ac969d9bd52c5a47d";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "dec0ec5bd69ff8fb510d22bc17164003c1a7f910078e25de43886143851f3f7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gps-umd/default.nix
+++ b/distros/humble/gps-umd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-humble-gps-umd";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_umd/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "150b520e8984fe3eb9b557f3d509ebeb32dda1f66c40752cfc02ca53c73c356a";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gps_umd/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "18950b156b61ae7b47d520ad4a8fcc75e606a11b91a25eb7e2f6050f017ed639";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gpsd-client/default.nix
+++ b/distros/humble/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-gpsd-client";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gpsd_client/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "d72bfbd5eebb5cc792a02a97f30d0620d1f2fa3d91b5ce04b3884b6e2fe9f239";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/humble/gpsd_client/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "be1423b927aac354a0a8433acb477631619f06ff92518dcdd396519bc3f293ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-common/default.nix
+++ b/distros/humble/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-humble-mola-common";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_common/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "1fce8091f43db8b368d32a3adddb240f2d881746687ed9c71745f264ba38643f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_common/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "429998fc9493eec01f6ae4cc6a5fcc694d596b7dfd4d823b341acd13af5124cb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-euroc-dataset";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3f39d4ddd15d0b07158352c2211275421a517cf89ab2f238b82f1595b25afcad";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from EUROC SLAM datasets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-kitti-dataset";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "e750a6f84f23c8587f51b0de983503db7d05666099bcec9e7458910d35f991f2";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Kitti odometry/SLAM datasets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-kernel";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "6318388bae11442b31d9cd2abbb9219609eb6b01b833b18d8f8536c482a54908";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-yaml mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Fundamental C++ virtual interfaces and data types for the rest of MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "818169544b0fe72e8ef1e3de1a635a32faf323ea6ed99092081381cc1d2edd07";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "cdda8616ef2a829ad9219967d2a9976a3981d5002373bab617b28d9322b9c0e5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mp2p_icp/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "bfe472e0e3b7f7d59fa9029758ce615d976e666b65b86c55f68305153b8e45bc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mp2p_icp/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "17fb5a522cc6d41a6884a7c9c933d477551e90d57e249890dfb426db2afd25a4";
   };
 
   buildType = "cmake";

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.7.4-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "1946b15ee214bb6053d9825064113f0a75221a57da61daf462b4fa3d83b6e009";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "25279effce76ac05bdbfc80091f01bec92b20080ed127d68c0d9208fd130b151";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nmea-navsat-driver/default.nix
+++ b/distros/humble/nmea-navsat-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, nmea-msgs, python3Packages, pythonPackages, rclpy, sensor-msgs, tf-transformations }:
+buildRosPackage {
+  pname = "ros-humble-nmea-navsat-driver";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nmea_navsat_driver-release/archive/release/humble/nmea_navsat_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5fdf08a9869f81f1e453ba03e4ae717d35500f9b749584115c1d78be0001524a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs nmea-msgs python3Packages.numpy python3Packages.pyserial rclpy sensor-msgs tf-transformations ];
+
+  meta = {
+    description = ''Package to parse NMEA strings and publish a very simple GPS message. Does not
+        require or use the GPSD deamon.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/rig-reconfigure/default.nix
+++ b/distros/humble/rig-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-rig-reconfigure";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/humble/rig_reconfigure/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "7e05cbfd8760a1246e6526ced1e305d797e8f314d3898f906a400741be8af707";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/humble/rig_reconfigure/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "aea0c1d09fe555523c6d3c639e5371e7ff5fe3cd341961ec62fc1baa2a39b239";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-based-ros2-control/default.nix
+++ b/distros/humble/topic-based-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hardware-interface, picknik-ament-copyright, rclcpp, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, hardware-interface, picknik-ament-copyright, rclcpp, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-topic-based-ros2-control";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/topic_based_ros2_control-release/archive/release/humble/topic_based_ros2_control/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "3f19f78526ac82065e515e9449dd4048b3bd8c82ff0b6718a7335d44bfbaf651";
+    url = "https://github.com/PickNikRobotics/topic_based_ros2_control-release/archive/release/humble/topic_based_ros2_control/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "102d8ff9d1aa0537f6986d2e9d65e0464a49f6e117bf0767209de7ff0fbe21a9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common picknik-ament-copyright ros2-control-test-assets ];
-  propagatedBuildInputs = [ hardware-interface rclcpp sensor-msgs ];
+  propagatedBuildInputs = [ angles hardware-interface rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "77dfbcf2c983927d186413fb0b8d45baaed4d7675ce6324560e272129451cb76";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9e2b31c47a15d99e5b97bd901d9af84739451d4a460f6427208d4572d4dc1fa8";
   };
 
   buildType = "cmake";

--- a/distros/humble/usb-cam/default.nix
+++ b/distros/humble/usb-cam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-humble-usb-cam";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/humble/usb_cam/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "fc7ffde88bd2b3766b87a52d3bab612deb778964f14b91aae45784c78e10ba10";
+    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/humble/usb_cam/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "63272f4f6873929dd3eb23bc693bbd7981df81d6a51fe362a5018f0abed9c471";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.3.5-r1";
+  version = "4.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.5-1.tar.gz";
-    name = "4.3.5-1.tar.gz";
-    sha256 = "aab822b5f21adb51bcda53c9b6d2f943013f410826bcec794f14dbc0c1ee8d28";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.6-1.tar.gz";
+    name = "4.3.6-1.tar.gz";
+    sha256 = "f65c0d93208af72dd0d1269c9b857dc9227ad494f995211143c6050888954baf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -898,6 +898,12 @@ self: super: {
 
  mola-common = self.callPackage ./mola-common {};
 
+ mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
+
+ mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
+
+ mola-kernel = self.callPackage ./mola-kernel {};
+
  mola-yaml = self.callPackage ./mola-yaml {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};

--- a/distros/iron/mola-common/default.nix
+++ b/distros/iron/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-iron-mola-common";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_common/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "d055feb72e1f72b4e0b32361387084f447bd1e0ce467b0d8930ffc0a94afc1d4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_common/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "f93da2a8b68465ecddf852891f96565971f724a874caf6207e2434aef5da3267";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-euroc-dataset/default.nix
+++ b/distros/iron/mola-input-euroc-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-input-euroc-dataset";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "fd20de10f7d43c58ef8c0489d21720ce8d43db36eb2f3e820e0d914a4e0f72d7";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from EUROC SLAM datasets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mola-input-kitti-dataset/default.nix
+++ b/distros/iron/mola-input-kitti-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-input-kitti-dataset";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "fa4aa64b8d33dc80590cf071dfa51fb8eacac506f53f1adfd9026e32288d1711";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Kitti odometry/SLAM datasets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mola-kernel/default.nix
+++ b/distros/iron/mola-kernel/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-kernel";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "c90bfad41604c995f2b7cb3eb9dd696517f351830c2b828ef05b7e60b69855e2";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-yaml mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Fundamental C++ virtual interfaces and data types for the rest of MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-yaml";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "f728130a1eabc674aa3cbee1c3eed2f7e3cfe16e608120a2785528cb557a6d76";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "21db2592475ca3297460e66e1476584dd83c2faafccf2c7d720a0797370cfd32";
   };
 
   buildType = "cmake";

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mp2p_icp/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "8beabb817e756299291b78d3d2c8e5fc961ed3c4b8b4b72479a4ed44dcde4ce4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mp2p_icp/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "71437c9667c9be83a2a102f439223fe8033edbd335d79568484792ad0d87f1d8";
   };
 
   buildType = "cmake";

--- a/distros/iron/mvsim/default.nix
+++ b/distros/iron/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-iron-mvsim";
-  version = "0.7.4-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "c02e109f6e5aabd5edd797da90ed60b0db1b3212c31249839dfeb1e540402b7a";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "925d86747246f69457e0497471274fa9ba1ae7d2a7d31347b5d36538f961996a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nmea-navsat-driver/default.nix
+++ b/distros/iron/nmea-navsat-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, nmea-msgs, python3Packages, pythonPackages, rclpy, sensor-msgs, tf-transformations }:
 buildRosPackage {
   pname = "ros-iron-nmea-navsat-driver";
-  version = "2.0.0-r3";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nmea_navsat_driver-release/archive/release/iron/nmea_navsat_driver/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "da5c9d407335d81a0ac8ad93af42a632fb1e2b87139145aacef860d25b0129c3";
+    url = "https://github.com/ros2-gbp/nmea_navsat_driver-release/archive/release/iron/nmea_navsat_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a4e99d6929fbe6bf0791d7210868a1569a14a7b42dbe9cfeeb3e2c81f16405ec";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rig-reconfigure/default.nix
+++ b/distros/iron/rig-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-rig-reconfigure";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/iron/rig_reconfigure/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "8f31ea1675e0c96b164e5102cb1b7971af05fcd4d0c1c4cd318d83107b758e7c";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/iron/rig_reconfigure/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "fa51a7a7b2a86fdb187f3da386c0bab216a5f67869db171b38d3c3ecdfed1116";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/usb-cam/default.nix
+++ b/distros/iron/usb-cam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-iron-usb-cam";
-  version = "0.6.0-r2";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/iron/usb_cam/0.6.0-2.tar.gz";
-    name = "0.6.0-2.tar.gz";
-    sha256 = "a552f20572a97cf5230acdfeee42f86878a220f1feb85afc98c20ac5541b6fc8";
+    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/iron/usb_cam/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "1c8fcacc133ee976ab1a2dd0548d22b705dc7559713004a257ad6c8ff45b4936";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/ackermann-steering-controller/default.nix
+++ b/distros/noetic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, controller-manager-msgs, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, std-msgs, std-srvs, tf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ackermann-steering-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "9ec642f1a8508bf41ea70f7ca39e559962aafe350383af60b179f4365fdfcf92";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "a637541e0c9ffd7b8e9385d7af5341cea07f4b0fc8aa004c5f84e64b82260e42";
   };
 
   buildType = "catkin";

--- a/distros/noetic/behaviortree-cpp/default.nix
+++ b/distros/noetic/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ros-environment, roslib, sqlite }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp";
-  version = "4.3.5-r1";
+  version = "4.3.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.3.5-1.tar.gz";
-    name = "4.3.5-1.tar.gz";
-    sha256 = "82873d422154d4b51eda7c24134cd284a2d784a7358d6984c047ee7fa8454612";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.3.6-2.tar.gz";
+    name = "4.3.6-2.tar.gz";
+    sha256 = "c5f74c1c7db149eb101bd91e9faf7fe3378aee1be66253aa5875f74c534047b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "94ebec519ac5d8a172ad4c198c6e77b04cbc24a98195918cff8647e93baf9d8b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "7b4d530e17311416566a10daafc881d38734f335be4e1063ebf4f414396915a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2-ros, urdf, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "ec486e648cd5644c9ce7d1e01925e7274e03dd1272ea6a3c87c14e63a266ae20";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "d60e7a2df8ce7b2dd92bfe51b2b70e9310ba2b8faffb3bc090e3e5c6289e82d4";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ boost camera-info-manager cv-bridge depthai depthai-ros-msgs image-transport opencv ros-environment roscpp sensor-msgs std-msgs stereo-msgs vision-msgs ];
+  propagatedBuildInputs = [ boost camera-info-manager cv-bridge depthai depthai-ros-msgs image-transport opencv robot-state-publisher ros-environment roscpp sensor-msgs std-msgs stereo-msgs tf2-ros urdf vision-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "6c8ddb82a3e633ce18390b2beed00e578dbc0a3a53874e1b1aefd2da680bc9d8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "bfcc5dd47614e1538752c61fa2a79b6ed037f195a0616a61d0f73cd3ab4308af";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "9ad512bc1dcf8b8e117bd2db307b5990ec423e1d508125684fcb8a8dd2313b26";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "99fb188b054dca632c95471e232f6406b533db5b5adf546e8050bdbb3dc5cdd6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, depthai-ros-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "42b1d29e4d36fb7736ac3ed26bd27027505a67efc3d83531c03d31627a622b21";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "deb0e6315bba29dd5c2a981f0e32e3ba58a2838a64e8e76ae643c9651c359817";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet opencv roscpp sensor-msgs vision-msgs visualization-msgs ];
+  propagatedBuildInputs = [ cv-bridge depthai-ros-msgs dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet opencv roscpp sensor-msgs vision-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "7b08d58cb927a921d22ae7e71886a63005dcb6842db1a52f1f1f8d0f66fdd309";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "7d7eb95efcd00db467654964b0e9001bcc4bff8f0dfb7e553b92464dc1569a1e";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ camera-info-manager cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet pluginlib roscpp rospy sensor-msgs std-msgs std-srvs vision-msgs ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depthai depthai-bridge depthai-descriptions depthai-examples depthai-ros-msgs diagnostic-msgs diagnostic-updater dynamic-reconfigure image-pipeline image-transport image-transport-plugins message-filters nodelet pluginlib roscpp rospy sensor-msgs std-msgs std-srvs vision-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "92b20dec4fb844011addf19165818e432e0b6d74651fecbf40abdb2c0cf16a1c";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "86dc07776901b3a93d55f43e1e40b7fa3561f24d157d480520c6a0287049601a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.7.5-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.7.5-1.tar.gz";
-    name = "2.7.5-1.tar.gz";
-    sha256 = "d3cd2f8ddaa7fb96bf05074871582c0f2650c8d52c39d2d39a12c47875e3ca11";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "9f69aaed5179de3af72dbb56d8edfa24385cfd7685bf08e8bfee3d949c518eaa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diff-drive-controller/default.nix
+++ b/distros/noetic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, rostopic, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-diff-drive-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "e75b021feca32420a2538d746a16418e94e4d50ef788d1955a63231f59786b48";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "1a1c2aac67c8ef698107f2a111e8edfc3c3c10e47e64c2980cd7485a990fd9e8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/effort-controllers/default.nix
+++ b/distros/noetic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, joint-state-controller, pluginlib, realtime-tools, robot-state-publisher, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-effort-controllers";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "a9a66d95cbf9f411432c02a64c2ec3b926e6d364cfad6af8e9a273a3a23fd871";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "0d9c0e5b92dfae4feb80ee4d12ba8caf1830960ee6d190d91c653e376727ab5e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/force-torque-sensor-controller/default.nix
+++ b/distros/noetic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-force-torque-sensor-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "072db63595fd7cb0c8df7a8ba28e94cfd09c6950dbf21d2160b22c33ec0c3200";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "39b65f9b5d755c90dceb30634d8c23fefc8e90d090b7997cd60eca1fe607969b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/forward-command-controller/default.nix
+++ b/distros/noetic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-forward-command-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "5e0da91dd971bc9cf09c4251e076355dd3ffcec02d0a90c61d5558cd7f4d55a2";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "0782b44164bf501102fc0fe9bf1ae9d9c109e97e6520694b7d1df71b94f965c7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/four-wheel-steering-controller/default.nix
+++ b/distros/noetic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rosgraph-msgs, rostest, std-msgs, std-srvs, tf, urdf-geometry-parser, xacro }:
 buildRosPackage {
   pname = "ros-noetic-four-wheel-steering-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "707059f1318b760df190f02b0ef8473cd27dbe1025043d14620ef054d8563e15";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "4093446fdce7e75c9b44c4603a9bc153b39b71accf7924df0865e77aac3317a0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-custom-sensor-preloader/default.nix
+++ b/distros/noetic/gazebo-custom-sensor-preloader/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gazebo-dev, gazebo-ros, pluginlib, rosbash }:
+buildRosPackage {
+  pname = "ros-noetic-gazebo-custom-sensor-preloader";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/gazebo_custom_sensor_preloader/-/archive/release/noetic/gazebo_custom_sensor_preloader/1.1.0-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "114669818049c6e24a52fa887ebea28d26f7f3298e427e18891db7b5d693bb50";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ boost catkin ];
+  propagatedBuildInputs = [ gazebo-dev gazebo-ros pluginlib rosbash ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Gazebo plugin that allows writing custom Gazebo sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1078,6 +1078,8 @@ self: super: {
 
  fuse-viz = self.callPackage ./fuse-viz {};
 
+ gazebo-custom-sensor-preloader = self.callPackage ./gazebo-custom-sensor-preloader {};
+
  gazebo-dev = self.callPackage ./gazebo-dev {};
 
  gazebo-msgs = self.callPackage ./gazebo-msgs {};
@@ -2642,11 +2644,17 @@ self: super: {
 
  qb-move-hardware-interface = self.callPackage ./qb-move-hardware-interface {};
 
+ qb-softhand-industry = self.callPackage ./qb-softhand-industry {};
+
  qb-softhand-industry-bringup = self.callPackage ./qb-softhand-industry-bringup {};
+
+ qb-softhand-industry-control = self.callPackage ./qb-softhand-industry-control {};
 
  qb-softhand-industry-description = self.callPackage ./qb-softhand-industry-description {};
 
  qb-softhand-industry-driver = self.callPackage ./qb-softhand-industry-driver {};
+
+ qb-softhand-industry-hardware-interface = self.callPackage ./qb-softhand-industry-hardware-interface {};
 
  qb-softhand-industry-msgs = self.callPackage ./qb-softhand-industry-msgs {};
 
@@ -2711,6 +2719,8 @@ self: super: {
  rc-visard-driver = self.callPackage ./rc-visard-driver {};
 
  rcdiscover = self.callPackage ./rcdiscover {};
+
+ reach = self.callPackage ./reach {};
 
  realsense2-camera = self.callPackage ./realsense2-camera {};
 

--- a/distros/noetic/gripper-action-controller/default.nix
+++ b/distros/noetic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gripper-action-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "7fa4dfa383f738067f6b9b04b5092bb6ed2ffcad9e03461fd71f75332c2cc6eb";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "9a2c4adbf4cba789cc6e40f97d47db2173b0d90e1cf8c51e1867d3ef4f644c20";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-sensor-controller/default.nix
+++ b/distros/noetic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-imu-sensor-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "55b76a3936dcb4386e2eb67e8f92974c262b5bfa92ea5d2f57c3bbce0d9310c4";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "646ea2c4e2b3e4eb2c667734cbd6abad57dd61febc0000c94da7515bb0f55e81";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-controller/default.nix
+++ b/distros/noetic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "f4273452c44dd20301ffe24c82913ae05a0db0c9063d89196808726d51b5a6f4";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "60971dd00558f070dd85da9d25f68a2ecb438137f19550485c630fa673cea251";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-trajectory-controller/default.nix
+++ b/distros/noetic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, boost, catkin, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, std-msgs, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-joint-trajectory-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "333d133c70c87427c9039f55cab66ea03ce09c003a3a807ffda15f81ec5dfcf9";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "3c32851d08b004ea9e441f89cf5a11be089c27533c52b6cad8ae3fdb1551add2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "e4a919e9c2fdb4b87f615c011c31b5af88baab46bce4e41cdf2a6db347cd4a9c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "d109488ce62c317d0611a8a7770dfb2dfe070064c0460322b81af2cb131de61b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "8c2129cd8b8c0aec4a0a1d4088fdaa78beb4073f0a6a6e32256feb146b9e263d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "4bfb9dc306e2c65428a707cb6476c01b59ffd1926f2ecaecd902c5d0d4116cc6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.7.3-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "ad88aea9b20e13c3746d76c5a5531701f28875882ff6be24cb9988d6d8e8004b";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "485198adce8458f05ba2f2a960d613c50eda2e02f17b190d15c32361b7b1c085";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "9e7e3d82aa0a76bb1987634ea746ed0d9a985f5f5eadcc561a146beb4fa7ad27";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "7d7b6dc1ec5bfcddad7c054301807534c1b41dab5d829e43da04d05b0cc628a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "4a16be83340fdbbabe91eaddfc174c3097c2802334c8250d64de028503f19b1e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "ff43b4ce6e09885ba16c7e0f0acbc735a7f536fd7be3905f401f51398a317627";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "c0d023de47115acfb4382e50ce1f37b9904630b5c6c4631bd47f7b57ee4c7b1e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "b193d304dc44f0705babebf82f626bad89298aa0c8454a37dd771fcc5642493a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "0ad032bd5e2c1377dae874d7d78114cc311472ee5cc1def7006798b8badb01ef";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "a88d53bba1682122505ed067d3fd04897fcf289466672867f7fb48de68db1e89";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openzen-sensor/default.nix
+++ b/distros/noetic/openzen-sensor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslaunch, rostest, sensor-msgs, std-msgs, std-srvs, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-openzen-sensor";
-  version = "1.2.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/lp-research/openzen_sensor-release/archive/release/noetic/openzen_sensor/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "d2a6931e13d2e6ddb0623a71397a4e9408335ec109831f0aeff988b46414f85c";
+    url = "https://github.com/lp-research/openzen_sensor-release/archive/release/noetic/openzen_sensor/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "7d6e5ad201246d3469bf5834928532d849d3d0934e6569759fadb9e60ffb99d1";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''ROS driver for LP-Research OpenZen'';
+    description = ''ROS driver for LP-Research inertial measurement units and satellite navigation senors'';
     license = with lib.licenses; [ mit "BSL-1.0" lgpl3Only bsdOriginal ];
   };
 }

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "3cd589c6d5c17737b2677e381fad8e15402bfcb9fa272ae51a047cd441a91501";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "e71c02c6f5c825b7314defd90a5f9293feceae690b51a3c965c8d05bcce27ef4";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ map-server roslint rostest trajectory-tracker ];
-  propagatedBuildInputs = [ actionlib costmap-cspace costmap-cspace-msgs diagnostic-updater geometry-msgs move-base-msgs nav-msgs neonavigation-common neonavigation-metrics-msgs planner-cspace-msgs roscpp sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs trajectory-tracker-msgs ];
+  propagatedBuildInputs = [ actionlib costmap-cspace costmap-cspace-msgs diagnostic-updater dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs neonavigation-common neonavigation-metrics-msgs planner-cspace-msgs roscpp sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs trajectory-tracker-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/position-controllers/default.nix
+++ b/distros/noetic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-position-controllers";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "c500dd7552be7a2cc00d187813d1d36247e7cebbd4c732a393a747fb7c7ae091";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "b009d624dac2ae9689759964bbbded06e50316299db29b66596f23ffd0c6a315";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-bringup/default.nix
+++ b/distros/noetic/qb-softhand-industry-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-bringup";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_bringup/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "fcf381a6f89df099e48bbdcd20c65fc446d9a4b739109314bcd217d273197ba5";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_bringup/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "571efd14b1ee6c8c6f7169a11a9d32f5e99504fecdda94db166f7bcf1f0bb8b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-control/default.nix
+++ b/distros/noetic/qb-softhand-industry-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, qb-softhand-industry-hardware-interface, qb-softhand-industry-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-control";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_control/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "66ea8d028817dc932afa0033028168773f44f35c8b572d48d0ee306f50250e62";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_control/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "1323b8d15588b11ce536eae55e6fd8debff33a286d584a0a8cfc1b4b7c733010";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-description/default.nix
+++ b/distros/noetic/qb-softhand-industry-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-description";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_description/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "91dcb24363564b11140bc07844b3c8d6c9acbf9c3ced3378672e330cb6c7d72a";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_description/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "d60108e783fd9a0583721b4989c91c400b29c65919344575b83e814225f22a3c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-driver/default.nix
+++ b/distros/noetic/qb-softhand-industry-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-softhand-industry-srvs, qb-softhand-industry-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-driver";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_driver/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "eeaf81137095e5e50a6f60d6a2dee1aa13814331a84d5884503b7288bd3f9556";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_driver/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "bc92b13e95b8d3f01836c40a1efc545b2d2d157e88040ed2b8aac625b378fca4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-hardware-interface/default.nix
+++ b/distros/noetic/qb-softhand-industry-hardware-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, joint-limits-interface, qb-softhand-industry-msgs, qb-softhand-industry-srvs, roscpp, transmission-interface }:
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-manager, hardware-interface, joint-limits-interface, qb-softhand-industry-msgs, qb-softhand-industry-srvs, roscpp, transmission-interface }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-hardware-interface";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_hardware_interface/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "283c6f5eaff8648bbfc5504297a8de5a562888a16a3393bf1eb29b72b6eb9847";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_hardware_interface/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "521fb29de835669dd478e60ba39bede92993e2987cd906c486440a5bfc397a57";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ control-toolbox hardware-interface joint-limits-interface qb-softhand-industry-msgs qb-softhand-industry-srvs roscpp transmission-interface ];
+  propagatedBuildInputs = [ control-toolbox controller-manager hardware-interface joint-limits-interface qb-softhand-industry-msgs qb-softhand-industry-srvs roscpp transmission-interface ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/qb-softhand-industry-msgs/default.nix
+++ b/distros/noetic/qb-softhand-industry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-msgs";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_msgs/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "7a93da3d20a36be7fd9273386f8ba0308969ad48584077ab5a147523fc435a56";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_msgs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "9ee66ddf0c23b6f30d3714a9c31ad0dc510f7a9a354ee7c1b2b27d7c570635d9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-srvs/default.nix
+++ b/distros/noetic/qb-softhand-industry-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-softhand-industry-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-srvs";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_srvs/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "71162fc3f7929b4955bb55ae724dde8f8402b5bf1276dcffaf0ad6963799a4c6";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_srvs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "9ba47ff27cf74620b5f20d16bbb6e9a304920735237c14a20582e73686668b7d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-utils/default.nix
+++ b/distros/noetic/qb-softhand-industry-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-utils";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_utils/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "10d10faabf08997ecde9c0c2ba8a8b97d07d7376311cd7c0a5cd13c5c56849f9";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_utils/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "f4c7cff988737ad1f9869cc9ccb6616ec5131395580f2a2d90d398c70a4d2878";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry/default.nix
+++ b/distros/noetic/qb-softhand-industry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-softhand-industry-control, qb-softhand-industry-description, qb-softhand-industry-hardware-interface, qb-softhand-industry-utils }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry";
-  version = "1.0.8-r3";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry/1.0.8-3.tar.gz";
-    name = "1.0.8-3.tar.gz";
-    sha256 = "50ccae1b5840fa471232eadda461943143cd8479ef4b441a21b5d3764a9a2de6";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "a23fa40e605cbf4c71a7b24ce43568a5809f3d4d0be21fa2191317f96bec56be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/reach/default.nix
+++ b/distros/noetic/reach/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, boost-plugin-loader, cmake, eigen, gtest, llvmPackages, pcl, ros-industrial-cmake-boilerplate, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-noetic-reach";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/reach-release/archive/release/noetic/reach/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "d964980c543134ce0e38fc522819379c539c764f60c4b8252c7a690ba8ce4265";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost boost-plugin-loader eigen llvmPackages.openmp pcl ros-industrial-cmake-boilerplate yaml-cpp ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The reach package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ros-controllers/default.nix
+++ b/distros/noetic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "3786fd145afe12f1822e42878a3f87bbcc5d854d9d6577cc4ef5bcd1daadf7c1";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "b8414db400adac7037f6013b8667771c08f49577918f60775e24c5fb6a69ba60";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/noetic/rqt-joint-trajectory-controller/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-joint-trajectory-controller";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "a05b3a672cd5e090031c165489f0ec0dfe8e86d52b89df3ed4b3dc6732f74a04";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "779762c837c19d2deba1d9032ba74a56000baed1840e1e0dbc0e85912ab16c95";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ control-msgs controller-manager-msgs python-qt-binding python3Packages.rospkg qt-gui rospy rqt-gui rqt-gui-py trajectory-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''Graphical frontend for interacting with joint_trajectory_controller instances.'';

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "692d195266ae18d8b5135fcee7e263f8c081a36cef168a00c6a57aaafc47f965";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "4109b14ce04faa1c43ddeac35355da56cd96d6c2633f2101eba28dee2b202490";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "c06c9901c705131b2ac9e23f95045909e2f08d8805d1cc44a150a44a8cb4526e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "8ef320c9b1bedaf6059ff338092a755087b427bbd25329a4532c770dcfc0ec8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.14.2-r1";
+  version = "0.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "522a45c629455ea2198212718ffc7f6f1d122a7974ea45eef1936f32a4b42c2f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "397fe84c1418836fa8775a7c213ead0a0cdac64817812c8537b56ca9ace642b0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "63f00c7f92f61373e4b087d2317737d684755d5f4708703b123b950b4bece2e8";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "113484ad1e622c5a1ef046e01f495f2171c1051eefea949a13316b2cbeb71986";
   };
 
   buildType = "cmake";

--- a/distros/noetic/velocity-controllers/default.nix
+++ b/distros/noetic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, roscpp, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-velocity-controllers";
-  version = "0.21.1-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.21.1-1.tar.gz";
-    name = "0.21.1-1.tar.gz";
-    sha256 = "6bd0772935ba2de9d7015e174c45b94942f89a29899ec0bfc2828eaea941f2a6";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "9d5ccee520704ca2fad93077875ea435013debff489df49396ea502fca511b87";
   };
 
   buildType = "catkin";

--- a/distros/rolling/action-msgs/default.nix
+++ b/distros/rolling/action-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime, service-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-action-msgs";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/action_msgs/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "644486978531000c7e8264c083015a460de3c014c8037019c234f632818caaa7";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/action_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "87dc34c755e414b301c8c5f51129a274813d11594a6b1b810b2b4b0f7c3b0244";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "a99081e414e1d6bfc31737248a9f0a835a4848f7966dab28e8e4bd1dc357b594";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "600d63c2288cad3e69b24e3fd27b53b2c30bedf00ee2bb7a6c1f7d023e88ad3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-interfaces/default.nix
+++ b/distros/rolling/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-interfaces";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "f822309eb439e5272db05920cecca06217d037b77d78338509a99645ed291971";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "43a47ff6cf56bc044162c9b719e4dc74fbbe338887abd22de7210fcc7e991622";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-lint-auto, ament-lint-common, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "6aa6092fa8ad0fa12dcb0adaf6702aedff4e1a44f729c9477167c3a3cfc8e2a4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "062e8ee87353f12abbaa4b1f36df6011c3ce6b63e33b5ee64551327e59370c07";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-auto/default.nix
+++ b/distros/rolling/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-auto";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "31585e0c2c25da03e2ff15ecdd7ae6ebb579c8be07aba2b812050e3125a9d9d1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "8f9db37c4d285c7568d996916f0acdf3fe532b2dc9fe475c2d0bd42acc80b2be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-core/default.nix
+++ b/distros/rolling/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-core";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "240200d24d40f70feca477970ebe1624f1d4053829dbdc29eefc71e896a2f03e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "d5cea40f1bfc9a4e390ddef3e7887bcbff2db36d66294c28e9ed07e65a499f29";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-definitions/default.nix
+++ b/distros/rolling/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-definitions";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b07642679b2e38e214c1da59247a16b90a4d2e5829e62f6d748c6914d1d87d07";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "5d0b9cfa9ba0494eac9ad102e789ace949a063aba3bc304869bb93caecd94d82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-dependencies";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "2e8098b2115f2d31bf275205f2e3e00301904ce2c3b6bc492e21b2af5b014462";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "97766304c44ab6b6f2872e2db42eca6aaf29b6d5c64ec4f15e06926c99ea4ebd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-include-directories";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b38114a73d064456efeaea5d61615a260be992a048681501789f71e42ba90d7c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "83ba156f9a89c6bda2421afb7dee501b3244724f8c0e7c61b466cb11a106d428";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-interfaces/default.nix
+++ b/distros/rolling/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-interfaces";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "3ea4f1974fcbbe8b1c01ae4355aac1a01bde7a31d208f96c1560d398bdd40b44";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "da00f7a32ed7a1d4437675afe075a96ab9ec401f5e959228129bd5836e4c790b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-libraries/default.nix
+++ b/distros/rolling/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-libraries";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "a79257a3a719ded0dccddea5f3a0cb914c864f100458eed8b1a967fc79905933";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "4036d994f6e56c95888fb0705ee589ad3e015dc65a75183fd2275ee8c06de329";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-link-flags/default.nix
+++ b/distros/rolling/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-link-flags";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "d2fe2be6d212612b72dcada6f613271d1c68ed55737eb6e40e42dd9b9a4d1de4";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "57649e587176fe495aa756d39277f5f91fd40cd95a013e85d55f27f7f46dc448";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-targets/default.nix
+++ b/distros/rolling/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-targets";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "7cabc25ab032f19a6960aedf3dbbc95cf4ae1a38e6ddd13b419d80389f6e00b2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "f2e588a90e1ea1c986a129a1270207dbaa77e18d87dcc6355d7f84a0fb0a69cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gen-version-h/default.nix
+++ b/distros/rolling/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gen-version-h";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "ecd3e1d4a579b2d49cd7534af83aab455394b88339e4913f66ab877ab61cb6ba";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "0a05613c630cf21b3e75dee7c6a5b988f62e51226ee40b3cf0b9ac60cbb9dc60";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gmock/default.nix
+++ b/distros/rolling/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gmock";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "1fd40ce700bda0597c195e059e4d62da04bffe1902c8530db90661f9df2b69c5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "587a21491b25d683806b7a62ab77cee2927ad684241f91d14dfc73e1796e8581";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-google-benchmark/default.nix
+++ b/distros/rolling/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-google-benchmark";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "4d574042b71b8413930cb69bed77fbd0ed29ca166ca71fc50710f3958047660f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "5f345420c2fa171de1da2e8b995da0ed38e466c3e97442acc3be59209c497d44";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gtest/default.nix
+++ b/distros/rolling/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gtest";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "306cf36a324908e4106f0d1f89c662a3a38f03e6e3469abd0f936f30bdf9d049";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "6170b60b20bf02a78e41507606439441d692739a80cb354ad459d6ce4338156c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-include-directories";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "820fc4edf5d775542117df34cf0977367c5d00bf7a51c18eeae49703f708f385";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ed1ee3cd5fb89e3d43eaef477e280facf683afba540cb0d787886e8f0c6d6822";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-libraries/default.nix
+++ b/distros/rolling/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-libraries";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "d31821d717015899534dc4bf28b01c26417ecfc5d8a652717208e6abf58ee3ef";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a464c5dac574ca6433d0cbf251351584210157a6f32f06ff5543374f898d42f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pytest/default.nix
+++ b/distros/rolling/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pytest";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "412512d26746cc92d4643d82f6982af12bccc2667e61020cb58f1c8df3252fe0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a45ceac4186aa21143f2acafaf700b3f26666ef213bd7a585388820c1ffe28ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-python/default.nix
+++ b/distros/rolling/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-python";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "da4d975bf12f5c5551889eb88b971d321965269f35c8256de9e8d5ee5ab080ff";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "c1637e34b7f780af656f0d235da054b2aa4c39338fc05f421eead2598c57bccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-target-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-target-dependencies";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "17ba135c66fc9b8678dfc542ce1d2da9f46ee275bf3401fc4d00bbe016b634ce";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "20d5a255e095a59f310bdea2e30f4523321166ccfc3848ce4c44ad6df0a4dd82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-test/default.nix
+++ b/distros/rolling/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-test";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "8714192fe4bc44047f61b46443ec3e2cd8fac0ff83aac35ffad0a07d34887549";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2e42db5e706bed2da92c77217947e7d4e691e36269577599527925c14e02b799";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-vendor-package/default.nix
+++ b/distros/rolling/ament-cmake-vendor-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-vendor-package";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "e08ac052d62bef11229305f87222202fe56e02653e707f8c6dd84b58706b34f5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "c9f114060e0f30db57c06aa0aed163001e4bef976182a8221da3351618cb3f5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-version/default.nix
+++ b/distros/rolling/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-version";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "6ae64c988e1ff2a89603ef9e0c87d60d7353221362bca23248372591fe1bf579";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3086af945afc699190c8b9de5e1c57dbf999937d5f10150fdedf384b557d07a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake/default.nix
+++ b/distros/rolling/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "2c7d2eadf680a9480e5ac2a624cfbd3e9b16efed685b8df69f8415f7986a3eb8";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "76a43f6b98092e0f9b35ebbf0423a57e90969cb4bb472b20375eb31ab37616a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.3.3-r1";
+  version = "4.3.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.3.3-1.tar.gz";
-    name = "4.3.3-1.tar.gz";
-    sha256 = "276c217f0bb246e00f3feb136cce02f7173d86b911ab76dfd084d3f2204afca5";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.3.6-2.tar.gz";
+    name = "4.3.6-2.tar.gz";
+    sha256 = "6b0fdad2d9979e3785a6c9283b06d576795835d4478d9dba15237a7689ae43ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/builtin-interfaces/default.nix
+++ b/distros/rolling/builtin-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-rolling-builtin-interfaces";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/builtin_interfaces/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "aba41f3ca01ac963f94190ca5fb137be22871dc99373a035d4167329c1aab901";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/builtin_interfaces/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6a865e8b79274254b4b336dcc3d17dce614aa08d770fb0289311b9751e588249";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "06d23615a2cca4a5047e95a995ece95827dee4dd1c00720ff9cc2bffe2835a23";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "01e39ffee1a2aa68d605b0709425be8c146ba88330796f926a87ca222eead248";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "9d2256fa21a6e6f94ecf4257cd563c633e8e909df9c535e8329268dc7bfc8e3e";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "21166dce373cf805f0ab95a507980376ee7a8097de6a94a366e44e3ae9221ac7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition-interfaces/default.nix
+++ b/distros/rolling/composition-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-composition-interfaces";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/composition_interfaces/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "e68a7223f28c612d206674ac09d9d8b5f511f8fc5f836b70ebb2fe821bf0b511";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/composition_interfaces/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "5f2e9dbc60c05814035cabb20de67bbbcb6ad2fa228948870349e196679f841c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "54c746d6f779aa40c6b967076b60f7acc975421c8f575c82eb465ac7674cdcc7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "006ae634e57c909e49fb5a2ffa91a871bf671f8b04e36cacf6fff5dbc635614e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "2b048da41f9070623828dddf21a3e9aea6aa81e14d10735ff613a90d7432ca7e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "422557a197a9a20f789dfe99b1eca2d0c1ddeb5182ad9e82df51cb3403a51ad2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "89e7ad6df468e84acc945dfc7084dfb8588ac05e8068c392ab8f0bdc3bd0239c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "1f088cabc469cbdcb55d2e444399a4871330d654f1ca970f43a53e9867d02ec0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, pythonPackages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "c2f75b9ded1faa99113098f875ec4bba97fd7fd81d3bb671fe6a6ce87f87081d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "724e9194ecd98205108d4b4fedd1e5889b6f479b500896d567003b466b8c5379";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "f859a920c0dddfc12d9c8fe46fe7fce3dbfd422b16120e7888df347025f74217";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "8d11e0d2f0a3bedba53b7ae3b09bd960c1ae9d8206712ad1d1a1cc648c6d2ab7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "a7c320ca8336fae7564da1eeed4a2c88774e3726558d8565ba7651584b513eb5";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "9884bf6aed898d05e09d66b826eb4a6cfcd1ff8bbc74e307a728d2667f8548e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "84ce410ee904eda3c6184f8fb216a4bc3344bcc5fce64a240476bc73d29bedcd";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "737b176f701523754b8b892b0b8ab1738f87a3ecb489b332b58e6586dda14f31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "3f45be72753fb57c9ef1f819694b1d430137f7559253d74fb365d332d8f00a56";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "22744587b9045b6693a78f3dab116c5af61cc6e956f926b7de1afb3571d0a41e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/fastrtps/default.nix
+++ b/distros/rolling/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps";
-  version = "2.11.1-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.11.1-1.tar.gz";
-    name = "2.11.1-1.tar.gz";
-    sha256 = "03e35dba782990f572ce2901229207d77f0d07fb904b7206e5b41d8a4ab95e4b";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "1096d672a0afe6c3f8991dd6c8028ca43384229d20b74fe7cf7cdaa7885b1967";
   };
 
   buildType = "cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -866,6 +866,12 @@ self: super: {
 
  mola-common = self.callPackage ./mola-common {};
 
+ mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
+
+ mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
+
+ mola-kernel = self.callPackage ./mola-kernel {};
+
  mola-yaml = self.callPackage ./mola-yaml {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "11a1356d0f56a3eea81c0881034a8bd2b986ef3363c85937c9d3b7177420fc20";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "15041fb63ad9b412e85d472e58ac834e7717112112a3370e6e5561531f0fc5bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "a87d71225a2fb78d5ec05c3cf75b071131b62dfd01c40743a981e4866019381d";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "353eae354c3ba5c8c2b146a347a3a744d9cc81ba55c643c248e3dcf2df00a924";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "a7f4e053eb8a8981586eeeb650ffc8a7943efe8bc9dda0512af55303ad2dab90";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "c45b2816aff7e4256c51ea0fd0ff38f244d9b4f9cd2d76da910241f8cae875a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "2defebae01485e8aeeb0fc7894613ec98fc19cc763c6380156adf72baa37657d";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "d03bb5ee785fd3141b88884f8ff4221ff58fe45fa8cc605769d2f97b2d1d8a18";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "32476741d589cbe37289b41c29d56723e9d79597a7e35a320e597ae66734f893";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "f24b96a6a78cf36ac201cdd1a83f66fa96b394fa733da4aa71c164b85671710a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-pytest/default.nix
+++ b/distros/rolling/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-pytest";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "88aee429024a7b6ba962bef57fbf2327bec6169d767bf3819bacfb12e468c00b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "70a762406508a26549e1fcce8b89ac1c1793c363f7931ccd8e4cbd372edd684c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-ros/default.nix
+++ b/distros/rolling/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-launch-ros";
-  version = "0.26.1-r1";
+  version = "0.26.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.26.1-1.tar.gz";
-    name = "0.26.1-1.tar.gz";
-    sha256 = "aef1e6c7024aab62a18816ada99d872d25bd9b190a85e110877f238d344c8eab";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.26.2-1.tar.gz";
+    name = "0.26.2-1.tar.gz";
+    sha256 = "1f15f560281a19feb9e8db59f24d82ac1d8d4f26eb863c140a820b057d69e223";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing-ament-cmake/default.nix
+++ b/distros/rolling/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ament-cmake";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f79cffb4309cdb0bea587100f768e282d7c881df8fa323bf4d59be2bcb636912";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "6e1198c37cf3886bc5fed072ab0afb0b3996348a94da9b4190c191c339772236";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-testing-ros/default.nix
+++ b/distros/rolling/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ros";
-  version = "0.26.1-r1";
+  version = "0.26.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.26.1-1.tar.gz";
-    name = "0.26.1-1.tar.gz";
-    sha256 = "bb4c8cd4c0bfb80e1cc5ddceb5fbec0f6694d37d317ed4347998aaf46325a0e2";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.26.2-1.tar.gz";
+    name = "0.26.2-1.tar.gz";
+    sha256 = "4d26cd5250cc7da58d6b2498d677edcbbb376ce4a8347ae9b4eae2eaa39f704a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing/default.nix
+++ b/distros/rolling/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9d440482a82695fc71fd29ffaf755b603a28ed03da5e4938a32413b54c9f7799";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "ada050aa3066bb3379f36ab22b175f42c51c4e097e9f8962df1a6b2e4cba0f5b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-xml/default.nix
+++ b/distros/rolling/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-xml";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8f80c0c0c01443806a638406036e369b0f33b89cfceaefa405cf483a22ed989b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "e3cac7cdcd017a18aa220f02e3684d31c358f5d9704adbc572dcef6d696245af";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-yaml/default.nix
+++ b/distros/rolling/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-yaml";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "126d35782641ed4fcd48184f5e9f60005b2b35302a8e670debd444cde00d7551";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "b5a820e301df315bc786cc57d381957f0a09580bf4a84484e2859381b10c3b57";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch/default.nix
+++ b/distros/rolling/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "400c94ae2994cb8e2cef33d3b004156ff8e9ce0e5133f88c1564f3ff0da5b052";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "8d7cc87b8eda34979540c9b2c6e29b99bfc493de38b85d091f252626a8385e81";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle-msgs/default.nix
+++ b/distros/rolling/lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-msgs";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/lifecycle_msgs/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "5060ba7dd9bc78bc17a26c112c7c3e9e51bb949f402cfd51be69e7a1d03e8509";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/lifecycle_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "4832882012d840a2b11f3e43f94ad470c4b78e58f580a659dac63b550d3836d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "e6a66197118eba0e3370deffdd29e149857dc104c46e2d3f5436c2d2816a363f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "34f901ee06d54002b7b03e2365f43ec0095bcdfc20e7f293031d12fc8c0c13ac";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "66f287ea0f694bf6f2a1384e0bd44e68cbac525e0d54d73dc737665580c64e2e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "e89219926137d8590b4edc89c525a92d7d52bfea61439cf32a24081094dd7e70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "2dbba736ef64d19740f1b3324be5bb75e7b18432881ebbc33b892440757b266a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "ac818b156d76a9b22e40fbd51245a1b1dc9ac89a5c3721359abc4f5a55d7fe94";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-common/default.nix
+++ b/distros/rolling/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-mola-common";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_common/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "bbfa18e2e65eb54af149a1e0b627a8efd60edeee5a3c67859cf6b80769f4d1f3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_common/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "7f3e8a4b6b6b6b403b02fab84d08a6dfbb5cba803a1b0609282c85de09e63552";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-euroc-dataset";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d40b42ffb8b5a0a4832a28fec69a65cff58ed0aafed4a36da65eca638aa47dcf";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from EUROC SLAM datasets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-kitti-dataset";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "bc18ffa98e46250ca058de3bacc1d09537709f9d54487a5f155ece741ed574e2";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Kitti odometry/SLAM datasets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-kernel";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "82cbe0a84e38fdafa22b3b94cb178c6cb27fc6fd7fde80284004b63406670c6e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-yaml mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Fundamental C++ virtual interfaces and data types for the rest of MOLA modules'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "b2a9954be64a5a4e7732f5038b227b0258e2611220cb80133938410178c3de9a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "4e722779bf88c8dbe54eaf2fbecf13823a1572fa80c21930f9ee1459fa503bd6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mp2p_icp/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "1e261574579a9964c741a8424a20a05e6a0740429426a95aca42b072b9fa6643";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mp2p_icp/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "5fca17b2980848359e6bfaaca8fa2a364785f1770253b420f7d25ada9e717bd4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.7.4-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "9248611a3ceef6f8866e472a2700fb7e94baf1e8ea8c280ca018662c25205938";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "54a7ac67fd633b8addfce3066b93aae95aa62c6322438707f93a32de4469b6c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nmea-msgs/default.nix
+++ b/distros/rolling/nmea-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nmea-msgs";
-  version = "2.0.0-r4";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nmea_msgs-release/archive/release/rolling/nmea_msgs/2.0.0-4.tar.gz";
-    name = "2.0.0-4.tar.gz";
-    sha256 = "01d3f9ff81deee1ca94f9e9cbe21b1ba116d4dd45a4904e306800b5a57a4dcce";
+    url = "https://github.com/ros2-gbp/nmea_msgs-release/archive/release/rolling/nmea_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "83a27d2759899781dab4ce305e2564fbfe288e130e70f467db05ebb505195594";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nmea-navsat-driver/default.nix
+++ b/distros/rolling/nmea-navsat-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, nmea-msgs, python3Packages, pythonPackages, rclpy, sensor-msgs, tf-transformations }:
 buildRosPackage {
   pname = "ros-rolling-nmea-navsat-driver";
-  version = "2.0.0-r2";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nmea_navsat_driver-release/archive/release/rolling/nmea_navsat_driver/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "4c8f9602db904910a10c41b97ed5305e0cb342bd93a79591bf7ca46b50e6d7b1";
+    url = "https://github.com/ros2-gbp/nmea_navsat_driver-release/archive/release/rolling/nmea_navsat_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e8cbe6a0cd088496471fef8f084b0d6c6b737c630989990d2165c63aec7fa9d5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "bb2a2373a1e1f8ccb4a59fa59447495dbf733925cdb7db2ebda95996407b5b47";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "c9f3e4d504eae49ccbc52dfab1179338a3b78b315f391f1cfef9341c4e59d42c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "2b411c886ae5a3529950825c196c371acd82f269036820166ba9839c7448192d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "5c2343a485b578d75d300428c576acf955ed6088fcc0e11e46f2a7add7603142";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "6baaf5656117fd4f287765682f431b1cb2c2f575dca64a177d7322f90cf9c4c7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "fd99444e25f1d6ca85ec000798d2d416c0a30584a4a05ec1b7614a8c68fae529";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "1a335f4e16baf2ac87a2a3e588128abc3729052d13253637bafde805905ad26d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "2bac9cd7b0cd82d42bc33c30973759c6848c4e8c66b224636319b47fc5d9234a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "7.1.0-r1";
+  version = "7.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.1.0-1.tar.gz";
-    name = "7.1.0-1.tar.gz";
-    sha256 = "9f90e7868bd9ba6b27de7d99c94691a27dd34a9089b6a848d2be01b5c59734c9";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.1.1-1.tar.gz";
+    name = "7.1.1-1.tar.gz";
+    sha256 = "cb41f2852758d0c7dc9fadf449f8afcd7e2223796536be9e51c965f1bab7ee93";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-interfaces/default.nix
+++ b/distros/rolling/rcl-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rcl-interfaces";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rcl_interfaces/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "f0e346c5b39bbc10234eb8f233f9aaf05a608e96c7948f7378d2394ee71e33e6";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rcl_interfaces/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "4d7f0bbe98938ecc97e0790c7fc065818151f3e6a21a3c01c8dfc20cfc6f08b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "7.1.0-r1";
+  version = "7.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.1.0-1.tar.gz";
-    name = "7.1.0-1.tar.gz";
-    sha256 = "550e3c17a1f0d913e6bf6d5b1f5a3467f24bc4124f58789f968fe375f838faf8";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.1.1-1.tar.gz";
+    name = "7.1.1-1.tar.gz";
+    sha256 = "e5f2b92eda866b6220d118f1ad734fad841e739e092977ae6d3bc4140ce24f2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-interface/default.nix
+++ b/distros/rolling/rcl-logging-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-interface";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_interface/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "0b067af1166d08d50d54ad4181ac01427d99ad4f5d79ff0cd354b11569d02670";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_interface/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "b2ff80009f77124ff2dcaae50c8b020aa6205a77bb37b011ffbd2236a07950fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-noop/default.nix
+++ b/distros/rolling/rcl-logging-noop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, python3Packages, rcl-logging-interface, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-noop";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_noop/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "5dc1d65bbea1008dd7e68ec40fa8dac6ddd737147c5c737f2a40a6aa0a966ed9";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_noop/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "05de8691a713f45ae15705d4f5133450b5084d872e2337e20d1bddc01194c600";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-spdlog/default.nix
+++ b/distros/rolling/rcl-logging-spdlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcl-logging-interface, rcpputils, rcutils, spdlog, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-spdlog";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_spdlog/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "425b41ecf232e3145c562dae664c75bf2ce68add553a0b9ee1ceb809d07709bd";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_spdlog/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "b3ec80f2418bf73baa82464fd96ed0dd3b33d88807e8f7b55af203c3fc354c75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "7.1.0-r1";
+  version = "7.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.1.0-1.tar.gz";
-    name = "7.1.0-1.tar.gz";
-    sha256 = "441cc90991df6b7bf772a4eb8b585b991a8ec6d6064848f3af24ae89d166ddaa";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.1.1-1.tar.gz";
+    name = "7.1.1-1.tar.gz";
+    sha256 = "fa0159331a944470db71d93fac50531e662ffa037f6fd6887a5f72a7af6d47ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "7.1.0-r1";
+  version = "7.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.1.0-1.tar.gz";
-    name = "7.1.0-1.tar.gz";
-    sha256 = "43bb1f3331fd6f6944e43d9ec2a899aba1167e8f280dd6234300a26a239dc9fe";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.1.1-1.tar.gz";
+    name = "7.1.1-1.tar.gz";
+    sha256 = "c4fb395a10892b1d27ca156654b9e3d6037f288885882d17d1e926a3e71f0705";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "22.1.0-r1";
+  version = "22.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/22.1.0-1.tar.gz";
-    name = "22.1.0-1.tar.gz";
-    sha256 = "ad42961fe8d7be5735cb93bd9e3f53aace3895a42ac6b43179effa046be06213";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/22.2.0-1.tar.gz";
+    name = "22.2.0-1.tar.gz";
+    sha256 = "937a0425735a75a93d41e24b0f75d8c61d8b1e392a1d63d0a39b837e48c64e55";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "22.1.0-r1";
+  version = "22.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/22.1.0-1.tar.gz";
-    name = "22.1.0-1.tar.gz";
-    sha256 = "67936bf407e3bc16493418462a4a3eb51f62fbe820ed4f7bdf8ea78a99e7bb94";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/22.2.0-1.tar.gz";
+    name = "22.2.0-1.tar.gz";
+    sha256 = "a6f1c49bd3de0da8d19584d246f30a62c02c0c7e6db6cf1d0f7c0a4c34e33b8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "22.1.0-r1";
+  version = "22.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/22.1.0-1.tar.gz";
-    name = "22.1.0-1.tar.gz";
-    sha256 = "133ffc1fe10d2995d9043c741fa9012421c16b2e0d58af40ebbc6e169ba8c215";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/22.2.0-1.tar.gz";
+    name = "22.2.0-1.tar.gz";
+    sha256 = "afa41cc401eb1820e9ab82e429959f6509cb6861d986b741401852c9de5bf7ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "22.1.0-r1";
+  version = "22.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/22.1.0-1.tar.gz";
-    name = "22.1.0-1.tar.gz";
-    sha256 = "5d30cbfc7daefb90984d8293f30274186b4016abe3cb1251361701414adf3764";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/22.2.0-1.tar.gz";
+    name = "22.2.0-1.tar.gz";
+    sha256 = "7ed439c96c62b9c7515cef41540c923b86bc5fb6297467b5fb37909935e146aa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros python3 ];
   checkInputs = [ ament-cmake-gmock ament-cmake-google-benchmark ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor performance-test-fixture rmw rmw-implementation-cmake rosidl-default-generators test-msgs ];
-  propagatedBuildInputs = [ ament-index-cpp builtin-interfaces libstatistics-collector rcl rcl-interfaces rcl-yaml-param-parser rcpputils rcutils rmw rosgraph-msgs rosidl-dynamic-typesupport rosidl-runtime-cpp rosidl-typesupport-c rosidl-typesupport-cpp statistics-msgs tracetools ];
+  propagatedBuildInputs = [ ament-index-cpp builtin-interfaces libstatistics-collector rcl rcl-interfaces rcl-logging-interface rcl-yaml-param-parser rcpputils rcutils rmw rosgraph-msgs rosidl-dynamic-typesupport rosidl-runtime-cpp rosidl-typesupport-c rosidl-typesupport-cpp statistics-msgs tracetools ];
   nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros python3 ];
 
   meta = {

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "5.0.1-r1";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.0.1-1.tar.gz";
-    name = "5.0.1-1.tar.gz";
-    sha256 = "e42bfd32fc9281c5582511bb6b6047f7352ed9766ff977b8418d349c584889c7";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "253792b5c01ffe66177412531fdf76ddc62c3c25efea3a7b1399b8dcf7ebf3f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcpputils/default.nix
+++ b/distros/rolling/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcpputils";
-  version = "2.7.1-r1";
+  version = "2.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "b7c3c8c9e3d716a2354d7f3f86050c1202ada42645de3723b066d488444f95b2";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "427f30e5cd2da2e83120f3d218523214655e122701c51d25b675903f5193a8c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcss3d-nao/default.nix
+++ b/distros/rolling/rcss3d-nao/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nao-lola-command-msgs, nao-lola-sensor-msgs, rclcpp-components, rcss3d-agent, rcss3d-agent-msgs-to-soccer-interfaces, soccer-vision-3d-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcss3d-nao";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcss3d_nao-release/archive/release/rolling/rcss3d_nao/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a6c0946b4247bddfa2cf288b75fa7592cb8a04095686ea728f16a05d602c2807";
+    url = "https://github.com/ros2-gbp/rcss3d_nao-release/archive/release/rolling/rcss3d_nao/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "29559c9f3de65b4b81e7b42e2695fa38d60a8f37f550512ebdda7b9e3673e0fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.3.0-r1";
+  version = "6.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.3.0-1.tar.gz";
-    name = "6.3.0-1.tar.gz";
-    sha256 = "00d1c4202f429d4b7379faa0f452fedbd36fafc3c6a4315d3397b8922ba2725a";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.3.1-1.tar.gz";
+    name = "6.3.1-1.tar.gz";
+    sha256 = "6577299c8479b50ee38d110250abc7f6f4246ff24ebee4ecd817237b31524ae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rig-reconfigure/default.nix
+++ b/distros/rolling/rig-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rig-reconfigure";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/rolling/rig_reconfigure/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "2689e42f5786b8bd1277846e5b20aca19124c709af52753167b39c76c9a30463";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/rolling/rig_reconfigure/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "02d0f224f9b83b959b84e38dd8efb1039570e34b48375a636f7109c6267c58b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "7.4.0-r1";
+  version = "7.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/7.4.0-1.tar.gz";
-    name = "7.4.0-1.tar.gz";
-    sha256 = "feea4ee29d5c838a1eb2b6810d2d394cbbbe125de6c1b7e038b8fdd5fb0655c0";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/7.5.0-1.tar.gz";
+    name = "7.5.0-1.tar.gz";
+    sha256 = "c06e9ebf9e559d87e7688d2c0095ffaf4a592f78dfe0681ef2c83e4ab635bc31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "7.4.0-r1";
+  version = "7.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/7.4.0-1.tar.gz";
-    name = "7.4.0-1.tar.gz";
-    sha256 = "00c4578bba162306969c855252ca06c62e817822201c78d7a88e87795e745846";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/7.5.0-1.tar.gz";
+    name = "7.5.0-1.tar.gz";
+    sha256 = "01e840f33f2b4043908bfa0c65261d16bb5e1d7b95cbbf71c1a651f0cc278aab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "7.4.0-r1";
+  version = "7.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/7.4.0-1.tar.gz";
-    name = "7.4.0-1.tar.gz";
-    sha256 = "081d0557b74aabcd37cf8d9a8aacb85c61ea63964fa6e4a9ef49f6015b6005fd";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/7.5.0-1.tar.gz";
+    name = "7.5.0-1.tar.gz";
+    sha256 = "e62451a18f7cbc16e6f18e15a5b4ef2b168538eedc93899efb30a3cddde178b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2launch/default.nix
+++ b/distros/rolling/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2launch";
-  version = "0.26.1-r1";
+  version = "0.26.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.26.1-1.tar.gz";
-    name = "0.26.1-1.tar.gz";
-    sha256 = "be17858723afd84d9e1d3cdc602d26c80179f9c693f342ce8d41ea4dba21faa5";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.26.2-1.tar.gz";
+    name = "0.26.2-1.tar.gz";
+    sha256 = "9e13de4ef4eeb09993c7887981de7ac184abbfc97acf1371d1a8e5914dcfdcfc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosgraph-msgs/default.nix
+++ b/distros/rolling/rosgraph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosgraph-msgs";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rosgraph_msgs/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "28c8e485173b3edf3192e9068d9fe7e74df5d69464ceb189bf7fafac24b3a055";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rosgraph_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "68d23c502dcee47662f66e58ea9a842c8e8a5f28ae4267f6b694c3e23fec3399";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "0e740fa4e2664552e9955036a1b2751571c7b285cb0b2fe5bd7be61afc969ee4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "848ebbd77af7f8f613244d8d34165ab32d9814ad6c615563ee1710e65d27829d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "3634283182797389c88fa4437c449f2552422a2479bbd8b5b33d8bba54746d70";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "cf9355cf33e8b5b1b0f051a335b8e97d3a5866f2052fea654ce9aa2d4d3643f3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "48f21a59ef0ef7d294fe3e790efece27f063b729218c791c82e4a1bc35be10b2";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "9f71d98de19b51beee5dc6ff77a5d53a2d6acaa8db75128eb5feb2c1946d6ffe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-dynamic-typesupport/default.nix
+++ b/distros/rolling/rosidl-dynamic-typesupport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rcutils, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-dynamic-typesupport";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/rolling/rosidl_dynamic_typesupport/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "276be3d68c0c7eb312c7605ceafe19180b9e70d2006c90fe3e91211586cb8bed";
+    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/rolling/rosidl_dynamic_typesupport/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "11e14b425641b0aa7f5dda1aaa1897652e790a6f7aff03212c27f03f2834fa43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "e0af8678f9f70061bbcf846f1d97f37557d01edc07f7f02a9430249b8ee906f9";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "5dea5e18b6fbde81a1d8fa847a4eb6c674ab8f92edbb9969fbe61ae468d40218";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-python ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake-core ament-index-python python3 rcutils rosidl-cli rosidl-generator-type-description rosidl-parser rosidl-pycommon rosidl-typesupport-interface ];
+  propagatedBuildInputs = [ ament-cmake-core ament-index-python python3 rcutils rosidl-cli rosidl-cmake rosidl-generator-type-description rosidl-parser rosidl-pycommon rosidl-typesupport-interface ];
   nativeBuildInputs = [ ament-cmake-core ament-cmake-python ament-cmake-ros python3 rosidl-pycommon ];
 
   meta = {

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "4dd8b8ca2744cfd9d5d5ea12b6fc1e20727b74e8861238f8dba01565e2091607";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "92ed6e62299abdfc4241fba8b55a40182ff71ad7ef60473fdee0bf826d5a5a0b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake-core ament-index-python python3 rosidl-cli rosidl-generator-c rosidl-generator-type-description rosidl-parser rosidl-pycommon rosidl-runtime-cpp ];
+  propagatedBuildInputs = [ ament-cmake-core ament-index-python python3 rosidl-cli rosidl-cmake rosidl-generator-c rosidl-generator-type-description rosidl-parser rosidl-pycommon rosidl-runtime-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-core python3 rosidl-pycommon ];
 
   meta = {

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "8984d013920686283aab05d66b5c35fde5b794d02685b53ca4870a07a072f40c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "b6e7df625bfa916f92b320d418da6cb0c6d66fa42808662017156ef7e23ad425";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "bca8706d1e2366dcc7175bf72e369611a9852efefd4cef5d4217e8aca05461d2";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "d29f41b2c1f107fd76dc8e3da3ca426c112c0bdb45c2cadd3b7de654eed7d52f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "2d8edd9f5214682bb0d2cf758e00bbe68bb7da3fc0b504d96885fcb359bf680b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "cd2c51d1167aa5f4b7a8944798b0aca973bb5c5a9205c8800a1c9504c08978b9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "2e3fa9411061d78ea2cea3eb20bc9f32cc82d508af17e2f82cfddf1082527eb2";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "a7025bc72bb76747a6d4f971d1084621da791f1dda7b0009c0df2386dd877ae4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "2bca68acd76b4ff0a5691e3d550ee2170b06edf35142184cd0893457752ca1c2";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "9e94ebeac6376fce1d47a2622490f6ddf79fe685ba1cdf9351481bfbf75d9a54";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "bbffea10a64933b5d504dcfed93b9c469c7f62a08e3f03c20a5f2f485a771bca";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "2fff8b455b0b6423c6c8ae450634d5d741ab0283815cff033815d790fa0cabe3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "a2926cb144fb4b245ef64ddca80dfc72288f28cfbe6130d5d9e93fd77871c371";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "6007ded464b9a218980df303d81d151ca6dc811ca403d1c6ec7d3b255a1c545f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake ament-index-python python3 rosidl-cli rosidl-generator-c rosidl-parser rosidl-pycommon rosidl-runtime-c rosidl-typesupport-interface ];
+  propagatedBuildInputs = [ ament-cmake ament-index-python python3 rosidl-cli rosidl-cmake rosidl-generator-c rosidl-parser rosidl-pycommon rosidl-runtime-c rosidl-typesupport-interface ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros python3 rosidl-generator-c rosidl-pycommon ];
 
   meta = {

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "4.3.1-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.3.1-1.tar.gz";
-    name = "4.3.1-1.tar.gz";
-    sha256 = "2f665b307734efe19c3e871e25dc692c7994144c163ede1b461d3180f213e17a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "d2254900f3429191c8112477ccfebc5a9213fca47d8d600fb2b3e395adadba55";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake ament-index-python python3 rosidl-cli rosidl-generator-c rosidl-generator-cpp rosidl-parser rosidl-pycommon rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-interface rosidl-typesupport-introspection-c ];
+  propagatedBuildInputs = [ ament-cmake ament-index-python python3 rosidl-cli rosidl-cmake rosidl-generator-c rosidl-generator-cpp rosidl-parser rosidl-pycommon rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-interface rosidl-typesupport-introspection-c ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros python3 rosidl-generator-c rosidl-generator-cpp rosidl-pycommon ];
 
   meta = {

--- a/distros/rolling/rqt-py-console/default.nix
+++ b/distros/rolling/rqt-py-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-console";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/rolling/rqt_py_console/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "9394a589e9bb177a20bb340853caa15d9f5d461931787718af628e42c4fe6222";
+    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/rolling/rqt_py_console/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "5d2ec9dfb4507042d3d606c556e51859bd12507f6aca228c31684ceb6338a5c8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-reconfigure/default.nix
+++ b/distros/rolling/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-reconfigure";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "169f637c8996a73e4adaf73bc30f0429624bd52e8f7b4b94927d91e5ebf51369";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ca4b216198aaa9829d7cb2340cd163d8ccb23d6ba0a70403a1f72f613feac17d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "021f0ab39c71617275a3014655f6368730f6a4fad29774eb8913e2aea3ad4cdc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "c50087381ce488d0445314a30131b895def23288b723f1e2b6261dc8e4683319";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "b6a927b994ab6ce08bd414ea13a2aef7a0c73962adcba4896f95bca540c0e74a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "611b9b063d80b8de1a5a3385b9eac6e3e6a6846b3b40c5cdfa4f7ea3483cb357";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "6385224dd04e94d8511eb5cce862f2939a469bb04b9e1a6e0bab2e1de169ea9e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "c1836b015be522ebf19d96e8230ea4be7745d118efe0313aee8b76e74512759a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "445a37a4f86dae2475b898c4152aa23fe322c7e4b45813dc51da283b04fb2276";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "eb9ad801fe7a6af65e9643a39ed576a554891607b71050a04d8de32be8823918";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "87af2c80c8159dd0f0408cdbbb10c6111e008f7c7becc580f510ee6f09dc2681";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "07f45ff88f7e25dbdf0fc4bd595419c704a85fb1aa4da49f3f6550a391c51b75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "3bdd0d4d5c65927a52e177556d23980d392608c37781ce4594afee67e0c7e138";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "6661c8034d344766493a6a129c88c333eae56d71e8c2c30343e685a4f72caf29";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "3ba23e72a9910396d98b9b7b394d5d3ab5064612ab773325a20b2a8833e59f7e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "b589af61681dfd548514243c547390341072a2b0d49db56a103816d54242d051";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.0.0-r1";
+  version = "13.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.0.0-1.tar.gz";
-    name = "13.0.0-1.tar.gz";
-    sha256 = "2e08e51de2ad7bf8028cf1435cb5b0fca7d6e28768703634dd68204146e6daac";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.0-1.tar.gz";
+    name = "13.1.0-1.tar.gz";
+    sha256 = "85a48f164331a99f2380966313fe09942087c43704eb0992c6f257ac7b203e94";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/service-msgs/default.nix
+++ b/distros/rolling/service-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-rolling-service-msgs";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/service_msgs/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "8b84a0461f3c8318e4648975acb65de07af63f4b3b702f38e6d9fb67a22a965d";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/service_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "664d76efc94649c08c69b4d1f750771bfb8ea4913e60e9e72af8391190eb5158";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/statistics-msgs/default.nix
+++ b/distros/rolling/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-statistics-msgs";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/statistics_msgs/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "68e77277a5cb98c1003eb57a6390a42a34b5a2071941649fb3795edd0f3e0c84";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/statistics_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "65dfa3ae2bc50769fc264c166e3b35f6fd5faa19bf1b7254e43a2a236f4a7262";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/test-msgs/default.nix
+++ b/distros/rolling/test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, test-interface-files }:
 buildRosPackage {
   pname = "ros-rolling-test-msgs";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/test_msgs/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "1f721eea977730babd0b840cf3634616623304ab50decd6086c774bc6c831e3b";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/test_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "caf68899f642d4d36c0d9680dd86f9f60014db6a9a4c4be9e8595b5c7b9bf7b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "e7e2e23fef26427bfd3700b5aa517a858828115f8fff5df8f147957b234acac0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "1389f7f6ef409cfcbfa6b1e5ca411ad2637dea7a7f5a9518c01112215656bb32";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "91c40f4919e8ca4e027658c402ac809e1ad677ff38a5bbc6b7dc806cd87a8dd0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "2db5f6d50205dddb0a17511a782238c8376e4d499ebcc815519a39ebd789cf86";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "48e9bccdfefd1561a265b291f74d40a16ef9d86889c7c50f5603b856f91c680f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "a8178be9253ce8fb0f02e4b10cf8444d027bf4475170cc080c81290b6080a6bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "3c6ad8a6147bebf9cc22e42782a8eeb2de32ca7888db805e3f19fcffbdaae6cc";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "76f003b4af72a3c1b766fa3d73e94d178e45ef33fbb2431060101ff5443aa5cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "94c811096b483821f360f6e7883f3f358835da776e3a59d31ba0795923b9b34b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "bb39ccaaf9b2cd45a527e08ee0d5211c7ab614033fb08f4e00139c57be883efc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "297352edaf4232934d79367e5d9fa32d7f7f5af298debe5798fe526e2f37900c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "adbf514037b865d54a11c9f3b49bb46b52eee27bb1760327a0dde17bdafdf9e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "3018341d31e6e93988d262e5c51772eb86d45a102315eebd887868e7b1eea7cf";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "9fb101025c95cb6dc0488c70f2274703ac49e3c3184c1eab540b7770fb445f2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "733df81db1aa9806b042ff8dd98c18bb29970a8b9ce0d05bb6562de5d137634c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "a16f708d974ea7960d5508f4b35a0bc4b29222bc104ead37be4754fa723779b8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "166b58e1446226c737d1fc02e4612369df646d53066430ceba2ed214c5b217d1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "32b337565657ce216b6bbf50085f48e27448ccd1edb0c800ca7a9804955a5113";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "cb479ecfb8fc839773fcc92a58e4dea543fde3f0963a8f4f5ef048b4c10cf13f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "f58a1269b4158167d750931cab377b9b42c0c00ff9488715c58dc6e935c3cfff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "18cc09829797fa6be166e0246804c86223f2dc7b5ad45eee0738b951b15879d4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "abe84a64d8aba75f032e26deaf65cec7b92641c4ef9e49017bb0ae0b930b27d1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "c2ef41c27ebdfeb143eb99d35f72fce07287d42587e563cb4c3b71aaeb51ef75";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "fc899295ad39bba6c73d7e1d92e626e747c888e1f0aa2a0fd555da88aa03f6d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-based-ros2-control/default.nix
+++ b/distros/rolling/topic-based-ros2-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hardware-interface, picknik-ament-copyright, rclcpp, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, hardware-interface, picknik-ament-copyright, rclcpp, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-based-ros2-control";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/topic_based_ros2_control-release/archive/release/rolling/topic_based_ros2_control/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "63222b251a31141b3b889b1248b712169e0d5d31f360a926c2fccb2080de389f";
+    url = "https://github.com/PickNikRobotics/topic_based_ros2_control-release/archive/release/rolling/topic_based_ros2_control/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "226ec871a9053c7925d032d435e61aebd1128503d3f654dfa87812715e955b38";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common picknik-ament-copyright ros2-control-test-assets ];
-  propagatedBuildInputs = [ hardware-interface rclcpp sensor-msgs ];
+  propagatedBuildInputs = [ angles hardware-interface rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "9032347712e350d9eb7403f1e54ff83268a2848d8519f54052a14ff05ed2f0d1";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "4e10bb3c43c33a9833bad8afb2696be25ef6e6ca0d92c70743dfef56eafffe93";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "cd3313e2814a6aaa941098e4e0eea20cc6bcce25ea2c3fe3af8541810b99b977";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "0f2ee8e4d9b557989c179dee96d18cbd6f246875d39a1916b235db83fda009f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/turtlesim/default.nix
+++ b/distros/rolling/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-turtlesim";
-  version = "1.7.2-r1";
+  version = "1.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.7.2-1.tar.gz";
-    name = "1.7.2-1.tar.gz";
-    sha256 = "ed4e862f01d0be8e790622844405d5e6f8e9b3b5d38efe3e8ce759aea484e36d";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.7.3-1.tar.gz";
+    name = "1.7.3-1.tar.gz";
+    sha256 = "2e2b939dfc5e2e82aa7e61918fa970ec0f6f1e7fc41e8e57e51b49a1ca7fd5cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/type-description-interfaces/default.nix
+++ b/distros/rolling/type-description-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-core-generators, rosidl-core-runtime, service-msgs }:
 buildRosPackage {
   pname = "ros-rolling-type-description-interfaces";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/type_description_interfaces/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "ce4231326964780f5ec25e9d7633270eccc7d30c6edeae6642ea2f5c6a05231a";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/type_description_interfaces/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "81243577b6c5bc424ee2c7e71ec43e53d69180cb1fa54c588d7a2530a22c3bb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "a3655e45c5f0bfc106110ae7de12ec8bbbf964f11a0bafaeb6cff053df952b42";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "6558ea4ab6b482a0455b3d5a9f56eceb2177ed2a2b01a3c174e66f4a2f75f8b3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/usb-cam/default.nix
+++ b/distros/rolling/usb-cam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-rolling-usb-cam";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/rolling/usb_cam/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "d398a2128567d016563c4b00dfc4593c99c696bde6ec6ee26ffc2fa42542ab66";
+    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/rolling/usb_cam/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "f3ebaf94bd5d35d03432c515e13e5d6972db8e0ff83890e28aa6f5c45d090101";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 0c68b03e1fb8732d892ae62e1d1d962c3cefbcc7.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *behaviortree-cpp 4.3.5-r1 --> 4.3.6-r1*
* *boost-plugin-loader 0.2.1-r1*
* *clearpath-config 0.0.6-r1 --> 0.1.0-r1*
* *depthai-bridge 2.7.5-r1 --> 2.8.0-r1*
* *depthai-descriptions 2.7.5-r1 --> 2.8.0-r1*
* *depthai-examples 2.7.5-r1 --> 2.8.0-r1*
* *depthai-filters 2.7.5-r1 --> 2.8.0-r1*
* *depthai-ros 2.7.5-r1 --> 2.8.0-r1*
* *depthai-ros-driver 2.7.5-r1 --> 2.8.0-r1*
* *depthai-ros-msgs 2.7.5-r1 --> 2.8.0-r1*
* *ecal 5.12.0-r1 --> 5.12.0-r2*
* *gps-msgs 2.0.2-r1 --> 2.0.3-r1*
* *gps-tools 2.0.2-r1 --> 2.0.3-r1*
* *gps-umd 2.0.2-r1 --> 2.0.3-r1*
* *gpsd-client 2.0.2-r1 --> 2.0.3-r1*
* *mola-common 0.2.0-r1 --> 0.2.1-r1*
* *mola-input-euroc-dataset 0.2.1-r1*
* *mola-input-kitti-dataset 0.2.1-r1*
* *mola-kernel 0.2.1-r1*
* *mola-yaml 0.2.0-r1 --> 0.2.1-r1*
* *mp2p-icp 0.2.0-r1 --> 0.2.1-r1*
* *mvsim 0.7.4-r1 --> 0.8.0-r1*
* *nmea-navsat-driver 2.0.1-r1*
* *rig-reconfigure 1.3.0-r1 --> 1.3.2-r1*
* *topic-based-ros2-control 0.1.1-r1 --> 0.2.0-r1*
* *ur-client-library 1.3.2-r1 --> 1.3.3-r1*
* *usb-cam 0.6.0-r1 --> 0.7.0-r1*

Iron Changes:
-------------
* *behaviortree-cpp 4.3.5-r1 --> 4.3.6-r1*
* *mola-common 0.2.0-r1 --> 0.2.1-r1*
* *mola-input-euroc-dataset 0.2.1-r1*
* *mola-input-kitti-dataset 0.2.1-r1*
* *mola-kernel 0.2.1-r1*
* *mola-yaml 0.2.0-r1 --> 0.2.1-r1*
* *mp2p-icp 0.2.0-r1 --> 0.2.1-r1*
* *mvsim 0.7.4-r1 --> 0.8.0-r1*
* *nmea-navsat-driver 2.0.0-r3 --> 2.0.1-r1*
* *rig-reconfigure 1.3.0-r1 --> 1.3.2-r1*
* *usb-cam 0.6.0-r2 --> 0.7.0-r1*

Noetic Changes:
---------------
* *ackermann-steering-controller 0.21.1-r1 --> 0.21.2-r1*
* *behaviortree-cpp 4.3.5-r1 --> 4.3.6-r2*
* *costmap-cspace 0.14.2-r1 --> 0.15.0-r1*
* *depthai-bridge 2.7.5-r1 --> 2.8.0-r1*
* *depthai-descriptions 2.7.5-r1 --> 2.8.0-r1*
* *depthai-examples 2.7.5-r1 --> 2.8.0-r1*
* *depthai-filters 2.7.5-r1 --> 2.8.0-r1*
* *depthai-ros 2.7.5-r1 --> 2.8.0-r1*
* *depthai-ros-driver 2.7.5-r1 --> 2.8.0-r1*
* *depthai-ros-msgs 2.7.5-r1 --> 2.8.0-r1*
* *diff-drive-controller 0.21.1-r1 --> 0.21.2-r1*
* *effort-controllers 0.21.1-r1 --> 0.21.2-r1*
* *force-torque-sensor-controller 0.21.1-r1 --> 0.21.2-r1*
* *forward-command-controller 0.21.1-r1 --> 0.21.2-r1*
* *four-wheel-steering-controller 0.21.1-r1 --> 0.21.2-r1*
* *gazebo-custom-sensor-preloader 1.1.0-r1*
* *gripper-action-controller 0.21.1-r1 --> 0.21.2-r1*
* *imu-sensor-controller 0.21.1-r1 --> 0.21.2-r1*
* *joint-state-controller 0.21.1-r1 --> 0.21.2-r1*
* *joint-trajectory-controller 0.21.1-r1 --> 0.21.2-r1*
* *joystick-interrupt 0.14.2-r1 --> 0.15.0-r1*
* *map-organizer 0.14.2-r1 --> 0.15.0-r1*
* *mvsim 0.7.3-r1 --> 0.8.0-r1*
* *neonavigation 0.14.2-r1 --> 0.15.0-r1*
* *neonavigation-common 0.14.2-r1 --> 0.15.0-r1*
* *neonavigation-launch 0.14.2-r1 --> 0.15.0-r1*
* *obj-to-pointcloud 0.14.2-r1 --> 0.15.0-r1*
* *openzen-sensor 1.2.0-r1 --> 1.3.2-r1*
* *planner-cspace 0.14.2-r1 --> 0.15.0-r1*
* *position-controllers 0.21.1-r1 --> 0.21.2-r1*
* *qb-softhand-industry 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-bringup 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-control 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-description 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-driver 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-hardware-interface 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-msgs 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-srvs 1.0.8-r3 --> 1.0.9-r1*
* *qb-softhand-industry-utils 1.0.8-r3 --> 1.0.9-r1*
* *reach 1.5.1-r1*
* *ros-controllers 0.21.1-r1 --> 0.21.2-r1*
* *rqt-joint-trajectory-controller 0.21.1-r1 --> 0.21.2-r1*
* *safety-limiter 0.14.2-r1 --> 0.15.0-r1*
* *track-odometry 0.14.2-r1 --> 0.15.0-r1*
* *trajectory-tracker 0.14.2-r1 --> 0.15.0-r1*
* *ur-client-library 1.3.2-r1 --> 1.3.3-r1*
* *velocity-controllers 0.21.1-r1 --> 0.21.2-r1*

Rolling Changes:
----------------
* *action-msgs 1.7.0-r1 --> 2.0.0-r1*
* *action-tutorials-cpp 0.31.0-r1 --> 0.31.1-r1*
* *action-tutorials-interfaces 0.31.0-r1 --> 0.31.1-r1*
* *action-tutorials-py 0.31.0-r1 --> 0.31.1-r1*
* *ament-cmake 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-auto 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-core 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-export-definitions 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-export-dependencies 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-export-include-directories 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-export-interfaces 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-export-libraries 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-export-link-flags 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-export-targets 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-gen-version-h 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-gmock 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-google-benchmark 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-gtest 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-include-directories 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-libraries 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-pytest 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-python 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-target-dependencies 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-test 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-vendor-package 2.2.2-r1 --> 2.3.0-r1*
* *ament-cmake-version 2.2.2-r1 --> 2.3.0-r1*
* *behaviortree-cpp 4.3.3-r1 --> 4.3.6-r2*
* *builtin-interfaces 1.7.0-r1 --> 2.0.0-r1*
* *camera-calibration-parsers 4.5.0-r1 --> 4.5.1-r1*
* *camera-info-manager 4.5.0-r1 --> 4.5.1-r1*
* *composition 0.31.0-r1 --> 0.31.1-r1*
* *composition-interfaces 1.7.0-r1 --> 2.0.0-r1*
* *demo-nodes-cpp 0.31.0-r1 --> 0.31.1-r1*
* *demo-nodes-cpp-native 0.31.0-r1 --> 0.31.1-r1*
* *demo-nodes-py 0.31.0-r1 --> 0.31.1-r1*
* *dummy-map-server 0.31.0-r1 --> 0.31.1-r1*
* *dummy-robot-bringup 0.31.0-r1 --> 0.31.1-r1*
* *dummy-sensors 0.31.0-r1 --> 0.31.1-r1*
* *examples-tf2-py 0.33.0-r1 --> 0.33.1-r1*
* *fastrtps 2.11.1-r1 --> 2.11.2-r1*
* *geometry2 0.33.0-r1 --> 0.33.1-r1*
* *image-common 4.5.0-r1 --> 4.5.1-r1*
* *image-tools 0.31.0-r1 --> 0.31.1-r1*
* *image-transport 4.5.0-r1 --> 4.5.1-r1*
* *intra-process-demo 0.31.0-r1 --> 0.31.1-r1*
* *launch 3.0.0-r1 --> 3.0.1-r1*
* *launch-pytest 3.0.0-r1 --> 3.0.1-r1*
* *launch-ros 0.26.1-r1 --> 0.26.2-r1*
* *launch-testing 3.0.0-r1 --> 3.0.1-r1*
* *launch-testing-ament-cmake 3.0.0-r1 --> 3.0.1-r1*
* *launch-testing-ros 0.26.1-r1 --> 0.26.2-r1*
* *launch-xml 3.0.0-r1 --> 3.0.1-r1*
* *launch-yaml 3.0.0-r1 --> 3.0.1-r1*
* *lifecycle 0.31.0-r1 --> 0.31.1-r1*
* *lifecycle-msgs 1.7.0-r1 --> 2.0.0-r1*
* *lifecycle-py 0.31.0-r1 --> 0.31.1-r1*
* *logging-demo 0.31.0-r1 --> 0.31.1-r1*
* *mola-common 0.2.0-r1 --> 0.2.1-r1*
* *mola-input-euroc-dataset 0.2.1-r1*
* *mola-input-kitti-dataset 0.2.1-r1*
* *mola-kernel 0.2.1-r1*
* *mola-yaml 0.2.0-r1 --> 0.2.1-r1*
* *mp2p-icp 0.2.0-r1 --> 0.2.1-r1*
* *mvsim 0.7.4-r1 --> 0.8.0-r1*
* *nmea-msgs 2.0.0-r4 --> 2.1.0-r1*
* *nmea-navsat-driver 2.0.0-r2 --> 2.0.1-r1*
* *pendulum-control 0.31.0-r1 --> 0.31.1-r1*
* *pendulum-msgs 0.31.0-r1 --> 0.31.1-r1*
* *quality-of-service-demo-cpp 0.31.0-r1 --> 0.31.1-r1*
* *quality-of-service-demo-py 0.31.0-r1 --> 0.31.1-r1*
* *rcl 7.1.0-r1 --> 7.1.1-r1*
* *rcl-action 7.1.0-r1 --> 7.1.1-r1*
* *rcl-interfaces 1.7.0-r1 --> 2.0.0-r1*
* *rcl-lifecycle 7.1.0-r1 --> 7.1.1-r1*
* *rcl-logging-interface 2.6.0-r1 --> 2.7.0-r1*
* *rcl-logging-noop 2.6.0-r1 --> 2.7.0-r1*
* *rcl-logging-spdlog 2.6.0-r1 --> 2.7.0-r1*
* *rcl-yaml-param-parser 7.1.0-r1 --> 7.1.1-r1*
* *rclcpp 22.1.0-r1 --> 22.2.0-r1*
* *rclcpp-action 22.1.0-r1 --> 22.2.0-r1*
* *rclcpp-components 22.1.0-r1 --> 22.2.0-r1*
* *rclcpp-lifecycle 22.1.0-r1 --> 22.2.0-r1*
* *rclpy 5.0.1-r1 --> 5.1.0-r1*
* *rcpputils 2.7.1-r1 --> 2.8.0-r1*
* *rcss3d-nao 1.0.0-r1 --> 1.1.0-r1*
* *rcutils 6.3.0-r1 --> 6.3.1-r1*
* *rig-reconfigure 1.3.0-r1 --> 1.3.2-r1*
* *rmw-fastrtps-cpp 7.4.0-r1 --> 7.5.0-r1*
* *rmw-fastrtps-dynamic-cpp 7.4.0-r1 --> 7.5.0-r1*
* *rmw-fastrtps-shared-cpp 7.4.0-r1 --> 7.5.0-r1*
* *ros2launch 0.26.1-r1 --> 0.26.2-r1*
* *rosgraph-msgs 1.7.0-r1 --> 2.0.0-r1*
* *rosidl-adapter 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-cli 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-cmake 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-dynamic-typesupport 0.1.1-r1 --> 0.1.2-r1*
* *rosidl-generator-c 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-generator-cpp 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-generator-type-description 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-parser 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-pycommon 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-runtime-c 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-runtime-cpp 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-typesupport-interface 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-typesupport-introspection-c 4.3.1-r1 --> 4.4.0-r1*
* *rosidl-typesupport-introspection-cpp 4.3.1-r1 --> 4.4.0-r1*
* *rqt-py-console 1.2.0-r1 --> 1.2.1-r1*
* *rqt-reconfigure 1.4.0-r1 --> 1.5.0-r1*
* *rviz-assimp-vendor 13.0.0-r1 --> 13.1.0-r1*
* *rviz-common 13.0.0-r1 --> 13.1.0-r1*
* *rviz-default-plugins 13.0.0-r1 --> 13.1.0-r1*
* *rviz-ogre-vendor 13.0.0-r1 --> 13.1.0-r1*
* *rviz-rendering 13.0.0-r1 --> 13.1.0-r1*
* *rviz-rendering-tests 13.0.0-r1 --> 13.1.0-r1*
* *rviz-visual-testing-framework 13.0.0-r1 --> 13.1.0-r1*
* *rviz2 13.0.0-r1 --> 13.1.0-r1*
* *service-msgs 1.7.0-r1 --> 2.0.0-r1*
* *statistics-msgs 1.7.0-r1 --> 2.0.0-r1*
* *test-msgs 1.7.0-r1 --> 2.0.0-r1*
* *tf2 0.33.0-r1 --> 0.33.1-r1*
* *tf2-bullet 0.33.0-r1 --> 0.33.1-r1*
* *tf2-eigen 0.33.0-r1 --> 0.33.1-r1*
* *tf2-eigen-kdl 0.33.0-r1 --> 0.33.1-r1*
* *tf2-geometry-msgs 0.33.0-r1 --> 0.33.1-r1*
* *tf2-kdl 0.33.0-r1 --> 0.33.1-r1*
* *tf2-msgs 0.33.0-r1 --> 0.33.1-r1*
* *tf2-py 0.33.0-r1 --> 0.33.1-r1*
* *tf2-ros 0.33.0-r1 --> 0.33.1-r1*
* *tf2-ros-py 0.33.0-r1 --> 0.33.1-r1*
* *tf2-sensor-msgs 0.33.0-r1 --> 0.33.1-r1*
* *tf2-tools 0.33.0-r1 --> 0.33.1-r1*
* *topic-based-ros2-control 0.1.1-r1 --> 0.2.0-r1*
* *topic-monitor 0.31.0-r1 --> 0.31.1-r1*
* *topic-statistics-demo 0.31.0-r1 --> 0.31.1-r1*
* *turtlesim 1.7.2-r1 --> 1.7.3-r1*
* *type-description-interfaces 1.7.0-r1 --> 2.0.0-r1*
* *ur-client-library 1.3.2-r1 --> 1.3.3-r1*
* *usb-cam 0.6.0-r1 --> 0.7.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] hdf5-tools
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libpaho-mqtt-dev
 * [ ] libpaho-mqttpp-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libtins-dev
 * [ ] meson
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-natsort
 * [ ] python3-ply
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

