### PR TITLE
rosdistro sync, Fri Oct  6 13:48:50 2023

### DIFF
--- a/distros/humble/aandd-ekew-driver-py/default.nix
+++ b/distros/humble/aandd-ekew-driver-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, weight-scale-interfaces }:
 buildRosPackage {
   pname = "ros-humble-aandd-ekew-driver-py";
-  version = "0.0.2-r1";
+  version = "0.0.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/TechMagicKK/aandd_ekew_driver_py-release/archive/release/humble/aandd_ekew_driver_py/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "24e36b1a642e89fe9dbabe70bf616a1d33e0a4a6dd917c8952cdcb9d2e24bf97";
+    url = "https://github.com/ros2-gbp/aandd_ekew_driver_py-release/archive/release/humble/aandd_ekew_driver_py/0.0.2-3.tar.gz";
+    name = "0.0.2-3.tar.gz";
+    sha256 = "60582a27125ea1fa0ab6d964d1ae7e23fd0e4a65ad2a9ce27a375def1faad6b4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "6f777f4166ce65a9cabc3d4a583df4decdd3cf55b744147f9110222a2c2305fd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "447a3fb440ca40a0b103098cf472494837dd49e3d2675cd688de3f531b5237b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "a978f386109db6751464d809e09cafc9d55350ba1f1b48d270ead2c971b5a3a9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "1a8259a623c677f281db8eba3b400c6c3da20ec3e5c0666787de7f822fe17af9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/aruco-msgs/default.nix
+++ b/distros/humble/aruco-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-aruco-msgs";
-  version = "5.0.0-r1";
+  version = "5.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_msgs/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "71b615a09b28bc3ac55c7c2203dea9455bd37bcad7e9e164a2c702cf829af226";
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_msgs/5.0.3-1.tar.gz";
+    name = "5.0.3-1.tar.gz";
+    sha256 = "9da6b2ed8e68ab83f6aabb4cdaea8413d8f66530905cfa76c855d0da62725cad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/aruco-ros/default.nix
+++ b/distros/humble/aruco-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, aruco, aruco-msgs, cv-bridge, geometry-msgs, image-transport, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-aruco-ros";
-  version = "5.0.0-r1";
+  version = "5.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_ros/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "82efd2943b491cc0d620dcee270649528fa7e5c765ebbbcd27cd42b8e47f7ff2";
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco_ros/5.0.3-1.tar.gz";
+    name = "5.0.3-1.tar.gz";
+    sha256 = "f9822b2604028e438262577bc3543b6c6be7f14c33fb5501ae839424adf93b5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/aruco/default.nix
+++ b/distros/humble/aruco/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen }:
 buildRosPackage {
   pname = "ros-humble-aruco";
-  version = "5.0.0-r1";
+  version = "5.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "6d964a16ebd216b99eda6720bac0a01cf0661d947805ec66ed56da2790bca1b4";
+    url = "https://github.com/pal-gbp/aruco_ros-release/archive/release/humble/aruco/5.0.3-1.tar.gz";
+    name = "5.0.3-1.tar.gz";
+    sha256 = "ef6192f44fceb9a53a3f14baa4a0fc08a1ec9184cc089e2872162a17dc2e8c66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/aws-sdk-cpp-vendor/default.nix
+++ b/distros/humble/aws-sdk-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl, zlib }:
 buildRosPackage {
   pname = "ros-humble-aws-sdk-cpp-vendor";
-  version = "0.1.1-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/humble/aws_sdk_cpp_vendor/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f98659d79e692a49d2324b3798d77b74fae43b739f9e6e11bc76f4cc165ee3b5";
+    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/humble/aws_sdk_cpp_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3955e09d7edfe2510084b614e7d813034de26d0181638772e80f6560c81d48c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "ff398aefd6085c8159c25b4151c8b5e07d187f15805cb78ee5b4276d0a14a94c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "7f0ac3e8cb47c90305e6643f252e645a55d4a6779017dee20b176aa2f0ba57e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "a4981fdcadc1d3b8dd927289edc271fa6c8e04287afd7cf08d3302bed4dac865";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "8ce2d99e9986395463fe975e06a57f3dd0a17665cf09308289494d7358b39c85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config-live/default.nix
+++ b/distros/humble/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config-live";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "71a278e2280ac0829085df272c286fbd0f0a7e7756c6d917bf052bbf5de66323";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "7ec905414bbb9bfc09d1ce7afa3522bddd2892aced10a28b8defb58394f921fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "7b202e7d533ebac41399892568bf770bd5b962b99249a8c149fe84b24956a869";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "635ba85c7a2bee51e545a262b3088cb97d99c4c87a09b1cc5b7f978440519710";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "b09ee88fa8c5ea196ceebe0da4de88da9d4f56391e070e3eac234d3feb588d51";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "37ed801ef0488e895d6329177c1a740d875b51077cbb89f5fe5012ee8786145f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "2930bed323484e57fc256935f192a33d040b9dacbbd742e82f6fa76ffc19b7f5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "16455b7299b5218cc1f95aef891ac0f3cf6f2d8cf2069d4ba6460ebb296cd112";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-desktop/default.nix
+++ b/distros/humble/clearpath-desktop/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-msgs, clearpath-viz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-desktop";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "9cb15b0623a4ea62bb1c6866666a197479b00ecb5d39a5eb3a02cca1020c4a65";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "88e2075c1b5e179c9999df7371847f7bef79110741e7e83a3cbb76369aacf613";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-platform-msgs clearpath-viz ];
+  propagatedBuildInputs = [ clearpath-config-live clearpath-platform-msgs clearpath-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "0bab9b04acb1914deffa862fd270fb06036085ba1d56f2ebd850cf6f8eec6b18";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "62f37665fb1864d6e53b02f7a6be33451be93fa6f46a206400d1c494d5e1bdd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-gz/default.nix
+++ b/distros/humble/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-gz";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "8bf241a2ec1227552862a2d9b442c970d6ca4575be650b91af36b9548259728c";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "9a5afe4f2fa8f02c0c73b69b1a8574e7eff6fe6e5cc0b7021b5cc6bad0ba8b89";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-gz/default.nix
+++ b/distros/humble/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, ign-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-gz";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "b6fbf39f00d9bf2c196fd4d86b9d69f84278c166b2665a1217ff11e967c8433d";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "0573623bba39b926633059b84f8b1b30e7cec819f444df61f19193b11803958a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "25b0a37418ff310c5f80603058a064c9cce9844a1cb3f3ea82d1812d7dfc4474";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "4a2cc5de27a43a09a19b7e1130d68a918fb6f77564e73308828aa9171274ae7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "0ab06706c5ff682020a10e90e77000a056df505cec57910e69499fcd7e1c58e4";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "89b4ebbd283a01ff152ce5da4b2850631f9e78e2d7c09c583fb89f6ea416e02a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "cbce1d4079554d21e7e7fda13a8a67237af9a986024b8acd6742b9d4a0c4c49c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "9ca6df16fc19d3f915fad2220f1b69e80af9d1901de042356d6914d4257a4f19";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "58bda4705e63ea7d92d9ab80fee829637ed60da4ac02354f8f06ffed6ea61ac5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "20f912b5e6ff122a3e0213cb698c1cb4d40582d116610db4d5b1651c2936ef53";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-simulator/default.nix
+++ b/distros/humble/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-simulator";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "933673b579b302b0950571642b71d58f0ffdd011e3a49590e69dbe9a67534af9";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "b2346f054496e33d1732d190bd2886fea1c350df2c964e69acdf3cde2e33edd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-viz/default.nix
+++ b/distros/humble/clearpath-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-clearpath-viz";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "175a11f7b587b04e2e692e686d622ef33ee6eea3b66f70dc663d2fe8f83d472b";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "61895704d80635420a8795ae0508520e4a9d5f4cc8e7dca79d7e09409537e3ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/collision-log-msgs/default.nix
+++ b/distros/humble/collision-log-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-collision-log-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/metrics_msgs-release/archive/release/humble/collision_log_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "3977b62f2041c37b0eab06d70c4580ae937914b30dc21a62f6056411b5038deb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages for describing collisions (simulated or not)'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "4930c369dee1ecfb1e8f7cd20ae19fdd1c6bd98cc031021b3e44878a2fa58d68";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "79d1dcc4fb9ef6f28ce274336c9a55363d4934e8c4d8bcf0fcbe2e2ee22819bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "d8fe20b7e898a36f64feb9c6f17115ef461ac8e688027380913b409ca5c87377";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "c62bfa2e03c6640ad977c0b26887f670cd997b776911ec216decadbfcd05399f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "9f657f5a9b56c29796ff0decaf5ae95c9f73abdb7068db832e0ce7eeb465b5ae";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "da12d5d519610ad39387b92b1d749d2d425d3e84bcaa3de83e62df1d8e8b3113";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "5fa99e2a6d585289a3fd4b06d8a516260933be54f198824c80a62406ba772b57";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "4220bb1b73a0f49de6b2bf4b7fd2c52ca2ac9970e08579293b9fe105761f90f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "3df4d881a14a3dd9590f08d00dc796674d86187e4f9ac560514f400fba92d4be";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "4b250ed19435bd7c09a16fe6b9fbdd4e2f3c97197105a6dd98920925e6e8a737";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "6764a5c52d07b2be1713e22f737e015b9abfe470087a9e41c7f76820823066a8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "57419885f931d302a1f283b7b3408c5f2dc9b4083b9940981cb321d22e3b4f54";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "e81d75506130f315473d1163561e4b4338c2165165cf5c9dc275fe0822a9c828";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "14909d47c7fe221ff7d66a5431163b4ac4b52cb194aa29e846860350a83302db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "6e2659eb8c6612390370d72640545be7756b4173d8dac65e8dc445b67afe1dc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "3f83af79bd2ebfde7d364d5434a7c958c71135fe68ec60c0f2094c3e908208d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "688c1922245d62d360709d09b0341eada8c198805efec8b7eb3e5c5b1b30d452";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "d16902d0ffb4a2a5a8e21740264fe05120470edfc382d22174bb49c5b9412229";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "9be2df269dfcafa0b0edf7919119ebd68b6da10d988c7b5f335f8db1ec386757";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "549927dcef973e9490e98aa4f0bf31c58e00cf458b529d253b671eafa435344e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/event-camera-py/default.nix
+++ b/distros/humble/event-camera-py/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-event-camera-py";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/humble/event_camera_py/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "372bc3c7d08c7ef46267797a048969a8ec91c519df26dce1129ebf06ea539031";
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/humble/event_camera_py/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "a8100b5c6b53b05d21c77e3feb38ce2b959d7254227d23ec26dff006ae310f5e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy rclpy rosbag2-py rosbag2-storage-default-plugins rosidl-runtime-py ];
   propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
 

--- a/distros/humble/fadecandy-driver/default.nix
+++ b/distros/humble/fadecandy-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-updater, fadecandy-msgs, libusb1, rclcpp, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-updater, fadecandy-msgs, libusb1, pkg-config, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-humble-fadecandy-driver";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/eurogroep/fadecandy_ros-release/archive/release/humble/fadecandy_driver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "efb31dbc7b4690dcf552e0d0156cba5baaa467bea7904d080fe48a15fe59ffbc";
+    url = "https://github.com/eurogroep/fadecandy_ros-release/archive/release/humble/fadecandy_driver/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "cf122b02c764947767a7351a8a4e60b2a0bbcf93b9f4311761ec4e7e015429dc";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake pkg-config ];
   checkInputs = [ rclpy ];
   propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs libusb1 rclcpp ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/humble/fadecandy-msgs/default.nix
+++ b/distros/humble/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-fadecandy-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/eurogroep/fadecandy_ros-release/archive/release/humble/fadecandy_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "4f5f1e8358b826b59e401319c382af130ad7bc42188e5e50a1b4cc6828f08dc2";
+    url = "https://github.com/eurogroep/fadecandy_ros-release/archive/release/humble/fadecandy_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "16629179ec834b935eef72c2a38873024385c1d1251bf5d01d6c652170b576d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "c8ae449923b95e0f77767cb1555987f9ecc171a7c289dc8c0c3702572d928cf4";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "4c21993323d49ac2d808e196fba5fd12f4456bd1eed2c4bdfaf9e934d1c7cac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "071857c4edf87b92f5110845d87a305d77607a82ddf090c0c22ec8c351e24ddc";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "ce68c14fdbda05ccb7f18947b266e24878183415caba44670413f8266b902b7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "8441ae5dac473f61d0e3e9943080346435a77bd0b242f534bc7b1525656f282b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "b4d80e631d5cd30c806563f07ea1a2785d50e06351692e5427f4d04bec2c9133";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "14c88b515044a7bebd9ffcda62170d38bfde70082223a2f758019ab4b550a9ae";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "b3616d726e0ca2c4280b33a1388b285642a847a6da481645119a6285f22fe46b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -338,6 +338,8 @@ self: super: {
 
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
+ collision-log-msgs = self.callPackage ./collision-log-msgs {};
+
  color-names = self.callPackage ./color-names {};
 
  color-util = self.callPackage ./color-util {};
@@ -1064,6 +1066,10 @@ self: super: {
 
  metavision-driver = self.callPackage ./metavision-driver {};
 
+ metro-benchmark-msgs = self.callPackage ./metro-benchmark-msgs {};
+
+ metro-benchmark-pub = self.callPackage ./metro-benchmark-pub {};
+
  micro-ros-diagnostic-bridge = self.callPackage ./micro-ros-diagnostic-bridge {};
 
  micro-ros-diagnostic-msgs = self.callPackage ./micro-ros-diagnostic-msgs {};
@@ -1569,6 +1575,8 @@ self: super: {
  radar-msgs = self.callPackage ./radar-msgs {};
 
  random-numbers = self.callPackage ./random-numbers {};
+
+ range-sensor-broadcaster = self.callPackage ./range-sensor-broadcaster {};
 
  raspimouse = self.callPackage ./raspimouse {};
 

--- a/distros/humble/grid-map-filters/default.nix
+++ b/distros/humble/grid-map-filters/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, filters, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pluginlib, tbb }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, filters, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pluginlib, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-humble-grid-map-filters";
   version = "2.0.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake grid-map-cmake-helpers ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros pluginlib tbb ];
+  propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros pluginlib tbb_2021_8 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "617bf3a4df7c6a44027ac3cc11e6ffb6ccf6ce560bab826997461dcd510198bc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "03b1dc7e8bdcebc5c2aec87ca27cce2fd269334f4a175397175f11301f114478";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gtsam/default.nix
+++ b/distros/humble/gtsam/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-humble-gtsam";
   version = "4.2.0-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake eigen tbb ];
+  buildInputs = [ boost cmake eigen tbb_2021_8 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "c67b29d545b9bc6881b68072f605934c958570e2ccba8aa92a93692162624a7b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "af432ecc0f8fdb155fdd0d151a9a0d2b2464eab5c89996099e3423c783260d6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "08ac980cddf8501acd2b6992c1eec91ded82916a105d881129919c6659049db0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "1c00958de8068f298d8a0caba7c4c66c157427cf8bc6bde1e3fc5c5791010103";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "2efbfa6419c008ef08df4b1ce1bdfd2a4f8fc612c623d76879faec5a0d09e9c2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "e4d87915d8e310f913e01606f97d8c32a9f0cfef3ee0500590f19c76cb93a892";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "eb5a0ed57e79fcf6d97dcf2a3ee7e86b687f81830055525e1749487d1cd88896";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "6d89f463a47338efebe06fbb4bc659ae458a3febbb27706da230ee3c6f3f1265";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "0ef3b95108081fca560eea95631fc7e24f0e9ad1958fd31525bbb9d39e558fce";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "1fdb00dd2f25971f11fdcf3261dc83a82790af6a5b8f41da490ce41cce5a3652";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/metro-benchmark-msgs/default.nix
+++ b/distros/humble/metro-benchmark-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-metro-benchmark-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/metrics_msgs-release/archive/release/humble/metro_benchmark_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "e386ad57072512c958f86efec0dcf604a6617bce369fda96f4c9188107226e42";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS interfaces for recording compute time and other related benchmarking concepts'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/humble/metro-benchmark-pub/default.nix
+++ b/distros/humble/metro-benchmark-pub/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, metro-benchmark-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-metro-benchmark-pub";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/metrics_msgs-release/archive/release/humble/metro_benchmark_pub/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "aa7e2bf9a5b0df7b0ec8341af9847d637620f8167c176549dabd0d8733508c2c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ];
+  propagatedBuildInputs = [ metro-benchmark-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''Utilities for publishing / processing metro_benchmark_msgs'';
+    license = with lib.licenses; [ "BSD-3-clause" ];
+  };
+}

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.10.0-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "021997c0b7021f1f7c5721bdc6b8675b716ae12a3fb26f2ebd08b2af6f4e3eef";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "5c8e2f2ef450bd84e98f142c394bf265adf2ddbc958e1bf17a9480767bb9d9c8";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 python3Packages.pip pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libfyaml libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "4772d385f2f19e44175cc17a0ef3dea207987bcbac5404ad61e6bbd23f0131ef";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "a989a7a5ac497aa85723a552e96309ca1f0b24188716626b443776c473481d60";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "5c20e6453e724ebdb677dfbbdd8b9795684c0d46f072f83902bf2cdb0b7e43b3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "b1413695e0673dc31adfd546df3e4a091df9676edc233a12553ecb8c49d2e976";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "4934da1403d7d20baa1baba5884b0d0e7c6b22038001d0e95ed0b1ed74aecb62";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "7d434daea4423e47887122d9dbbc72c027e2a12fd09c3bad50f022c2be8fa8de";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "dff106028c99cf27e0a4d22ff790238aa948bc75fc307745948a9a5fe99ee238";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "f3844fedda787a90cc905ac20bd9e3119548d0cf7a5c5f3af2b73bc4eb4b8065";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "8c744c19538fb858eb83d908bdb8f8d3339d14945b4631a544d1bf573d402819";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "10594c3ae1d566801d1660bd5c97f7b5e6932770258a0d31de153ddd2324af0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "0683ab82e71433ef64bfcc5676009698207fe73c41b9a8e0c86adede90336216";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "4edfe805811ccb9ab13b625c26769ac9ac8e0c31a6e3c0d2d07239d25eb11707";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "75a01d866e23fc6fdc5ae0a6e55b69875786d65d889a2062008bc0314ae798fe";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "8b462a9197f0f6f84346557f16f38af4e932c3c90c532794854e795f939c651d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "5e1069dddebe908cd4827fd64936c465b4bb36ce2414bc090d13beceec3de81b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "895703c36cb0e8ee7ac75093c97cde782847d5de0306824beb925f3315e3cba3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "7afe57787817b32c2345b2772d0da17d06d6aab94d6573669a4ca17417f4608d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "c340da10bc2093bff81ec9ad1fba2c86cf537ffd0a9515868cc6750f37fd16d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "e4cebb590924fae49146ad5adbac761c76c42fa3e076a6d88a05ac4ab2c2c0d3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "e88e6c4e54a629a996a18d732bab28d7c0f63a17c7d41e8d3f77c5dbc6d6cd47";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "52d22123419993e735aaf6f69fdbe65cc3e0c6f5e12dd7f2148389881e7f4e48";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "5a124ca00c53c9482793f0464aa397e8d00a278806e343510b30ed1b0b89ff16";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "41aac50d11d8769a875196694bc467bcf96cf2ec84e029eb3d0ed6ffb99b45e0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "1ae25a9474c8e8dff541dd2472ef978d7d107b3e313dbbd3ca45dc0ce5489e6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "0727415d479fc6e03f7224f6109c7a47b87449c62a8ffe3e7dd85136d1668481";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "2598149baf3965f6c7add31df1e2fc90d2aebf10882df200b86c8a7f4cff7b01";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "d56af0acd4e036e464030873d6999daf164396879a7992e2dec2cc2eca2b0831";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "6432aa3b9a6437c7140e4ff163320da16ac6a2612befc31cc5e37a3240c96dba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "d15d45ac4617ef1b822800dc7ba45d0168d093431bac1fa62b8e7159ee28c1d8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "76a61e24e874228e61b3a633c983220b8284e445e53997d4523bbdb039e687a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "367ccb91bca1d5bb0d3913da3a4a8cdd665583ffcff4d8ac3251ba4badc8797f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "a456f8b30e775a48adde7ee72b16aabc7ae2efbbdf450629642e638dae5c0f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-mppi-controller/default.nix
+++ b/distros/humble/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-humble-nav2-mppi-controller";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "bec31d66625fbd3f8610d56fa3149e950b73813d9f7c227b56ae984cb63accc9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "933cfffd500d0b56f828ea8cd7dd08ac614fddfa8bd3fc2dc7ee8b9702abceeb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "cba087c6295bfae89055b60fbec79f0c9ab61cc55ab06133f2babc9018f8c2ad";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "f99acd8d61f86a4acbb501c99838f4f2cd46aeb17e016b63633e39a78dac256a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "73e1566ca9fda8007a02fe308d6d631b8bd03f5f5f657457012f0ac4b14b4e06";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "9738ef4ebbf5a9cfe5281f8082faee64cea341c5f4a1efa5e6a43d0853b5402a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "f5f391cce895d8f9394ff80ae9cf966c7e1e8dc370087bdd398ae98fc995979e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "dba04c762e54962ba80b37fafb0eef0b27ffe18d28e65e7bb1ab44ab03fbd137";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "abe6ac60ceb647bbff6e3cf4bddbcf93b5a0e65d6b3048864c1d41eabc19e48c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "ee05f5fdb2ae91f6022274f689677afac7c3b1f05d7a15c639e591d28d521857";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "076ae7691483c128f0925d3e1911df88ad892380a3757bfea701bb9306d93063";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "014a9fc9ea86f052eeddfc517f342e76ca0adab5776190ec16a7e8e12c42c29b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "b4c2cd6521ca8362cafdf21f46fce4cca07102dde2d3bed84e3b57b865c5ab51";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "9ba7474900709fbc5935db0c93664ea559cb83a5de8fc4e6c911b059a0760b58";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "b986789db6c0022f658a3c7ad07ec9ae1b81d6439874db05bc452888c3728007";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "b15a9262037e4e72988dde08ff01e1d4547e0e4760162cefee70ef2d28ded133";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "aa065427f7c54455816e84e744fcaaaf10043bfcfeb89cc8dc73816f44a28199";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "2a9ef2b01bcecd754376439f03adcfe1f259ef257cab5544997bc7edc8220e6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "b1ba033a7ea93969f0b1614dfbf84936d670051fdf8ba65a6f86f90c13857401";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "878994fd29318e224678296900a52580e92c4d0f49af06649e048830d2eda13c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "0959eaf13b13a0a89d10c3ed42de35c4a9570994c3dbf66b439affdf653eaa60";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "8791e6b2b058372455509082e3a20a10a06a2b468572522c848aaaf99f023716";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "21e1214813f50fb5b0d8e40364319776ff6e90dc8cf68dc9d4fce903cb887046";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "5c51ed3f52832c3d8a34f5082d7d962801f69541b7fd24d5c2b0429464891684";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "d00b110eb21f5bf764941f6046f458bdacdd4044c673bdd500ec0e705cfbca53";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "5649d7486a386621ed7ab629a30cf91d1cd7af421a62c009f067aa80ab8363eb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ action-msgs ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing-ament-cmake launch-testing-ros std-srvs test-msgs ];
-  propagatedBuildInputs = [ action-msgs bond bondcpp boost geometry-msgs launch launch-testing-ament-cmake lifecycle-msgs nav-msgs nav2-common nav2-msgs rclcpp rclcpp-action rclcpp-lifecycle tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ action-msgs bond bondcpp boost geometry-msgs launch launch-testing-ament-cmake lifecycle-msgs nav-msgs nav2-common nav2-msgs rcl-interfaces rclcpp rclcpp-action rclcpp-lifecycle tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "d7eefbc887593142db036784887251520155307111825aa14d9fcaa4fbdee897";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "570c5e52e4fa868c7b8df72e63d54997ece9cdfaf27d9ad4cbcb188bc5c31584";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "37071cb91876a4120b5525d449cc96d4f362fafcd1ce59f37738f99c9e0e51a6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "9e11f251f61f0059c988b75987cdc49066f9cdda734888547f9ca1527a2450f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "cb192af3c391326c909453dffc590b52c7aa687ce56cc779849a0fd8a0f3b065";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "2ee703f9b5cc330194446bd52422631d604985b56572184a862ab249b2d67629";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.9-r1";
+  version = "1.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "a260342e79cd62407cff3b81f15f676ffe9db41f6f2d98e0ab4aca60afcdee59";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.12-1.tar.gz";
+    name = "1.1.12-1.tar.gz";
+    sha256 = "cfcd62625fc8faee60ca87f91e18105fbd85105cec82f98177779ff2cf607595";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2-msgs/default.nix
+++ b/distros/humble/play-motion2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-play-motion2-msgs";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "4baf0586af2b17dea8ffe15e47d6eaf2ca1dc3623e8cefb74c636ff4f2ecbb62";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "c2c1d2c3882c9e6d0751633cbf7fa43305120b4d3f6ca5823c4eb3344eb07efc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2/default.nix
+++ b/distros/humble/play-motion2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, control-msgs, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch-pal, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, sensor-msgs, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-play-motion2";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "016e77439d72ef8b89370d3da6c2462dd470879fe1e696b6654d8aaf191b8e49";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "0e6845cbb7f6b150967e4f13d86ccebb358d2174c5a8474cc5753aa19c1cf013";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-interfaces/default.nix
+++ b/distros/humble/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-interfaces";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_interfaces/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7a9787d4376560976373dfc68c4119b5f64478091a123fe5ac2f57f9d1864b88";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_interfaces/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "55fc2ab4b24bfbbbff862def7757eeb6b75cfa6e1f0fc6db611e15c51bf73646";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport-plugins/default.nix
+++ b/distros/humble/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-plugins";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_transport_plugins/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "cafc70a45a533aa9235f610aa34f94d9665373a248ce790aaa990592faade3cf";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_transport_plugins/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "e85c2307bf4155cecce88eba0d897d5d75f5a43ffe05befdf6b06d1c8da39088";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport-py/default.nix
+++ b/distros/humble/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-py";
-  version = "1.0.13-r1";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.13-1.tar.gz";
-    name = "1.0.13-1.tar.gz";
-    sha256 = "46ee8293ee578ca44c3a7ebb3c25729c27167ebc818eefa810164914b7a7ed75";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "402d950cc31132ffec8eb6f13cd4cf687866692c322041326975592ee8f97701";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport/default.nix
+++ b/distros/humble/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport";
-  version = "1.0.13-r1";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.13-1.tar.gz";
-    name = "1.0.13-1.tar.gz";
-    sha256 = "21d39ce504937be31327afc6da23a5e34c9cc91d65b10f5ecef15c44579cf22e";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "9ec263b5dc068e32c9973f2ebbb59b0a45305ab2e23cfcb2376a201e7f8fd52b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "09e0f09f473fdf9fd14efa47029e40e92212be6cc452769276b53fcb5643c8f7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "99bb147fae7ad0ce9b1b283ddf0fbccad0907b92f3003c3ccaad76e2bbf4832e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-range-sensor-broadcaster";
+  version = "2.26.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "a54e0425f137e5b4dcb0b040be7f88f81cfdecf6ad720a32cc22d82749bf7d40";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller to publish readings of Range sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/reach-ros/default.nix
+++ b/distros/humble/reach-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, interactive-markers, joint-state-publisher, moveit-core, moveit-msgs, moveit-ros-planning-interface, reach, robot-state-publisher, sensor-msgs, tf2-eigen, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-reach-ros";
-  version = "1.3.2-r2";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/reach_ros2-release/archive/release/humble/reach_ros/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "0857ca1e6224ffa71d8d7a68385c9c346f7c96d835d11c76334b4115e1e682a0";
+    url = "https://github.com/ros2-gbp/reach_ros2-release/archive/release/humble/reach_ros/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "823d1ceb8e817aea41288da1491df084956d7433d6a71fb5de213946fcba5e35";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/reach/default.nix
+++ b/distros/humble/reach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, boost-plugin-loader, cmake, eigen, gtest, llvmPackages, pcl, ros-industrial-cmake-boilerplate, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-reach";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/reach-release/archive/release/humble/reach/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "f24ae9d69dd24d6a0bf49eebc743a7b769eb0ba1657c3264e197a685d294e4e5";
+    url = "https://github.com/ros2-gbp/reach-release/archive/release/humble/reach/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "666dde128046d8dcf25a3ab93326af933333e2800c7b64ce8b0ad34a9a86adc2";
   };
 
   buildType = "cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "f79baafd8c77b244018ca34fa049a034613756a6360d07fa498ac54a171b7554";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "83f596f93f55bf38bbea6ae05e8267fc90d6986d8c69318e9c7647f28e19baf0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "b6e1ad3fb601e81f067df52ad40d118892fdd4e8224f84af8da0f85bfb58353c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "104be2643b649379363156c8aaf34c032fcf7eb881d747781ff16dd64854bc02";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "e631ac640b99c24bc80fbecac15969e3c837de3a48da55726ea596dfed6b8eb9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "e0724b97e7fc6ac7952fd78a7da4bb2294fd9cbd5db2c33cb959df3b9affcd9b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "48b20b62bbf662082fa52d0a8d3c4f80620fa28c85642f1f585e7d04101236d0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "0f2a9b95e557d74d0dde38c8f6011c9bcb3cab04a9d236b80aa64067b475bf1b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "8e06730489aa57072f3e159c4858346315b43f83c0a359ced9e2fe5629933406";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "5ad2b8951b4b050254819fd5bcd857626b6dad49370015dee319d9bf3c66ec9b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosapi-msgs/default.nix
+++ b/distros/humble/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosapi-msgs";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "2a08000fd0ae32eb771a5689839129c373001800e76866270a72870b66f115d4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "593765a7bebe4083fb57e2c40dc1ae2b9b5aa0f84781e58f8036d267b2fe2806";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosapi/default.nix
+++ b/distros/humble/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosapi";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "90459e7105d498c75a42ac39911b5f1755dd8448e4570224d59db02d9f1596d5";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "f709148e3c9dbbb68822642d4a578191940dc2b57042a34c40aa84004c9ca2ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-library/default.nix
+++ b/distros/humble/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-library";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "3d9730d50cca9b68f47f1eff36f2a61fe7671fc6d37ba3da4db29aa2d1f65999";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "973fad1ffed13bfda0efb52c88baaf240b39a672c9c0930ce7b9ab1c24385bc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-msgs/default.nix
+++ b/distros/humble/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-msgs";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "8b3b2eed3876eca3fddbf515267aef4f6af59a8bf5d09ee52db209f4dad593cd";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "c54700a985e435b8c5be72a104446cbf3c377bdcea5b434400e3c405df198ab1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-server/default.nix
+++ b/distros/humble/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-server";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "c1344e1d9b2f593e9bce6bff69e8cb0518eef3d11781af626e049f67fc572355";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "14b6093760298794b6194bdc1427ff162d739af5f61d6c1791a6838c696e1628";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-suite/default.nix
+++ b/distros/humble/rosbridge-suite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-suite";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "402a522e6405ddca4b00de5c4b776096485946df02792601b6e163d3582d66e6";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "2701fbe8ab7aa6de2416373e92990a726e132d19d2a2dc4c80eed7e8fc3b47da";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ];
+  buildInputs = [ ament-cmake ];
   propagatedBuildInputs = [ rosapi rosbridge-library rosbridge-server ];
-  nativeBuildInputs = [ ament-cmake-core ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Rosbridge provides a JSON API to ROS functionality for non-ROS programs.

--- a/distros/humble/rosbridge-test-msgs/default.nix
+++ b/distros/humble/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-test-msgs";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "d7dbf6b797946819da9f2dafbc9217ffd54fc82fd7039dac44bdb6a80b57083b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "734f8fc2a34d367527a203917b1e06b3e954b71b377e279182b0a22e2b78e7f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "999d569f22ec40ac9a6a58a268f6f133eef01d5dc7baf6beb3adcfbc9c13df4a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "320759f863d0d30efdda4bcb088776cc151ecba4d8c9454ad51ad83beefa6b99";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "6295081b93330d33e8e9c7d76a4709c9f514d8ec140748d7490f18a6416dd5d9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "cd027fbc9b773b5fe9e82b0bb7329c1658c78e6eb23a9a10ec79f9bd63129b48";
   };
 
   buildType = "ament_python";

--- a/distros/humble/simple-launch/default.nix
+++ b/distros/humble/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-simple-launch";
-  version = "1.7.1-r1";
+  version = "1.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "38f984c036b08c3d5a048fe2f376b3f5bdf4c557a6ba201c1ce1674518c0addc";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.7.2-1.tar.gz";
+    name = "1.7.2-1.tar.gz";
+    sha256 = "63b64bc0b1805f0d073db1bfd5da41ccea0faf42211233d984cdcba6d2d66909";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/slam-toolbox/default.nix
+++ b/distros/humble/slam-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb_2021_8, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-slam-toolbox";
-  version = "2.6.5-r1";
+  version = "2.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.5-1.tar.gz";
-    name = "2.6.5-1.tar.gz";
-    sha256 = "b2b6dbec2cf653dd25c892a81085a1984d54ed1eedc0ae55a24e0679c0a162e9";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/humble/slam_toolbox/2.6.6-1.tar.gz";
+    name = "2.6.6-1.tar.gz";
+    sha256 = "1294e6ee5f96516e2baf92892f53a0fa1a0d95ae056aec4278494d31b1d679ac";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-uncrustify ament-lint-auto launch launch-testing ];
-  propagatedBuildInputs = [ boost builtin-interfaces ceres-solver eigen interactive-markers liblapack message-filters nav-msgs nav2-map-server pluginlib qt5.qtbase rclcpp rosidl-default-generators rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ boost builtin-interfaces ceres-solver eigen interactive-markers liblapack message-filters nav-msgs nav2-map-server pluginlib qt5.qtbase rclcpp rosidl-default-generators rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tbb_2021_8 tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "80ab117dcb8b1cb3c16ef5628ae8c9061a84a80fcfea9e864f3228ce9045724d";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "2eb152e919b595bc5d83f093aee910f03af412814424de25d96847d954b66525";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "b0e90babb2432cde66fa80051d5c65d8f05f313251cd180ccc1fdba349ad554f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "89360220e813e6d3f5b1fd01499757cd262fe81d9d8ca8a6337ae33f01c1d41e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.31.0-r1";
+  version = "2.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "31f75e23d848208b9d2eaea96f427054ab5d1ff455388f62f699c9be9ca66a9a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.32.0-1.tar.gz";
+    name = "2.32.0-1.tar.gz";
+    sha256 = "d49e74d7ff8db2341b3430c5eaa6620e757a6ba58039205ec52c1274a8c985cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "c6b47c80116481fde88c285e6adab5baa05de2946f2eb69d205c343e9b065555";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "99ef322d25c755aee3ebc4cb19012c61406ad55644a1de89d95ed263ba892a86";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "a5364b50c6f5e872517c6c590c8f9c81e9934ec38444884c28f497fccc4dc030";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "7b4b197e938f07f15b5aaa86601ba7d4b3746741b05ad5f3d4d23af66d132139";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "9e2b31c47a15d99e5b97bd901d9af84739451d4a460f6427208d4572d4dc1fa8";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "e0e2c457247ea7e9a8345947efa05f31d3e58cc766c2631fd365b66bf10868df";
   };
 
   buildType = "cmake";

--- a/distros/humble/urdf-tutorial/default.nix
+++ b/distros/humble/urdf-tutorial/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, urdf-launch }:
 buildRosPackage {
   pname = "ros-humble-urdf-tutorial";
-  version = "1.0.0-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/humble/urdf_tutorial/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "fe14125ca9decf3111e771750242b1fc0bb7a7b51adff32896bce34a4258b2b2";
+    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/humble/urdf_tutorial/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "50f0673e2efe6c7e893da4984f8bd7dac87523db1a58b03bea9bb19c57eed1e1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ urdf-launch ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''This package contains a number of URDF tutorials.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "BSD-3-clause" ];
   };
 }

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.25.0-r1";
+  version = "2.26.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.25.0-1.tar.gz";
-    name = "2.25.0-1.tar.gz";
-    sha256 = "4505bc8a1f9b4b76c26e5b280f6a2d99e71bac02cb473640f85bf80ac6037bf0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.26.0-1.tar.gz";
+    name = "2.26.0-1.tar.gz";
+    sha256 = "36710ca472426fa5f082c07c1c8c0df8f28e9c77e89e5a12482accb13e24128e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zlib-point-cloud-transport/default.nix
+++ b/distros/humble/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-zlib-point-cloud-transport";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zlib_point_cloud_transport/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "bd210adca5b27c283018e43e4ca3cb6e57b7085f4343357fec4d1cf9f428e104";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zlib_point_cloud_transport/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "aac9d44a1542ee247dddfa7c8965f324e8fb4d210f0728ab9f414a9babde1b31";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zstd-point-cloud-transport/default.nix
+++ b/distros/humble/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-point-cloud-transport";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zstd_point_cloud_transport/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b012aece778044a901d0b7c4bc6fbffa5aa41ce6d76977def04de0aabb2f88de";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zstd_point_cloud_transport/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "cd95f788f3090a2389b0b860629d4cdba5d0748fa6a962d9e0ed0a9bf0f3b49b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/aws-sdk-cpp-vendor/default.nix
+++ b/distros/iron/aws-sdk-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl, zlib }:
 buildRosPackage {
   pname = "ros-iron-aws-sdk-cpp-vendor";
-  version = "0.1.1-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/iron/aws_sdk_cpp_vendor/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "d684e1829eea7de31132685dd7f37eee45094faf5192a2c95092de90ba2b2103";
+    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/iron/aws_sdk_cpp_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "8c196ea3e201837bb591a98ed082d0ac1d0b167eb5c6af16b3b5807fb78a1345";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "2f2b9b8658ea569ccf9040b5d08faca9c88cbfeed2834b6e632b18e6e9e5d671";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "7e95501ea8e2d581eb0142cfdc90188f580a0936818a36542948fc2c742d0681";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "0caf17b2c600ab82f7f40b842401e90533a963f406624da145f3aae84d3ae3b5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "dc44054ad5ef6590c9472a6537a09487a7108f5064ad494ed2a7083a7c59268b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "ac51d1afec0cf367e2596c8b84f5e3bc3560071525919898b5b5d8587c871426";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "6f56cf4573864a4f7704e7e5bae94126ad08479dd22d981716015848ce73a2d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/costmap-queue/default.nix
+++ b/distros/iron/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-costmap-queue";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/costmap_queue/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "c42dc99163d9ec869bc82b82a32df3afd38afdaeca0405b6297b1474dab93086";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/costmap_queue/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "b3c1e4427dbfd85bad6a6427b53c06affacfef44876639d9159786e53811f91f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-core/default.nix
+++ b/distros/iron/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-core";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_core/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "8cd1de3144c11bab0f2dde3db1a9b9d84482d6e8ceb0ef832c940e4e3e997fe8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_core/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "97acee43296251ac6daaf986992917cb886a78380c34eb36e1a8d5c4424e77e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-critics/default.nix
+++ b/distros/iron/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-critics";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_critics/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "60d756ef000032a214e17fc463ab008c48f76181b6cdd61fa0c471010a230ff3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_critics/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "a29e7130c17456d6718efa6012c45383e55de364930050b65c2815b63b997253";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-msgs/default.nix
+++ b/distros/iron/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-msgs";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_msgs/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "6cd8c10a4b4dddaf49d3624bded1bde0d87f85ba46b22a27cabd1d37ab64e8aa";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_msgs/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "6e3b63ee0e76931b6ce6191efd9ca25e193a24728be9783c01eb3621ef93ba10";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-plugins/default.nix
+++ b/distros/iron/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-dwb-plugins";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_plugins/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "64e48c5236ae28ceb306c8463b4b93d0d2cf2891a0a7f4167caa2484ec1e300b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_plugins/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "a3baeb5a882f677b2a327777c01ccdf9ca0fd79ccf43a45cf164fa2cf934e034";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/grid-map-filters/default.nix
+++ b/distros/iron/grid-map-filters/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, filters, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pluginlib, tbb }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, filters, grid-map-cmake-helpers, grid-map-core, grid-map-msgs, grid-map-ros, pluginlib, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-iron-grid-map-filters";
   version = "2.1.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake grid-map-cmake-helpers ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros pluginlib tbb ];
+  propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros pluginlib tbb_2021_8 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/gtsam/default.nix
+++ b/distros/iron/gtsam/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-iron-gtsam";
   version = "4.2.0-r5";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake eigen tbb ];
+  buildInputs = [ boost cmake eigen tbb_2021_8 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "3e7d6658eeabafb38467debfaa54b9e7f17b609cb1b63ec631387792293c9bf6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "49fb7037f91ebd728f1094ffea5eb201d0790a22f7b28e9b1406e5b84e863690";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "ce65ba5a1abfa412a955a4f32269ccc1d69111532de3aa4946e2cf735c4465d6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "1b4ee75e3ad52dac7847e898459eb02e220f61e47c712e788ff6a47330ace15a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.10.0-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "613bcfa3c5637b3c8622848d05b391e45d6a6e8982c728e9a1cecfe141f7bb5e";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "9016ce788dafa85afee13fa123b2d11d719642caa0bf1492557ef9b9ef9948be";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 python3Packages.pip pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libfyaml libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/nav-2d-msgs/default.nix
+++ b/distros/iron/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav-2d-msgs";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_msgs/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "dbff43021eefed9bac6a2b04bb501bc7d6787b0c07f2ac9b97c0e67bd9007d06";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_msgs/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "c1b83020ecdbbd8839c0bd1b9bf663c3e29702215edd54b5a68a95cade7a99c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav-2d-utils/default.nix
+++ b/distros/iron/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav-2d-utils";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_utils/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "6b713b37844de3d0bc2986fb9e69858a949f5439316253b8e2617bec6296089c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_utils/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "ad98ba3f7ee80c95ee24641178be9edd60fc48335051ee1e8d519d7c025e7c98";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-amcl/default.nix
+++ b/distros/iron/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-amcl";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_amcl/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "115ae95c752c3337441802933aa498e13221bfc50d342d493e1eba6007ce714a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_amcl/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "a481c0d1c562a5ebad596ae7c9adf52889d252302ba2117deb4a78c5cb30204d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-behavior-tree/default.nix
+++ b/distros/iron/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-behavior-tree";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behavior_tree/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "658e38d7d43f8e17f6759ec4f2ef31b94eb251d30a3726e4b8ab4da630797c6a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behavior_tree/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "64faa9db498e6d2b30f6a2c4123006d7d29a01d9674d85856a571f7387c8cb2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-behaviors/default.nix
+++ b/distros/iron/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-behaviors";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behaviors/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "a6182493a4443d1513b07c91fc244e0b5ace226ab0ebe7190afe88f2b3cb7a22";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behaviors/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "e90995d211b6cad9ed2fcf42f2ff82be742f9f15f68634651254aee918abd64c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-bringup/default.nix
+++ b/distros/iron/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-iron-nav2-bringup";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bringup/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "275ad933213bd38b37d4752e725cbbc73209f446606992f84b22bb2a43e6762c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bringup/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "20e3a9902479e0a1dfd080410377ec2ba965ed7350978ef47f5ccfda3e01fc63";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-bt-navigator/default.nix
+++ b/distros/iron/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-bt-navigator";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bt_navigator/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "fd1cb121f0a4258966547b6298f3d7738300c257b4ea7ef41ff07ee456c355a9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bt_navigator/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "945eebad3541bf3ee705467efbf9d8ba7e7359b7b8b93e256e98b686399d3f0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-collision-monitor/default.nix
+++ b/distros/iron/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-msgs, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-collision-monitor";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_collision_monitor/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "bcabcc759c69a450a6c2306917aa006d61041bce5bdedf02aa0362053be50fa5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_collision_monitor/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "30ff075ef04c19802464265a8284d8a5cae3833cf7ae407bf3d149e610b4ae45";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-common/default.nix
+++ b/distros/iron/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-nav2-common";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_common/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "87008918ddef7596df86af7025beba37eec0da3cdd7543a105aaeb1c08348ab8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_common/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "e44f19e70a7b17dd0d8b93f903f75a7edc19054f4ec017dd13071c13d0f22e14";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-constrained-smoother/default.nix
+++ b/distros/iron/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-nav2-constrained-smoother";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_constrained_smoother/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "b614d7267bd294e27d3c571a211e4e3158bd08ec210f7f7c27d086691c4e8972";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_constrained_smoother/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "9f4aa90d549fa40f0df54280a6912f83f712f4e6e8432761c6262107609dbf68";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-controller/default.nix
+++ b/distros/iron/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-controller";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_controller/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "0cd84c748b1af52cde7ba3be17fca3107ab3a54cb562d0c09be2794f06a40f73";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_controller/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "24f00983d58e7e661062c58d894413aac5d28045de7d0d1eebf57804f9f17f1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-core/default.nix
+++ b/distros/iron/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-behavior-tree, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-core";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_core/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "ac1fc95d9b16d5b0a8639de1eefbbea3e8c853269206398dba9fa679b410ba4d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_core/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "7cf7a4b9737d131b20676d33d89a00a1a5d11d038f69de007ae4fb7f2c76c5f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-costmap-2d/default.nix
+++ b/distros/iron/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-costmap-2d";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_costmap_2d/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "60cdeef30d63a3e14e351d06359483020763d1c1e8f38efe3aaf4bea1673efa8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_costmap_2d/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "e689d88eddb6598822442eb5ed372888d77eebcaaf51ce7c5c7a8f5cf9e202cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-dwb-controller/default.nix
+++ b/distros/iron/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-iron-nav2-dwb-controller";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_dwb_controller/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "59fc0d7e4446e3ff516c9572b1b3b6b71086762e5bffbf6941b10cf4fcd39778";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_dwb_controller/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "f38216d7284b04501fd83cfef160ffcf8d522c6fc07b7f58cff51107b32b8c46";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-lifecycle-manager/default.nix
+++ b/distros/iron/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-lifecycle-manager";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_lifecycle_manager/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "b3001729a8cebec2db6dacbe6e2c86655cd2c22289b1cf6b82291ef62bb0def9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_lifecycle_manager/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "e54d95d9a6c2f7dd023a4323ce10dc0ace1bd66a6e69568e877a326bf71e12ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-map-server/default.nix
+++ b/distros/iron/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-nav2-map-server";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_map_server/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "2e5ebc32883ac5f610a7f5951315628a965811acfda206cf708fe86244156952";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_map_server/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "901172a86ef4b6b90811ed1ec751687aba3889557034b47603e0f4646748e7dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-mppi-controller/default.nix
+++ b/distros/iron/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-iron-nav2-mppi-controller";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_mppi_controller/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "4f366f372ed3e41776a436fbb9a68a058cb0589423950c0d10b9c4c01aef7c34";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_mppi_controller/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "0976d68b073ccf5c77a912411e66495a30e258affa8a0b30fdbb3cb50fd409ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-msgs/default.nix
+++ b/distros/iron/nav2-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-msgs";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_msgs/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "f59da0dcbce617155238888a4a07c59c5049aec14b395a591104c53d4be1deab";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_msgs/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "985fa51e5c3610be12cfacc4cb06ab1ea7d8ba84756f1703b6568c0a5ab56ec4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake nav2-common ];
-  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs nav-msgs rclcpp rosidl-default-generators std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geographic-msgs geometry-msgs nav-msgs rclcpp rosidl-default-generators std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/nav2-navfn-planner/default.nix
+++ b/distros/iron/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-navfn-planner";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_navfn_planner/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "f9fab6b99cfa0e78deec594ca3683a26b0cef1d649f882f1fe5e39d9cc55d315";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_navfn_planner/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "265738340243b0fad9bf848c0c0b9225847d93575e140c92286f5ea2189ad456";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-planner/default.nix
+++ b/distros/iron/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-planner";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_planner/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "02aa0a5dee2d9a9d444ee7eff8e4d22ea23ebc2452cc10ccea6b10704b9a1320";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_planner/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "cee8a67c1b341eb071ac683fb70954ec2055b1bf9e0d8e65131215305b08a59b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/iron/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-regulated-pure-pursuit-controller";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_regulated_pure_pursuit_controller/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "6fa0cbe9f22be88f9dd03eae131f4c1a8c5e34f4b96235f6f0fec6cbd6e26e24";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_regulated_pure_pursuit_controller/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "603d54d11d42780041a2df3782950d542ffe66bfc04750fb64b93324b9486995";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-rotation-shim-controller/default.nix
+++ b/distros/iron/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-iron-nav2-rotation-shim-controller";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rotation_shim_controller/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "4a957b2bfbb33c554cf2eab17eecc96339a5e79ba6cf4916cc7a13a6ec440b06";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rotation_shim_controller/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "f2aeeaf43ffbca9f109d68623392ee80f299fa1586547f67b131cde2990b4ab7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-rviz-plugins/default.nix
+++ b/distros/iron/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-nav2-rviz-plugins";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rviz_plugins/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "a90356a6d4a4e6582ecfe6519ba2b9013dcb639594df0cd6d744450bf2f27898";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rviz_plugins/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "39e222aecce2642f8fd11709a834a96d9a9433885c6d612710ca9d2b326657ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-simple-commander/default.nix
+++ b/distros/iron/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-nav2-simple-commander";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_simple_commander/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "04f98d087a83b71cc3db2eb5c8a8e6484481e87155ff3d2bd29b8ba925508fb7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_simple_commander/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "bf7bc8337f09134ec55dba0e0af28ebab639cbcd9fc6d14d38953deb39feddd0";
   };
 
   buildType = "ament_python";

--- a/distros/iron/nav2-smac-planner/default.nix
+++ b/distros/iron/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-smac-planner";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smac_planner/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "e8ae2a46ea030e0322196c03543afd38c92c7e5ebe65b2d333c26dcb06681819";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smac_planner/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "e79bc913e10312d9fbc5efa0fb0d3bbf3f88d7410662a72331c51192b83be9bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-smoother/default.nix
+++ b/distros/iron/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-smoother";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smoother/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "c5a1184361047ede5f77200cdbd0a2381a543bd7054e25e0c7bc23bee424adbb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smoother/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "ccf3f372ac0d2c65e41119631109f5dec40a2f4187b623ac349ce80dccf8b1de";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-system-tests/default.nix
+++ b/distros/iron/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-system-tests";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_system_tests/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "229c46665a8446f12b0666fb7f09359d72688f260b1eb4ca94e33a33ac7da05a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_system_tests/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "9022f278de2e7c93f2014c44a3b5d9cf384e8610b74e92a1232ca439f016480a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-theta-star-planner/default.nix
+++ b/distros/iron/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-theta-star-planner";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_theta_star_planner/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "c387e6a976bfa153a7c6c9ecf54c4f19718ef0a8eb3808d917926f2dc19b8977";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_theta_star_planner/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "213ea5d1c411d582b3f06cd8a0eea31197b0a272f9671b8b4ffa5dc400a93ba9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-util/default.nix
+++ b/distros/iron/nav2-util/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-util";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_util/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "9151042e7573691c50867ef09c5dc470461d7282c52f1ab85c2616efaf99a613";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_util/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "72f1d7ab642fa03f94d392c9c152a66dcd29dac813ca88ee032b7efc870eeaf0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ action-msgs ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing-ament-cmake launch-testing-ros std-srvs test-msgs ];
-  propagatedBuildInputs = [ action-msgs bond bondcpp boost geometry-msgs launch launch-testing-ament-cmake lifecycle-msgs nav-msgs nav2-common nav2-msgs rclcpp rclcpp-action rclcpp-lifecycle tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ action-msgs bond bondcpp boost geometry-msgs launch launch-testing-ament-cmake lifecycle-msgs nav-msgs nav2-common nav2-msgs rcl-interfaces rclcpp rclcpp-action rclcpp-lifecycle tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/nav2-velocity-smoother/default.nix
+++ b/distros/iron/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-nav2-velocity-smoother";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_velocity_smoother/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "a42ea651875eee7f5d23f3994643402eab85163f4505d87f043970c730fc36cf";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_velocity_smoother/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "c1e5a9fc8d65a5bc02965bd47a0c1b6a1a4d690f50e032bf883069cc18a6d0e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-voxel-grid/default.nix
+++ b/distros/iron/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-nav2-voxel-grid";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_voxel_grid/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "7b31db3e73ed0e5cff31cc270117c62b1eb9b1d4134fda5ae1d849c755864a81";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_voxel_grid/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "93b0ad4d2f29c623f61fa3209798eefde38e8a499997000ccdfa0993ee1cb5ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-waypoint-follower/default.nix
+++ b/distros/iron/nav2-waypoint-follower/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, geographic-msgs, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-localization, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-waypoint-follower";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_waypoint_follower/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "6954ccb9cf7a68c0cba57a449c559a47b650beb06cbd0b922a8d84491cdb0033";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_waypoint_follower/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "76d6e2469d378dda8bd695f956129d402508e68cec2bb9bc86aab900a204ac97";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge image-transport nav-msgs nav2-common nav2-core nav2-msgs nav2-util pluginlib rclcpp rclcpp-action rclcpp-lifecycle tf2-ros ];
+  propagatedBuildInputs = [ cv-bridge geographic-msgs image-transport nav-msgs nav2-common nav2-core nav2-msgs nav2-util pluginlib rclcpp rclcpp-action rclcpp-lifecycle robot-localization tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/navigation2/default.nix
+++ b/distros/iron/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-iron-navigation2";
-  version = "1.2.2-r2";
+  version = "1.2.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/navigation2/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "b446406ffb6b2577aec7d6f538ab84f6ac8aa3a2de89ab43f844f770ceb830df";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/navigation2/1.2.5-2.tar.gz";
+    name = "1.2.5-2.tar.gz";
+    sha256 = "8eb4abbb7e49b05f2e1406d2fdd931a542dce29ed51c18cecb2470e404b93180";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-interfaces/default.nix
+++ b/distros/iron/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-interfaces";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "bc7d45b4862ae3156a3048bb7b072fd92a3ed90b9c594fc149fabcfdab47ebdf";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_interfaces/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "efbab54f34c68b9bb9f3a529bf04df56ecf5d17d0088a82ee87265dd8c45cb12";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport-plugins/default.nix
+++ b/distros/iron/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport-plugins";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_transport_plugins/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "d75a26cd79ddf79217b6c19f7b5422b94adfe9880386c14eb6d563ac0ff62cb6";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_transport_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "3d8d5f8963eef58eee86c41d23f9658df39edcd6a5f0811f379aa2d016b081c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport-py/default.nix
+++ b/distros/iron/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport-py";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "8bf6463db538f30a26c90069f09b05b3e93a875845c24a1ede917c41691841aa";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "0cd9de660ac96621b7ad1f759a1a673b249f699c66f58eb48bab6680bb514bd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport/default.nix
+++ b/distros/iron/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f2c2a78ea9b071e5e8fe151d9ea7784779000987c2e494fb9b48dbf6f1d22be5";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e4fc94ffb0513e508876da035ffc2685e471e24bf4953c1222d12bc345444c86";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "49b2ab4230bfc6ac26d255bcb68d2af0446fd4e135122fa50565824bfdcc3c78";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "a764edfd515e2a5d40ae27428585f7c129e2401cdd0942c206feea1836eb3112";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "3674dac60353faa54b6408b29b7511f4445536f6eaed428f489db4acbcb890df";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "1a30e7dbc8094f560c2891fe4f3d49d9cd030ac861ad4c63071c6caae076c0bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "d9dfcb49d716db6a672fc581afb8455394699b86d62a7b486bbcfae7bb946b68";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "9bfa2c43bb231980b0eda172b0c09fdddf454611cd0a18aa69dccf1432a8ea05";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosapi-msgs/default.nix
+++ b/distros/iron/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rosapi-msgs";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi_msgs/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "89e8fe10458f212eb11bad36d89127c766dd143d4acbd95015b61ca4b4975bf7";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "7c580a7a65ae5718edc03384d47490619baeca7549aff0bf38c1c720a12e64ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosapi/default.nix
+++ b/distros/iron/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosapi";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "cc1c2e9d5e2b94447933ed592c9faa6876a3629354f0f8fe1b4c4cf034cf66da";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "e70bf23428b3610962529b5afc4e5ca3e8aefc924913e91f5dacaba8487aafab";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbridge-library/default.nix
+++ b/distros/iron/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-library";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_library/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "3fc22a6da8cc113f0b9df57e56aae0db0f4a12d03d4664cd0b019b5e92edea4b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_library/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "78b32f280bfe77de1d651cdd27c329e2104d339331446ef97f62b29967db1581";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbridge-msgs/default.nix
+++ b/distros/iron/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-msgs";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_msgs/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "d4313588d4c75744bdc39d6fa9131822bb45fc7c7dfc860fe8c0a3ca18e238c4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "023219ec16b43659d576ced3fe863615800376f4bb15676169b41cad39a5eaec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbridge-server/default.nix
+++ b/distros/iron/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-server";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_server/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "ed19003d150dc8a24129ed666dc8ab1eb10d26880e42701d8a854254627ec582";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_server/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "528e8adddb43de6ecf6c344c7510445f6ac1b6ddcca578f2fdd3c9078d2d748f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbridge-suite/default.nix
+++ b/distros/iron/rosbridge-suite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-suite";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_suite/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "7ca74fbbba81c85921b097bcf93b6c952cd9069723addd4da04b074e0a93b601";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_suite/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "4150a9f0770201acc4ed103c96ddb2a2b806c6749c4999733b36b666227722e9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ];
+  buildInputs = [ ament-cmake ];
   propagatedBuildInputs = [ rosapi rosbridge-library rosbridge-server ];
-  nativeBuildInputs = [ ament-cmake-core ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Rosbridge provides a JSON API to ROS functionality for non-ROS programs.

--- a/distros/iron/rosbridge-test-msgs/default.nix
+++ b/distros/iron/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-test-msgs";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_test_msgs/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "e97ede299fc93a227eb9acfa7637ac9373f36da2f731d9c0aea59281d19bd1e2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_test_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "f6e65bd810b035781e39aa6bb2b4ea41304bc9bdfe85d12a61f2b232a767f0c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "ad9a80e083a44448f46ee91f884f6c303e9af90b44c9e172c27a0c74b2e0612b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "7a5a68b21acdbfd3df2864a9d93143d28d3253248006302af969412f236518c3";
   };
 
   buildType = "ament_python";

--- a/distros/iron/simple-launch/default.nix
+++ b/distros/iron/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-iron-simple-launch";
-  version = "1.7.1-r1";
+  version = "1.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "973e8ab0426c7158d2717e9a0776d34a674502ecdc2444e50ae79dad128a2012";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.7.2-1.tar.gz";
+    name = "1.7.2-1.tar.gz";
+    sha256 = "ef2aff17cd3d266cb1fbe998ae6265785b11a386b4b10dff998865077ed52ec2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/slam-toolbox/default.nix
+++ b/distros/iron/slam-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb_2021_8, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-slam-toolbox";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/iron/slam_toolbox/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "5c6ff242385682ab0706b0dde1557818e0686417a47751842852e4087dfd875d";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/iron/slam_toolbox/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "f80edb217ec2dcb2900f7420e81e00ce5c949233a0ae9d36b572331107107f18";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-uncrustify ament-lint-auto launch launch-testing ];
-  propagatedBuildInputs = [ boost builtin-interfaces ceres-solver eigen interactive-markers liblapack message-filters nav-msgs nav2-map-server pluginlib qt5.qtbase rclcpp rosidl-default-generators rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ boost builtin-interfaces ceres-solver eigen interactive-markers liblapack message-filters nav-msgs nav2-map-server pluginlib qt5.qtbase rclcpp rosidl-default-generators rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tbb_2021_8 tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "0fb368653f76e2877aa2b7de5685077f3b461a5ff92b90f374966627cfba8711";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "829f72e4537c90e20cae473b4d8a4bfc17c69562e82d86c7822c491513ff327b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-client-library/default.nix
+++ b/distros/iron/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-iron-ur-client-library";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "74b334d4cdf1bfb87b616ae6d2f1e80a544f11400d1e64a0d4eac7acfeaf7efc";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "c7461f5a5f2c0158423d146358c4002b096551cf273b706b53219355d1830de8";
   };
 
   buildType = "cmake";

--- a/distros/iron/urdf-tutorial/default.nix
+++ b/distros/iron/urdf-tutorial/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, urdf-launch }:
 buildRosPackage {
   pname = "ros-iron-urdf-tutorial";
-  version = "1.0.0-r4";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/iron/urdf_tutorial/1.0.0-4.tar.gz";
-    name = "1.0.0-4.tar.gz";
-    sha256 = "9ac3c45151ead4281d8fe1e318d26dcc969fea7df64df55f1298f670b77c19a1";
+    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/iron/urdf_tutorial/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2eb0a1ec06bc05bc12c5a9a3793b0dbb114e4c77b14f91bbc1c5b04674967cf1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ urdf-launch ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''This package contains a number of URDF tutorials.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "BSD-3-clause" ];
   };
 }

--- a/distros/iron/zlib-point-cloud-transport/default.nix
+++ b/distros/iron/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-zlib-point-cloud-transport";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zlib_point_cloud_transport/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "17197218cac678a607c4129beb6d2f0b24a211a5929c041e51635ccdb1dfd7ed";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zlib_point_cloud_transport/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "3668dcb35b9082e55c91bcb6a761a7f3c87236fa5cf3f521e12bb711cde3fe44";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zstd-point-cloud-transport/default.nix
+++ b/distros/iron/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-iron-zstd-point-cloud-transport";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zstd_point_cloud_transport/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "405fbf095e89e5954dbec1b2ee3adb403e616dd03d352e0f3cb1dd061a79e619";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zstd_point_cloud_transport/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6118c1c44d7b86dc02f356387624a50e3770ad9fc473ed4bcf3a575baab024bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/cpr-onav-description/default.nix
+++ b/distros/noetic/cpr-onav-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cpr-onav-description";
-  version = "0.1.8-r1";
+  version = "0.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.8-1.tar.gz";
-    name = "0.1.8-1.tar.gz";
-    sha256 = "a7d3900a84a18d3c86717525840eaacde06719699c553ded72b4e1ca014293da";
+    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.9-1.tar.gz";
+    name = "0.1.9-1.tar.gz";
+    sha256 = "2a52b9d2e752b30b9c3045faa2f60b1998e2c728b03d24ca7945f0d9d9b80384";
   };
 
   buildType = "catkin";

--- a/distros/noetic/grid-map-filters/default.nix
+++ b/distros/noetic/grid-map-filters/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, filters, grid-map-core, grid-map-msgs, grid-map-ros, gtest, opencv, tbb }:
+{ lib, buildRosPackage, fetchurl, catkin, filters, grid-map-core, grid-map-msgs, grid-map-ros, gtest, opencv, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-noetic-grid-map-filters";
   version = "1.6.4-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros opencv tbb ];
+  propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros opencv tbb_2021_8 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/gtsam/default.nix
+++ b/distros/noetic/gtsam/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-noetic-gtsam";
   version = "4.2.0-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake eigen tbb ];
+  buildInputs = [ boost cmake eigen tbb_2021_8 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.10.0-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "3909975e3bb8eae08ddaf54f5dd63a67b7c7f3614abf4fc00da1b27dcf1b62f3";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "eefeff667c2157f597fb860999779393008600f8cc0ea733474a560dafca6235";
   };
 
   buildType = "cmake";
-  buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 python3Packages.pip pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/nav2d-karto/default.nix
+++ b/distros/noetic/nav2d-karto/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, nav-msgs, nav2d-localizer, nav2d-msgs, roscpp, suitesparse, tbb, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, nav-msgs, nav2d-localizer, nav2d-msgs, roscpp, suitesparse, tbb_2021_8, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-nav2d-karto";
   version = "0.4.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ eigen geometry-msgs nav-msgs nav2d-localizer nav2d-msgs roscpp suitesparse tbb tf visualization-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs nav-msgs nav2d-localizer nav2d-msgs roscpp suitesparse tbb_2021_8 tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/reach/default.nix
+++ b/distros/noetic/reach/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, boost-plugin-loader, cmake, eigen, gtest, llvmPackages, pcl, ros-industrial-cmake-boilerplate, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-reach";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/reach-release/archive/release/noetic/reach/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "4055142acd4239e1435e9ed32e8ce84fd49207f2167baac80b9b3d49f3b0060c";
+    url = "https://github.com/ros2-gbp/reach-release/archive/release/noetic/reach/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "d245fd2ce71a1457aec8e2cb0974be0f2cf5f8c93fb55589fb5f03b6203b41a2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rosapi/default.nix
+++ b/distros/noetic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosapi";
-  version = "0.11.16-r2";
+  version = "0.11.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosapi/0.11.16-2.tar.gz";
-    name = "0.11.16-2.tar.gz";
-    sha256 = "bf9ce72d57cbb66cb7eb52ed5fe4cdb54e39c1d46418880efbbc2afd75d9c054";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosapi/0.11.17-1.tar.gz";
+    name = "0.11.17-1.tar.gz";
+    sha256 = "7f94f672ef42b8a8d33be48c5890f43f8b9cf1de4495e018242d0eb0231d9ec8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbridge-library/default.nix
+++ b/distros/noetic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, python3Packages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, rosunit, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-library";
-  version = "0.11.16-r2";
+  version = "0.11.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_library/0.11.16-2.tar.gz";
-    name = "0.11.16-2.tar.gz";
-    sha256 = "3088f6ad0760a950cf1862ce787b98b0e47e2331b9f585d94734936e202af605";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_library/0.11.17-1.tar.gz";
+    name = "0.11.17-1.tar.gz";
+    sha256 = "01ae6153076f7ae789bf7c2a5a2a4387878fc36e1f0a1c6378486b442df677fc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbridge-msgs/default.nix
+++ b/distros/noetic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-msgs";
-  version = "0.11.16-r2";
+  version = "0.11.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_msgs/0.11.16-2.tar.gz";
-    name = "0.11.16-2.tar.gz";
-    sha256 = "17222a92d38c32deb3e38d9722357b8acd0cccc16ce646ee656e8c4db1a30443";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_msgs/0.11.17-1.tar.gz";
+    name = "0.11.17-1.tar.gz";
+    sha256 = "1ff3a4b77b2c21903d043307f5cbfb75bb498536ae5afa4b3e3756027c2e332d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbridge-server/default.nix
+++ b/distros/noetic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-server";
-  version = "0.11.16-r2";
+  version = "0.11.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_server/0.11.16-2.tar.gz";
-    name = "0.11.16-2.tar.gz";
-    sha256 = "9726b4b3f01480655e44fbdafa1d96985bdbab22723a80fdbc8737d4c2f7c940";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_server/0.11.17-1.tar.gz";
+    name = "0.11.17-1.tar.gz";
+    sha256 = "fc9a4d0972e6d161f78ef78bcbd74dfb5f26e978bbd05732e33876df1a2f30c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbridge-suite/default.nix
+++ b/distros/noetic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-suite";
-  version = "0.11.16-r2";
+  version = "0.11.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_suite/0.11.16-2.tar.gz";
-    name = "0.11.16-2.tar.gz";
-    sha256 = "34365bcf7dd624e5f6ad9d7faf4b98c125f623b663e088388b1d4d7154e73205";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_suite/0.11.17-1.tar.gz";
+    name = "0.11.17-1.tar.gz";
+    sha256 = "e80beaca82081afc1bdaf4306a5e3d76354e93c6ed6fb205ea174c80565a6559";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmon-core/default.nix
+++ b/distros/noetic/rosmon-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, ncurses, python3, python3Packages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-rosmon-core";
-  version = "2.5.0-r2";
+  version = "2.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_core/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "b3bf928b65c486dc166ee27510dbdf079a9df8fb10986aa8340db7f952e43e21";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_core/2.5.1-2.tar.gz";
+    name = "2.5.1-2.tar.gz";
+    sha256 = "d1efe8c55dccb1073937b44a4f0a2059eb82dc5b7af393926f4b8d3c99328f04";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmon-msgs/default.nix
+++ b/distros/noetic/rosmon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosmon-msgs";
-  version = "2.5.0-r2";
+  version = "2.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_msgs/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "8c74faaf6ed0b29287802446e7968ec1a4e47f0d1723aec8afedcb10514cdd36";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_msgs/2.5.1-2.tar.gz";
+    name = "2.5.1-2.tar.gz";
+    sha256 = "d64fd909a64d8c995d333a6aeb96ff362f13567ccfca3c91fa24b021c907a2bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmon/default.nix
+++ b/distros/noetic/rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosmon-core, rqt-rosmon }:
 buildRosPackage {
   pname = "ros-noetic-rosmon";
-  version = "2.5.0-r2";
+  version = "2.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "bb4c3387d7d5a05cb27837d635782383cb9c83aa84a2bfc4f30162923c4fda10";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon/2.5.1-2.tar.gz";
+    name = "2.5.1-2.tar.gz";
+    sha256 = "e5ed98beb02e31e437d17c8996b25892f247010492ec7259e88a286bc4a19fbd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-console/default.nix
+++ b/distros/noetic/rqt-console/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, roslib, rospy, rqt-gui, rqt-gui-py, rqt-logger-level, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-console";
-  version = "0.4.11-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/noetic/rqt_console/0.4.11-1.tar.gz";
-    name = "0.4.11-1.tar.gz";
-    sha256 = "f2fed22a56e9c85c5092337ad2b1c043f28e548b82ab9d2eb5514089552ffb94";
+    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/noetic/rqt_console/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "9d28654f41fb82fc298140b8ea5b7041b15d5ade3bccc467b01f7b1763be1c36";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg roslib rospy rqt-gui rqt-gui-py rqt-logger-level rqt-py-common ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''rqt_console provides a GUI plugin for displaying and filtering ROS messages.'';

--- a/distros/noetic/rqt-logger-level/default.nix
+++ b/distros/noetic/rqt-logger-level/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosnode, rospy, rosservice, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-logger-level";
-  version = "0.4.11-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_logger_level-release/archive/release/noetic/rqt_logger_level/0.4.11-1.tar.gz";
-    name = "0.4.11-1.tar.gz";
-    sha256 = "4048c4d54ffe875a97ad927ce8b00658a17ea685624dcd0fb6a62b4106dd8ea3";
+    url = "https://github.com/ros-gbp/rqt_logger_level-release/archive/release/noetic/rqt_logger_level/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "cff5ad8cdb8089e87fee61958e967d032ccd81798af6bf4b1a7236b258b53f05";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg rosnode rospy rosservice rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''rqt_logger_level provides a GUI plugin for configuring the logger level of ROS nodes.<br/>

--- a/distros/noetic/rqt-moveit/default.nix
+++ b/distros/noetic/rqt-moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosnode, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, rqt-topic, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-moveit";
-  version = "0.5.10-r1";
+  version = "0.5.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_moveit-release/archive/release/noetic/rqt_moveit/0.5.10-1.tar.gz";
-    name = "0.5.10-1.tar.gz";
-    sha256 = "6c481788f1737b83c47f4696dbaf2202b1305cdb206c9b73778028c3199c4a94";
+    url = "https://github.com/ros-gbp/rqt_moveit-release/archive/release/noetic/rqt_moveit/0.5.11-1.tar.gz";
+    name = "0.5.11-1.tar.gz";
+    sha256 = "38a31a5536e36e503751d3742ccc6c2277ef6c80768fad6088bbcc3a7e6efbdb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-robot-monitor/default.nix
+++ b/distros/noetic/rqt-robot-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-robot-monitor";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_robot_monitor-release/archive/release/noetic/rqt_robot_monitor/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "2b6ea56c5b17fae4955f5ea8061adc9991715efe202a8dcb347442aad4bab6b8";
+    url = "https://github.com/ros-gbp/rqt_robot_monitor-release/archive/release/noetic/rqt_robot_monitor/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "05072df9d2c010e529c53c3c2171cd2d90a1f4996a428acb3df95f191fd93ae8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-rosmon/default.nix
+++ b/distros/noetic/rqt-rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, roscpp, rosmon-msgs, rqt-gui, rqt-gui-cpp }:
 buildRosPackage {
   pname = "ros-noetic-rqt-rosmon";
-  version = "2.5.0-r2";
+  version = "2.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rqt_rosmon/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "bd616519f9e479b01f3815009a69f594683dd99198bbfe8ebeea4328e5579f64";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rqt_rosmon/2.5.1-2.tar.gz";
+    name = "2.5.1-2.tar.gz";
+    sha256 = "13ec4a82f87904645da16150e6fbea7b426136ea2cf88558980f899c13315f60";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-runtime-monitor/default.nix
+++ b/distros/noetic/rqt-runtime-monitor/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-runtime-monitor";
-  version = "0.5.9-r1";
+  version = "0.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_runtime_monitor-release/archive/release/noetic/rqt_runtime_monitor/0.5.9-1.tar.gz";
-    name = "0.5.9-1.tar.gz";
-    sha256 = "237206b6bdd8850ce375e7900125b5864646556a68acb107989624cefc5c0d33";
+    url = "https://github.com/ros-gbp/rqt_runtime_monitor-release/archive/release/noetic/rqt_runtime_monitor/0.5.10-1.tar.gz";
+    name = "0.5.10-1.tar.gz";
+    sha256 = "73e578dce9b08303961a8eff30fb38d15024a3f16c74533b4ce1dcae3bbbea3c";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui rospy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''rqt_runtime_monitor provides a GUI plugin viewing DiagnosticsArray messages.'';

--- a/distros/noetic/rqt-tf-tree/default.nix
+++ b/distros/noetic/rqt-tf-tree/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, rospy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rqt-tf-tree";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "5f07d027e135ff74636fc97216b666aa0ee16aa5f10cd631db1f2226496bb351";
+    url = "https://github.com/ros-gbp/rqt_tf_tree-release/archive/release/noetic/rqt_tf_tree/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "c2bccb3aeae478e741d7beb55a46a23eb32707db54bce2a91867ecf7eaeb4366";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   checkInputs = [ python3Packages.mock ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-dotgraph rospy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = ''rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'';

--- a/distros/noetic/slam-toolbox/default.nix
+++ b/distros/noetic/slam-toolbox/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, gtest, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb, tf, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, gtest, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb_2021_8, tf, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox";
   version = "1.5.7-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ ceres-solver eigen interactive-markers libg2o liblapack map-server message-filters message-runtime nav-msgs pluginlib qt5.qtbase rosconsole roscpp sensor-msgs slam-toolbox-msgs sparse-bundle-adjustment std-msgs std-srvs suitesparse tbb tf tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ceres-solver eigen interactive-markers libg2o liblapack map-server message-filters message-runtime nav-msgs pluginlib qt5.qtbase rosconsole roscpp sensor-msgs slam-toolbox-msgs sparse-bundle-adjustment std-msgs std-srvs suitesparse tbb_2021_8 tf tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/spatio-temporal-voxel-layer/default.nix
+++ b/distros/noetic/spatio-temporal-voxel-layer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, laser-geometry, message-filters, message-generation, openexr, openvdb, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, std-msgs, tbb, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, laser-geometry, message-filters, message-generation, openexr, openvdb, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, std-msgs, tbb_2021_8, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-spatio-temporal-voxel-layer";
   version = "1.4.5-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ costmap-2d dynamic-reconfigure geometry-msgs laser-geometry message-filters openexr openvdb pcl-conversions pcl-ros pluginlib roscpp sensor-msgs std-msgs tbb tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ costmap-2d dynamic-reconfigure geometry-msgs laser-geometry message-filters openexr openvdb pcl-conversions pcl-ros pluginlib roscpp sensor-msgs std-msgs tbb_2021_8 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "113484ad1e622c5a1ef046e01f495f2171c1051eefea949a13316b2cbeb71986";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "d2152d337556de06073c71742806c6d1d5acabfe432339ca27874923f42e429e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/action-msgs/default.nix
+++ b/distros/rolling/action-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime, service-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-action-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/action_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "87dc34c755e414b301c8c5f51129a274813d11594a6b1b810b2b4b0f7c3b0244";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/action_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4f6079b90666adb1ec87bb322eb4ba9425c2fba81b2c59a222703376de419d26";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-clang-format/default.nix
+++ b/distros/rolling/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-format";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "8969e81770376db78e36c2681608fcf0c5408fea36e8926338793765283cc4a8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "77c03e3940461063711ff0ecb4b34a1dd94b9379d9fae508ec7b7b895c475cb3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-clang-tidy/default.nix
+++ b/distros/rolling/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-tidy";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "a25e9dcdf8a7debf5c175a55b990c5fbd382aa84edf11be587c8946a6ced1512";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "5a7ac9b93a24de3f9731ee935d15686a753d9290e75ae2aaf901b7fd6585007a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-clang-format/default.nix
+++ b/distros/rolling/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-format";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "96289cfe185abcdcb195e0a549e7cb048e668f06a26ead27b4629725223e5b7a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "88148b8944613ba89503d27028efdd4b843b1583e638899602f8071d2d66caaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-tidy/default.nix
+++ b/distros/rolling/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-tidy";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "3be9b8fc693634df1bc82c5f3581310d2656098926253705fab3462736283165";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "a1bb73172d4c1ca55f4892cd9a5917845e39c3088a42255d58c50b5eb6749e50";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-copyright/default.nix
+++ b/distros/rolling/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-copyright";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "7d1447d91c6dcbdd6f78b15d762029d7ec455c8a633ebb1c9b49a4672078cafb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "5b7823a7288b087470646c6d5fc0fe23d6191a50f81e067aab197635dd26c077";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cppcheck/default.nix
+++ b/distros/rolling/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cppcheck";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "91e637161c7c7a8c1cd798d0f645b3b53b82b428abc915627085105af1d20dde";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "5625e07d0d26f0bf69fe42c5bab2d24f49c979fa70e742ad2b11140c84474638";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cpplint/default.nix
+++ b/distros/rolling/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cpplint";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "172572393f1df8db57f3a1a8cd85c3cb037e499f75ebb6d2245ba8fe6eb76409";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "76b5d955d927421f6f1a4f2bb960b9ef095113496c408ac2cc4b41524aec2e04";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-flake8/default.nix
+++ b/distros/rolling/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-flake8";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "0bf8325ac97d8d1b9da2ecbd774d68e87b17e30bf1410df374dcd752e44b1792";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "bfc00840fab1c3b7d1c9ed45588808fd87a4bd8d96ba59ae76e553e479dbde6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-lint-cmake/default.nix
+++ b/distros/rolling/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-lint-cmake";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "5c8a6838a28ed599824586cd401805824fd72e4faf220bda8631b177b4183746";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "8bc69b46fb1223a72721c8bcb9819729f57938d58b0e1712bce10057f287bea3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-mypy/default.nix
+++ b/distros/rolling/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-mypy";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "bf1cb84f35d4c023e6d04b8cbab06e84afa4b476af48e8c60611aed7d1d47c5a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "2f451e78b8ed5339ff6b920193153adc8b3a4c3050c3236ddb62c4d60981d96d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pclint/default.nix
+++ b/distros/rolling/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pclint";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "710f49d7caeb8809668e6e17cbba5c131880eb409c2c6e407f33e265c9b4290c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "8ace74db9f12ca1f1ab4c6bcb34007afbe974b35c8d08540ec207585f7c55ddf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pep257/default.nix
+++ b/distros/rolling/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pep257";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "7b9a4f39833dd32c4f6f0842efa784282760a4c523a685d31b7517c7e36860a1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "9b87503dc4e382cba7485ddd090abd912906b9d8db74a4483b06a1971f4d6af3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pycodestyle/default.nix
+++ b/distros/rolling/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pycodestyle";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "d4d522b163f071adcc7490ad8a6469b168347d9baacf46332beeb93922f47b03";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "d4971d871ab34ed271ded51ae49c81e6aeb996dba4b7ff245e975845d6890371";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pyflakes/default.nix
+++ b/distros/rolling/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pyflakes";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "75d68a81a11b44b28f4c5b2740a39290d729de3647396249499c0f19de428752";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "e67d03629c64f719dc492e7224b8668a4b0983a6a699b25f270531d17958f077";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-uncrustify/default.nix
+++ b/distros/rolling/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-uncrustify";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "4c46d71061d8778004b77de64a12b29f21a88ef9ba279c556c35ee6d30dbe827";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "8af06e69559da4be17d3abc24480c29d7d3f9513c22f3363f4429da6e88d8f29";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-xmllint/default.nix
+++ b/distros/rolling/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-xmllint";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "f52f046d97af13c64497fe5ce5ca7bcd0ef4c2ab60b9fbc33aa0b9469edbffa8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "fd4504ada011a3b92f677904dec0a69d90ddc53455ad8ac9a77bcc2b0fd2f173";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-copyright/default.nix
+++ b/distros/rolling/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-copyright";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "e0c4fa94c9deaa31d11b1bc077b38bb758a498c50a742dd08b6c5d7e8eda701b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "b7407e925fbf577cb4375c49cfc7fc7601ae947b87cd9c5807b92000fc031b8d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cppcheck/default.nix
+++ b/distros/rolling/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cppcheck";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "6fb4b3924ca7c4895db9546b5947d9928e41ef1e32ec0fbb5a4d6ddfc962120e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "7bb9abd73aa940603ed4d9064d140e195a251fee232003001cdbf73a5a1447ac";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cpplint/default.nix
+++ b/distros/rolling/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cpplint";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "0672d798b7a083254571fb522db7d40aa0d8e8961cc2faa346de5e7e13725373";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "bb84d3c922e87b4c758e989056bae17c91b7f8e21f7f46135902ea580340d53a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-auto/default.nix
+++ b/distros/rolling/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-auto";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "8fe8b710c95d0f4268d8d9aa2e9a3131be82f782290f5591d8b0fbec27cc14f1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "e7edf2c0020f2cca459c1049fbacbfc93a8df0cb6a4ae14ca9830c83e542556e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint-cmake/default.nix
+++ b/distros/rolling/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-cmake";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "c64f2c43e28f95c23ee274ce5444433ab8ce165c8a47f89f8186555ddc87277b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "207e8e3dae3850839ba7cf13e48c9bd4d668adf46db4b427032961bec746a214";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-common/default.nix
+++ b/distros/rolling/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-common";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "1aeb8c86d8cea8952dfd85104bdf3871d70c0cfe28bda3563219353ec96fd62c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "6ad4a1eb44b8445ba11ed065e7a69a9e6e2ac67cff1711c27fcf210c3268bb1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint/default.nix
+++ b/distros/rolling/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "8f8fea9bd0aacc83f9ec4509d53d0ddc69589c5b95aa138760066b578a2f7b0d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "f7fb82b5f4fe8e70fad466a08699dfa38cdaa2db47ed71f92fda4be4bc910c06";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-mypy/default.nix
+++ b/distros/rolling/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-mypy";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "eb3443f0257784cb7d127f578804b82a6351a56bda1b0ce0931e26d2d36e9fac";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "bfcb2c8b32a16136d5e5b2c2bd654a62587a70e6aa602eccef1387c5603ea4d3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pclint/default.nix
+++ b/distros/rolling/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pclint";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "b73a73ed31056deeb0aaa28b1d031d735a1e47706870d8f82f5f35e3ab337ddf";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "be880c47b85d7120d024519643542d47b1a399444a7638bd8c24f4d567d56444";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pep257/default.nix
+++ b/distros/rolling/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pep257";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "1ccce5e538fe73d2c569061691e602ef346c55957aa0762819af7bcb48518c32";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "5ac228223f314d20c5661e23a14babd2467b53dfaefd44a9a74b117aec05da36";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pycodestyle/default.nix
+++ b/distros/rolling/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pycodestyle";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "43f40a872fd19f6f8a40cfbdcefa75d4ab0dcbdbff83916840014ead4400e391";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "ddcecaf36176ed35b47afca2e55bcb4dacc7c8ad62d3be137cd89120f9b100c7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pyflakes/default.nix
+++ b/distros/rolling/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pyflakes";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "f3c58ed083e9f8052a85d457272a57459be220786a0e1b5209234f9fb246c400";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "dc84a753490111c5c37200ccc1599fc52b2fb274750bad87fc06fee86deb2f09";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-uncrustify/default.nix
+++ b/distros/rolling/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-uncrustify";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "5c9a22d96c63cb7a4a5fe0721496a20691a41931283825d0d5dd3541a4250bea";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "4f28afa9d9780dcf0c3feb3c72f4d9d26e0ee0439e942a739b22eef39d3f11cb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-xmllint/default.nix
+++ b/distros/rolling/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-xmllint";
-  version = "0.15.2-r1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "c83901913f1b401548588365c9c97f03d975a6e308982b5f2b7c7b2b6df64f83";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "3961ce21c7187ac081d8b98b328ab4c70a581e5b57e018554f03c125fb073a46";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/aws-sdk-cpp-vendor/default.nix
+++ b/distros/rolling/aws-sdk-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, curl, openssl, zlib }:
 buildRosPackage {
   pname = "ros-rolling-aws-sdk-cpp-vendor";
-  version = "0.1.1-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/rolling/aws_sdk_cpp_vendor/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "c92015ce6fd7b08dc33cab87a6176623f64246f224630861f519136f83e15993";
+    url = "https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release/archive/release/rolling/aws_sdk_cpp_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "5167c0f54ba538b151f717bbed423f909d5a89d386da5cef0b702c7d3a359ba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/builtin-interfaces/default.nix
+++ b/distros/rolling/builtin-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-rolling-builtin-interfaces";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/builtin_interfaces/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "6a865e8b79274254b4b336dcc3d17dce614aa08d770fb0289311b9751e588249";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/builtin_interfaces/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a08436d9b28d43318ef00a132ac23029cf489a6ed69f348c3a586d19f47f0252";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition-interfaces/default.nix
+++ b/distros/rolling/composition-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-composition-interfaces";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/composition_interfaces/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "5f2e9dbc60c05814035cabb20de67bbbcb6ad2fa228948870349e196679f841c";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/composition_interfaces/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c9cfea107fd886878fdc6987d2a8fc2f04b779253eb9e9b52bfc3c91ebbb22e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "e9ac3b0c1f8bcc6dcc09d6015bbaf807b0e2cbbd8828e7b2c6b8a256548f7993";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "678dcd99c7dd14a74eb0720f24fd13ea9fe470d45853e0328febe63a2d12a1a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "f0b4490737e70865662fc770d4761c4f5c713bb47851d15d5de0e216ca1c664e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "87cd5c619bf67bb7216adc708423abaac7ea790f0d15a25853cf090e4f069715";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "61eef116663e053c467ffc2ec1b7d83b3d9c5b8fb8baa509caff3ea4a86fc658";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "c07a0614e32d94528b325d0173e557128d8820884113b5d3cae070f68dc3c999";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/event-camera-py/default.nix
+++ b/distros/rolling/event-camera-py/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-event-camera-py";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/rolling/event_camera_py/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "06574f6106066a660ed5a2820f081b18edbf5110eff5c45461a2c72b2d9026a8";
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/rolling/event_camera_py/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "2765ea79f241210ff730833bd04378095e76262dacf3ae0d1acbdfcf28570fc9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy rclpy rosbag2-py rosbag2-storage-default-plugins rosidl-runtime-py ];
   propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
 

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "22744587b9045b6693a78f3dab116c5af61cc6e956f926b7de1afb3571d0a41e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "73f5994c6f2ed29cbdd68b92d80d99c95421141c0f0f076687fd24671702d8ec";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/fastrtps-cmake-module/default.nix
+++ b/distros/rolling/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps-cmake-module";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/fastrtps_cmake_module/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "e54a2326abf160cde8e51702048e05fdee74f361aadfac1fa4da84d9d2a0f5b6";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/fastrtps_cmake_module/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "019bf3ee4f43ca5d032de0478dffb1f0e41c5bf763578e05fb8f3b50754de0a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -116,8 +116,6 @@ self: super: {
 
  ament-download = self.callPackage ./ament-download {};
 
- ament-flake8 = self.callPackage ./ament-flake8 {};
-
  ament-index-cpp = self.callPackage ./ament-index-cpp {};
 
  ament-index-python = self.callPackage ./ament-index-python {};

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "15041fb63ad9b412e85d472e58ac834e7717112112a3370e6e5561531f0fc5bf";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "2c79fe0f7b3627aa91a50409b801a6ba72e51053c1c0f679cb90737d770fbdad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gtsam/default.nix
+++ b/distros/rolling/gtsam/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-rolling-gtsam";
   version = "4.2.0-r4";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake eigen tbb ];
+  buildInputs = [ boost cmake eigen tbb_2021_8 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "133a57519926bc9b0a6b4a938d901f902a4d85a3a9c870ff354fe1749b6decce";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "467662a4fac62d1b6e0727a366588588fe54d401e4218efbdd307273535a458d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/interactive-markers/default.nix
+++ b/distros/rolling/interactive-markers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rclcpp, rclpy, rcutils, rmw, std-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-interactive-markers";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/interactive_markers-release/archive/release/rolling/interactive_markers/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "5519d561de8300c9143446e6616cbd1b6427e0cdf529f598d27fe001f9bfefa0";
+    url = "https://github.com/ros2-gbp/interactive_markers-release/archive/release/rolling/interactive_markers/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "4e140e4ec8695cb80a619031b8f832665197673872a150fc8eb377058beb0eb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "b4d34fa5ab62325365a203b5e151f60952cae74bfa50928561ec6c39d08ac77e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "e3550a0c83c4f4c6f8b74204ff11c5a2b70e37d65f401ae664f518c44cfab3b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-pytest/default.nix
+++ b/distros/rolling/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-pytest";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "c956b24af66ddb59d441ed8f505b725807d5f384af132b3c8bdfa88393e87fa5";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "8e6e0787361e282e03316e3cdf0a37c1eed0875dc6f2027d8748c75acdd10570";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing-ament-cmake/default.nix
+++ b/distros/rolling/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ament-cmake";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "7d30093e93c2da63dc08b379213fbf1117a1524901825af5282a89278d30d37f";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "fc1d5c7adcb1bbd2b1f0deb8c0f6b219844f168bb6196c9f2f0d7ab7b479a838";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-testing/default.nix
+++ b/distros/rolling/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "c136e540b2509fcc4e1b2e100426edef734bffec3c56a6d399204b8b198aaa3c";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "61006167c5b3fd912d706aa95bc21a46c7fe4a83af3dd2d9fd1cd71a66be432c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-xml/default.nix
+++ b/distros/rolling/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-xml";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "81c00638b0fc85818f83da33e8f0c1ed92922116565acf267953aafab9cd7f1f";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "194a9e4b3be6b4aceed15ed8fc48f3c6d9080439eb1859157a1038976e3e55bf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-yaml/default.nix
+++ b/distros/rolling/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-yaml";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "abbc2826a2b2ba66af9908eed7da1e59b116ae12cf812454d7f5e3755ba44f56";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "434b4f59cd20045f95c7d9ae9d4e6456bad60d668b0890067c38ad37eb6733a2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch/default.nix
+++ b/distros/rolling/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "83e8676b5984d5c34a7e398a645b012565a5d5f3b0a66b8f79f7e13e743c37d7";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "301b1d023e0c4dc441457fdc2ac4d37ac09b1725ce247e4def4ac4b85a886a84";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle-msgs/default.nix
+++ b/distros/rolling/lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/lifecycle_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4832882012d840a2b11f3e43f94ad470c4b78e58f580a659dac63b550d3836d9";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/lifecycle_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "69c8cf9e0f87ad63d010aa051e89500ec028593548a12fc4b45410b597f6ef55";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-interfaces/default.nix
+++ b/distros/rolling/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-interfaces";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "677f032da654125d20f5ddb66737a9023da7fb32157fa8a51f3f557ddbf20f6e";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "6cc77668f11090f490fd9818727b1cb9e297770aa9f5b040cc225727a7939622";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-plugins/default.nix
+++ b/distros/rolling/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-plugins";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ac3ad370dc425647f13980949064745cbd5e7bf15acd264ae439f4aa25044b21";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "ef68183eee7d532e68d6ef69c017ffcd65b62c1805e4ef851efceeac5124fc4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5fa06f84fb843b301b4985916608f223ed0144ee9e241fc80f5f233d778553a5";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "4c7fe7010e69ebb90f08409b68814ed7813c5d28b50c018537156a39b6af7c98";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "00f7ceaf8d35a93ebd64545c95f8de54a61c226003fd4e6095dc58fff36b7216";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "f762d01f3a63c0ce8c933c3a814ea41ceb1d6b663e40d051d05688a2289afffb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "7.1.1-r1";
+  version = "7.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "cb41f2852758d0c7dc9fadf449f8afcd7e2223796536be9e51c965f1bab7ee93";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.2.0-1.tar.gz";
+    name = "7.2.0-1.tar.gz";
+    sha256 = "4c7f2b1bda7cebe9931b36c614dcb9d0b7f0c5988dc5f6adc2d5ccba34f91b97";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-interfaces/default.nix
+++ b/distros/rolling/rcl-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rcl-interfaces";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rcl_interfaces/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4d7f0bbe98938ecc97e0790c7fc065818151f3e6a21a3c01c8dfc20cfc6f08b1";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rcl_interfaces/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "916987ec65cc11e61892a76f54e86aa573fa93b49f6c815a316c30d966a504f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "7.1.1-r1";
+  version = "7.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "e5f2b92eda866b6220d118f1ad734fad841e739e092977ae6d3bc4140ce24f2f";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.2.0-1.tar.gz";
+    name = "7.2.0-1.tar.gz";
+    sha256 = "42a9d2891c5f0abf5ddc4088d0e278752186d68e11c5c5dd56ab3932c12a2f64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "7.1.1-r1";
+  version = "7.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "fa0159331a944470db71d93fac50531e662ffa037f6fd6887a5f72a7af6d47ea";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.2.0-1.tar.gz";
+    name = "7.2.0-1.tar.gz";
+    sha256 = "5196debea5924d9146a39802c6c6cb89c9dda2fa466cb87d9f762eafdb3c5cf9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor osrf-testing-tools-cpp performance-test-fixture rcpputils ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor osrf-testing-tools-cpp performance-test-fixture ];
   propagatedBuildInputs = [ libyaml libyaml-vendor rcutils rmw ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "7.1.1-r1";
+  version = "7.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.1.1-1.tar.gz";
-    name = "7.1.1-1.tar.gz";
-    sha256 = "c4fb395a10892b1d27ca156654b9e3d6037f288885882d17d1e926a3e71f0705";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.2.0-1.tar.gz";
+    name = "7.2.0-1.tar.gz";
+    sha256 = "51bef31c8bc9277d47e6424c34f453a12930f04b531e96512b3c335c34da6497";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake rosidl-runtime-cpp test-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rmw rmw-implementation-cmake rosidl-runtime-cpp test-msgs ];
   propagatedBuildInputs = [ libyaml libyaml-vendor rcl-interfaces rcl-logging-interface rcl-logging-spdlog rcl-yaml-param-parser rcutils rmw rmw-implementation rosidl-runtime-c service-msgs tracetools type-description-interfaces ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "23.0.0-r1";
+  version = "23.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/23.0.0-1.tar.gz";
-    name = "23.0.0-1.tar.gz";
-    sha256 = "aacffa67bea18af8c7903fd4bbd7d8c971279c5c2b977db4c558d6fa3ee5363c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/23.1.0-1.tar.gz";
+    name = "23.1.0-1.tar.gz";
+    sha256 = "8e80de46edff802301af6b9971d608d8e538837c7782de3e99d447464c8f8d34";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "23.0.0-r1";
+  version = "23.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/23.0.0-1.tar.gz";
-    name = "23.0.0-1.tar.gz";
-    sha256 = "8d737f5b05b98966aa629c87f4a7bb3abe2b0cb0aaa1dbab393721bcd5338835";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/23.1.0-1.tar.gz";
+    name = "23.1.0-1.tar.gz";
+    sha256 = "61599a3cfdc7384ba1cbab496fdeb432c1f36bfc3fb04f16499f4658ed9a5e8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "23.0.0-r1";
+  version = "23.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/23.0.0-1.tar.gz";
-    name = "23.0.0-1.tar.gz";
-    sha256 = "507d251cc13b5da1a1f0d41745ba9c56872f0100e4d07ec491d88bd703296477";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/23.1.0-1.tar.gz";
+    name = "23.1.0-1.tar.gz";
+    sha256 = "e432a0cea91bf0bb08018456fcd3231cac59f0cf5e4885ab875e93944a67afe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "23.0.0-r1";
+  version = "23.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/23.0.0-1.tar.gz";
-    name = "23.0.0-1.tar.gz";
-    sha256 = "c029f6d83a69521fd67877cfc75f0183fe920120e66889b1eaa0de6896bde51f";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/23.1.0-1.tar.gz";
+    name = "23.1.0-1.tar.gz";
+    sha256 = "7cc6309b60beb120c375a600796a80de8c76bbbfafe941a52608505c8d46169f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "5.2.0-r1";
+  version = "5.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "818a5a3a2d50e7b5557079970941ecda630338e0803cbb4b0167c7ace6f754e0";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.3.0-1.tar.gz";
+    name = "5.3.0-1.tar.gz";
+    sha256 = "c74a7422f79716b770df59a7438e57d1da68bf7eb9eaa3f5a930f639f86f94e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.3.1-r1";
+  version = "6.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.3.1-1.tar.gz";
-    name = "6.3.1-1.tar.gz";
-    sha256 = "6577299c8479b50ee38d110250abc7f6f4246ff24ebee4ecd817237b31524ae3";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.4.0-1.tar.gz";
+    name = "6.4.0-1.tar.gz";
+    sha256 = "4f9ea18c584b95f45e1e115cfd4271643a42943b96ee53908b596a2abbda65bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.17.0-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "24b3bc0704ceb0567fb3794ee863627fb1d3f4d2226986732b082f69f49182a9";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "69353cf5fa431e0dfdaa9ba48a72cf88a603d0fa1c5c3cb39671f3adbff7c6fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.17.0-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "4bcfefacc3ded12abec026714e6eff717641403c6f10edf3fd5d041ec7d5beac";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "b0d4213fd0688187e941e6f1bd17bf29a1b0e89422f80764a099ef3cd8800c06";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "1.9.0-r1";
+  version = "1.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "24960d59dba72d794872b19bcd2bdbc0f9c9e0d5da864b4fb4050aae8e5f34b1";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/1.10.0-1.tar.gz";
+    name = "1.10.0-1.tar.gz";
+    sha256 = "60e88a070b28c77baee1616790a4979c4eeb21edefcec8d7e0642437e67ab1e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "7.5.0-r1";
+  version = "7.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/7.5.0-1.tar.gz";
-    name = "7.5.0-1.tar.gz";
-    sha256 = "c06e9ebf9e559d87e7688d2c0095ffaf4a592f78dfe0681ef2c83e4ab635bc31";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/7.6.0-1.tar.gz";
+    name = "7.6.0-1.tar.gz";
+    sha256 = "2caa7db4c8874819aa494d3e87168caf862b19d8f6c02412e1e4946085806029";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "7.5.0-r1";
+  version = "7.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/7.5.0-1.tar.gz";
-    name = "7.5.0-1.tar.gz";
-    sha256 = "01e840f33f2b4043908bfa0c65261d16bb5e1d7b95cbbf71c1a651f0cc278aab";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/7.6.0-1.tar.gz";
+    name = "7.6.0-1.tar.gz";
+    sha256 = "28ac6aeacaf3d97f1571cfe3fc5bbe86c141bfd4321c6e929078e86826f26150";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "7.5.0-r1";
+  version = "7.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/7.5.0-1.tar.gz";
-    name = "7.5.0-1.tar.gz";
-    sha256 = "e62451a18f7cbc16e6f18e15a5b4ef2b168538eedc93899efb30a3cddde178b1";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/7.6.0-1.tar.gz";
+    name = "7.6.0-1.tar.gz";
+    sha256 = "f145a8f612f53796ba29e7aa9d7745da4248490286416eeaea18bfecb7340c90";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation/default.nix
+++ b/distros/rolling/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-fastrtps-dynamic-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation";
-  version = "2.13.0-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "a24a1c6feee358b610803c98917bf036315caa8f8b33eb369bf8849ea8a7c966";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "e5de78a53a2528e7325810079e13cf239789ebbdaeda522cb58e9e743db29f99";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "0399096a33cfced62aab4de08727766cac55b9149aff3a16c7a47ceccef1ae07";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "4db3754434fb96f8ff486b420dc01d5279ad6099cd17f35d2c7d4132f48f4a20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "07eaa33896aee9559dbf626649bda1af410ab222fa26faa74e7ce349848bb9b7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "d705c7684fa606b1e8120cbad77f27027968208336cd7a9d5c39a50e156690ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "cc247af01c5e1100135e99b1bedab4eb4acda4d6ab50f806af6f9d41df9126b0";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "3125ed682b8609f1c585bf270e51b327e0ecfd18de35d52215bf75600fa7db16";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "bc54238d9106f16ce0bff10d07ed7369e7c242fcfb462f94ee3b7ca435fe69ff";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "88e7d3d6842ebcbd1814b9702c33ea226311b9a3d27fc91708168937e25332b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "c7ba46647a5997d5a12595a3ef0945603d2f8c38ee005f83bcbf2b64e6e70fca";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "26de20b950be8a911addbc28389cb987d4bf629f058e49f5e6a67a97ddd99905";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "14255c50f21b3f1559e7867874d8ccd0bb66cf299573ea9476d293ae3dae7728";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "eec1776052c4d37676d9de7630b366abf78cd614dd91875ede83e336a37d80b6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "8ddb5d12c1975269de929db7ee3c0f9c1e3746d96d0508c55ec3e49599ef6df5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "89a74d0023521bcf62101958886fa7886a6a05e80bd62d567e0f3740603f528c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "a00187d3ec0f0ebdbadbba463ba7761c6386b0061a37ac51f31283022f92125a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "0cc1828d6213011a0f65c6ddb106d256865c39c3f7a6c1c6d966b58e9d69d7e6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "ebbf73e3e4a3f8f378f4c6d6c42a4d4698f3ac5a240607d62d91efd1433f330f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "7f1f7f305240b50f7a0ab3c5bf15192a2864c0e2eae61e6b2e47b9bc1946507e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "cea30cdb0f46acd978b3b3daaebebc55e6d5b1d3a961b1859a6ab57a8c4fba3f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "6dec7c13257c188527465795e4acf00a9baf2aa11992aa8b578ba7972f56d333";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "98e39dd16c6c146dfd5669fdc2a50c24f9dd333c1f3c400f9ba250e523a1f87c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "55bb1e18ab59ccbacb962fe5bce5e63a3c40391dec46ac451b6a08c18e6a3b88";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "d67b2f69f4b4631d696ab8a0ab76d8b959b6de8586b22b67d075041573f92e27";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "3483d104a78c23f022474db6b693a48d1018d41cdca1b6c39d95b4274ec86262";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "e0a78659c871b007bdf3479b29d54d6abedda313478421fa803ebdb72a89e7ff";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "1bcbee979e89be6398b22aa854cf5c7bb673e3a055cfc883305c0a6e6f4e497d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "0309db3baa541b2d66f79e815fdbbb42469b02c7276163966830bf99a78cbfd4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "5f400e6af0297913a9e714f32d44d1f528e09dd3166442842ec4daaae5402fbc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "9a922d1f3d5a9d81acde679ef5ff365d33a7618890abd01fa42973b674a9a57a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "756ea121b777453459682679ddf7140a3a4185762dfd257a6886f85f60818d64";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "cff9fa847295a0d29e3b6a0f2944efedfa89185c263a1c0664ecde15bba2323a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "5e73f4d83024aecf869a97bc0bf76f7559759544a376844043a251a7f89f321d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "1f21ddb72998d06d96ddb3ef1fd3118f78f203c34386dadb65f35922278623f0";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "54f83eaafd91092c938ecaf469606fbd1574de45db2b25b63f13ffcc58f5ea50";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.29.0-r1";
+  version = "0.29.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "46021979ed40117735fd011b144bd941e40c910bfa5455f9e0f6caa93ab311a6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.29.1-1.tar.gz";
+    name = "0.29.1-1.tar.gz";
+    sha256 = "6e1e351285fdefefd25115b7f57a078fa22437c9ea7973fd38512ba87aa634da";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosapi-msgs/default.nix
+++ b/distros/rolling/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosapi-msgs";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "c3221160e7f2b9a7fe58ff0c9bba66b7100c2fc9c30533f549acb5a75c1d640a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "d265f93a806631ef45db03b3ef66c449bab42924ca32d4bd7623a2e054f93640";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosapi/default.nix
+++ b/distros/rolling/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosapi";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "b84964b0cdaf37bf38c8f690d1cb1efdffd365a01a4f46e984d12891f23de5be";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "b5feae21aff0d5987476ad97f20ac862aa59a92c0c30de18df0b9cd7e5cd815b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-library/default.nix
+++ b/distros/rolling/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-library";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "12cc8e0ca0b4fb682ff2ebc3a7c6fea2677c9bf7b8bf1a484ebf13b69125a9ea";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "6389aa179706405c938bee281895f7e50c6a64aac78559fea3005bb9c32b160a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-msgs/default.nix
+++ b/distros/rolling/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-msgs";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "e25b8f0e4409bb2075df5ee876104744ef16572041b0e768592c5c09bcc16f56";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "88b70ac16f136301caf9d622842c8178c50435a29d07a7d20fd7fc9189c98ab5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-server/default.nix
+++ b/distros/rolling/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-server";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "9585966ad47f247b50a6b863533f83d640800feb62d71434325c6de19557927d";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "b043e10cb1234de124eefed28ecc604ba43424925dece9ea76a1a5362b808d41";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-suite/default.nix
+++ b/distros/rolling/rosbridge-suite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-suite";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "21761d6d8a5ac5cc5ed4ae25dac0f14b56a401bc8812fd287113307a35cc8277";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "2127c85cdd7a198312116f27b4a620d1dcbd53d7a35159403988205233070a4f";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ];
+  buildInputs = [ ament-cmake ];
   propagatedBuildInputs = [ rosapi rosbridge-library rosbridge-server ];
-  nativeBuildInputs = [ ament-cmake-core ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Rosbridge provides a JSON API to ROS functionality for non-ROS programs.

--- a/distros/rolling/rosbridge-test-msgs/default.nix
+++ b/distros/rolling/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-test-msgs";
-  version = "1.3.1-r2";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/1.3.1-2.tar.gz";
-    name = "1.3.1-2.tar.gz";
-    sha256 = "f4ce444d33566e9f10e507fce1cfacdff521abe5aff078f4224f66f7ded9e376";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "eb679973f084aaecba708222da48b52278979b5f6eaca99d8fcd5a3d208ef91c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosgraph-msgs/default.nix
+++ b/distros/rolling/rosgraph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosgraph-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rosgraph_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "68d23c502dcee47662f66e58ea9a842c8e8a5f28ae4267f6b694c3e23fec3399";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/rosgraph_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4b97f95f2685c15f56e419d49df4effe69784c48e343acad05bed9a23bc8c66b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "848ebbd77af7f8f613244d8d34165ab32d9814ad6c615563ee1710e65d27829d";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "1270d9175b993f6f55ba6959b123111976d2623e6d8266199c491781435bf994";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "cf9355cf33e8b5b1b0f051a335b8e97d3a5866f2052fea654ce9aa2d4d3643f3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "effed58f57b7f59c9ccde1d3066145ca632040b0e82ac9eab619896bdd0a6fc8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "9f71d98de19b51beee5dc6ff77a5d53a2d6acaa8db75128eb5feb2c1946d6ffe";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "5b5ee0da8f37cfabdb86bb205581caf06c37e308183069cffe5fc778124d60d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "5dea5e18b6fbde81a1d8fa847a4eb6c674ab8f92edbb9969fbe61ae468d40218";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "173422a90788645b1586454db069b8b31f73b807c46dc54c395f06d197e27bc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "92ed6e62299abdfc4241fba8b55a40182ff71ad7ef60473fdee0bf826d5a5a0b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "4415cc2a796593849642463037b25d6cf2499ac985a225f1ddc218019ee6c5ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "b6e7df625bfa916f92b320d418da6cb0c6d66fa42808662017156ef7e23ad425";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "7d0678e67ea2630d14eabbc82f5da660af6f6700ee5407a994ee3d11ba6d9196";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "d29f41b2c1f107fd76dc8e3da3ca426c112c0bdb45c2cadd3b7de654eed7d52f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "3bffb0b23e48c81adaf069b7c67bb027c8fd75086f090920dd5e120a06da6eaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "cd2c51d1167aa5f4b7a8944798b0aca973bb5c5a9205c8800a1c9504c08978b9";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "241735da5b68391e0cf8f5b9fc24f5025d44c094dfe57cecf9f35b34c16ffbbf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "a7025bc72bb76747a6d4f971d1084621da791f1dda7b0009c0df2386dd877ae4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "8b43657529cea316c5dc3d366aad5bdaa14c1c63ab0651cb4f679971e6fd2b19";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "9e94ebeac6376fce1d47a2622490f6ddf79fe685ba1cdf9351481bfbf75d9a54";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "16b1f3dd75c8dad8a36b1ce7d79007bf83e419a51992de7f664ef08443da4198";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-c";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "d51973f70f49797c061ae1aa01d1a07889eb66745bcbbe7ab775619ae266cfdf";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "6345b2ac0b06f103722fb6b22cf968a9a7add799f41b5650c76be4c742d655af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-cpp";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "3b88dffa6662285522792821550a96f2ca25e265f620ceafc2aec36250d254c9";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2dae727f2727f643c3c674f825fe6a0ee107114b59a09ed08ac9cacb0d0efa03";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "2fff8b455b0b6423c6c8ae450634d5d741ab0283815cff033815d790fa0cabe3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "fdefdca593e37f65b1284929e6fc4153ed0dce5378c1a8afe9a97c092ddd8db3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "6007ded464b9a218980df303d81d151ca6dc811ca403d1c6ec7d3b255a1c545f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "569fc6f3463e5875d7c8a13617ee05fb024a06d69a3b37b60cc9805a0bf93244";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "d2254900f3429191c8112477ccfebc5a9213fca47d8d600fb2b3e395adadba55";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "afd56eb25b269701f98343ce58f88309aeabd3ce61e54a5593028daf717faba5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "4c48d3201731310bf6fb9d4f0597b44266be74a9d260141fcb4ee29182df3564";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "da77ba32f7db78d237001d3b63e67c46cd066cf2a419d3d68269a5d86f2bd683";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-reconfigure/default.nix
+++ b/distros/rolling/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-reconfigure";
-  version = "1.5.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "ca4b216198aaa9829d7cb2340cd163d8ccb23d6ba0a70403a1f72f613feac17d";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "1db5afeb324ff26fa017247642f27cca0f7078095179edd4c1ac0c1634981cb5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.17.0-r1";
+  version = "0.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "c27be162a8f5a9e8bef36b8bf0d49c8d18883d4eeb7789b2e0cdc04f0d6b75e4";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "ae5da5853bd2bddf015c6e1984f4aa4a49e23309a77d22a29afdc5b65059d9ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "c50087381ce488d0445314a30131b895def23288b723f1e2b6261dc8e4683319";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "6acc7596f45264635523cb63300cba0bfe5cacb915df3c49faab5ca4cf0b9c0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "611b9b063d80b8de1a5a3385b9eac6e3e6a6846b3b40c5cdfa4f7ea3483cb357";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "78b35847c8ef6ad859ea937ba91fbcee5183e7d90fcf2e2bd2b06a87aa69bd4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "c1836b015be522ebf19d96e8230ea4be7745d118efe0313aee8b76e74512759a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "7a4d32ea260e908ec482951e90a9cf288f5e29e2442547e59f4ecb8a6272e23d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "eb9ad801fe7a6af65e9643a39ed576a554891607b71050a04d8de32be8823918";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "775ff6e661ada8c06bf68c782ffab9d88af9caaffa0a288a417ad2356ea89a8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "07f45ff88f7e25dbdf0fc4bd595419c704a85fb1aa4da49f3f6550a391c51b75";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "3fa7ab4fe1494d071403509d5f5b83d948271a78683852abcc753f6d11c5b86f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "6661c8034d344766493a6a129c88c333eae56d71e8c2c30343e685a4f72caf29";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "45c22cf0a0cb2aac92306265ec9cb4ca1aff59c386436f309a112fbc3d769705";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto rviz-assimp-vendor ];
   propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module qt5.qtbase resource-retriever rviz-assimp-vendor rviz-ogre-vendor ];
-  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+  nativeBuildInputs = [ ament-cmake-ros eigen3-cmake-module ];
 
   meta = {
     description = ''Library which provides the 3D rendering functionality in rviz.'';

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "b589af61681dfd548514243c547390341072a2b0d49db56a103816d54242d051";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "55c24bf4e440cbf11a919d604e2e1439cdda74f57d57617cc11b9e6ae3fbd1d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.1.0-r1";
+  version = "13.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.0-1.tar.gz";
-    name = "13.1.0-1.tar.gz";
-    sha256 = "85a48f164331a99f2380966313fe09942087c43704eb0992c6f257ac7b203e94";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.1-1.tar.gz";
+    name = "13.1.1-1.tar.gz";
+    sha256 = "ef8b0b0338a259f3771be852db3c483fb81b7082b088712a5cb25efc18736b8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/service-msgs/default.nix
+++ b/distros/rolling/service-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-core-generators, rosidl-core-runtime }:
 buildRosPackage {
   pname = "ros-rolling-service-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/service_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "664d76efc94649c08c69b4d1f750771bfb8ea4913e60e9e72af8391190eb5158";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/service_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "6fb956b0868c25ae8359ab8fd57cad6157cbfd717556b686f53509862ae95ae6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/simple-launch/default.nix
+++ b/distros/rolling/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-simple-launch";
-  version = "1.7.0-r2";
+  version = "1.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/rolling/simple_launch/1.7.0-2.tar.gz";
-    name = "1.7.0-2.tar.gz";
-    sha256 = "1a12eb5bb131fad10eb23231746989f84989d7eb1b8a70c967ca1cb78785da7b";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/rolling/simple_launch/1.7.2-1.tar.gz";
+    name = "1.7.2-1.tar.gz";
+    sha256 = "b541379a59983a96ac4b7e0843210bdffc42a39c2315911dad79bc909a06f3ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/statistics-msgs/default.nix
+++ b/distros/rolling/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-statistics-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/statistics_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "65dfa3ae2bc50769fc264c166e3b35f6fd5faa19bf1b7254e43a2a236f4a7262";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/statistics_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "2371fc951262e43e7098a918d2098f176aee4d8f6c43e36b7a10172ebb06025d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/test-msgs/default.nix
+++ b/distros/rolling/test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, test-interface-files }:
 buildRosPackage {
   pname = "ros-rolling-test-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/test_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "caf68899f642d4d36c0d9680dd86f9f60014db6a9a4c4be9e8595b5c7b9bf7b0";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/test_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "9fe35ea77886f5d9514f432dcc595fd78f9b7fa4b6480fe0580a65d3ae1b55fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "1389f7f6ef409cfcbfa6b1e5ca411ad2637dea7a7f5a9518c01112215656bb32";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "21755c9fb5018e0b88cd1f418eb89ec7bd2f4aeb99c02bd8993226f7ac2c1328";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "2db5f6d50205dddb0a17511a782238c8376e4d499ebcc815519a39ebd789cf86";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "7c3100a5454f46da2e6d02f4bb2f3f61fae76ceac4001dfdd94445c35c8a5f6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "a8178be9253ce8fb0f02e4b10cf8444d027bf4475170cc080c81290b6080a6bd";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "a5d425c1796fa466a7919546efd73e791fb0ee5b0e9c411a70766424ed05a560";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "76f003b4af72a3c1b766fa3d73e94d178e45ef33fbb2431060101ff5443aa5cb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "ece3bdf22389cd77234453fb336faedfd189dda6721f0d1f22cc61309242c3d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "bb39ccaaf9b2cd45a527e08ee0d5211c7ab614033fb08f4e00139c57be883efc";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "ccf015edf50cfc251f7ab13c4cebaf07e799173f3667a9d2c73d512ce290ece9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "adbf514037b865d54a11c9f3b49bb46b52eee27bb1760327a0dde17bdafdf9e0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "115261c735abcd614975fa2bab1f11bc1a175f7d832a70064cd25d717fba336f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "9fb101025c95cb6dc0488c70f2274703ac49e3c3184c1eab540b7770fb445f2e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "fdac2fa5fcb5dbbc1de1178ad507e79c41dbadec7e0a2e09e95a66066fad5fc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "a16f708d974ea7960d5508f4b35a0bc4b29222bc104ead37be4754fa723779b8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "d2ba1466757d28521c407f8bdca27555a88a0a63cfcf1844b2ff4fafe9a244fd";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "32b337565657ce216b6bbf50085f48e27448ccd1edb0c800ca7a9804955a5113";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "db2a3cb4504b8a9d847f057d7eac196a7f40b634fe1163143431719f9477bb2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "f58a1269b4158167d750931cab377b9b42c0c00ff9488715c58dc6e935c3cfff";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "4f8d18e5d7d2a70f971d73b57f4e45c76ab1fae2d02bc1923b365fc4d63e7b9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "abe84a64d8aba75f032e26deaf65cec7b92641c4ef9e49017bb0ae0b930b27d1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "a1a820c102eb2c747d28ec38cc7655e54e8de202ab11bed5c830871617c2491e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.33.1-r1";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.33.1-1.tar.gz";
-    name = "0.33.1-1.tar.gz";
-    sha256 = "fc899295ad39bba6c73d7e1d92e626e747c888e1f0aa2a0fd555da88aa03f6d4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "8bc91545d8cb859cc28a736d9cf58b8f53f669a80004751c4eaaf47f71859c43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "3.18.0-r1";
+  version = "3.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "5e8a5ade52b42d07f45f76abdddc3e01963e3b48e15caa46b0eaa190bd03c952";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.19.1-1.tar.gz";
+    name = "3.19.1-1.tar.gz";
+    sha256 = "5f7fce401c176dcda640162defb575accb877e55d98d5e27de370f94636488b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/turtlesim/default.nix
+++ b/distros/rolling/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-turtlesim";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "2e2b939dfc5e2e82aa7e61918fa970ec0f6f1e7fc41e8e57e51b49a1ca7fd5cb";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "5fb941dfb1f639a2690643d48aa2372a996ba2d7fd63f6d7c3ffd26695bba4b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/type-description-interfaces/default.nix
+++ b/distros/rolling/type-description-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-core-generators, rosidl-core-runtime, service-msgs }:
 buildRosPackage {
   pname = "ros-rolling-type-description-interfaces";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/type_description_interfaces/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "81243577b6c5bc424ee2c7e71ec43e53d69180cb1fa54c588d7a2530a22c3bb4";
+    url = "https://github.com/ros2-gbp/rcl_interfaces-release/archive/release/rolling/type_description_interfaces/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "6948a5e0cdd8737a75c875ae4a602a22dfce3df220b87fdccec896364388d619";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "6558ea4ab6b482a0455b3d5a9f56eceb2177ed2a2b01a3c174e66f4a2f75f8b3";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "057e0e6d2e362caf25eb57fbaf43fc12df06aadc2ad18254a6a7df7e33cdb037";
   };
 
   buildType = "cmake";

--- a/distros/rolling/urdf-tutorial/default.nix
+++ b/distros/rolling/urdf-tutorial/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, urdf-launch }:
 buildRosPackage {
   pname = "ros-rolling-urdf-tutorial";
-  version = "1.0.0-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/rolling/urdf_tutorial/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "4c5775bcb1215caec09e7d1c0c630042ed1002950f2ff700b9d1f25a5c659f83";
+    url = "https://github.com/ros2-gbp/urdf_tutorial-release/archive/release/rolling/urdf_tutorial/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "cd4eaab7efa24875028071407e507a8c280119b0db92f32b0a2bf1572b742fcd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ];
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 xacro ];
+  propagatedBuildInputs = [ urdf-launch ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''This package contains a number of URDF tutorials.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ "BSD-3-clause" ];
   };
 }

--- a/distros/rolling/zlib-point-cloud-transport/default.nix
+++ b/distros/rolling/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-zlib-point-cloud-transport";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "efa2b6df5248654a0f58bac99b82c5ccbd3c342f0774a12a7178d38189c0c550";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "13944e28d1160e53bb962fc1d06d060aa78fd9833d8c1c8eb24e0ea00dfe35c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-point-cloud-transport/default.nix
+++ b/distros/rolling/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-point-cloud-transport";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "03986776de13c3ca9d3cbaa73ae1911040e458c2a7c05ad64a06e0c32b6033dd";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "dc56f67ac74edcc0792ced298b3c064d6b6ade21c1e4a5a898561dad2c0b5189";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit d37d5a670ac7dc2234b904681eea346c78a6fba9.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aandd-ekew-driver-py 0.0.2-r1 --> 0.0.2-r3*
* *ackermann-steering-controller 2.25.0-r1 --> 2.26.0-r1*
* *admittance-controller 2.25.0-r1 --> 2.26.0-r1*
* *aruco 5.0.0-r1 --> 5.0.3-r1*
* *aruco-msgs 5.0.0-r1 --> 5.0.3-r1*
* *aruco-ros 5.0.0-r1 --> 5.0.3-r1*
* *aws-sdk-cpp-vendor 0.1.1-r1 --> 0.2.1-r1*
* *bicycle-steering-controller 2.25.0-r1 --> 2.26.0-r1*
* *clearpath-common 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-config 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-config-live 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-control 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-description 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-desktop 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-generator-common 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-generator-gz 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-gz 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-mounts-description 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-platform 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-platform-description 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-sensors-description 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-simulator 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-viz 0.1.0-r1 --> 0.1.1-r1*
* *collision-log-msgs 0.1.1-r1*
* *controller-interface 2.31.0-r1 --> 2.32.0-r1*
* *controller-manager 2.31.0-r1 --> 2.32.0-r1*
* *controller-manager-msgs 2.31.0-r1 --> 2.32.0-r1*
* *costmap-queue 1.1.9-r1 --> 1.1.12-r1*
* *diff-drive-controller 2.25.0-r1 --> 2.26.0-r1*
* *dwb-core 1.1.9-r1 --> 1.1.12-r1*
* *dwb-critics 1.1.9-r1 --> 1.1.12-r1*
* *dwb-msgs 1.1.9-r1 --> 1.1.12-r1*
* *dwb-plugins 1.1.9-r1 --> 1.1.12-r1*
* *effort-controllers 2.25.0-r1 --> 2.26.0-r1*
* *event-camera-py 1.1.2-r1 --> 1.1.3-r1*
* *fadecandy-driver 1.0.1-r1 --> 1.0.2-r1*
* *fadecandy-msgs 1.0.1-r1 --> 1.0.2-r1*
* *flir-camera-description 2.0.6-r1 --> 2.0.7-r1*
* *flir-camera-msgs 2.0.6-r1 --> 2.0.7-r1*
* *force-torque-sensor-broadcaster 2.25.0-r1 --> 2.26.0-r1*
* *forward-command-controller 2.25.0-r1 --> 2.26.0-r1*
* *gripper-controllers 2.25.0-r1 --> 2.26.0-r1*
* *hardware-interface 2.31.0-r1 --> 2.32.0-r1*
* *imu-sensor-broadcaster 2.25.0-r1 --> 2.26.0-r1*
* *joint-limits 2.31.0-r1 --> 2.32.0-r1*
* *joint-state-broadcaster 2.25.0-r1 --> 2.26.0-r1*
* *joint-trajectory-controller 2.25.0-r1 --> 2.26.0-r1*
* *metro-benchmark-msgs 0.1.1-r1*
* *metro-benchmark-pub 0.1.1-r1*
* *mrpt2 2.10.0-r1 --> 2.10.2-r1*
* *nav-2d-msgs 1.1.9-r1 --> 1.1.12-r1*
* *nav-2d-utils 1.1.9-r1 --> 1.1.12-r1*
* *nav2-amcl 1.1.9-r1 --> 1.1.12-r1*
* *nav2-behavior-tree 1.1.9-r1 --> 1.1.12-r1*
* *nav2-behaviors 1.1.9-r1 --> 1.1.12-r1*
* *nav2-bringup 1.1.9-r1 --> 1.1.12-r1*
* *nav2-bt-navigator 1.1.9-r1 --> 1.1.12-r1*
* *nav2-collision-monitor 1.1.9-r1 --> 1.1.12-r1*
* *nav2-common 1.1.9-r1 --> 1.1.12-r1*
* *nav2-constrained-smoother 1.1.9-r1 --> 1.1.12-r1*
* *nav2-controller 1.1.9-r1 --> 1.1.12-r1*
* *nav2-core 1.1.9-r1 --> 1.1.12-r1*
* *nav2-costmap-2d 1.1.9-r1 --> 1.1.12-r1*
* *nav2-dwb-controller 1.1.9-r1 --> 1.1.12-r1*
* *nav2-lifecycle-manager 1.1.9-r1 --> 1.1.12-r1*
* *nav2-map-server 1.1.9-r1 --> 1.1.12-r1*
* *nav2-mppi-controller 1.1.9-r1 --> 1.1.12-r1*
* *nav2-msgs 1.1.9-r1 --> 1.1.12-r1*
* *nav2-navfn-planner 1.1.9-r1 --> 1.1.12-r1*
* *nav2-planner 1.1.9-r1 --> 1.1.12-r1*
* *nav2-regulated-pure-pursuit-controller 1.1.9-r1 --> 1.1.12-r1*
* *nav2-rotation-shim-controller 1.1.9-r1 --> 1.1.12-r1*
* *nav2-rviz-plugins 1.1.9-r1 --> 1.1.12-r1*
* *nav2-simple-commander 1.1.9-r1 --> 1.1.12-r1*
* *nav2-smac-planner 1.1.9-r1 --> 1.1.12-r1*
* *nav2-smoother 1.1.9-r1 --> 1.1.12-r1*
* *nav2-system-tests 1.1.9-r1 --> 1.1.12-r1*
* *nav2-theta-star-planner 1.1.9-r1 --> 1.1.12-r1*
* *nav2-util 1.1.9-r1 --> 1.1.12-r1*
* *nav2-velocity-smoother 1.1.9-r1 --> 1.1.12-r1*
* *nav2-voxel-grid 1.1.9-r1 --> 1.1.12-r1*
* *nav2-waypoint-follower 1.1.9-r1 --> 1.1.12-r1*
* *navigation2 1.1.9-r1 --> 1.1.12-r1*
* *play-motion2 0.0.9-r1 --> 0.0.10-r1*
* *play-motion2-msgs 0.0.9-r1 --> 0.0.10-r1*
* *point-cloud-interfaces 1.0.7-r1 --> 1.0.8-r1*
* *point-cloud-transport 1.0.13-r1 --> 1.0.14-r1*
* *point-cloud-transport-plugins 1.0.7-r1 --> 1.0.8-r1*
* *point-cloud-transport-py 1.0.13-r1 --> 1.0.14-r1*
* *position-controllers 2.25.0-r1 --> 2.26.0-r1*
* *range-sensor-broadcaster 2.26.0-r1*
* *reach 1.5.2-r1 --> 1.6.0-r1*
* *reach-ros 1.3.2-r2 --> 1.4.0-r1*
* *ros2-control 2.31.0-r1 --> 2.32.0-r1*
* *ros2-control-test-assets 2.31.0-r1 --> 2.32.0-r1*
* *ros2-controllers 2.25.0-r1 --> 2.26.0-r1*
* *ros2-controllers-test-nodes 2.25.0-r1 --> 2.26.0-r1*
* *ros2controlcli 2.31.0-r1 --> 2.32.0-r1*
* *rosapi 1.3.1-r1 --> 1.3.2-r1*
* *rosapi-msgs 1.3.1-r1 --> 1.3.2-r1*
* *rosbridge-library 1.3.1-r1 --> 1.3.2-r1*
* *rosbridge-msgs 1.3.1-r1 --> 1.3.2-r1*
* *rosbridge-server 1.3.1-r1 --> 1.3.2-r1*
* *rosbridge-suite 1.3.1-r1 --> 1.3.2-r1*
* *rosbridge-test-msgs 1.3.1-r1 --> 1.3.2-r1*
* *rqt-controller-manager 2.31.0-r1 --> 2.32.0-r1*
* *rqt-joint-trajectory-controller 2.25.0-r1 --> 2.26.0-r1*
* *simple-launch 1.7.1-r1 --> 1.7.2-r1*
* *slam-toolbox 2.6.5-r1 --> 2.6.6-r1*
* *spinnaker-camera-driver 2.0.6-r1 --> 2.0.7-r1*
* *steering-controllers-library 2.25.0-r1 --> 2.26.0-r1*
* *transmission-interface 2.31.0-r1 --> 2.32.0-r1*
* *tricycle-controller 2.25.0-r1 --> 2.26.0-r1*
* *tricycle-steering-controller 2.25.0-r1 --> 2.26.0-r1*
* *ur-client-library 1.3.3-r1 --> 1.3.4-r1*
* *urdf-tutorial 1.0.0-r3 --> 1.1.0-r1*
* *velocity-controllers 2.25.0-r1 --> 2.26.0-r1*
* *zlib-point-cloud-transport 1.0.7-r1 --> 1.0.8-r1*
* *zstd-point-cloud-transport 1.0.7-r1 --> 1.0.8-r1*

Iron Changes:
-------------
* *aws-sdk-cpp-vendor 0.1.1-r1 --> 0.2.1-r1*
* *controller-interface 3.18.0-r1 --> 3.19.1-r1*
* *controller-manager 3.18.0-r1 --> 3.19.1-r1*
* *controller-manager-msgs 3.18.0-r1 --> 3.19.1-r1*
* *costmap-queue 1.2.2-r2 --> 1.2.5-r2*
* *dwb-core 1.2.2-r2 --> 1.2.5-r2*
* *dwb-critics 1.2.2-r2 --> 1.2.5-r2*
* *dwb-msgs 1.2.2-r2 --> 1.2.5-r2*
* *dwb-plugins 1.2.2-r2 --> 1.2.5-r2*
* *hardware-interface 3.18.0-r1 --> 3.19.1-r1*
* *joint-limits 3.18.0-r1 --> 3.19.1-r1*
* *mrpt2 2.10.0-r1 --> 2.10.2-r1*
* *nav-2d-msgs 1.2.2-r2 --> 1.2.5-r2*
* *nav-2d-utils 1.2.2-r2 --> 1.2.5-r2*
* *nav2-amcl 1.2.2-r2 --> 1.2.5-r2*
* *nav2-behavior-tree 1.2.2-r2 --> 1.2.5-r2*
* *nav2-behaviors 1.2.2-r2 --> 1.2.5-r2*
* *nav2-bringup 1.2.2-r2 --> 1.2.5-r2*
* *nav2-bt-navigator 1.2.2-r2 --> 1.2.5-r2*
* *nav2-collision-monitor 1.2.2-r2 --> 1.2.5-r2*
* *nav2-common 1.2.2-r2 --> 1.2.5-r2*
* *nav2-constrained-smoother 1.2.2-r2 --> 1.2.5-r2*
* *nav2-controller 1.2.2-r2 --> 1.2.5-r2*
* *nav2-core 1.2.2-r2 --> 1.2.5-r2*
* *nav2-costmap-2d 1.2.2-r2 --> 1.2.5-r2*
* *nav2-dwb-controller 1.2.2-r2 --> 1.2.5-r2*
* *nav2-lifecycle-manager 1.2.2-r2 --> 1.2.5-r2*
* *nav2-map-server 1.2.2-r2 --> 1.2.5-r2*
* *nav2-mppi-controller 1.2.2-r2 --> 1.2.5-r2*
* *nav2-msgs 1.2.2-r2 --> 1.2.5-r2*
* *nav2-navfn-planner 1.2.2-r2 --> 1.2.5-r2*
* *nav2-planner 1.2.2-r2 --> 1.2.5-r2*
* *nav2-regulated-pure-pursuit-controller 1.2.2-r2 --> 1.2.5-r2*
* *nav2-rotation-shim-controller 1.2.2-r2 --> 1.2.5-r2*
* *nav2-rviz-plugins 1.2.2-r2 --> 1.2.5-r2*
* *nav2-simple-commander 1.2.2-r2 --> 1.2.5-r2*
* *nav2-smac-planner 1.2.2-r2 --> 1.2.5-r2*
* *nav2-smoother 1.2.2-r2 --> 1.2.5-r2*
* *nav2-system-tests 1.2.2-r2 --> 1.2.5-r2*
* *nav2-theta-star-planner 1.2.2-r2 --> 1.2.5-r2*
* *nav2-util 1.2.2-r2 --> 1.2.5-r2*
* *nav2-velocity-smoother 1.2.2-r2 --> 1.2.5-r2*
* *nav2-voxel-grid 1.2.2-r2 --> 1.2.5-r2*
* *nav2-waypoint-follower 1.2.2-r2 --> 1.2.5-r2*
* *navigation2 1.2.2-r2 --> 1.2.5-r2*
* *point-cloud-interfaces 2.0.1-r1 --> 2.0.2-r1*
* *point-cloud-transport 2.0.1-r1 --> 2.0.2-r1*
* *point-cloud-transport-plugins 2.0.1-r1 --> 2.0.2-r1*
* *point-cloud-transport-py 2.0.1-r1 --> 2.0.2-r1*
* *ros2-control 3.18.0-r1 --> 3.19.1-r1*
* *ros2-control-test-assets 3.18.0-r1 --> 3.19.1-r1*
* *ros2controlcli 3.18.0-r1 --> 3.19.1-r1*
* *rosapi 1.3.1-r3 --> 1.3.2-r1*
* *rosapi-msgs 1.3.1-r3 --> 1.3.2-r1*
* *rosbridge-library 1.3.1-r3 --> 1.3.2-r1*
* *rosbridge-msgs 1.3.1-r3 --> 1.3.2-r1*
* *rosbridge-server 1.3.1-r3 --> 1.3.2-r1*
* *rosbridge-suite 1.3.1-r3 --> 1.3.2-r1*
* *rosbridge-test-msgs 1.3.1-r3 --> 1.3.2-r1*
* *rqt-controller-manager 3.18.0-r1 --> 3.19.1-r1*
* *simple-launch 1.7.1-r1 --> 1.7.2-r1*
* *slam-toolbox 2.7.1-r1 --> 2.7.2-r1*
* *transmission-interface 3.18.0-r1 --> 3.19.1-r1*
* *ur-client-library 1.3.3-r1 --> 1.3.4-r1*
* *urdf-tutorial 1.0.0-r4 --> 1.1.0-r1*
* *zlib-point-cloud-transport 2.0.1-r1 --> 2.0.2-r1*
* *zstd-point-cloud-transport 2.0.1-r1 --> 2.0.2-r1*

Noetic Changes:
---------------
* *cpr-onav-description 0.1.8-r1 --> 0.1.9-r1*
* *mrpt2 2.10.0-r1 --> 2.10.2-r1*
* *reach 1.5.2-r1 --> 1.6.0-r1*
* *rosapi 0.11.16-r2 --> 0.11.17-r1*
* *rosbridge-library 0.11.16-r2 --> 0.11.17-r1*
* *rosbridge-msgs 0.11.16-r2 --> 0.11.17-r1*
* *rosbridge-server 0.11.16-r2 --> 0.11.17-r1*
* *rosbridge-suite 0.11.16-r2 --> 0.11.17-r1*
* *rosmon 2.5.0-r2 --> 2.5.1-r2*
* *rosmon-core 2.5.0-r2 --> 2.5.1-r2*
* *rosmon-msgs 2.5.0-r2 --> 2.5.1-r2*
* *rqt-console 0.4.11-r1 --> 0.4.12-r1*
* *rqt-logger-level 0.4.11-r1 --> 0.4.12-r1*
* *rqt-moveit 0.5.10-r1 --> 0.5.11-r1*
* *rqt-robot-monitor 0.5.14-r1 --> 0.5.15-r1*
* *rqt-rosmon 2.5.0-r2 --> 2.5.1-r2*
* *rqt-runtime-monitor 0.5.9-r1 --> 0.5.10-r1*
* *rqt-tf-tree 0.6.3-r1 --> 0.6.4-r1*
* *ur-client-library 1.3.3-r1 --> 1.3.4-r1*

Rolling Changes:
----------------
* *action-msgs 2.0.0-r1 --> 2.0.1-r1*
* *ament-clang-format 0.15.2-r1 --> 0.16.0-r1*
* *ament-clang-tidy 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-clang-format 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-clang-tidy 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-copyright 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-cppcheck 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-cpplint 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-flake8 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-lint-cmake 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-mypy 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-pclint 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-pep257 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-pycodestyle 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-pyflakes 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-uncrustify 0.15.2-r1 --> 0.16.0-r1*
* *ament-cmake-xmllint 0.15.2-r1 --> 0.16.0-r1*
* *ament-copyright 0.15.2-r1 --> 0.16.0-r1*
* *ament-cppcheck 0.15.2-r1 --> 0.16.0-r1*
* *ament-cpplint 0.15.2-r1 --> 0.16.0-r1*
* *ament-lint 0.15.2-r1 --> 0.16.0-r1*
* *ament-lint-auto 0.15.2-r1 --> 0.16.0-r1*
* *ament-lint-cmake 0.15.2-r1 --> 0.16.0-r1*
* *ament-lint-common 0.15.2-r1 --> 0.16.0-r1*
* *ament-mypy 0.15.2-r1 --> 0.16.0-r1*
* *ament-pclint 0.15.2-r1 --> 0.16.0-r1*
* *ament-pep257 0.15.2-r1 --> 0.16.0-r1*
* *ament-pycodestyle 0.15.2-r1 --> 0.16.0-r1*
* *ament-pyflakes 0.15.2-r1 --> 0.16.0-r1*
* *ament-uncrustify 0.15.2-r1 --> 0.16.0-r1*
* *ament-xmllint 0.15.2-r1 --> 0.16.0-r1*
* *aws-sdk-cpp-vendor 0.1.1-r1 --> 0.2.1-r1*
* *builtin-interfaces 2.0.0-r1 --> 2.0.1-r1*
* *composition-interfaces 2.0.0-r1 --> 2.0.1-r1*
* *controller-interface 3.18.0-r1 --> 3.19.1-r1*
* *controller-manager 3.18.0-r1 --> 3.19.1-r1*
* *controller-manager-msgs 3.18.0-r1 --> 3.19.1-r1*
* *event-camera-py 1.0.2-r1 --> 1.0.3-r1*
* *examples-tf2-py 0.33.1-r1 --> 0.33.2-r1*
* *fastrtps-cmake-module 3.2.0-r1 --> 3.3.0-r1*
* *geometry2 0.33.1-r1 --> 0.33.2-r1*
* *hardware-interface 3.18.0-r1 --> 3.19.1-r1*
* *interactive-markers 2.5.1-r1 --> 2.5.2-r1*
* *joint-limits 3.18.0-r1 --> 3.19.1-r1*
* *launch 3.1.0-r1 --> 3.2.0-r1*
* *launch-pytest 3.1.0-r1 --> 3.2.0-r1*
* *launch-testing 3.1.0-r1 --> 3.2.0-r1*
* *launch-testing-ament-cmake 3.1.0-r1 --> 3.2.0-r1*
* *launch-xml 3.1.0-r1 --> 3.2.0-r1*
* *launch-yaml 3.1.0-r1 --> 3.2.0-r1*
* *lifecycle-msgs 2.0.0-r1 --> 2.0.1-r1*
* *point-cloud-interfaces 3.0.0-r1 --> 3.0.1-r1*
* *point-cloud-transport 3.0.0-r1 --> 3.0.1-r1*
* *point-cloud-transport-plugins 3.0.0-r1 --> 3.0.1-r1*
* *point-cloud-transport-py 3.0.0-r1 --> 3.0.1-r1*
* *rcl 7.1.1-r1 --> 7.2.0-r1*
* *rcl-action 7.1.1-r1 --> 7.2.0-r1*
* *rcl-interfaces 2.0.0-r1 --> 2.0.1-r1*
* *rcl-lifecycle 7.1.1-r1 --> 7.2.0-r1*
* *rcl-yaml-param-parser 7.1.1-r1 --> 7.2.0-r1*
* *rclcpp 23.0.0-r1 --> 23.1.0-r1*
* *rclcpp-action 23.0.0-r1 --> 23.1.0-r1*
* *rclcpp-components 23.0.0-r1 --> 23.1.0-r1*
* *rclcpp-lifecycle 23.0.0-r1 --> 23.1.0-r1*
* *rclpy 5.2.0-r1 --> 5.3.0-r1*
* *rcutils 6.3.1-r1 --> 6.4.0-r1*
* *rmw-connextdds 0.17.0-r1 --> 0.18.0-r1*
* *rmw-connextdds-common 0.17.0-r1 --> 0.18.0-r1*
* *rmw-cyclonedds-cpp 1.9.0-r1 --> 1.10.0-r1*
* *rmw-fastrtps-cpp 7.5.0-r1 --> 7.6.0-r1*
* *rmw-fastrtps-dynamic-cpp 7.5.0-r1 --> 7.6.0-r1*
* *rmw-fastrtps-shared-cpp 7.5.0-r1 --> 7.6.0-r1*
* *rmw-implementation 2.13.0-r1 --> 2.14.0-r1*
* *ros2-control 3.18.0-r1 --> 3.19.1-r1*
* *ros2-control-test-assets 3.18.0-r1 --> 3.19.1-r1*
* *ros2action 0.29.0-r1 --> 0.29.1-r1*
* *ros2cli 0.29.0-r1 --> 0.29.1-r1*
* *ros2cli-test-interfaces 0.29.0-r1 --> 0.29.1-r1*
* *ros2component 0.29.0-r1 --> 0.29.1-r1*
* *ros2controlcli 3.18.0-r1 --> 3.19.1-r1*
* *ros2doctor 0.29.0-r1 --> 0.29.1-r1*
* *ros2interface 0.29.0-r1 --> 0.29.1-r1*
* *ros2lifecycle 0.29.0-r1 --> 0.29.1-r1*
* *ros2lifecycle-test-fixtures 0.29.0-r1 --> 0.29.1-r1*
* *ros2multicast 0.29.0-r1 --> 0.29.1-r1*
* *ros2node 0.29.0-r1 --> 0.29.1-r1*
* *ros2param 0.29.0-r1 --> 0.29.1-r1*
* *ros2pkg 0.29.0-r1 --> 0.29.1-r1*
* *ros2run 0.29.0-r1 --> 0.29.1-r1*
* *ros2service 0.29.0-r1 --> 0.29.1-r1*
* *ros2topic 0.29.0-r1 --> 0.29.1-r1*
* *rosapi 1.3.1-r2 --> 1.3.2-r1*
* *rosapi-msgs 1.3.1-r2 --> 1.3.2-r1*
* *rosbridge-library 1.3.1-r2 --> 1.3.2-r1*
* *rosbridge-msgs 1.3.1-r2 --> 1.3.2-r1*
* *rosbridge-server 1.3.1-r2 --> 1.3.2-r1*
* *rosbridge-suite 1.3.1-r2 --> 1.3.2-r1*
* *rosbridge-test-msgs 1.3.1-r2 --> 1.3.2-r1*
* *rosgraph-msgs 2.0.0-r1 --> 2.0.1-r1*
* *rosidl-adapter 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-cli 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-cmake 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-generator-c 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-generator-cpp 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-generator-type-description 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-parser 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-pycommon 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-runtime-c 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-runtime-cpp 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-typesupport-fastrtps-c 3.2.0-r1 --> 3.3.0-r1*
* *rosidl-typesupport-fastrtps-cpp 3.2.0-r1 --> 3.3.0-r1*
* *rosidl-typesupport-interface 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-typesupport-introspection-c 4.4.0-r1 --> 4.4.1-r1*
* *rosidl-typesupport-introspection-cpp 4.4.0-r1 --> 4.4.1-r1*
* *rqt-controller-manager 3.18.0-r1 --> 3.19.1-r1*
* *rqt-reconfigure 1.5.0-r1 --> 1.6.0-r1*
* *rti-connext-dds-cmake-module 0.17.0-r1 --> 0.18.0-r1*
* *rviz-assimp-vendor 13.1.0-r1 --> 13.1.1-r1*
* *rviz-common 13.1.0-r1 --> 13.1.1-r1*
* *rviz-default-plugins 13.1.0-r1 --> 13.1.1-r1*
* *rviz-ogre-vendor 13.1.0-r1 --> 13.1.1-r1*
* *rviz-rendering 13.1.0-r1 --> 13.1.1-r1*
* *rviz-rendering-tests 13.1.0-r1 --> 13.1.1-r1*
* *rviz-visual-testing-framework 13.1.0-r1 --> 13.1.1-r1*
* *rviz2 13.1.0-r1 --> 13.1.1-r1*
* *service-msgs 2.0.0-r1 --> 2.0.1-r1*
* *simple-launch 1.7.0-r2 --> 1.7.2-r1*
* *statistics-msgs 2.0.0-r1 --> 2.0.1-r1*
* *test-msgs 2.0.0-r1 --> 2.0.1-r1*
* *tf2 0.33.1-r1 --> 0.33.2-r1*
* *tf2-bullet 0.33.1-r1 --> 0.33.2-r1*
* *tf2-eigen 0.33.1-r1 --> 0.33.2-r1*
* *tf2-eigen-kdl 0.33.1-r1 --> 0.33.2-r1*
* *tf2-geometry-msgs 0.33.1-r1 --> 0.33.2-r1*
* *tf2-kdl 0.33.1-r1 --> 0.33.2-r1*
* *tf2-msgs 0.33.1-r1 --> 0.33.2-r1*
* *tf2-py 0.33.1-r1 --> 0.33.2-r1*
* *tf2-ros 0.33.1-r1 --> 0.33.2-r1*
* *tf2-ros-py 0.33.1-r1 --> 0.33.2-r1*
* *tf2-sensor-msgs 0.33.1-r1 --> 0.33.2-r1*
* *tf2-tools 0.33.1-r1 --> 0.33.2-r1*
* *transmission-interface 3.18.0-r1 --> 3.19.1-r1*
* *turtlesim 1.7.3-r1 --> 1.7.4-r1*
* *type-description-interfaces 2.0.0-r1 --> 2.0.1-r1*
* *ur-client-library 1.3.3-r1 --> 1.3.4-r1*
* *urdf-tutorial 1.0.0-r3 --> 1.1.0-r1*
* *zlib-point-cloud-transport 3.0.0-r1 --> 3.0.1-r1*
* *zstd-point-cloud-transport 3.0.0-r1 --> 3.0.1-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

