### PR TITLE
Miscellaneous Foxy fixes and improvements

### DIFF
--- a/distros/foxy/aruco-opencv/default.nix
+++ b/distros/foxy/aruco-opencv/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport libyamlcpp python39Packages.img2pdf python3Packages.numpy python3Packages.opencv3 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ aruco-opencv-msgs cv-bridge image-transport libyamlcpp python39Packages.img2pdf python3Packages.numpy python3Packages.opencv4 rclcpp rclcpp-components rclcpp-lifecycle tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/cv-bridge/default.nix
+++ b/distros/foxy/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv3 rcpputils sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv4 rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/foxy/overrides.nix
+++ b/distros/foxy/overrides.nix
@@ -89,10 +89,15 @@ rosSelf: rosSuper: with rosSelf.lib; {
     ];
   });
 
-  rviz-ogre-vendor = patchVendorUrl rosSuper.rviz-ogre-vendor {
+  rviz-ogre-vendor = (patchVendorUrl rosSuper.rviz-ogre-vendor {
     url = "https://github.com/OGRECave/ogre/archive/v1.12.1.zip";
     sha256 = "1iv6k0dwdzg5nnzw2mcgcl663q4f7p2kj7nhs8afnsikrzxxgsi4";
-  };
+  }).overrideAttrs ({ preFixup ? "", ... }: {
+      preFixup = ''
+        # Prevent /build RPATH references
+        rm -r ogre_install
+      '' + preFixup;
+  });
 
   urdfdom = rosSuper.urdfdom.overrideAttrs ({
     patches ? [], ...

--- a/distros/foxy/overrides.nix
+++ b/distros/foxy/overrides.nix
@@ -38,6 +38,19 @@ rosSelf: rosSuper: with rosSelf.lib; {
     };
   };
 
+  pendulum-control = rosSuper.pendulum-control.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # Remove the malloc_hook from the pendulum_demo (for glibc 2.34).
+      (self.fetchpatch {
+        url = "https://github.com/ros2/demos/commit/754612348e408675f526174c5f03786e08ad8a70.patch";
+        hash = "sha256-B+UW1OL0SOs7mOEOtpu5CSo8zSk5ifJdwC/deY/7zTg=";
+        stripLen = 1;
+      })
+    ];
+  });
+
   python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/foxy/overrides.nix
+++ b/distros/foxy/overrides.nix
@@ -75,6 +75,17 @@ rosSelf: rosSuper: with rosSelf.lib; {
     ];
   });
 
+  ros2cli = rosSuper.ros2cli.overrideAttrs ({
+    propagatedBuildInputs ? [], ...
+  }: {
+    propagatedBuildInputs = propagatedBuildInputs ++ [
+      # Add argcomplete as a propagated ros2cli dependency.
+      # https://github.com/ros2/ros2cli/pull/564
+      # https://github.com/ros2/ros2cli/blob/26715cbb0948258d6f04b94c909d035c5130456a/ros2cli/ros2cli/cli.py#L45
+      rosSelf.python3Packages.argcomplete
+    ];
+  });
+
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/foxy/overrides.nix
+++ b/distros/foxy/overrides.nix
@@ -92,7 +92,16 @@ rosSelf: rosSuper: with rosSelf.lib; {
   rviz-ogre-vendor = (patchVendorUrl rosSuper.rviz-ogre-vendor {
     url = "https://github.com/OGRECave/ogre/archive/v1.12.1.zip";
     sha256 = "1iv6k0dwdzg5nnzw2mcgcl663q4f7p2kj7nhs8afnsikrzxxgsi4";
-  }).overrideAttrs ({ preFixup ? "", ... }: {
+  }).overrideAttrs ({ patches ? [], preFixup ? "", ... }: {
+      patches = patches ++ [
+        # Fix AArch64 builds.
+        (self.fetchpatch {
+          url = "https://github.com/ros2/rviz/pull/828.patch";
+          hash = "sha256-KpY9+oOsFxH+zhIxyP6UTOXTLaaUdCRzUMZnM7+uRAk=";
+          stripLen = 1;
+        })
+      ];
+
       preFixup = ''
         # Prevent /build RPATH references
         rm -r ogre_install

--- a/distros/foxy/stereo-image-proc/default.nix
+++ b/distros/foxy/stereo-image-proc/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv3 rclpy ros-testing ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv4 rclpy ros-testing ];
   propagatedBuildInputs = [ cv-bridge image-geometry image-proc image-transport message-filters rclcpp rclcpp-components sensor-msgs stereo-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright pythonPackages.pytest ];
-  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv3 rclpy webots-ros2-driver ];
+  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces python3Packages.numpy python3Packages.opencv4 rclpy webots-ros2-driver ];
 
   meta = {
     description = ''Tesla ROS2 interface for Webots.'';


### PR DESCRIPTION
This PR switches the Python version of OpenCV to OpenCV 4 (as has been done in rosdep), adds `argcomplete` as a propagated build input of `ros2cli` (backported from Humble), and fixes various build errors.