### PR TITLE
rosdistro sync, Fri Sep 22 13:12:15 2023

### DIFF
--- a/distros/humble/aandd-ekew-driver-py/default.nix
+++ b/distros/humble/aandd-ekew-driver-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, weight-scale-interfaces }:
 buildRosPackage {
   pname = "ros-humble-aandd-ekew-driver-py";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/TechMagicKK/aandd_ekew_driver_py-release/archive/release/humble/aandd_ekew_driver_py/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "dc6357fb7e60f945af1cc7520f48c625d1ecf6abf4620869ab5b504d557be7a5";
+    url = "https://github.com/TechMagicKK/aandd_ekew_driver_py-release/archive/release/humble/aandd_ekew_driver_py/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "24e36b1a642e89fe9dbabe70bf616a1d33e0a4a6dd917c8952cdcb9d2e24bf97";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "e6055d5efb122d8f400f93155713811c42828ec416311f82b85e52b6f955b9f5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "6f777f4166ce65a9cabc3d4a583df4decdd3cf55b744147f9110222a2c2305fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "4d8ab20e64d9a52d41b1ecb631dd663d8a1b744b7f2949a425bdd4a660096e85";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "a978f386109db6751464d809e09cafc9d55350ba1f1b48d270ead2c971b5a3a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-clang-format/default.nix
+++ b/distros/humble/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-clang-format";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_format/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "990a4f81a75ebd6aa2c77f39ea9ed61691ea0d5f207c81674f01d931ac21de33";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_format/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "9c3f9a49b80141213495c10e44eec5a0e34dfbe2650ac7c258f995f20e852b92";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-clang-tidy/default.nix
+++ b/distros/humble/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-clang-tidy";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_tidy/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "e3cf15ac7db7aacc53ff8497a81865c58104a249126fcffc359a7a43b254cd98";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_tidy/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "c5faa7570e8899fa84a058ea87eb3ef9eb33bf9f52b238250dbf1ffbffa35c39";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cmake-clang-format/default.nix
+++ b/distros/humble/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-clang-format";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_format/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "e1683e60ccd4a8ba46f10de4e317700e10e997cd7ad4289a323eb30017a4fbd4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_format/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "66e73b3aa101ac0f861447e8faaa73542ebab4d439685aace3cc2c57962f63f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-clang-tidy/default.nix
+++ b/distros/humble/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-clang-tidy";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_tidy/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "2c32cf98876f8302245264007abf5aaa099d2a82bbf76545dfce306092a52154";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_tidy/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "a38b7bb3980ed87d5593ac8a33f987a069e40ff27a8a8f5af7dd2398882114bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-copyright/default.nix
+++ b/distros/humble/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-copyright";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_copyright/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "632ecb7f866d61b178aaba39b90be969d3371c8bbd3e247666df32cdddc3857e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_copyright/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "5b808bcda2fa3fda65dd96e59dc383edcd08c3825db27e0f32445c0f9a418213";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-cppcheck/default.nix
+++ b/distros/humble/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-cppcheck";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cppcheck/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "010010ba284aa804e9d6f06e62ce7cc260aadfe422aebb1c0296b49752e3e749";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cppcheck/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "ed649b00cf80706817142dc7bf039e35139c8f2aeb44e4e970592a9cb802bebf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-cpplint/default.nix
+++ b/distros/humble/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-cpplint";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cpplint/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "130cc2b9b5dea425e54a9fe478c3bc61a735ace856295a97a8e43480b2e467b6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cpplint/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "6fe3fe0b3a8892c5ad65aa43fbfeec7b28305560b2c553ca0aaf4e8ef1583512";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-flake8/default.nix
+++ b/distros/humble/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-flake8";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_flake8/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "ac0b3f5e3a32c9f30d5f51964dd369e9007f998407145aef2787f82c8d511370";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_flake8/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "03640b459c0750e7f463366b108cd72347b49944e3cfe28ab821ae90d0089c55";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-lint-cmake/default.nix
+++ b/distros/humble/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-lint-cmake";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_lint_cmake/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "ed53fc5d0df0693d1b79fecee442b361f6866dbfd7cf3bfd829d8e2c5a7ffaec";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_lint_cmake/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "5834082fb427ee5d4c0252e0ea63fb334fc104bf99f78ab840060ac3a0774e91";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-mypy/default.nix
+++ b/distros/humble/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-mypy";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_mypy/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "390743f08bca249efced10096aa795f26f27fc042326335efb9fa164f6526de5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_mypy/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "b95f32e8d63ee60e6f251c6ed9916d108781f9ab0a647a6f35db5f663f368c3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pclint/default.nix
+++ b/distros/humble/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pclint";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pclint/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "ddbbc0f84e598fc67817ffca2469d6e11c0fb7ac028f363857e0d2b983f07367";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pclint/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "b778f0e2901bb30b61c2ff8932e30befe36cdba895401beb40d191753ef3d0f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pep257/default.nix
+++ b/distros/humble/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pep257";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pep257/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "53f776a272924af7a96fb4a609673f226dc47bc308c06642fafcb010c33aceff";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pep257/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "23a3320cc9c0c33c547e7d2986f454eb316351f7268a5290ca84d9c9e18ec085";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pycodestyle/default.nix
+++ b/distros/humble/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pycodestyle";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pycodestyle/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "41b474f86008a253eb42c1a59e3bbd4778a6d976cbd87612f97421be3952d7dc";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pycodestyle/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "1d8ac5d38d5aad2e1cfce78fb7c910c1bca05922b8b768ad4cc9749b13bb23c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pyflakes/default.nix
+++ b/distros/humble/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pyflakes";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pyflakes/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "c153a6a12621dbbd3f7c79cda2341f7446fc8f99526813ba3e766f6d3f971fac";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pyflakes/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "da85d0a5e81a909f5acda3346d8bbd79158b65bb5963d79533c537e076143028";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-uncrustify/default.nix
+++ b/distros/humble/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-uncrustify";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_uncrustify/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "44b71c265521bed035ba9edb49b7eeecf27246a011da5ca997619446cedbe7e6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_uncrustify/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "1a4ab73dfc7a7ad94bab96799f0b37607a9bd52f46cde934bbb31b3a9172414e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-xmllint/default.nix
+++ b/distros/humble/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-xmllint";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_xmllint/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "73770135229386e1191c719b51c186938c53d2d93d07b82c0f162409b35ae195";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_xmllint/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "019f16f9ad1f2ed61baf5e8277a0d8435617a75ea16af4d28f3acaf5f34e1055";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-copyright/default.nix
+++ b/distros/humble/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-copyright";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_copyright/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "211b52f844ffd9b0a311dd75868b005c88034a16bbea52b215492ec33c2f64fd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_copyright/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "9087bedc6bfe7ba068c8d92ba952a759494b015465b8d5914382960e7ddaf5bb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cppcheck/default.nix
+++ b/distros/humble/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-humble-ament-cppcheck";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cppcheck/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "b7c9e0121f96db669be06730e44ed237ac378bb73c0b6f0923dc3419bf1d7c1a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cppcheck/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "adef094695774fe8a3c71eaea6d760aea5f7bdfb73ef2db2ffe1d1390ef555d2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cpplint/default.nix
+++ b/distros/humble/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-cpplint";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cpplint/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "30dc9767d733476209dc21502817493edd1be126973bc73568788a1ea31578cb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cpplint/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "5481a317aeeb25c357de3c4ef5ed73dc35fab0166f76ba750497b3c7f6fe5852";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-flake8/default.nix
+++ b/distros/humble/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-flake8";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_flake8/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "f3b481ea3ab7299b441605bc9f5aa5b843f79d47db617fd9a2f63fb1a21a9cc3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_flake8/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "4a65f3fcd8063dc0ff53988b5449541c33bf15d56ad0f4a3bdda78ddaf390586";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-lint-auto/default.nix
+++ b/distros/humble/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-auto";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_auto/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "b1e910511e4fb7c385c2c36804aafb356a7c34380ef6c7237550386e9705ffbb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_auto/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "ffbb6bb02e350020977c108ce2037a7dd3c66448d7270d95c5677077625797f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-lint-cmake/default.nix
+++ b/distros/humble/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-cmake";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_cmake/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "d3f708cf16f126fed3ff89a333b958a65dc46d28aa5725468e6f777f5f8219a5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_cmake/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "5a57e1f0575ba8438c29526aef7cd103ee68bb10aa370576d777c98421c182ba";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-lint-common/default.nix
+++ b/distros/humble/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-common";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_common/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "272b6b6adefd9fca9f3a2929f96d812724489eab5bdc46a2af021ceb62a83f1b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_common/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "01d566ba394a902503fdbe04d87e24b180a6e32d971a4d0bd4b31da1b48db5a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-lint/default.nix
+++ b/distros/humble/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-humble-ament-lint";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "7cc63054678276af19d9ddb8999fa0a88e70e5a1205874a9f9d4c9fea1472c5a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "075c49feca0a4dd48e5d291ad0d7e0f3921e19b91e2ffefb26ba9766dfd0b0b0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-mypy/default.nix
+++ b/distros/humble/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-mypy";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_mypy/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "0c1c2bba8c6b48a8fce994f8660170ffeb9c686857caa46cf8dee2663a34319e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_mypy/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "fd15d0bfc1c710c29aeba0a4ee67ab88949dafc56cd3a79a753373b036d09da6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pclint/default.nix
+++ b/distros/humble/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-pclint";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pclint/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "05138c8a1da422221432b116717f8f727ff43074d2b0a82d474d504ff9073afc";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pclint/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "db2a77b16247fbe07e045192add6a32c57cefe391223a5199a9ef63f59cdfeb8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pep257/default.nix
+++ b/distros/humble/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-pep257";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pep257/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "40940977c96b2b94fa038c4c9a67756820cf3349b57ff265131fc5d631decaa5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pep257/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "bdad7ae03f31d813aaec2e8661656a1cf0cb443a75f227a7ee11b0699d0a840e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pycodestyle/default.nix
+++ b/distros/humble/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-pycodestyle";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pycodestyle/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "b8565f073503ab0260a2a1ac220de4c244e3577d5eb6ac08621a2c30b91b8671";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pycodestyle/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "4df765615fc6b6e10eb18b769c23b26586308a65450361126a3c878456521c9d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pyflakes/default.nix
+++ b/distros/humble/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-pyflakes";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pyflakes/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "ffe685e918eada4d11009cea033fb9b6c8e15182909fa08f83e6b92208e626a2";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pyflakes/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "9cbf9517e8b83c4e9a4db44fcc8f1cf2d5a563cb49dbefd8b207654799d946b1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-uncrustify/default.nix
+++ b/distros/humble/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-uncrustify";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_uncrustify/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "9c96ec76c23819d361b2d5826ed445f9e1c1857ef6f18883ea4d5c2c31f5ae01";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_uncrustify/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "f41c10f271a73ef1b0925106a0a67c4818fa80160b3f7c1984b07c2c3c43cadb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-xmllint/default.nix
+++ b/distros/humble/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-xmllint";
-  version = "0.12.7-r2";
+  version = "0.12.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_xmllint/0.12.7-2.tar.gz";
-    name = "0.12.7-2.tar.gz";
-    sha256 = "57fffed5f4009fb172061ee87bdba1018702f6cdd8f2da6e3b03f81c272adab8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_xmllint/0.12.8-1.tar.gz";
+    name = "0.12.8-1.tar.gz";
+    sha256 = "10b55b7cdb1cced54a559621fafb0ba6ebddfa47efa05cbc3f40b500514d7143";
   };
 
   buildType = "ament_python";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "ef67abceaf223e005601021e676459d306e2cb1f3b1d11ce9afa57423567c630";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "ff398aefd6085c8159c25b4151c8b5e07d187f15805cb78ee5b4276d0a14a94c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-nav2-demos/default.nix
+++ b/distros/humble/clearpath-nav2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, nav2-bringup, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-clearpath-nav2-demos";
-  version = "0.0.2-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/humble/clearpath_nav2_demos/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "296e5408d7d0018f0e79d726148b721700c1979c297a37e3919de281d1d49f1d";
+    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/humble/clearpath_nav2_demos/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "26dbfec36b93adb5afe0825422ad5f940a386e878b07511b8c487bcadb06ff8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-dbw-common/default.nix
+++ b/distros/humble/dataspeed-dbw-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, rclcpp, ros2-socketcan }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-dbw-common";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_common/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ae6dad10446fc098c02088c625dd2d786b82a84b3313837a33cf271700f55a36";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_common/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "18b702547eae717be609c555ebc5017ec2e2455474384578d60622df05511b13";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-dbw-gateway/default.nix
+++ b/distros/humble/dataspeed-dbw-gateway/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, dataspeed-dbw-common, dataspeed-dbw-msgs, dbw-fca-msgs, dbw-ford-msgs, dbw-polaris-msgs, diagnostic-msgs, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-dbw-gateway";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_gateway/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "bb6fa62d393825fbc90387f2dee97ec750e46565cc8c8fde06b34182caad0403";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_gateway/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "0eef31efddfd0c1330afc1b94573f8f9b9006cd35d253b7e8e238ecf08c275a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-dbw-msgs/default.nix
+++ b/distros/humble/dataspeed-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-dbw-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "e90290e1f3f731933040dd4b32054767adc259df2d43d1650892cd55647b1a1f";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_msgs/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "a5fe26afa96373dc74b38e8b9affa07a92342813c0d088514564dbe6628b4cc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc-can/default.nix
+++ b/distros/humble/dataspeed-ulc-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-dbw-common, dataspeed-ulc-msgs, geometry-msgs, rclcpp, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc-can";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_can/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "e91ea32c708f283029ee723c667b7ba4b1054c293f0ac64492558b3776a469b2";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_can/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "b1563c9998bdabb57d54a3243950ee69b60c6406ee7a95549ab287c690bbff57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc-msgs/default.nix
+++ b/distros/humble/dataspeed-ulc-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "d6463b600e0123d46e4cd994cc10dd68368637b09d6e22829bbd667266a3dba3";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_msgs/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "fe170ec9f49205322c78edf08eb68ff62d18dfcee3958d72e11a7371401f1be7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc/default.nix
+++ b/distros/humble/dataspeed-ulc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-ulc-can, dataspeed-ulc-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "14eb7e0d0054222f4efc820b73eafd0182bbe943934e4ed7fa207650cde5cb47";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "bc52fe40d8f9049585ed8e2129f5e991f320f1495aa61b2279eebdff137cc957";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-can/default.nix
+++ b/distros/humble/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-can";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_can/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "6eca01a7af4c8de36e79f533c5289082af2135145c20ca0d039542f8a5b43905";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_can/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "30ef91eb69d973a1ce28039d0f3302fb29c7d699bbbb5ee7976a8f47f9b5569d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-description/default.nix
+++ b/distros/humble/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-description";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "04bc168ad69f14482530926af9f76815a836c00218452b92cef76ba0438ffd29";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_description/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "48d5260311f0af86902faf74be90672936a9ad9d35ac6531c24fecccbaeda9db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-joystick-demo/default.nix
+++ b/distros/humble/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-fca-can, dbw-fca-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-joystick-demo";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_joystick_demo/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "4ee22bba8a68075fbb962bd5aa6d0330c4ec9f629ed7e3732b6a39b060d7a9bc";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_joystick_demo/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "57b77dde2c49ea3d0b8423615e6d370b3449c538d11575a2df0df1458f4bf9e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-msgs/default.nix
+++ b/distros/humble/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "c2822680773dab951ac1c96f0f515a75601bb4750ae37bb9a12f515e47b78ab0";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_msgs/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "63c9085654fac36703d82f30ebdf58fb54d29c65df332320a63fef277b2083cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca/default.nix
+++ b/distros/humble/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "4d4d7ee487c8fa57a856a11c63a5171738143c919f1323d19f21c78565f45185";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "47b4ce1b73ca5b391ca105ce974bec3d85a5ab017c1962cadea99b082e8074d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-can/default.nix
+++ b/distros/humble/dbw-ford-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-ford-description, dbw-ford-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-can";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_can/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "662d843d1e553401d0304f9ae4bfe1825a12fe73e21d5b42b37644907270081b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_can/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "a7547971f4a42e53f5a6926247bb0555d565cc315d67e1a47d6f83ac554310fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-description/default.nix
+++ b/distros/humble/dbw-ford-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-description";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "32daa3b66ffbc26682cf4f3ee729249f1096c8e924e6fd465d1f0ae1c03a2ebc";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_description/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "62424e4ae5b3eae5f595171a9157cce34204e4222a28677a3c93bc784079505e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-joystick-demo/default.nix
+++ b/distros/humble/dbw-ford-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-ford-can, dbw-ford-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-joystick-demo";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_joystick_demo/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "3fe4e461c3bd9ab7052cf9c68a27300d3576f5aa6ee863cedd887ca04ad84c63";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_joystick_demo/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "233015c3ffbe0b646379f9c1d38490bf6f2cba138dbce872cc1c53cd4c8b814b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-msgs/default.nix
+++ b/distros/humble/dbw-ford-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "a00d8a8528b8850eb7e71838825b8125e7567bc6501bdeab5767aaebf2b60c2a";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_msgs/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "cf4b4304a7998228eed60388525d7f87ae8f5fb97d693963726cee798d6059fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford/default.nix
+++ b/distros/humble/dbw-ford/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-ford-can, dbw-ford-description, dbw-ford-joystick-demo, dbw-ford-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "144ee7d55b8fdf62b5400361550bfc59a49f7204b312750e3940509117b07f01";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "87de75e12f2f16cfc4e8c82f746f864dc957732157f72e3f2ad0e910f67de620";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-can/default.nix
+++ b/distros/humble/dbw-polaris-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-can";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_can/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "a0d9d8f2de9f2de0c313a1f442fcfdeb99f86800d8b969d7fd9d4af995fdf999";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_can/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "7433eb88680cf23c48848becce11ea26d8b278ce2cc4d0240d5752107f078a64";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-description/default.nix
+++ b/distros/humble/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-description";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "79c187e96b509fefa1787a9f25ddc756cfafc90de881d0cb533238086de911b6";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_description/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "55d6a73595115281713fbdfb4a47e2a802ed953bc76e8e8323ae24709d44950d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-joystick-demo/default.nix
+++ b/distros/humble/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-polaris-can, dbw-polaris-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-joystick-demo";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_joystick_demo/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "872301d1189de912ff60b840d299ecc041945bf6cbc0cfea305aef9573feef57";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_joystick_demo/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "9fdfdeab9df0111d7ee730e83426c90895988f78fc5c8c89fcd21fecc4ad5fa7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-msgs/default.nix
+++ b/distros/humble/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-msgs";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ef019802cf637829f53f3f328390440fe94bb2ba5899d80413f28e9c54e6c64d";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_msgs/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "10de28cf5a43298fe95e0c389d03032ee423899e2b9486bda9b7d840fddade7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris/default.nix
+++ b/distros/humble/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris";
-  version = "2.1.1-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "d9200b64339338ad9a8e83a33e5f77d8dcfcab53d9f2a2964b4df3b6afe41e8b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "a301cbf2a3aec9e3da64bb2c0a201acf61dd96a5557e579e3e6d682e8c14795d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "354914a5bce645dc89a7873acba36bdf7f70edad2056a25e283e290d60cb9ac1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "3df4d881a14a3dd9590f08d00dc796674d86187e4f9ac560514f400fba92d4be";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "90f3591761ea654c56ad314bf7f985750ebe4410266e8f6b2b66c4a2decfc2ec";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "9be2df269dfcafa0b0edf7919119ebd68b6da10d988c7b5f335f8db1ec386757";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/event-camera-codecs/default.nix
+++ b/distros/humble/event-camera-codecs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, class-loader, event-camera-msgs, rclcpp, ros-environment, rosbag2-cpp }:
+buildRosPackage {
+  pname = "ros-humble-event-camera-codecs";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/humble/event_camera_codecs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a51029a431c5752775ca421c0f703d7d796df3d5414871774bc964297ee81c34";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp rosbag2-cpp ];
+  propagatedBuildInputs = [ class-loader event-camera-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''package to encode and decode event_camera_msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/event-camera-py/default.nix
+++ b/distros/humble/event-camera-py/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-event-camera-py";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/humble/event_camera_py/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "372bc3c7d08c7ef46267797a048969a8ec91c519df26dce1129ebf06ea539031";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy ];
+  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
+
+  meta = {
+    description = ''Python access for event_camera_msgs.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/event-camera-renderer/default.nix
+++ b/distros/humble/event-camera-renderer/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-event-camera-renderer";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/humble/event_camera_renderer/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "fc127ef4fe320828ff514cb7ac4b1aa843655ac9f1be92088586ca0a7dd96491";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs image-transport rclcpp rclcpp-components ros-environment sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''package for rendering event_camera_msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/examples-tf2-py/default.nix
+++ b/distros/humble/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-examples-tf2-py";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "49ad11ad11749b96b90325ddd82356e12409c9fa5687a18faa880a61114b0ae9";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "e3cd1d0fab414e156d9da8ee72877b871f64e89820df9350f7733321c2b7bbd7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/fadecandy-driver/default.nix
+++ b/distros/humble/fadecandy-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-updater, fadecandy-msgs, libusb1, rclcpp, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-fadecandy-driver";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/eurogroep/fadecandy_ros-release/archive/release/humble/fadecandy_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "efb31dbc7b4690dcf552e0d0156cba5baaa467bea7904d080fe48a15fe59ffbc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ rclpy ];
+  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs libusb1 rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS driver for fadecandy LED controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/fadecandy-msgs/default.nix
+++ b/distros/humble/fadecandy-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-fadecandy-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/eurogroep/fadecandy_ros-release/archive/release/humble/fadecandy_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4f5f1e8358b826b59e401319c382af130ad7bc42188e5e50a1b4cc6828f08dc2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS msgs for fadecandy LED controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "5aa86f25bddadcbd72e80262d5c25bb29741277ac6bb756642692df671f1f1cc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "8441ae5dac473f61d0e3e9943080346435a77bd0b242f534bc7b1525656f282b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "066ab413a8aca7e5f4ce5e81b68cb3e636a0d4578d67a68ee123dff680258a9f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "14c88b515044a7bebd9ffcda62170d38bfde70082223a2f758019ab4b550a9ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -550,7 +550,13 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ event-camera-codecs = self.callPackage ./event-camera-codecs {};
+
  event-camera-msgs = self.callPackage ./event-camera-msgs {};
+
+ event-camera-py = self.callPackage ./event-camera-py {};
+
+ event-camera-renderer = self.callPackage ./event-camera-renderer {};
 
  example-interfaces = self.callPackage ./example-interfaces {};
 
@@ -599,6 +605,10 @@ self: super: {
  examples-tf2-py = self.callPackage ./examples-tf2-py {};
 
  executive-smach = self.callPackage ./executive-smach {};
+
+ fadecandy-driver = self.callPackage ./fadecandy-driver {};
+
+ fadecandy-msgs = self.callPackage ./fadecandy-msgs {};
 
  fastcdr = self.callPackage ./fastcdr {};
 
@@ -1492,7 +1502,15 @@ self: super: {
 
  pmb2-simulation = self.callPackage ./pmb2-simulation {};
 
+ point-cloud-interfaces = self.callPackage ./point-cloud-interfaces {};
+
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
+
+ point-cloud-transport = self.callPackage ./point-cloud-transport {};
+
+ point-cloud-transport-plugins = self.callPackage ./point-cloud-transport-plugins {};
+
+ point-cloud-transport-py = self.callPackage ./point-cloud-transport-py {};
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
@@ -2612,7 +2630,11 @@ self: super: {
 
  zenoh-bridge-dds = self.callPackage ./zenoh-bridge-dds {};
 
+ zlib-point-cloud-transport = self.callPackage ./zlib-point-cloud-transport {};
+
  zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
+
+ zstd-point-cloud-transport = self.callPackage ./zstd-point-cloud-transport {};
 
  zstd-vendor = self.callPackage ./zstd-vendor {};
 

--- a/distros/humble/geometry2/default.nix
+++ b/distros/humble/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-humble-geometry2";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "e2b26740787a0e6c21b3a689f7a4854756fc15656d1e477b93b52b65ba2432b8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "6f90a4a25ea2a819886a8e8f690f1da39b8da4f9e0044c309ea38a5e04cfafd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "172de240fea425eea6fb57d076a3a5abfd716819fb4b59a8eacdd3fa6b797e6b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "617bf3a4df7c6a44027ac3cc11e6ffb6ccf6ce560bab826997461dcd510198bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "941720d8ccaed1b221189f42dcc5c9aa94877912d2a46fe3be46f687dd78c39c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "08ac980cddf8501acd2b6992c1eec91ded82916a105d881129919c6659049db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "0f04f00245fdb3e17d4b244dfab3a756e91adebd7d66ecd8aa56fcd7d6273f5f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "eb5a0ed57e79fcf6d97dcf2a3ee7e86b687f81830055525e1749487d1cd88896";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "12230e32ee2f21ba2e0be2fd2da69a01c3a6ce0920680c2ed60af4bf78cc8333";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "0ef3b95108081fca560eea95631fc7e24f0e9ad1958fd31525bbb9d39e558fce";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-ros/default.nix
+++ b/distros/humble/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-launch-ros";
-  version = "0.19.5-r2";
+  version = "0.19.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.5-2.tar.gz";
-    name = "0.19.5-2.tar.gz";
-    sha256 = "370a430def9e405893b6d98249cec341d634ff02245ef09aed3c083cbf113af9";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.6-1.tar.gz";
+    name = "0.19.6-1.tar.gz";
+    sha256 = "900250ae2b2007cec3a19801fce176caf24b7f6cafa193c6d7e389eb1fa9f8be";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing-ros/default.nix
+++ b/distros/humble/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ros";
-  version = "0.19.5-r2";
+  version = "0.19.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.5-2.tar.gz";
-    name = "0.19.5-2.tar.gz";
-    sha256 = "a4b2c523948e836e357d29d09f9e218b27151f9eddcb8b72bb66d40186fe787a";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.6-1.tar.gz";
+    name = "0.19.6-1.tar.gz";
+    sha256 = "24c026deea443c3753de020fb4dbb8ccb88b437ea7d1d562a6ad2b0247ff0b25";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "fee50904b8871dc6a9de4010851dc7d25f847b5c103363a946a9d5923bf0778c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "ede3693a7b9c1a9d3a605c11990b774c9019ba868390aa36c5a85302bf833503";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mqtt-client-interfaces/default.nix
+++ b/distros/humble/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client-interfaces";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "026068e21175f8a4b966a6d4453d09326d87ec2dd5e4bdf2fa6c3e88a031f721";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "7b94837b0fd5fd9c6398a6eaf243286ce4144e8e9a0c4256619e8bd016a45090";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mqtt-client/default.nix
+++ b/distros/humble/mqtt-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rcpputils, ros-environment, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a644d682d807ccfaaf1084c2b2793c9e39ab55b523da17f8fead561db69632b9";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "765380fd5d63718c71df863acd54f5218456416f003df8ced20fee714cb1634b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ mqtt-client-interfaces paho-mqtt-c paho-mqtt-cpp rclcpp rcpputils ros-environment std-msgs ];
+  propagatedBuildInputs = [ fmt mqtt-client-interfaces paho-mqtt-c paho-mqtt-cpp rclcpp rclcpp-components rcpputils ros-environment std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/point-cloud-interfaces/default.nix
+++ b/distros/humble/point-cloud-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-point-cloud-interfaces";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_interfaces/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "7a9787d4376560976373dfc68c4119b5f64478091a123fe5ac2f57f9d1864b88";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''msg definitions for use with point_cloud_transport plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/point-cloud-transport-plugins/default.nix
+++ b/distros/humble/point-cloud-transport-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
+buildRosPackage {
+  pname = "ros-humble-point-cloud-transport-plugins";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_transport_plugins/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "cafc70a45a533aa9235f610aa34f94d9665373a248ce790aaa990592faade3cf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ draco-point-cloud-transport point-cloud-interfaces zlib-point-cloud-transport zstd-point-cloud-transport ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage with common point_cloud_transport plugins'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/point-cloud-transport-py/default.nix
+++ b/distros/humble/point-cloud-transport-py/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-point-cloud-transport-py";
+  version = "1.0.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.13-1.tar.gz";
+    name = "1.0.13-1.tar.gz";
+    sha256 = "46ee8293ee578ca44c3a7ebb3c25729c27167ebc818eefa810164914b7a7ed75";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  propagatedBuildInputs = [ pluginlib point-cloud-transport pybind11-vendor rclcpp rpyutils sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+
+  meta = {
+    description = ''Python API for point_cloud_transport'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/point-cloud-transport/default.nix
+++ b/distros/humble/point-cloud-transport/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
+buildRosPackage {
+  pname = "ros-humble-point-cloud-transport";
+  version = "1.0.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.13-1.tar.gz";
+    name = "1.0.13-1.tar.gz";
+    sha256 = "21d39ce504937be31327afc6da23a5e34c9cc91d65b10f5ecef15c44579cf22e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
+  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tl-expected ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/pose-cov-ops/default.nix
+++ b/distros/humble/pose-cov-ops/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-humble-pose-cov-ops";
-  version = "0.3.10-r1";
+  version = "0.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.10-1.tar.gz";
-    name = "0.3.10-1.tar.gz";
-    sha256 = "fcfda105c2e5195c99264d1420102c400ae56c8c3b3fc8564c2be5aaab930ad9";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/humble/pose_cov_ops/0.3.11-1.tar.gz";
+    name = "0.3.11-1.tar.gz";
+    sha256 = "0cce4d002fe466e7bdaeacbfd44cf312842980dfe73c11b528535752227a5c31";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "e96012fc71356a2a93a1890efa3ea7a8c0e0e16499fb3bc205d98e30a1e992a6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "09e0f09f473fdf9fd14efa47029e40e92212be6cc452769276b53fcb5643c8f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-action/default.nix
+++ b/distros/humble/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rcl-action";
-  version = "5.3.4-r3";
+  version = "5.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.4-3.tar.gz";
-    name = "5.3.4-3.tar.gz";
-    sha256 = "d6b53052c63fc97fba5b3f44a39e8822afdbfadd02ab5329a9d626ec6e7cfe18";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.5-1.tar.gz";
+    name = "5.3.5-1.tar.gz";
+    sha256 = "cc8ffc39984d2eb27c1afd47696a60394f41c23eb4781205d58b2d5c601b95a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-lifecycle/default.nix
+++ b/distros/humble/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl-lifecycle";
-  version = "5.3.4-r3";
+  version = "5.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.4-3.tar.gz";
-    name = "5.3.4-3.tar.gz";
-    sha256 = "6d8aaedb73a18d29f32f033d55c0d72998c70df8a8e508290ade3f984481b46c";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.5-1.tar.gz";
+    name = "5.3.5-1.tar.gz";
+    sha256 = "bccb5a57f7626c842ebfd958e485759bc1183871da75e3469f59ff1895604908";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl-yaml-param-parser/default.nix
+++ b/distros/humble/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-humble-rcl-yaml-param-parser";
-  version = "5.3.4-r3";
+  version = "5.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.4-3.tar.gz";
-    name = "5.3.4-3.tar.gz";
-    sha256 = "31d0e6710df41a1093dba1043003a59f547862be9670510b9185ec07340e2f80";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.5-1.tar.gz";
+    name = "5.3.5-1.tar.gz";
+    sha256 = "c9b40d3fd8e3cdfe9d9f30e47f3eb75a91a0ad74844b921b5afa81e6fd5760d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcl/default.nix
+++ b/distros/humble/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl";
-  version = "5.3.4-r3";
+  version = "5.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.4-3.tar.gz";
-    name = "5.3.4-3.tar.gz";
-    sha256 = "47acbce528e095f32dce0243a81f353b9a584c4d9d665e7044cb1afde53240f5";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.5-1.tar.gz";
+    name = "5.3.5-1.tar.gz";
+    sha256 = "f14e9367c108440c6d6f0e20908de6d0838da3ea0c70c8c953d8ba36b0bcd14f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-action/default.nix
+++ b/distros/humble/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-action";
-  version = "16.0.5-r2";
+  version = "16.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.5-2.tar.gz";
-    name = "16.0.5-2.tar.gz";
-    sha256 = "566012792c3f9dc2b905a0f8dd2a37bbad6d12095fb19b9b986bf4e995fe04ef";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.6-1.tar.gz";
+    name = "16.0.6-1.tar.gz";
+    sha256 = "44972c65eef79e9fb1aff2bd33f5d762fc9c037682e6d5c489627da0c5baff70";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-components/default.nix
+++ b/distros/humble/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-components";
-  version = "16.0.5-r2";
+  version = "16.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.5-2.tar.gz";
-    name = "16.0.5-2.tar.gz";
-    sha256 = "390f0062449155255c14cb3a65b3511fe97b7f516087c0ecee621e03fe31b6ff";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.6-1.tar.gz";
+    name = "16.0.6-1.tar.gz";
+    sha256 = "b2772d9c0307102525e2b4769a8619b364746c676c4d7afecc40d8bc1563d1f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-lifecycle/default.nix
+++ b/distros/humble/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-lifecycle";
-  version = "16.0.5-r2";
+  version = "16.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.5-2.tar.gz";
-    name = "16.0.5-2.tar.gz";
-    sha256 = "fd26251bb7da261ee261af923b89a174f67707e9af7b24f9384f7b6d4a412380";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.6-1.tar.gz";
+    name = "16.0.6-1.tar.gz";
+    sha256 = "676173d02021ccb493589fb174e147ae031fbdb95b2990d1456f282fac75f32e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp/default.nix
+++ b/distros/humble/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rclcpp";
-  version = "16.0.5-r2";
+  version = "16.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.5-2.tar.gz";
-    name = "16.0.5-2.tar.gz";
-    sha256 = "5bb6025168de2a00ba10614fb6d60453e38f09784d98e3b080372cb161888ded";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.6-1.tar.gz";
+    name = "16.0.6-1.tar.gz";
+    sha256 = "d9140a5026b0d4142704347c296855222d8b978b120c380853d6d408f9899bd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclpy/default.nix
+++ b/distros/humble/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclpy";
-  version = "3.3.9-r1";
+  version = "3.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.9-1.tar.gz";
-    name = "3.3.9-1.tar.gz";
-    sha256 = "80ee364a00aeccab49a57d8d7d4c671852430249478532615b7d21c65b1bd8f0";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.10-1.tar.gz";
+    name = "3.3.10-1.tar.gz";
+    sha256 = "9d55579632c23d98cc4aab9fef3b8199be6535bee98e96a918a70f29efdc1b25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/reach-ros/default.nix
+++ b/distros/humble/reach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, interactive-markers, joint-state-publisher, moveit-core, moveit-msgs, moveit-ros-planning-interface, reach, robot-state-publisher, sensor-msgs, tf2-eigen, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-reach-ros";
-  version = "1.3.2-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/reach_ros2-release/archive/release/humble/reach_ros/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "4213994e610a04a51997ba083bc307867bd0f1fb0fe000ebd4e382e796a57ed5";
+    url = "https://github.com/ros2-gbp/reach_ros2-release/archive/release/humble/reach_ros/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "0857ca1e6224ffa71d8d7a68385c9c346f7c96d835d11c76334b4115e1e682a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-cpp";
-  version = "6.2.3-r1";
+  version = "6.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.3-1.tar.gz";
-    name = "6.2.3-1.tar.gz";
-    sha256 = "3c5211690474965643ccacb4cbd3a346acb5343bf5ef1850a97bfbe531c8490c";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.4-1.tar.gz";
+    name = "6.2.4-1.tar.gz";
+    sha256 = "ac34ee18959f9dea85fb920c50af3e840b05c1e6bee78e24ce2152cc09797942";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-dynamic-cpp";
-  version = "6.2.3-r1";
+  version = "6.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.3-1.tar.gz";
-    name = "6.2.3-1.tar.gz";
-    sha256 = "285146bd149cb7cd235976cd9cad9b917af3d4f6e4e4f5b2bfc7a61c5311f05d";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.4-1.tar.gz";
+    name = "6.2.4-1.tar.gz";
+    sha256 = "ff1ee2a085cab4d695d6ca0a8259340f4c09bc12c471e7d7f82510867f2cd8b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-shared-cpp";
-  version = "6.2.3-r1";
+  version = "6.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.3-1.tar.gz";
-    name = "6.2.3-1.tar.gz";
-    sha256 = "6f4eba36e0b3c202f6271f8850f6bd12ba0dd0b2d4cb503df8bdc2de5c76bb11";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.4-1.tar.gz";
+    name = "6.2.4-1.tar.gz";
+    sha256 = "a203f57a2fccc203d0433bf728febbf005f9a1a323a00c41a7b3d1b63b4cff84";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robotraconteur/default.nix
+++ b/distros/humble/robotraconteur/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, swig, zlib }:
+{ lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-humble-robotraconteur";
-  version = "0.16.0-r4";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/0.16.0-4.tar.gz";
-    name = "0.16.0-4.tar.gz";
-    sha256 = "588df38a171f3cefd97f2ab935b6d80c1a6310c506946d23d6a58b5e9c38937d";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "38056a0041df92701b6a291b84ccd743e9310e53b573902d91ae7015feb7abba";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake swig ];
+  buildInputs = [ cmake ];
   checkInputs = [ gtest ];
   propagatedBuildInputs = [ bluez boost dbus libusb1 openssl python3 python3Packages.numpy python3Packages.setuptools zlib ];
-  nativeBuildInputs = [ cmake swig ];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
-    description = ''Robot Raconteur ROS Package'';
+    description = ''The robotraconteur package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "e6edc2db08ce6d7f6a573de699f23886cd2e56ff84a73d8f18458105c6f17d75";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "e631ac640b99c24bc80fbecac15969e3c837de3a48da55726ea596dfed6b8eb9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "9623d065161bcace655ae561a78db243a1bf66add3b921ee00c7880b42da40aa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "48b20b62bbf662082fa52d0a8d3c4f80620fa28c85642f1f585e7d04101236d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2bag/default.nix
+++ b/distros/humble/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py }:
 buildRosPackage {
   pname = "ros-humble-ros2bag";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "a58d23bd941411f5a9189f43506de8dd13617628f362b425065740ccb6b4e207";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "09fcacd59c1a7e04ca9f004ee0c718a76a8c8e2c3c9fc7d9a45485d002e3fe7d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2launch/default.nix
+++ b/distros/humble/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2launch";
-  version = "0.19.5-r2";
+  version = "0.19.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.5-2.tar.gz";
-    name = "0.19.5-2.tar.gz";
-    sha256 = "07a3e8b7553fd404f1b5025d49f5e67f3a74825d64d31b8f56adcaf9b1b7576d";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.6-1.tar.gz";
+    name = "0.19.6-1.tar.gz";
+    sha256 = "6aa77570a1993e08a1d31d63f416c55cd4e35b35288aedd846f67f6b15e8fc1b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosbag2-compression-zstd/default.nix
+++ b/distros/humble/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression-zstd";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "aac77eea7a2a2b760481ef177cfba01f65ca4a74f6dc517f8bd88f68add1d1b4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "e5bf70da178d21759640455c4677615efb63670b11fb033082be75cf04264581";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-compression/default.nix
+++ b/distros/humble/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "0a28ac98b319647211126cacac2705048228d68cec2e2a09d1c48ca8f363c89d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "24b74ea15e9ea36efa5446ed80c1f5f1cc252931692860d26c2b3c0a45986493";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-cpp/default.nix
+++ b/distros/humble/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-cpp";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "d7a84b9029069d079aeba5814a753d7ab27e148cb31455df2f59d652a62b6322";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "5c4f82b7eb91f1c657d09fcb6669ab480f470d78cd73dc0ceb4feced4b76ecb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-interfaces/default.nix
+++ b/distros/humble/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-interfaces";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "e8f79831babd0bfd82f236c99284ff3583cee92fb5a2879ec463b79ec64fe350";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "f7c449849bcff3cd3fa1459a60e4759ebfa88fb4db375c2e903188906397c4c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-performance-benchmarking/default.nix
+++ b/distros/humble/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rmw, rosbag2-compression, rosbag2-cpp, rosbag2-storage, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-performance-benchmarking";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "06d5f05c07ae5f8d44c2f103fdb70aa0b2c9af53d02716745b9ec35d70f7263f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "9a96105ffa511bb402df421c0d147956f75465ee91af654f08d47a9743f3bd97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-py/default.nix
+++ b/distros/humble/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-py";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "cfab04c1ccdf2b47c96bf0d97e5331da23cd8725174fde43958ed6a2cf8d81b5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "8cf26a587044e414731555a9f38fb192917ae85ea3938fab3a92771c9983ce24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-default-plugins/default.nix
+++ b/distros/humble/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-default-plugins";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "c983f95374a1b388d387fa298d0f616d6082c969ac9e8ab3d846b004d5c3dd4d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "ab667169fcf15d91a075d0adafe9c35a5a26378d613f0b5bad18ccd866581540";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap-testdata/default.nix
+++ b/distros/humble/rosbag2-storage-mcap-testdata/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap-testdata";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "1926e751206a63693ef29351b6c58744b9d32598b7be0684399b5efc165c2a7c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "3505919bce97771f1194563bc7f205d1fe4751a9a55a5f446c8a902fc15ae4c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-storage-mcap-testdata, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "87d6e1809672a4a2bb86119954419e32132318cb316e772eedba177b4c92fd97";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "0104415da88f7ddca607ee50fd19e118146dbb6a88fdaa63efa6b27b20450b4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage/default.nix
+++ b/distros/humble/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "d994c244cb846f891b98b146d5c1ae4534eb305810a15f9063574dfd5a179991";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "375f9b64bb2de7cdefc3ce6e4488838ebb598500d73f6793a917527ad03b9889";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-test-common/default.nix
+++ b/distros/humble/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-test-common";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "c44cc6a55c2befe9d3767d4a261232cb00439c6fbf936320913cbda0dd3567c3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "eeeede5affe8ac3ed60fffa83cb1effac7d0198d480a41ebe52f2163bcc5d4e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-tests/default.nix
+++ b/distros/humble/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-tests";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "4487d2ac144c3c5e012a131bc2211a3f31ba5c7d3d39fa3636e1aafffd70ff17";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "7a5bbca01be9b8f38624f593d5e5f7d72b2bd2505e6a44d14e1c060c2cc8b625";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-transport/default.nix
+++ b/distros/humble/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-transport";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "bd6ad77377b86891a06547b6c98f808976e3c4670d42f8d0bc517b59c525c02d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "e8fb98897e8f3c5e34b10c582b963fe5ffce8e5d0ea6f013e8cf78c1e5b62df4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2/default.nix
+++ b/distros/humble/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "a83befcc262570de3c4d58878a2270a743101267a2aa205d4f6446d9b2fb02f3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "6c135117394339fd4f1e306f80ef3fc8d8c4f9dfd7c6c7d9e8e943a82bf8490d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "99632a14354c4a83ab876b7b81af2aea4c3a4df25cf67f8ecaecb06ba47d274f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "6295081b93330d33e8e9c7d76a4709c9f514d8ec140748d7490f18a6416dd5d9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "ad63d8d977ae5e3f02baf586cea9cb6547430cfa3ed7410be1cdf136ed456b80";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "80e6f190ef779a6e330c5cbd3e5d67994e971b8068065f4b03581bb633df5449";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "c6e0d36ebf10882ae9c61b39807f3b7ba815d884abaa13eb8ee8e12574fc9e8b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "ae8154d0a1194c2f6e2a7c6047906234e3493c0ed423ec6ecdf3b31278c24bcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "85a30a20bcbdfd3ada32f132c18a43ce738a725a7ca5557d3e982f7b6d0e5e1f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "8aa9e3b8ad86c4e7ae0e26a72d49ce7044dbae56f168c74544e3e070b3fd6180";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "2593ef85dc2d47577345246ea77449257d20480774ff34bef4f5e7ed67778954";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "b04cddf6e503116011e18d99c53026b39b560ed385545dc776dd3f32d4ead4ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "11e0125bb6650dcbadd37ba486fda4a0c4e8037beb2491d44e4e13ea29058ccd";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "5c77cf8ce3b03b52b18fe408e581d360cfca560f85b770d4f629064235ad5b26";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "36ecbca42b0a23e23fa2c6785f6efef94336caaabfcd6ca36c4b10eea1e182fa";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "89a3090e094b26312a277688e8f76dc4405a620a40b813eef2624aff5d2c0d2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "98ca7deb3d1f605627335e93eedfbc86eff62b657026967e02852fa33238db30";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "18e7a44770e20ad3462fb9a1318afbfdb645558dc6f4d969471b65dd2fdc3ab4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.7-r1";
+  version = "11.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.7-1.tar.gz";
-    name = "11.2.7-1.tar.gz";
-    sha256 = "e46a66cce6cb2606a09d10644db99a4ab44a64023e48086df471aa9d7bbc53c9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.8-1.tar.gz";
+    name = "11.2.8-1.tar.gz";
+    sha256 = "4e62ab6b62162269fbebe8986af3a48fdd7438b1211230fbf29cf3e08584aba3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/shared-queues-vendor/default.nix
+++ b/distros/humble/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-shared-queues-vendor";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "b785b8ebd6d647d4d1d1aad41b73465ac3f7ca06e4a5c58511d87672a1e1fe78";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "d782ae9a139969e976867e1bd26c3becb7e03dad320c507e337ed0f0b6b831f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/simple-actions/default.nix
+++ b/distros/humble/simple-actions/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
+{ lib, buildRosPackage, fetchurl, action-msgs, action-tutorials-interfaces, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
 buildRosPackage {
   pname = "ros-humble-simple-actions";
-  version = "0.2.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_actions-release/archive/release/humble/simple_actions/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "7a075999fc87656abfef34749cb8ae4ef09a0d8b1f3f87978132f49c40a6f610";
+    url = "https://github.com/ros2-gbp/simple_actions-release/archive/release/humble/simple_actions/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "4b6c4c9a0988cbca7a445a9092fff6f4aca5f6c01a6a7282fa54ba801eee634b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
+  checkInputs = [ action-tutorials-interfaces ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
   propagatedBuildInputs = [ action-msgs rclcpp rclcpp-action rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/sqlite3-vendor/default.nix
+++ b/distros/humble/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-humble-sqlite3-vendor";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "fe1673a778e780a0aa2150fbfc8e4303133c353ee4f123c45229f08e78eb8b50";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "a2ea1652e2d85fffb461cb8aa22764487ec9a0c0fc2e916c2c2c27f9036cc6fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "a1dcd92a525ba7f728a403e67abef3be9bca98b1038e6c5795ce1eba92b5c774";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "b0e90babb2432cde66fa80051d5c65d8f05f313251cd180ccc1fdba349ad554f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-bullet/default.nix
+++ b/distros/humble/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-bullet";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "33de12fb4fca9b590ba9d25fd524809738ad9309c2a75bf06524ad7d34ab189f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "2b32c8a59f2eb11c6e038db1c719f0fe5584c20f933345f91eae440b880478f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen-kdl/default.nix
+++ b/distros/humble/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen-kdl";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "3dc7c9eee33fd374d9b4c127474d921afdca91e37ee2f2eb39181aa383d4c3d0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "da6f9b4a12d0a77df8e336f778e8cdb8ab087a9684288795763d25811b410198";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen/default.nix
+++ b/distros/humble/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "c2369dad6a56c9aed13d17ab7ee98cbbdf0f8db642c495a8c562888b3cb932f1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "93c0c6f9e773b4ed6b493b85ff8ddd236ed130ce69fd3efe436049e613172659";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-geometry-msgs/default.nix
+++ b/distros/humble/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-geometry-msgs";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "75117b2e399dbb3cec71c473ce71c92e8965606febeab57f403653d2432ea999";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "017fddc242d8c06d5c132bb64f6b560528fb80a786a52d7d4b103e03aadc8ab5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-kdl/default.nix
+++ b/distros/humble/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-kdl";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "bf39369dd0ea777e96219d06677f55965f78eab39a7e161b3d3359226a29b55e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "a7ef93be3705b6e3164d8a5227bb0add8db9681b35c3eb2f6d329bcd7e537273";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-msgs/default.nix
+++ b/distros/humble/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-tf2-msgs";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "89b2afc95e32990bd6f4c6760b5642a4c17454dcec2d62f08de440cc18e543c5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "c0a8a017678b0945248a5d73c616e7d6f8c8c87ba49454a6e25cf0f3fdad8f21";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-py/default.nix
+++ b/distros/humble/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-py";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "d8a718bf8b3bb747540b8d2345bd9ac922c21651926859f63459869b030be594";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "9d38e9ab67270af639b063c92c72e3e7a8191c7e5b4c3a7e6b2f1608e1808b66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-ros-py/default.nix
+++ b/distros/humble/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros-py";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "bab526a49b49ae68f410e04aa0b1b40d4d661b6741f0dc33d8b913d5f216067c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "9016e18eb5ef30b9e62dbede0763e4546c2cf349c157c6560814bb4b8e6fe3ca";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-ros/default.nix
+++ b/distros/humble/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "ee740d60576248000bea64a21e237e56cb329473e74b197af1a9f3aa4037c895";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "d19cbc6305af09461f18fd689845208886f8921dafb9d95a60766482ff8a1c8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-sensor-msgs/default.nix
+++ b/distros/humble/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-sensor-msgs";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "d1412d97b07dfd95d566b7ffd814975ed8aa4d4d2470a3b3f1317a260078627f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "0dd8cfe469dd42142f9e5031df063ebdcbadbd83fcebdf29b3f2ac6d8173ce2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-tools/default.nix
+++ b/distros/humble/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-tools";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "0f94a9b3115fb2c18ac351c08b7c2058ca40dc8c443550eb81efebf5981d8c54";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "ac4e92b08ed2b26e73c8a3512028de8b46e5e267dc7595bb4b25f7edad0c5814";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2/default.nix
+++ b/distros/humble/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-tf2";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "a97490b440b12cc8681b79ba03d5db8063e129994505e038b93d64128c94cccd";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "ca89991022982a6e74658a938b79817bd20ea9e5ffa0acd4c8a75d3ef8709ca8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "7f1ffed8a1728ebfcf864681b1fb4a3940c725e528396d7d5e891eaf290a788c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "c6b47c80116481fde88c285e6adab5baa05de2946f2eb69d205c343e9b065555";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "89bb8f91cfec74690a34b78a6970e133761a7fd79f4a484b976714786f5f0396";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "a5364b50c6f5e872517c6c590c8f9c81e9934ec38444884c28f497fccc4dc030";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/twist-mux/default.nix
+++ b/distros/humble/twist-mux/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-twist-mux";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/humble/twist_mux/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "c1b49bb229fb409e6c698f2fa29ce5dda9fc5234e8a8b31461270948f058465f";
+    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/humble/twist_mux/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "aadd3971ff9120bdc519259c805dec73a2ea4c5a4b4d2fa584a839b1ef127dd1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
-  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs twist-mux-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.24.0-r1";
+  version = "2.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.24.0-1.tar.gz";
-    name = "2.24.0-1.tar.gz";
-    sha256 = "7c187d53ff225a9aad0b4dc96c2b9335c46f3fea22380731d952ce85ae82e9a6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.25.0-1.tar.gz";
+    name = "2.25.0-1.tar.gz";
+    sha256 = "4505bc8a1f9b4b76c26e5b280f6a2d99e71bac02cb473640f85bf80ac6037bf0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zlib-point-cloud-transport/default.nix
+++ b/distros/humble/zlib-point-cloud-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
+buildRosPackage {
+  pname = "ros-humble-zlib-point-cloud-transport";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zlib_point_cloud_transport/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "bd210adca5b27c283018e43e4ca3cb6e57b7085f4343357fec4d1cf9f428e104";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib point-cloud-interfaces point-cloud-transport rclcpp zlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''zlib_point_cloud_transport provides a plugin to point_cloud_transport for sending point clouds
+    encoded with zlib'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/zstd-point-cloud-transport/default.nix
+++ b/distros/humble/zstd-point-cloud-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
+buildRosPackage {
+  pname = "ros-humble-zstd-point-cloud-transport";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zstd_point_cloud_transport/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b012aece778044a901d0b7c4bc6fbffa5aa41ce6d76977def04de0aabb2f88de";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib point-cloud-interfaces point-cloud-transport rclcpp zstd ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''zstd_point_cloud_transport provides a plugin to point_cloud_transport for sending point clouds
+    encoded with lib'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/zstd-vendor/default.nix
+++ b/distros/humble/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-vendor";
-  version = "0.15.7-r1";
+  version = "0.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.7-1.tar.gz";
-    name = "0.15.7-1.tar.gz";
-    sha256 = "798c2fd991241547e2374ac1a48eace5cfe4d35527c073cd3eb1f46bda398902";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.8-1.tar.gz";
+    name = "0.15.8-1.tar.gz";
+    sha256 = "98db6dad3a3de0f843644785167f3afd78660fc270461da07671a8991f599ce4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "862ea1222318e671f85d19a92b7fd9e711352cc60c015167184ecaa1d79e55ad";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "f792e466a75cd44fa589d4c4430ede193dafde032eb92c819fabf81e25df55e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "7671269d635a553ca7957c144e128e5f73644cba7b1fdda34c993c6f77b59c27";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "710114b43aee0fa4e2437315ab7a4aa30e936739955cdc18851d9e74bab5ff65";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "a86a6c5889031cf6ecf74bffb4e8c2fbfcf6dcce674576b12cbf5b54757f76ae";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "2cb4b1cf978309b6332740ed9792f06a1723f31d515febeb6b8dc620fe6bd458";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-bridge/default.nix
+++ b/distros/iron/depthai-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2-ros, vision-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-bridge";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "b859f6b0a1da005e3e3ec43c6d9c6c4929d575606b46cfc3644bd72a25722833";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "3da6da84d0a56963b1425e6ea3bae1b61ee43acc2087568f006cb15c68098780";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ boost camera-info-manager cv-bridge depthai depthai-ros-msgs image-transport opencv rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs tf2-ros vision-msgs xacro ];
+  propagatedBuildInputs = [ boost camera-info-manager composition-interfaces cv-bridge depthai depthai-ros-msgs image-transport opencv rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros vision-msgs xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/depthai-descriptions/default.nix
+++ b/distros/iron/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-descriptions";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "88df473aa7ab1ce097ff5a02a4dba03c660493dbe86a3aa257b3b36f328e9ef3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "e66b1b47967e5cd3b3435f15290b177223156f8cab6de0b5dbc23e6d49a47a31";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-examples/default.nix
+++ b/distros/iron/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-examples";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "52a44bfd929b92976910f1928400852484eec23d36e50eae850c801abd07f222";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "5b979fe132314a63841ee8b1cc21e7a7266bc824c576cb498b0d7b0cb5e04b2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-filters/default.nix
+++ b/distros/iron/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-filters";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "81c833e22b10f0487664c85531b8bc8a5b8932d7057c1dda4cb907ffa5abc86b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "0c0d623d36cbe328a3ae545ff70cf08fe4bc7b54b32ee9f572be94df5611c834";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-driver/default.nix
+++ b/distros/iron/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-driver";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "89fef21a334eaa5c30059119a5b93dc2bf440001992b02d24171e676053f5ef3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "afc600756b7b5077ffe7d0f3413e27713243460e6b1d895fdef00b95765aaeea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-msgs/default.nix
+++ b/distros/iron/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-msgs";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "cbf675882cbbf884581ee32641a1a1d2773531fe12a7bdc9b77d5a85a51dba17";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "96cfde7fa509b424f68fafe04d103af1588dcb57e1b9bc03ae5dc0728f06ddde";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros/default.nix
+++ b/distros/iron/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "ce5366559fd73cbced8121220f0b9577e69fb4bcab1e9835290522b7d50b41bf";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "c9390491f0566db7e85791d198f90e8c72cdc1da2362663cd0cffeb1bebce8df";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "552ac274873d705995ce2256b693b78f9e26ad11ee10ae2514dbdbefe87f5a13";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "ded85323b6cbcdced74a2ed1352403910f81e8c4224512bb94b8c9719e2a658c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "b76e7aa1da089578d1d6fa2c732de1202ff3aa040a8c72e5dfcf4addcef193ef";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "f705cd0805bbf9ffa8a29953149393d718ef0bcc99e8ff90ea87f6f740d3f907";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "1d016ecf17482c2896ceca5183944fc8348f884fe9476d80300617ed307bf61f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "0818790eac730f825beee7c3d811d1c51769c5570a0dbedc15e0e40b0e9d43b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "ab2038610dc55434773a8fceac73c3999574a7680cd1034f234ff471e1a5acb9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "1aa65cb78a5a90273b2e9f647111ed6ac30eb953e4c96afaf058010cc8f41c1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -1272,7 +1272,15 @@ self: super: {
 
  pluginlib = self.callPackage ./pluginlib {};
 
+ point-cloud-interfaces = self.callPackage ./point-cloud-interfaces {};
+
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
+
+ point-cloud-transport = self.callPackage ./point-cloud-transport {};
+
+ point-cloud-transport-plugins = self.callPackage ./point-cloud-transport-plugins {};
+
+ point-cloud-transport-py = self.callPackage ./point-cloud-transport-py {};
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
@@ -1541,6 +1549,8 @@ self: super: {
  robotiq-controllers = self.callPackage ./robotiq-controllers {};
 
  robotiq-description = self.callPackage ./robotiq-description {};
+
+ robotraconteur = self.callPackage ./robotraconteur {};
 
  ros2-control = self.callPackage ./ros2-control {};
 
@@ -2280,7 +2290,11 @@ self: super: {
 
  zenoh-bridge-dds = self.callPackage ./zenoh-bridge-dds {};
 
+ zlib-point-cloud-transport = self.callPackage ./zlib-point-cloud-transport {};
+
  zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
+
+ zstd-point-cloud-transport = self.callPackage ./zstd-point-cloud-transport {};
 
  zstd-vendor = self.callPackage ./zstd-vendor {};
 

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "c357ebd2622055b420c81bf39c6cc098848c1c4680a53802233f35ae9430ec56";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "e5ec1acbd86a6de3717f7a188318a1d918d8bd05ae3cd80472520aa7d6a99f1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "fb2d90f5d8dc27dd3009fe6806802c944af8bf5c5154ec2411996d81584aa513";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "db78606a26c707361c5800f1225ac8147454481ede3343f125ac400281ad68bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "197af1c5655ceb58c3ec35eab437041f690376760ab227f0b5924d9146db0e1d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "74dda8044bfbc0bd057b978e45cbee3222abac0f40d9f114e0410aedc7e8e2e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "35ff6e330e4218abd04dd663d1f9439e10e758f205f97797464269185f34a86c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "eb225d189aa786c865d30308da122b82fc2b448ba447935d879d956b05323d42";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mqtt-client-interfaces/default.nix
+++ b/distros/iron/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mqtt-client-interfaces";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "3de58da4fefce744246f7614d79f944cd98db37775c2993f96a424dbe607b0b6";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "dee2efa5f9fac0dbae92fa4d18290f717aa86c48e9fb625a3b7a3df0fa298f60";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mqtt-client/default.nix
+++ b/distros/iron/mqtt-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rcpputils, ros-environment, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mqtt-client";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "572ed4627fe043992097f9c0c9a7b322609dc3198828cb1921be27334a8d8dda";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "0e1e99f900c57944b7a49661873ce7175b84d8872ac6975898f0c736a369b69c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ mqtt-client-interfaces paho-mqtt-c paho-mqtt-cpp rclcpp rcpputils ros-environment std-msgs ];
+  propagatedBuildInputs = [ fmt mqtt-client-interfaces paho-mqtt-c paho-mqtt-cpp rclcpp rclcpp-components rcpputils ros-environment std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/point-cloud-interfaces/default.nix
+++ b/distros/iron/point-cloud-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-point-cloud-interfaces";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_interfaces/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "bc7d45b4862ae3156a3048bb7b072fd92a3ed90b9c594fc149fabcfdab47ebdf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''msg definitions for use with point_cloud_transport plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/point-cloud-transport-plugins/default.nix
+++ b/distros/iron/point-cloud-transport-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
+buildRosPackage {
+  pname = "ros-iron-point-cloud-transport-plugins";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_transport_plugins/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "d75a26cd79ddf79217b6c19f7b5422b94adfe9880386c14eb6d563ac0ff62cb6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ draco-point-cloud-transport point-cloud-interfaces zlib-point-cloud-transport zstd-point-cloud-transport ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage with common point_cloud_transport plugins'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/point-cloud-transport-py/default.nix
+++ b/distros/iron/point-cloud-transport-py/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-iron-point-cloud-transport-py";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "8bf6463db538f30a26c90069f09b05b3e93a875845c24a1ede917c41691841aa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  propagatedBuildInputs = [ pluginlib point-cloud-transport pybind11-vendor rclcpp rpyutils sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+
+  meta = {
+    description = ''Python API for point_cloud_transport'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/point-cloud-transport/default.nix
+++ b/distros/iron/point-cloud-transport/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
+buildRosPackage {
+  pname = "ros-iron-point-cloud-transport";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f2c2a78ea9b071e5e8fe151d9ea7784779000987c2e494fb9b48dbf6f1d22be5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
+  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tl-expected ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/pose-cov-ops/default.nix
+++ b/distros/iron/pose-cov-ops/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-iron-pose-cov-ops";
-  version = "0.3.10-r2";
+  version = "0.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/iron/pose_cov_ops/0.3.10-2.tar.gz";
-    name = "0.3.10-2.tar.gz";
-    sha256 = "84487b193317bf00daa10bd7b02a68b0ecea379f1a5ce0a578917661fe1ab364";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/iron/pose_cov_ops/0.3.11-1.tar.gz";
+    name = "0.3.11-1.tar.gz";
+    sha256 = "5c6a3d61bc65c0a03ed579f51014ef075fe3f07596d1f67366e0aa726c08e979";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "01eb84ccc967e7ddc6d478540d352b95a4917c622e31c1d97feaf0c6df89a929";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "d273251402b8a06298fd4b3b4b249cb8eca55cd947066fc046525c3230c7d463";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/range-sensor-broadcaster/default.nix
+++ b/distros/iron/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-range-sensor-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "042169dff77c7c1a27360e83b5e533120955cd1aec54dbfe06828ac5d932a898";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "8f6a22e908014ac38dca943c0fe85026e0c697192836d7ffd2f5225331157c22";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-fleet-adapter-python/default.nix
+++ b/distros/iron/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-iron-rmf-fleet-adapter-python";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter_python/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "e09f1080cb101efd5275a046d8fbeef673b44abd54676c8a17578dcc9e190a8c";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter_python/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ff474562168bc0dc1cd2856e305407a80415b766441c88216152f99781ea20f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-fleet-adapter/default.nix
+++ b/distros/iron/rmf-fleet-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-fleet-adapter";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "73765f4395bdb850972a4c69ad2942d36bce5af7a731ba8b02849b6765115c9e";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "13adefe1aa47d846d7287d139d349f39fe0efcc2bc9532cd6e6162c082b47997";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-task-ros2/default.nix
+++ b/distros/iron/rmf-task-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-iron-rmf-task-ros2";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_task_ros2/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "ed768edb8ef846d9a47de5c3a02f5b1fdef178cce38808de73f18df969689360";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_task_ros2/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "c8244b918257df621870d326c2dd706f4f8c317e6119a46d3456003da30b73d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-traffic-ros2/default.nix
+++ b/distros/iron/rmf-traffic-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-ros2";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_traffic_ros2/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "8a5608df41cfa1df1899f4d0abdfb256c48bf091c3ebbefa96b080a5728b694b";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_traffic_ros2/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "c0f365a2b0b540526bd2accbb397ed2e01faed94707103d0b7ed46256e88228a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-websocket/default.nix
+++ b/distros/iron/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-websocket";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_websocket/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "c4becd4cef5a0b9b742ba600ed316c1c7bdb4a4daff76a9cc3ab87f3793c95ca";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_websocket/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "ec30cab1f2871d77cf406490cee14c9c3e31f76b5ac38ac9560f0fca8996c3d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robotraconteur/default.nix
+++ b/distros/iron/robotraconteur/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
+buildRosPackage {
+  pname = "ros-iron-robotraconteur";
+  version = "0.18.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/iron/robotraconteur/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "ba4e2aacc13be461f75a8b85fe3dae0cb372931a29f2a9bf3346a1ea998aa3a5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ bluez boost dbus libusb1 openssl python3 python3Packages.numpy python3Packages.setuptools zlib ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The robotraconteur package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "849f66f57f2374df0c609a4ed983983c70ab0f9c95854099b020fcabc080b536";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "a56e08d1e91c56fa13a4267b45672b916c7d217079fcf271e4933c3f703d1a24";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "2231c2faab2be690980e7a4d9c281a407a64a182c1f18554b3423c4a89274b09";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "27cfd93e6eb3264b9dbbb07a984b06ee6653c075ea59e4a4e7d70231f71f2ce7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "6a9126722f1bcc7af124946a8fb32054605e63804478d3c2cf56b137cfc71b32";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "e468c16dbeefc56ee0e1490400ebd1d9003321b3e7d16006c83bb028f9d916e5";
   };
 
   buildType = "ament_python";

--- a/distros/iron/simple-actions/default.nix
+++ b/distros/iron/simple-actions/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
+{ lib, buildRosPackage, fetchurl, action-msgs, action-tutorials-interfaces, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
 buildRosPackage {
   pname = "ros-iron-simple-actions";
-  version = "0.2.2-r2";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_actions-release/archive/release/iron/simple_actions/0.2.2-2.tar.gz";
-    name = "0.2.2-2.tar.gz";
-    sha256 = "165862ae30f399bd9a149cddeb37cfd27f7da9979f03ad9a3e1b1c65d0436a8e";
+    url = "https://github.com/ros2-gbp/simple_actions-release/archive/release/iron/simple_actions/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2333da1f1dcf4993a6713b8ae6032f2b791569e25e72b3a0962f9acf969cc273";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
+  checkInputs = [ action-tutorials-interfaces ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
   propagatedBuildInputs = [ action-msgs rclcpp rclcpp-action rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "b04c8592ee7c916f5f2242832fa7e48e019836433b56f8ef3ecda5396a080ecc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "a23eb4302014d44e57c5276086362ef9c07a7d075633f8537b4bd2e84b5cf0cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "97320077f4bcfc384d2a5e42a815718b75b5838ff4846ddc336c78c3b51c7380";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "299f2db4efb0794e3b7ecb5d921fe3666f411174c02723a39325180f870dea10";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "067851097012bb50cad0adb679e109a6adfa0d262aab998b549312b2d07adc03";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "0a0c20fe26251e2fab5e3220f6990a8b50489617bfe013fc6cefab806c2228a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/twist-mux/default.nix
+++ b/distros/iron/twist-mux/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-twist-mux";
-  version = "4.1.0-r4";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/iron/twist_mux/4.1.0-4.tar.gz";
-    name = "4.1.0-4.tar.gz";
-    sha256 = "92312c1bae5440520562cd319e797be6c9f947409ce2dfd5c571ddea992456a2";
+    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/iron/twist_mux/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "f9d2b5c2865e4076fa8e3145fef5922911d7eab1b63891f3a6e69946a834d149";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
-  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs twist-mux-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/ur-calibration/default.nix
+++ b/distros/iron/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-ur-calibration";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "3165da1b852207f1428276f7dcee5506b371c3e14e1571a132afc763477132ee";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "7b8b5d44a5a5f580a54e02d4ec9dcc52117c3ba782cba44a4a2b4ad179c55aef";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-controllers/default.nix
+++ b/distros/iron/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-iron-ur-controllers";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "fcab5eea93a55693de438f2ca5c8de73cefbcde6adb5364ba23cd6903ffcf05a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "b4f05d7b296b32ccf7431128d6b66c5ac34f556f250f20cfef71aeeaa254a22c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-dashboard-msgs/default.nix
+++ b/distros/iron/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ur-dashboard-msgs";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "d7612b39ea3b90345fd55659dac25005ac36b60dd0911f9efb589aa323e93b69";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "95a407902a8b7bae6c8a11da32283f88ac04156617c83ae5b0395db118ffd33b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-moveit-config/default.nix
+++ b/distros/iron/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-iron-ur-moveit-config";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "1ab5d9e2f6cc44508e9b61f3bf9309152886d4fe9dec1e84d0587b1a4be8027d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "65d6677c6b19fe2acbf3110c93f61baa7c341a95ee70a9e1de26e82853aec3a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur/default.nix
+++ b/distros/iron/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-iron-ur";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "ddeb5b670923f8250305b63f7d19bd70fcbd0524c2e7e4bc97f2d8ad9fa3a7b2";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "f137a5d9b56f19541011db330f394550ea4446b63a8f330dc0519538affd0eb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "63f7935e6939155aaee7b54eab6afeae7a6d901e47295edb1ecc6fa6ba65e517";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "27b632484548883490d8addcd1731d03216c7863079956fcdf7ae7cd5b290511";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zlib-point-cloud-transport/default.nix
+++ b/distros/iron/zlib-point-cloud-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
+buildRosPackage {
+  pname = "ros-iron-zlib-point-cloud-transport";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zlib_point_cloud_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "17197218cac678a607c4129beb6d2f0b24a211a5929c041e51635ccdb1dfd7ed";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib point-cloud-interfaces point-cloud-transport rclcpp zlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''zlib_point_cloud_transport provides a plugin to point_cloud_transport for sending point clouds
+    encoded with zlib'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/zstd-point-cloud-transport/default.nix
+++ b/distros/iron/zstd-point-cloud-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
+buildRosPackage {
+  pname = "ros-iron-zstd-point-cloud-transport";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zstd_point_cloud_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "405fbf095e89e5954dbec1b2ee3adb403e616dd03d352e0f3cb1dd061a79e619";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib point-cloud-interfaces point-cloud-transport rclcpp zstd ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''zstd_point_cloud_transport provides a plugin to point_cloud_transport for sending point clouds
+    encoded with lib'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "7b4d530e17311416566a10daafc881d38734f335be4e1063ebf4f414396915a3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "932fc582103c2b88d2c31e04d45e972b3f9370c536732ab2121c0f27589f2318";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cpr-onav-description/default.nix
+++ b/distros/noetic/cpr-onav-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cpr-onav-description";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "a0939b184eb30709cc757d36b7f332e474a5e8092bb9885fac161b00e5b411ea";
+    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "a7d3900a84a18d3c86717525840eaacde06719699c553ded72b4e1ca014293da";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-can/default.nix
+++ b/distros/noetic/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-can";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "7ada7c56a985ff17631887059d277fa76134f3917937fd2f7758b89ac7edd797";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "5f33ca84c2c79c38208f02fa405fd2c7495ca0b45a34b0d75b215b8ccf8ab570";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-description/default.nix
+++ b/distros/noetic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-description";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "47b5160196cc4e2cb5c44ac7ad8bb9955008d1b06b74ee311eabecd146157daf";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "c7ae4d5faafac5bfb36fd0bbf93656db0e1fd2b20857ac21248eaef7d657389c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-joystick-demo/default.nix
+++ b/distros/noetic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-joystick-demo";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "4fe787498a1794d237365d13aeb5cf9c02ddae44aa7968704f82f0742d7279c6";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "524dcf21bf4cba913f774c2108e2260d71373881500d6c66ab041c6bc556d2c8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-msgs/default.nix
+++ b/distros/noetic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-msgs";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "28c05fd2d2621983975bdf7a4a8febc1e2cbdedcd2cbfce0417ce44c809ef515";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "13c731186f717f7d0798289e91cd4850049341e929fea9c13a4db1752e734a19";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca/default.nix
+++ b/distros/noetic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca";
-  version = "1.3.0-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "937e7500b7dd4c1d9fc1cdf5e810699cc6e53bf4f5aef6dbacbce8ee6a75a009";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "c5458ac390ee0d9bc4924f069958956c365fcce23ff4e9c7eb3704e3e4746b68";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-can/default.nix
+++ b/distros/noetic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-can";
-  version = "1.6.0-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "40e72e11a91c42f4118be832870e68198ad787d1fd04fe8e7aaf24cc086848b4";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "63d36d5a8c8892b922e5cc201e671e2502c9d60a16131ad95a47516c0bc77c9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-description/default.nix
+++ b/distros/noetic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-description";
-  version = "1.6.0-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "910acb3bcadbca9107c6b94bbfb1530078ffa012694061f6a69ecb2479342972";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "3550e7fb074685f55d693e25b746f07f37f707b43c54d5e464d912329b1f419d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/noetic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-joystick-demo";
-  version = "1.6.0-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "97ac3f61dff26b108262155a3b65a3329dbf1c792e64e836bfa065b7cf78cab5";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "611933f5a6dcf8d7afef3fbb6da89ec4bfa77821b63ea3ca7f23e44ca4b2c24b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-msgs/default.nix
+++ b/distros/noetic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "eccec84960b373eb380368373413d97fbbfa9ed94597d543e3901cf12351ed1f";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "d7dcb96c703c588c9f8575e283a2a08041955959d3de7762129c269283548568";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz/default.nix
+++ b/distros/noetic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz";
-  version = "1.6.0-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "d7c670c10032cde9de5179ebcfc445a54abf4a68568625c059660f77a16fad6b";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "60701b360d59265a38822f3adf4c7df5948bab9a3e8ed682981dcfaea6c812b1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-can/default.nix
+++ b/distros/noetic/dbw-polaris-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-can";
-  version = "1.1.0-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "061736379ea85c1884ea1b006bb2b2c0e902b8b67d9821fd44aeaaedd22c7a92";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "e9de945e3d0b21071b8dd763b7a5ddbd2c4bd2e4751d674b133a40f86d9cdf9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-description/default.nix
+++ b/distros/noetic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-description";
-  version = "1.1.0-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "341a41bd0252c37c6bd74a3e640499a9ca67e5dbbd03f572dec947bd564155b6";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c1b0b09df9efc830ddbf4b139a6bcb496d11e156e6cf20b8186f88487192064e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/noetic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-joystick-demo";
-  version = "1.1.0-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2dd9a9f970cd893988278d0be424ec92f468a3f7e830cee43be686dd092f2e97";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "641570f25836f6754a4f3d0d88b7a365e3fb7a31fdb0a1aa82362114de3afc97";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-msgs/default.nix
+++ b/distros/noetic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "b5648764cef4109d45d9adf4dc432beaa6170b372d596ec7d47dabed1eddf06f";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f5cdb5c1f1609fbd85c9d80e1670a1bdea351dd8d87552218820b88c04894656";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris/default.nix
+++ b/distros/noetic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris";
-  version = "1.1.0-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "970e83d8a82805769497a7094a49a500a8d28084c8b780be892620b395084aff";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "0404d2c65c202e92114a340e6573db501fe758c0337aa1ab3e128e52f7e4f64f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, resource-retriever, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "e3202aba29891530ad7e46c393fa2ee6f7cb444b8e6e5f5d33ef479d7b5013c9";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "23f61632c9b7b2842b6c9bc9e6c361d9c8ab5a0ff3503829c8a8069193f69ed0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1892,6 +1892,8 @@ self: super: {
 
  mk = self.callPackage ./mk {};
 
+ mlx90640-thermal-camera = self.callPackage ./mlx90640-thermal-camera {};
+
  mobile-robot-simulator = self.callPackage ./mobile-robot-simulator {};
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "d109488ce62c317d0611a8a7770dfb2dfe070064c0460322b81af2cb131de61b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "2cba0b4614744c7f28156ecd2b659269d580088ff5d3b06790203e6c98607d72";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "4bfb9dc306e2c65428a707cb6476c01b59ffd1926f2ecaecd902c5d0d4116cc6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "35b7c6a45cf458901cfaf308830376261a9bc828735a818f218ccdd95b0d6369";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mlx90640-thermal-camera/default.nix
+++ b/distros/noetic/mlx90640-thermal-camera/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-mlx90640-thermal-camera";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/vakshit/mlx90640_thermal_camera-release/archive/release/noetic/mlx90640_thermal_camera/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "63616ae4b6f16b35521e693d78974842efd54f8f1a887d7046489064d3d5ecec";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cv-bridge roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mlx90640_thermal_camera package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/mqtt-client-interfaces/default.nix
+++ b/distros/noetic/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mqtt-client-interfaces";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c356dd03af8a98b74597ad41d21d9b0d60836220c1eeba747dc925ba8210e61d";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client_interfaces/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "80c9b0430c76f135a292d909b39169260f06df6872f6d9ac09c43ba89e641cd9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mqtt-client/default.nix
+++ b/distros/noetic/mqtt-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mqtt-client-interfaces, nodelet, paho-mqtt-cpp, ros-environment, roscpp, std-msgs, topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, mqtt-client-interfaces, nodelet, paho-mqtt-cpp, ros-environment, roscpp, rosfmt, std-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mqtt-client";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "5adf70e99307666237469f599cda60a2f086f92dae8f0ef95354be448e888217";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b2032fc0f1e2d26f2094b6985b7aa58ec024631728bdf84d03a37d5a87920fc1";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ mqtt-client-interfaces nodelet paho-mqtt-cpp ros-environment roscpp std-msgs topic-tools ];
+  propagatedBuildInputs = [ mqtt-client-interfaces nodelet paho-mqtt-cpp ros-environment roscpp rosfmt std-msgs topic-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "7d7b6dc1ec5bfcddad7c054301807534c1b41dab5d829e43da04d05b0cc628a7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "cbc158c9401860bfaa9aafa9f6c94ddee04b005739227758aec1af91ddd3ba85";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "ff43b4ce6e09885ba16c7e0f0acbc735a7f536fd7be3905f401f51398a317627";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "c373547b36ebae3e0e1fce048b84544f3dde7ac9d71b9ca2b5154bc7daf082d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "b193d304dc44f0705babebf82f626bad89298aa0c8454a37dd771fcc5642493a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "1b0768c4ee26cf41b630b0610482452b191769d9ccfbf9cd093f8e7466573080";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "a88d53bba1682122505ed067d3fd04897fcf289466672867f7fb48de68db1e89";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "43aa82bae264c36263dc25af6597d3787e4c75cf743a55642049c1c52ce40bd5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "e71c02c6f5c825b7314defd90a5f9293feceae690b51a3c965c8d05bcce27ef4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "725e2c5e2143cb4cf36156562efbdad5013ef7b9d3862c35d8d14a366b71144c";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ map-server roslint rostest trajectory-tracker ];
-  propagatedBuildInputs = [ actionlib costmap-cspace costmap-cspace-msgs diagnostic-updater dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs neonavigation-common neonavigation-metrics-msgs planner-cspace-msgs roscpp sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs trajectory-tracker-msgs ];
+  propagatedBuildInputs = [ actionlib costmap-cspace costmap-cspace-msgs diagnostic-updater dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs neonavigation-common neonavigation-metrics-msgs planner-cspace-msgs roscpp sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs trajectory-tracker trajectory-tracker-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/pose-cov-ops/default.nix
+++ b/distros/noetic/pose-cov-ops/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, gtest, mrpt2, ros-environment, roscpp, rosunit, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-pose-cov-ops";
-  version = "0.3.10-r1";
+  version = "0.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.10-1.tar.gz";
-    name = "0.3.10-1.tar.gz";
-    sha256 = "03619eaac28b85c5ebf7e3dac56fd8c81637911ab31d1d108cda107e9f87d972";
+    url = "https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release/archive/release/noetic/pose_cov_ops/0.3.11-1.tar.gz";
+    name = "0.3.11-1.tar.gz";
+    sha256 = "fbb4fdeb3b6248f241770ffede71d04342567293fd4189f13c810c5c3154a64c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robotraconteur/default.nix
+++ b/distros/noetic/robotraconteur/default.nix
@@ -2,24 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bluez, boost, catkin, dbus, libusb1, openssl, python3, python3Packages, zlib }:
+{ lib, buildRosPackage, fetchurl, bluez, boost, catkin, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-noetic-robotraconteur";
-  version = "0.16.0-r2";
+  version = "0.18.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros-release/archive/release/noetic/robotraconteur/0.16.0-2.tar.gz";
-    name = "0.16.0-2.tar.gz";
-    sha256 = "b00b4e3e01787cad0d1263f45714043c7dcace192d4a51137ba416fba0f554ea";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros-release/archive/release/noetic/robotraconteur/0.18.0-2.tar.gz";
+    name = "0.18.0-2.tar.gz";
+    sha256 = "2c62cf4101258752094a69101186c757013eaf00c2b2f4bcc88591b8fa62077d";
   };
 
   buildType = "cmake";
-  buildInputs = [ catkin ];
-  propagatedBuildInputs = [ bluez boost dbus libusb1 openssl python3 python3Packages.numpy zlib ];
-  nativeBuildInputs = [ catkin ];
+  buildInputs = [ catkin cmake ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ bluez boost dbus libusb1 openssl python3 python3Packages.numpy python3Packages.setuptools zlib ];
+  nativeBuildInputs = [ catkin cmake ];
 
   meta = {
-    description = ''Robot Raconteur ROS Package'';
+    description = ''The robotraconteur package'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "4109b14ce04faa1c43ddeac35355da56cd96d6c2633f2101eba28dee2b202490";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "8b346c0d2333cb391aee666464b30e1b728afa257f64810e0582253b3843a1f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "8ef320c9b1bedaf6059ff338092a755087b427bbd25329a4532c770dcfc0ec8c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "490238bc0bbf1d4888d2461d92fcd0c8658fcbb10ff94f1dfa17e3be2a66c367";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.15.0-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "397fe84c1418836fa8775a7c213ead0a0cdac64817812c8537b56ca9ace642b0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "6e0d2ebe3302c4c1da7dcd3b2f5fc17fdf1195365b43778485fa2a7b8fda3c86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.0.16-r1";
+  version = "0.0.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.16-1.tar.gz";
-    name = "0.0.16-1.tar.gz";
-    sha256 = "4b8e81cd40f0f0c6f14b20eb42fadf547e1cc348e2578bd1b7b3c4d62f7bb1ea";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.17-1.tar.gz";
+    name = "0.0.17-1.tar.gz";
+    sha256 = "e5c49b35f3d72dc3dbd4bd171bad8f27c56689d29a221786a80f6857f8e37967";
   };
 
   buildType = "catkin";

--- a/distros/noetic/warthog-control/default.nix
+++ b/distros/noetic/warthog-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-warthog-control";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_control/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "21eec14d38d2ce664d280aab66761cc745f82ce11af6ff399bc54d954e319264";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_control/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "406224a6af7bfae1cb0a6b48626e46b8939e18285d5fcb18ee5acf15fe1fbfa6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/warthog-description/default.nix
+++ b/distros/noetic/warthog-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpr-onav-description, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-warthog-description";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_description/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "60b0703711572b756d04f57b0b729759b66c23d531c13c0bc9130e71b9711bd2";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_description/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "67647388b6324525a5ad1424907bd38f4ef17c27317b1a5b3755f19d6696d854";
   };
 
   buildType = "catkin";

--- a/distros/noetic/warthog-msgs/default.nix
+++ b/distros/noetic/warthog-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-warthog-msgs";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_msgs/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "05d9c5393c442a1c967c79766e87e4a9506ebdae16b2f5d6213175c757db2fb2";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/noetic/warthog_msgs/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "6e3300939f22481a59a39f0c0156c04757d6d5713551e6bdfaadb43d7f450f9e";
   };
 
   buildType = "catkin";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "831af96aba49114bb19dc7d71fb06c97ea9dfd2032866421818bc07981bb2d98";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "2488c10245e49911625f3bbf4b71d19202ca279834257b3c36c8fe3ffb7b3211";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "623c4e884a8120a7dfd10f228edd9433aaf95aa584e278d9b181ae6eb5d9a0a2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "c8daa6921851f2026edc2655b47242ad8bf365a64293f62818ba41524ba03c93";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "ab056a23a1a387eade0dfc63097247fbdf01a9866f12b4edee3020bd1d134da4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "416fc394fd0e05594fa0f1cf773ff5c895b1226220e7db59e2230089284fe729";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "f8821977e0223e4372f93f2ddb5481f25d283786a1bba0082c3b8561f35e3df2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "ba431d4e20ce182c6dd6c8ef1ce4628348988289e75f1f6867fe220f8a0ba571";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "5e7701f7e2e55a2c900e8e6ecc3f344d4e7b87172e3091d7c14311b625c40c58";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "2c8f7f7a639a1790b7c631440fdd8079ea03a7aaf351b7b83e4a8afa083a5975";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/event-camera-codecs/default.nix
+++ b/distros/rolling/event-camera-codecs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, class-loader, event-camera-msgs, rclcpp, ros-environment, rosbag2-cpp }:
+buildRosPackage {
+  pname = "ros-rolling-event-camera-codecs";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/rolling/event_camera_codecs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "830d6105464bdc53b80ff436f882a9077e906d234d1f91879f96aa79a193a81c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp rosbag2-cpp ];
+  propagatedBuildInputs = [ class-loader event-camera-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''package to encode and decode event_camera_msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/event-camera-py/default.nix
+++ b/distros/rolling/event-camera-py/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, ros-environment }:
+buildRosPackage {
+  pname = "ros-rolling-event-camera-py";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/rolling/event_camera_py/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "06574f6106066a660ed5a2820f081b18edbf5110eff5c45461a2c72b2d9026a8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy ];
+  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
+
+  meta = {
+    description = ''Python access for event_camera_msgs.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/event-camera-renderer/default.nix
+++ b/distros/rolling/event-camera-renderer/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-event-camera-renderer";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/rolling/event_camera_renderer/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "82d4d1a4d192c030b10fb9796986dc4e4c21e6dd3568d2261948c0889a2df2bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs image-transport rclcpp rclcpp-components ros-environment sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''package for rendering event_camera_msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "b39e801cc2e88cc7043fdf41c8d042974ff3eb10f4da0c9a8283cff6a35a5ccf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "6698ad614a2dd8b1fcb04439dfe41c72ecb97680a693511ae413157ec1083d5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "800dfc1497efb02ffccade37d63f6350be1f10eb90b2bd8d0d361243616ffd7d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "e4aac8e4aa288616186b48e949ba2e754b382f76e9821974ef8a49300da1396b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -444,7 +444,13 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ event-camera-codecs = self.callPackage ./event-camera-codecs {};
+
  event-camera-msgs = self.callPackage ./event-camera-msgs {};
+
+ event-camera-py = self.callPackage ./event-camera-py {};
+
+ event-camera-renderer = self.callPackage ./event-camera-renderer {};
 
  example-interfaces = self.callPackage ./example-interfaces {};
 
@@ -1156,7 +1162,15 @@ self: super: {
 
  pluginlib = self.callPackage ./pluginlib {};
 
+ point-cloud-interfaces = self.callPackage ./point-cloud-interfaces {};
+
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
+
+ point-cloud-transport = self.callPackage ./point-cloud-transport {};
+
+ point-cloud-transport-plugins = self.callPackage ./point-cloud-transport-plugins {};
+
+ point-cloud-transport-py = self.callPackage ./point-cloud-transport-py {};
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
@@ -2114,7 +2128,11 @@ self: super: {
 
  zenoh-bridge-dds = self.callPackage ./zenoh-bridge-dds {};
 
+ zlib-point-cloud-transport = self.callPackage ./zlib-point-cloud-transport {};
+
  zmqpp-vendor = self.callPackage ./zmqpp-vendor {};
+
+ zstd-point-cloud-transport = self.callPackage ./zstd-point-cloud-transport {};
 
  zstd-vendor = self.callPackage ./zstd-vendor {};
 

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "37331b9150b891b31f51469a3e134f198e982bdb5c3202d5de8dbf7403592850";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "3af67362f7768be06f7530eddca0691deaa94bbdd8f1bb89cd21a7367b2a4078";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "47918d221d81ac53186ab0706f5a02d8a8a02b826d90d1a3e4d3a75cfc9bb7b1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "50fad4feca97defc606618af3d6ff8e40aeefde67b4fc20b60d958d2873aee0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "957f5210b4f625e08b914b9713dd13bc338cf8f06e5209ebd9032779be85dc6c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "c17a2e2f4fc3d0fa0928921ee28a90887e560fa0f0e56fe44cc113a49893f840";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "73946b64e2a21f3aabf2eb4933b19e5564da0c019886062ebbef30c1137f9ee2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "17fed421d67da1f91262780a21bb06b09afbf4a6f73b7220be3d3813f2c84a77";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mqtt-client-interfaces/default.nix
+++ b/distros/rolling/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client-interfaces";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "17d6c7a53e6f01161d685f64a26da2bc7e9161d82d3e209f7968212d3d103cb8";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "a09e7743db3e21883c4fc4b3ddb7581a38eb67a34d8c1a1b4dd7e2e2eecbcfd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mqtt-client/default.nix
+++ b/distros/rolling/mqtt-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rcpputils, ros-environment, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c84ee4cb24b3723e622ef88d2dc6387193e89d10f8ef48af9c748da1a870bd4c";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "f856d8486ffde2d4eeeabfa38f8c5445b7288953492fe638c30b05a4a8a58892";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ mqtt-client-interfaces paho-mqtt-c paho-mqtt-cpp rclcpp rcpputils ros-environment std-msgs ];
+  propagatedBuildInputs = [ fmt mqtt-client-interfaces paho-mqtt-c paho-mqtt-cpp rclcpp rclcpp-components rcpputils ros-environment std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/point-cloud-interfaces/default.nix
+++ b/distros/rolling/point-cloud-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-point-cloud-interfaces";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "677f032da654125d20f5ddb66737a9023da7fb32157fa8a51f3f557ddbf20f6e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''msg definitions for use with point_cloud_transport plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/point-cloud-transport-plugins/default.nix
+++ b/distros/rolling/point-cloud-transport-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
+buildRosPackage {
+  pname = "ros-rolling-point-cloud-transport-plugins";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "ac3ad370dc425647f13980949064745cbd5e7bf15acd264ae439f4aa25044b21";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ draco-point-cloud-transport point-cloud-interfaces zlib-point-cloud-transport zstd-point-cloud-transport ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage with common point_cloud_transport plugins'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-point-cloud-transport-py";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "5fa06f84fb843b301b4985916608f223ed0144ee9e241fc80f5f233d778553a5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  propagatedBuildInputs = [ pluginlib point-cloud-transport pybind11-vendor rclcpp rpyutils sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+
+  meta = {
+    description = ''Python API for point_cloud_transport'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
+buildRosPackage {
+  pname = "ros-rolling-point-cloud-transport";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "00f7ceaf8d35a93ebd64545c95f8de54a61c226003fd4e6095dc58fff36b7216";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
+  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tl-expected ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Support for transporting PointCloud2 messages in compressed format and plugin interface for implementing additional PointCloud2 transports.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/pose-cov-ops/default.nix
+++ b/distros/rolling/pose-cov-ops/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, gtest, mrpt2, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-pose-cov-ops";
-  version = "0.3.10-r1";
+  version = "0.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/rolling/pose_cov_ops/0.3.10-1.tar.gz";
-    name = "0.3.10-1.tar.gz";
-    sha256 = "4040acf19b61f7fd48162a9c91f5f55edae23f5e1b4c974e51c09008ab9ae5a9";
+    url = "https://github.com/ros2-gbp/pose_cov_ops-release/archive/release/rolling/pose_cov_ops/0.3.11-1.tar.gz";
+    name = "0.3.11-1.tar.gz";
+    sha256 = "177d9e817a411b255c99a9d36bbabdca892c675cd66f5bcd2f9f14381c55a1ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "93f755e54e32d88d440c22634d27d7c2e44029ddcab439fbcfe92513b9a2d37b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "7c159cef1fe8f1fcb4ddd071f5df5bd496b4db1a49616534722d64ba19e53e24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "c0b1ec19f43041d441a4ec6a031b68b99e6b0d4ca3f59e34e83c1a56359f939a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "0273c84b877372df06200f5a2b52c28302d673f20376fad35a700dc1fee9819c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "a8353018bd37b15cea1f6ce8f4ad5c08b8d415377adc51540ed20b212ddd1bf8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "26f0ea6f74a689db51a8286a635fe2d7682ca2a738c8e2d94981e2eff442291c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "9aa819ffa36127738040cd5eb1d538d974c4e92eff30a5fa40547d604a88bf5e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "4c9529a7cc8f3a970cbbb81522a7e52a7ef98d66e17e2302e0a05ff8603d9786";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "15ad8eeae1c275b450a379940bf534b1883676ca16b25073022ac2eacb1fc036";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "7959113ca20fd7d6c16a45f9385b278433ceb779c1658702fe3a4cf103c19f2b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/simple-actions/default.nix
+++ b/distros/rolling/simple-actions/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
+{ lib, buildRosPackage, fetchurl, action-msgs, action-tutorials-interfaces, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-python, rclcpp, rclcpp-action, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-simple-actions";
-  version = "0.2.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_actions-release/archive/release/rolling/simple_actions/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "9298fe7352c4823fb6b7fb60e3ad4547dedda4c9f5298e9e885f3435dc1c3971";
+    url = "https://github.com/ros2-gbp/simple_actions-release/archive/release/rolling/simple_actions/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "a4f4bd87938884ac674274fc0d65c5676a64c7c45997e5692b32361f5b1dbb52";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
+  checkInputs = [ action-tutorials-interfaces ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ];
   propagatedBuildInputs = [ action-msgs rclcpp rclcpp-action rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "2c97fc85e1485cb3db4d27725e83f2ab5c2555288f37f1073637156c1a1b33b0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "456f8c875762793a710b6e6d757a3be0c1cab6d534a8cb549b99a9cc2f89dbe9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-console/default.nix
+++ b/distros/rolling/swri-console/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, qt5, rcl-interfaces, rclcpp, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, qt5, rcl-interfaces, rclcpp, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-swri-console";
-  version = "2.0.3-r2";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/swri_console-release/archive/release/rolling/swri_console/2.0.3-2.tar.gz";
-    name = "2.0.3-2.tar.gz";
-    sha256 = "3fb2155cda7106737f7c884db0710c2d6e53e4dca6ea8cd34ebee67ab0200306";
+    url = "https://github.com/ros2-gbp/swri_console-release/archive/release/rolling/swri_console/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "510f9ec0a58ae02f0b30fb07a2cdb31e6996854178cd458c3ee3ae44a3c270eb";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rosidl-default-generators ];
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
   propagatedBuildInputs = [ boost qt5.qtbase rcl-interfaces rclcpp rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "9c59f93214378e90f9fe0196d8868b08feef819daad41607af4d2040ad00afda";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "3184afc73fa295f5610a3fb642c3f50363b2f01fe5dda52bcbeced59d5de4609";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "817c48555b5c6c68b4aafbc9108de5d5c41c398986b61a9cf42180d96e40460e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "2b054768a59df5652dcee36cc67eb14d5dd1168b1b453ebfff1e7c6098c13773";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/twist-mux/default.nix
+++ b/distros/rolling/twist-mux/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-twist-mux";
-  version = "4.1.0-r3";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/rolling/twist_mux/4.1.0-3.tar.gz";
-    name = "4.1.0-3.tar.gz";
-    sha256 = "2c55c4037e6c0f6ec384616afd4684b1c949a702a383f8b965fcb95a0aae0c0c";
+    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/rolling/twist_mux/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "58e04bd273fd0582e02a16031dbca6f5b57517a53b58b515f237f01ffecb4466";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
-  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs twist-mux-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "c1cf908d973bfd5ee08d8ff90a85cb793739c03c92ed593d18d6873f77bdbcdd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "581b6ed76fc299b0c595f27b1a49d41223692f06e6f9c585afa82f857ca3d95d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "2dc87b6e6b1c075404f0bfc7bfdfa889d3817f772ae3ee22492d85754ff86a43";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "a350cbeedcbddc15f1188f8dce8cde2bcc39f11fa64793e5de227f646549ab2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "d6c5271f52a6d3ecfcbf3ce66035d423f3455be263df8ee1705b2a490f4169f9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "6b265124d53b4a6f8b6acd4fca5769a1303553f2e3e258c799d923836b6d8467";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "5a3a23d01d9d20137143f91e82b810cb9d725327f7b8ec1eb39bf8d221654305";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "951d07d42828c146fd5861780086d26b4b9b7fce0cec1116d243a8d54593f476";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "bdb870a3945da5c2bebf8f836c6353624a72369039d7d2791c21118bf1dd146b";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "569c5ae42820f139763d4f7e244c0291f4be43b84736c570aacbe108561d7695";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "3.15.0-r1";
+  version = "3.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.15.0-1.tar.gz";
-    name = "3.15.0-1.tar.gz";
-    sha256 = "b37e71f018c95def8eead1ec99c5abb33b012b72bad2d0678561afd2bf892c18";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.16.0-1.tar.gz";
+    name = "3.16.0-1.tar.gz";
+    sha256 = "d4e1f9f1957322ce7b4152dfcfb79608924bdafdf7bf6229e0fc7c9930699d95";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zlib-point-cloud-transport/default.nix
+++ b/distros/rolling/zlib-point-cloud-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
+buildRosPackage {
+  pname = "ros-rolling-zlib-point-cloud-transport";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "efa2b6df5248654a0f58bac99b82c5ccbd3c342f0774a12a7178d38189c0c550";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib point-cloud-interfaces point-cloud-transport rclcpp zlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''zlib_point_cloud_transport provides a plugin to point_cloud_transport for sending point clouds
+    encoded with zlib'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/zstd-point-cloud-transport/default.nix
+++ b/distros/rolling/zstd-point-cloud-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
+buildRosPackage {
+  pname = "ros-rolling-zstd-point-cloud-transport";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "03986776de13c3ca9d3cbaa73ae1911040e458c2a7c05ad64a06e0c32b6033dd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib point-cloud-interfaces point-cloud-transport rclcpp zstd ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''zstd_point_cloud_transport provides a plugin to point_cloud_transport for sending point clouds
+    encoded with lib'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 148dc07305802c41369839fb2d4d5291571ddb69.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aandd-ekew-driver-py 0.0.1-r1 --> 0.0.2-r1*
* *ackermann-steering-controller 2.24.0-r1 --> 2.25.0-r1*
* *admittance-controller 2.24.0-r1 --> 2.25.0-r1*
* *ament-clang-format 0.12.7-r2 --> 0.12.8-r1*
* *ament-clang-tidy 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-clang-format 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-clang-tidy 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-copyright 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-cppcheck 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-cpplint 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-flake8 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-lint-cmake 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-mypy 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-pclint 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-pep257 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-pycodestyle 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-pyflakes 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-uncrustify 0.12.7-r2 --> 0.12.8-r1*
* *ament-cmake-xmllint 0.12.7-r2 --> 0.12.8-r1*
* *ament-copyright 0.12.7-r2 --> 0.12.8-r1*
* *ament-cppcheck 0.12.7-r2 --> 0.12.8-r1*
* *ament-cpplint 0.12.7-r2 --> 0.12.8-r1*
* *ament-flake8 0.12.7-r2 --> 0.12.8-r1*
* *ament-lint 0.12.7-r2 --> 0.12.8-r1*
* *ament-lint-auto 0.12.7-r2 --> 0.12.8-r1*
* *ament-lint-cmake 0.12.7-r2 --> 0.12.8-r1*
* *ament-lint-common 0.12.7-r2 --> 0.12.8-r1*
* *ament-mypy 0.12.7-r2 --> 0.12.8-r1*
* *ament-pclint 0.12.7-r2 --> 0.12.8-r1*
* *ament-pep257 0.12.7-r2 --> 0.12.8-r1*
* *ament-pycodestyle 0.12.7-r2 --> 0.12.8-r1*
* *ament-pyflakes 0.12.7-r2 --> 0.12.8-r1*
* *ament-uncrustify 0.12.7-r2 --> 0.12.8-r1*
* *ament-xmllint 0.12.7-r2 --> 0.12.8-r1*
* *bicycle-steering-controller 2.24.0-r1 --> 2.25.0-r1*
* *clearpath-nav2-demos 0.0.2-r1 --> 0.1.0-r1*
* *dataspeed-dbw-common 2.1.1-r1 --> 2.1.3-r1*
* *dataspeed-dbw-gateway 2.1.1-r1 --> 2.1.3-r1*
* *dataspeed-dbw-msgs 2.1.1-r1 --> 2.1.3-r1*
* *dataspeed-ulc 2.1.1-r1 --> 2.1.3-r1*
* *dataspeed-ulc-can 2.1.1-r1 --> 2.1.3-r1*
* *dataspeed-ulc-msgs 2.1.1-r1 --> 2.1.3-r1*
* *dbw-fca 2.1.1-r1 --> 2.1.3-r1*
* *dbw-fca-can 2.1.1-r1 --> 2.1.3-r1*
* *dbw-fca-description 2.1.1-r1 --> 2.1.3-r1*
* *dbw-fca-joystick-demo 2.1.1-r1 --> 2.1.3-r1*
* *dbw-fca-msgs 2.1.1-r1 --> 2.1.3-r1*
* *dbw-ford 2.1.1-r1 --> 2.1.3-r1*
* *dbw-ford-can 2.1.1-r1 --> 2.1.3-r1*
* *dbw-ford-description 2.1.1-r1 --> 2.1.3-r1*
* *dbw-ford-joystick-demo 2.1.1-r1 --> 2.1.3-r1*
* *dbw-ford-msgs 2.1.1-r1 --> 2.1.3-r1*
* *dbw-polaris 2.1.1-r1 --> 2.1.3-r1*
* *dbw-polaris-can 2.1.1-r1 --> 2.1.3-r1*
* *dbw-polaris-description 2.1.1-r1 --> 2.1.3-r1*
* *dbw-polaris-joystick-demo 2.1.1-r1 --> 2.1.3-r1*
* *dbw-polaris-msgs 2.1.1-r1 --> 2.1.3-r1*
* *diff-drive-controller 2.24.0-r1 --> 2.25.0-r1*
* *effort-controllers 2.24.0-r1 --> 2.25.0-r1*
* *event-camera-codecs 1.1.1-r1*
* *event-camera-py 1.1.2-r1*
* *event-camera-renderer 1.1.2-r1*
* *examples-tf2-py 0.25.3-r1 --> 0.25.4-r1*
* *fadecandy-driver 1.0.1-r1*
* *fadecandy-msgs 1.0.1-r1*
* *force-torque-sensor-broadcaster 2.24.0-r1 --> 2.25.0-r1*
* *forward-command-controller 2.24.0-r1 --> 2.25.0-r1*
* *geometry2 0.25.3-r1 --> 0.25.4-r1*
* *gripper-controllers 2.24.0-r1 --> 2.25.0-r1*
* *imu-sensor-broadcaster 2.24.0-r1 --> 2.25.0-r1*
* *joint-state-broadcaster 2.24.0-r1 --> 2.25.0-r1*
* *joint-trajectory-controller 2.24.0-r1 --> 2.25.0-r1*
* *launch-ros 0.19.5-r2 --> 0.19.6-r1*
* *launch-testing-ros 0.19.5-r2 --> 0.19.6-r1*
* *mcap-vendor 0.15.7-r1 --> 0.15.8-r1*
* *mqtt-client 2.0.1-r1 --> 2.1.0-r1*
* *mqtt-client-interfaces 2.0.1-r1 --> 2.1.0-r1*
* *point-cloud-interfaces 1.0.7-r1*
* *point-cloud-transport 1.0.13-r1*
* *point-cloud-transport-plugins 1.0.7-r1*
* *point-cloud-transport-py 1.0.13-r1*
* *pose-cov-ops 0.3.10-r1 --> 0.3.11-r1*
* *position-controllers 2.24.0-r1 --> 2.25.0-r1*
* *rcl 5.3.4-r3 --> 5.3.5-r1*
* *rcl-action 5.3.4-r3 --> 5.3.5-r1*
* *rcl-lifecycle 5.3.4-r3 --> 5.3.5-r1*
* *rcl-yaml-param-parser 5.3.4-r3 --> 5.3.5-r1*
* *rclcpp 16.0.5-r2 --> 16.0.6-r1*
* *rclcpp-action 16.0.5-r2 --> 16.0.6-r1*
* *rclcpp-components 16.0.5-r2 --> 16.0.6-r1*
* *rclcpp-lifecycle 16.0.5-r2 --> 16.0.6-r1*
* *rclpy 3.3.9-r1 --> 3.3.10-r1*
* *reach-ros 1.3.2-r1 --> 1.3.2-r2*
* *rmw-fastrtps-cpp 6.2.3-r1 --> 6.2.4-r1*
* *rmw-fastrtps-dynamic-cpp 6.2.3-r1 --> 6.2.4-r1*
* *rmw-fastrtps-shared-cpp 6.2.3-r1 --> 6.2.4-r1*
* *robotraconteur 0.16.0-r4 --> 0.18.0-r1*
* *ros2-controllers 2.24.0-r1 --> 2.25.0-r1*
* *ros2-controllers-test-nodes 2.24.0-r1 --> 2.25.0-r1*
* *ros2bag 0.15.7-r1 --> 0.15.8-r1*
* *ros2launch 0.19.5-r2 --> 0.19.6-r1*
* *rosbag2 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-compression 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-compression-zstd 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-cpp 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-interfaces 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-performance-benchmarking 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-py 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-storage 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-storage-default-plugins 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-storage-mcap 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-storage-mcap-testdata 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-test-common 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-tests 0.15.7-r1 --> 0.15.8-r1*
* *rosbag2-transport 0.15.7-r1 --> 0.15.8-r1*
* *rqt-joint-trajectory-controller 2.24.0-r1 --> 2.25.0-r1*
* *rviz-assimp-vendor 11.2.7-r1 --> 11.2.8-r1*
* *rviz-common 11.2.7-r1 --> 11.2.8-r1*
* *rviz-default-plugins 11.2.7-r1 --> 11.2.8-r1*
* *rviz-ogre-vendor 11.2.7-r1 --> 11.2.8-r1*
* *rviz-rendering 11.2.7-r1 --> 11.2.8-r1*
* *rviz-rendering-tests 11.2.7-r1 --> 11.2.8-r1*
* *rviz-visual-testing-framework 11.2.7-r1 --> 11.2.8-r1*
* *rviz2 11.2.7-r1 --> 11.2.8-r1*
* *shared-queues-vendor 0.15.7-r1 --> 0.15.8-r1*
* *simple-actions 0.2.2-r1 --> 0.3.0-r1*
* *sqlite3-vendor 0.15.7-r1 --> 0.15.8-r1*
* *steering-controllers-library 2.24.0-r1 --> 2.25.0-r1*
* *tf2 0.25.3-r1 --> 0.25.4-r1*
* *tf2-bullet 0.25.3-r1 --> 0.25.4-r1*
* *tf2-eigen 0.25.3-r1 --> 0.25.4-r1*
* *tf2-eigen-kdl 0.25.3-r1 --> 0.25.4-r1*
* *tf2-geometry-msgs 0.25.3-r1 --> 0.25.4-r1*
* *tf2-kdl 0.25.3-r1 --> 0.25.4-r1*
* *tf2-msgs 0.25.3-r1 --> 0.25.4-r1*
* *tf2-py 0.25.3-r1 --> 0.25.4-r1*
* *tf2-ros 0.25.3-r1 --> 0.25.4-r1*
* *tf2-ros-py 0.25.3-r1 --> 0.25.4-r1*
* *tf2-sensor-msgs 0.25.3-r1 --> 0.25.4-r1*
* *tf2-tools 0.25.3-r1 --> 0.25.4-r1*
* *tricycle-controller 2.24.0-r1 --> 2.25.0-r1*
* *tricycle-steering-controller 2.24.0-r1 --> 2.25.0-r1*
* *twist-mux 4.1.0-r3 --> 4.2.0-r1*
* *velocity-controllers 2.24.0-r1 --> 2.25.0-r1*
* *zlib-point-cloud-transport 1.0.7-r1*
* *zstd-point-cloud-transport 1.0.7-r1*
* *zstd-vendor 0.15.7-r1 --> 0.15.8-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.15.0-r1 --> 3.16.0-r1*
* *admittance-controller 3.15.0-r1 --> 3.16.0-r1*
* *bicycle-steering-controller 3.15.0-r1 --> 3.16.0-r1*
* *depthai-bridge 2.8.0-r1 --> 2.8.1-r1*
* *depthai-descriptions 2.8.0-r1 --> 2.8.1-r1*
* *depthai-examples 2.8.0-r1 --> 2.8.1-r1*
* *depthai-filters 2.8.0-r1 --> 2.8.1-r1*
* *depthai-ros 2.8.0-r1 --> 2.8.1-r1*
* *depthai-ros-driver 2.8.0-r1 --> 2.8.1-r1*
* *depthai-ros-msgs 2.8.0-r1 --> 2.8.1-r1*
* *diff-drive-controller 3.15.0-r1 --> 3.16.0-r1*
* *effort-controllers 3.15.0-r1 --> 3.16.0-r1*
* *force-torque-sensor-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *forward-command-controller 3.15.0-r1 --> 3.16.0-r1*
* *gripper-controllers 3.15.0-r1 --> 3.16.0-r1*
* *imu-sensor-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *joint-state-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *joint-trajectory-controller 3.15.0-r1 --> 3.16.0-r1*
* *mqtt-client 2.0.1-r1 --> 2.1.0-r1*
* *mqtt-client-interfaces 2.0.1-r1 --> 2.1.0-r1*
* *point-cloud-interfaces 2.0.1-r1*
* *point-cloud-transport 2.0.1-r1*
* *point-cloud-transport-plugins 2.0.1-r1*
* *point-cloud-transport-py 2.0.1-r1*
* *pose-cov-ops 0.3.10-r2 --> 0.3.11-r1*
* *position-controllers 3.15.0-r1 --> 3.16.0-r1*
* *range-sensor-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *rmf-fleet-adapter 2.2.2-r1 --> 2.2.3-r1*
* *rmf-fleet-adapter-python 2.2.2-r1 --> 2.2.3-r1*
* *rmf-task-ros2 2.2.2-r1 --> 2.2.3-r1*
* *rmf-traffic-ros2 2.2.2-r1 --> 2.2.3-r1*
* *rmf-websocket 2.2.2-r1 --> 2.2.3-r1*
* *robotraconteur 0.18.0-r1*
* *ros2-controllers 3.15.0-r1 --> 3.16.0-r1*
* *ros2-controllers-test-nodes 3.15.0-r1 --> 3.16.0-r1*
* *rqt-joint-trajectory-controller 3.15.0-r1 --> 3.16.0-r1*
* *simple-actions 0.2.2-r2 --> 0.3.0-r1*
* *steering-controllers-library 3.15.0-r1 --> 3.16.0-r1*
* *tricycle-controller 3.15.0-r1 --> 3.16.0-r1*
* *tricycle-steering-controller 3.15.0-r1 --> 3.16.0-r1*
* *twist-mux 4.1.0-r4 --> 4.2.0-r1*
* *ur 2.3.3-r1 --> 2.3.4-r1*
* *ur-calibration 2.3.3-r1 --> 2.3.4-r1*
* *ur-controllers 2.3.3-r1 --> 2.3.4-r1*
* *ur-dashboard-msgs 2.3.3-r1 --> 2.3.4-r1*
* *ur-moveit-config 2.3.3-r1 --> 2.3.4-r1*
* *velocity-controllers 3.15.0-r1 --> 3.16.0-r1*
* *zlib-point-cloud-transport 2.0.1-r1*
* *zstd-point-cloud-transport 2.0.1-r1*

Noetic Changes:
---------------
* *costmap-cspace 0.15.0-r1 --> 0.16.0-r1*
* *cpr-onav-description 0.1.7-r1 --> 0.1.8-r1*
* *dbw-fca 1.3.0-r1 --> 1.3.2-r1*
* *dbw-fca-can 1.3.0-r1 --> 1.3.2-r1*
* *dbw-fca-description 1.3.0-r1 --> 1.3.2-r1*
* *dbw-fca-joystick-demo 1.3.0-r1 --> 1.3.2-r1*
* *dbw-fca-msgs 1.3.0-r1 --> 1.3.2-r1*
* *dbw-mkz 1.6.0-r1 --> 1.6.4-r1*
* *dbw-mkz-can 1.6.0-r1 --> 1.6.4-r1*
* *dbw-mkz-description 1.6.0-r1 --> 1.6.4-r1*
* *dbw-mkz-joystick-demo 1.6.0-r1 --> 1.6.4-r1*
* *dbw-mkz-msgs 1.6.0-r1 --> 1.6.4-r1*
* *dbw-polaris 1.1.0-r1 --> 1.1.2-r1*
* *dbw-polaris-can 1.1.0-r1 --> 1.1.2-r1*
* *dbw-polaris-description 1.1.0-r1 --> 1.1.2-r1*
* *dbw-polaris-joystick-demo 1.1.0-r1 --> 1.1.2-r1*
* *dbw-polaris-msgs 1.1.0-r1 --> 1.1.2-r1*
* *foxglove-bridge 0.7.1-r1 --> 0.7.2-r1*
* *joystick-interrupt 0.15.0-r1 --> 0.16.0-r1*
* *map-organizer 0.15.0-r1 --> 0.16.0-r1*
* *mlx90640-thermal-camera 1.0.0-r1*
* *mqtt-client 2.0.1-r1 --> 2.1.0-r1*
* *mqtt-client-interfaces 2.0.1-r1 --> 2.1.0-r1*
* *neonavigation 0.15.0-r1 --> 0.16.0-r1*
* *neonavigation-common 0.15.0-r1 --> 0.16.0-r1*
* *neonavigation-launch 0.15.0-r1 --> 0.16.0-r1*
* *obj-to-pointcloud 0.15.0-r1 --> 0.16.0-r1*
* *planner-cspace 0.15.0-r1 --> 0.16.0-r1*
* *pose-cov-ops 0.3.10-r1 --> 0.3.11-r1*
* *robotraconteur 0.16.0-r2 --> 0.18.0-r2*
* *safety-limiter 0.15.0-r1 --> 0.16.0-r1*
* *track-odometry 0.15.0-r1 --> 0.16.0-r1*
* *trajectory-tracker 0.15.0-r1 --> 0.16.0-r1*
* *urg-stamped 0.0.16-r1 --> 0.0.17-r1*
* *warthog-control 0.1.7-r1 --> 0.1.8-r1*
* *warthog-description 0.1.7-r1 --> 0.1.8-r1*
* *warthog-msgs 0.1.7-r1 --> 0.1.8-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 3.15.0-r1 --> 3.16.0-r1*
* *admittance-controller 3.15.0-r1 --> 3.16.0-r1*
* *bicycle-steering-controller 3.15.0-r1 --> 3.16.0-r1*
* *diff-drive-controller 3.15.0-r1 --> 3.16.0-r1*
* *effort-controllers 3.15.0-r1 --> 3.16.0-r1*
* *event-camera-codecs 1.0.2-r1*
* *event-camera-py 1.0.2-r1*
* *event-camera-renderer 1.0.2-r1*
* *force-torque-sensor-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *forward-command-controller 3.15.0-r1 --> 3.16.0-r1*
* *gripper-controllers 3.15.0-r1 --> 3.16.0-r1*
* *imu-sensor-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *joint-state-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *joint-trajectory-controller 3.15.0-r1 --> 3.16.0-r1*
* *mqtt-client 2.0.1-r1 --> 2.1.0-r1*
* *mqtt-client-interfaces 2.0.1-r1 --> 2.1.0-r1*
* *point-cloud-interfaces 3.0.0-r1*
* *point-cloud-transport 3.0.0-r1*
* *point-cloud-transport-plugins 3.0.0-r1*
* *point-cloud-transport-py 3.0.0-r1*
* *pose-cov-ops 0.3.10-r1 --> 0.3.11-r1*
* *position-controllers 3.15.0-r1 --> 3.16.0-r1*
* *range-sensor-broadcaster 3.15.0-r1 --> 3.16.0-r1*
* *ros2-controllers 3.15.0-r1 --> 3.16.0-r1*
* *ros2-controllers-test-nodes 3.15.0-r1 --> 3.16.0-r1*
* *rqt-joint-trajectory-controller 3.15.0-r1 --> 3.16.0-r1*
* *simple-actions 0.2.2-r1 --> 0.3.0-r1*
* *steering-controllers-library 3.15.0-r1 --> 3.16.0-r1*
* *swri-console 2.0.3-r2 --> 2.0.4-r1*
* *tricycle-controller 3.15.0-r1 --> 3.16.0-r1*
* *tricycle-steering-controller 3.15.0-r1 --> 3.16.0-r1*
* *twist-mux 4.1.0-r3 --> 4.2.0-r1*
* *ur 2.4.0-r1 --> 2.4.1-r1*
* *ur-calibration 2.4.0-r1 --> 2.4.1-r1*
* *ur-controllers 2.4.0-r1 --> 2.4.1-r1*
* *ur-dashboard-msgs 2.4.0-r1 --> 2.4.1-r1*
* *ur-moveit-config 2.4.0-r1 --> 2.4.1-r1*
* *velocity-controllers 3.15.0-r1 --> 3.16.0-r1*
* *zlib-point-cloud-transport 3.0.0-r1*
* *zstd-point-cloud-transport 3.0.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

