### PR TITLE
Disable Wayland in RViz2 and Gazebo, add bin/ to Gazebo PATH

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -153,10 +153,15 @@ rosSelf: rosSuper: with rosSelf.lib; {
   });
 
   rviz2 = rosSuper.rviz2.overrideAttrs ({
-    nativeBuildInputs ? [], postFixup ? "", meta ? {}, ...
+    nativeBuildInputs ? [], qtWrapperArgs ? [], postFixup ? "", meta ? {}, ...
   }: {
     dontWrapQtApps = false;
     nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
+    qtWrapperArgs = qtWrapperArgs ++ [
+      # Use X11 by default in RViz2.
+      # https://github.com/ros-visualization/rviz/issues/1442
+      "--set-default QT_QPA_PLATFORM xcb"
+    ];
     postFixup = postFixup + ''
       wrapQtApp "$out/lib/rviz2/rviz2"
     '';

--- a/pkgs/gazebo/default.nix
+++ b/pkgs/gazebo/default.nix
@@ -86,6 +86,10 @@ mkDerivation rec {
     # Let the gazebo binary see neighboring binaries.
     # It attempts to run gzclient from PATH.
     "--prefix PATH : ${placeholder "out"}/bin"
+
+    # Prevent Gazebo from attempting to use Wayland.
+    # As is the case with RViz2, OGRE does not yet support it.
+    "--set WAYLAND_DISPLAY dummy" # "dummy" is arbitrary - it just doesn't exist.
   ];
 
   meta = {

--- a/pkgs/gazebo/default.nix
+++ b/pkgs/gazebo/default.nix
@@ -82,6 +82,12 @@ mkDerivation rec {
     ignition-fuel-tools
   ];
 
+  qtWrapperArgs = [
+    # Let the gazebo binary see neighboring binaries.
+    # It attempts to run gzclient from PATH.
+    "--prefix PATH : ${placeholder "out"}/bin"
+  ];
+
   meta = {
     homepage = "http://gazebosim.org/";
     description = "Multi-robot simulator for outdoor environments";


### PR DESCRIPTION
Both RViz2 and Gazebo use OGRE, which does not yet run on Wayland at all. This PR adds to their wrappers to prevent Wayland from being used.

Gazebo also has issues when its bin/ directory is not in the PATH, as it attempts to run some of its own binaries. This fixes that in the wrapper as well.