### PR TITLE
rosdistro sync, Fri Oct 13 13:15:12 2023

### DIFF
--- a/distros/humble/andino-bringup/default.nix
+++ b/distros/humble/andino-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, andino-control, andino-description, joy-linux, laser-filters, rosbag2-storage-mcap, rplidar-ros, teleop-twist-joy, twist-mux, v4l2-camera }:
+buildRosPackage {
+  pname = "ros-humble-andino-bringup";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_bringup/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "fe63198244682db93ae6b7d02faacf065c473ad97dab5e5c41ac0485c8f18915";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ andino-control andino-description joy-linux laser-filters rosbag2-storage-mcap rplidar-ros teleop-twist-joy twist-mux v4l2-camera ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Contains launch files to bring up andinobot robot.'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-control/default.nix
+++ b/distros/humble/andino-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, andino-base, andino-description, controller-manager, diff-drive-controller, joint-state-broadcaster, ros2controlcli }:
+buildRosPackage {
+  pname = "ros-humble-andino-control";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_control/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "808403866629d4d840fc04d8b1522472009eec2eceddf3a525710420ec713575";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ];
+  propagatedBuildInputs = [ andino-base andino-description controller-manager diff-drive-controller joint-state-broadcaster ros2controlcli ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_control package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-description/default.nix
+++ b/distros/humble/andino-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher-gui, robot-state-publisher, ros2launch, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-humble-andino-description";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_description/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "5e9cb8b409dc35626d1517d51ce87399dc4d07e05ecfc0d8c82d957d528bdf1a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher-gui robot-state-publisher ros2launch rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_description package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-firmware/default.nix
+++ b/distros/humble/andino-firmware/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-andino-firmware";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_firmware/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "78742561f2cb6d2743e6dfa177e3a21d04092ca4925bdbb0814e03b58350bc70";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_firmware package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-gz-classic/default.nix
+++ b/distros/humble/andino-gz-classic/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, andino-control, andino-description, control-msgs, gazebo-ros, gazebo-ros-pkgs, gazebo-ros2-control, robot-state-publisher, ros2launch, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-humble-andino-gz-classic";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_gz_classic/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "5089dbcb96fdb604cdda5aa9367b5b15791d2a029ab737c6db2b8d0f5c625299";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ andino-control andino-description control-msgs gazebo-ros gazebo-ros-pkgs gazebo-ros2-control robot-state-publisher ros2launch rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch Gazebo simulation with Andino'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-hardware/default.nix
+++ b/distros/humble/andino-hardware/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-andino-hardware";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_hardware/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "631ed8de2cc2272e64d582d343a561c1d8a09e9fa20530ada7576a247ec0231f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_hardware package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-navigation/default.nix
+++ b/distros/humble/andino-navigation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, andino-gz-classic, launch-ros, nav2-bringup, navigation2, rviz2, turtlebot3-gazebo }:
+buildRosPackage {
+  pname = "ros-humble-andino-navigation";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_navigation/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6565c39e18655689f5e1f14a0c5b5a6cf20163c3c9dab467440e9ec601119879";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ andino-gz-classic launch-ros nav2-bringup navigation2 rviz2 turtlebot3-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Bring up nav2 package with Andino.'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-slam/default.nix
+++ b/distros/humble/andino-slam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-humble-andino-slam";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_slam/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "92a781dfa798cbab0d9dbf284ee5a2f451fae441511e53f756f40729bb8917b2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_slam package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.3.7-r1";
+  version = "4.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.7-1.tar.gz";
-    name = "4.3.7-1.tar.gz";
-    sha256 = "e302ccdc45c55288d02126a737699db34ff1354e5335e75a395e7824211d14a3";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.8-1.tar.gz";
+    name = "4.3.8-1.tar.gz";
+    sha256 = "e6ecd3174f40c94f916d52ff954d6a30e455d7199f871b5e1c5bf915715b6be2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "79d1dcc4fb9ef6f28ce274336c9a55363d4934e8c4d8bcf0fcbe2e2ee22819bb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "81f9f7607751de4f27d1308d81c75563d8457945feab169cf6702ecd4bf07383";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "c62bfa2e03c6640ad977c0b26887f670cd997b776911ec216decadbfcd05399f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "72fbe23aee674b9c0e52ee40374c5f9e96f1e62953e8c6bdd44803d3c96231cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "da12d5d519610ad39387b92b1d749d2d425d3e84bcaa3de83e62df1d8e8b3113";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "afded5e52b3892ee7159fa0c666b427f3cdb3d6df407e4c76bc054bc83ef4212";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -162,6 +162,22 @@ self: super: {
 
  ament-xmllint = self.callPackage ./ament-xmllint {};
 
+ andino-bringup = self.callPackage ./andino-bringup {};
+
+ andino-control = self.callPackage ./andino-control {};
+
+ andino-description = self.callPackage ./andino-description {};
+
+ andino-firmware = self.callPackage ./andino-firmware {};
+
+ andino-gz-classic = self.callPackage ./andino-gz-classic {};
+
+ andino-hardware = self.callPackage ./andino-hardware {};
+
+ andino-navigation = self.callPackage ./andino-navigation {};
+
+ andino-slam = self.callPackage ./andino-slam {};
+
  angles = self.callPackage ./angles {};
 
  apex-containers = self.callPackage ./apex-containers {};
@@ -2535,6 +2551,8 @@ self: super: {
  urdf-launch = self.callPackage ./urdf-launch {};
 
  urdf-parser-plugin = self.callPackage ./urdf-parser-plugin {};
+
+ urdf-sim-tutorial = self.callPackage ./urdf-sim-tutorial {};
 
  urdf-test = self.callPackage ./urdf-test {};
 

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "af432ecc0f8fdb155fdd0d151a9a0d2b2464eab5c89996099e3423c783260d6d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "911e5653930df225830d3ab58596bd6a8bdc890970a26c14c22e726d1e64aa2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "e4d87915d8e310f913e01606f97d8c32a9f0cfef3ee0500590f19c76cb93a892";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "dca663cec17d3bf034f2bffef037d84854eff759c600f6b6db58ab994a84878c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joy-linux/default.nix
+++ b/distros/humble/joy-linux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joy-linux";
-  version = "3.1.0-r3";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy_linux/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "db3542c66747f1d33c2d9aedea8b1008f875c056a6a51ca2528559b20b1af6dc";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy_linux/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "d04be1b7e0d50258f70557efca35367eed02aae8ae0fb8b7ed3c5b97f6124946";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joy/default.nix
+++ b/distros/humble/joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sdl2-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joy";
-  version = "3.1.0-r3";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "5dd57a85d2d77fddd44f438a90552e9e1fea066a051a90abaaed9606434ddf5b";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "65b642e7afe57a08c3cb9d7f94d71c2562c352b9b0bc939ec59ddeb65c238568";
   };
 
   buildType = "ament_cmake";
@@ -20,9 +20,8 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = ''The joy package contains joy_node, a node that interfaces a
-    generic joystick to ROS 2. This node publishes a &quot;Joy&quot;
-    message, which contains the current state of each one of the
+    description = ''The joy package contains joy_node, a node that interfaces a generic joystick to ROS
+    2. This node publishes a &quot;Joy&quot; message, which contains the current state of each one of the
     joystick's buttons and axes.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "41d9c45fe7e939dcd3eb2ba0b2622b9763d3cb89559c09cb50c9cc0d366729a3";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "c86c6291ad237224cbe0f2b16278463851c891f919714a0a0e2e7b16aea00819";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "83f596f93f55bf38bbea6ae05e8267fc90d6986d8c69318e9c7647f28e19baf0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "0843e86ac7b1e03d35d125294a88bc869e6828d886be8472c402643671fe9b40";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "104be2643b649379363156c8aaf34c032fcf7eb881d747781ff16dd64854bc02";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "7dbac2104fe699e8c09a4de7291cd6fabfd201427d733be40329aada2470b1da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "5ad2b8951b4b050254819fd5bcd857626b6dad49370015dee319d9bf3c66ec9b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "499662c5cb95bbbc84436d12c5f53db92fa04a0ef4e47653a71292e33df43101";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "320759f863d0d30efdda4bcb088776cc151ecba4d8c9454ad51ad83beefa6b99";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "cbe74c776498a04d3eae4ede9578012c2a555cce63bae8e626a1a8f77f546476";
   };
 
   buildType = "ament_python";

--- a/distros/humble/sdl2-vendor/default.nix
+++ b/distros/humble/sdl2-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL2, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-sdl2-vendor";
-  version = "3.1.0-r3";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/sdl2_vendor/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "9ce70b671242ae4b9b05b1d4e1a2a832dcfa360eaa27d0a0428ad4b80152abf6";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/sdl2_vendor/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "dcbf5323cc5429e8a943fd200b87408e8f3da662d584beca38bb77b0658ceb35";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spacenav/default.nix
+++ b/distros/humble/spacenav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, libspnav, rclcpp, rclcpp-components, sensor-msgs, spacenavd }:
 buildRosPackage {
   pname = "ros-humble-spacenav";
-  version = "3.1.0-r3";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/spacenav/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "11ad278a0731a7fb325c90ee6636dbf95b8317f1aa0719fbcbef1e91a73df73e";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/spacenav/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "864c44481a48d7c6686f25b55b97aa481601478e1e807022f5a3145dca061ab8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "d49e74d7ff8db2341b3430c5eaa6620e757a6ba58039205ec52c1274a8c985cb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "e55c8b2d11a763ef3c63c8770d7f4825b452f1b467384194f43d83469ee70e25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "988eecb90062c67d645ef7ae518e6b87f415f0144fd6a447d311c2f61a42438e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "979ddd12a795c6c8c15b08fd03156e49f1b1a81daa5499e00e54bd6596755763";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "dc152ff94cb45a07de35c6152b90638d526a53d658412def7291b9d0646d4a76";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "9d9145227bac23a689ae36e650079e83c2efa30f958c030175e03ca67abe72fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "9a4e65b1a18713714c433b30abe8429af2ccd50c8fe37b9e081ad973569c5e66";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "18762bdfcb03739a3b85726047261a2fbbd43483b1209a467091f714ad970f9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "1dc640590b63bb9605094f17ed2c42b200da046cf2710b5defe8f2546a888282";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "b2c73cf310c91fcb1a5746cd6647176881d811d299aa409ca8bd9b417e95ac74";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "eb21f652aaec1444c69cd5567d9553cc09cba13f106b2dc9d316287902a7e4ff";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "19337f3a1f3590ad67c4bc91322d3986e0ea91b5cd277ce227dc3cff37bd28fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "3bcdd234269809ce00921e120fb1ef97d232bab87c231237c1cc7d78dd84017f";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "5fab58218e01c4ee9050c1117d4e3a5ee5ad8b74572d11c9ca61fe75cde5362e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/urdf-sim-tutorial/default.nix
+++ b/distros/humble/urdf-sim-tutorial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, gazebo-ros, position-controllers, robot-state-publisher, rqt-robot-steering, rviz2, urdf-tutorial, xacro }:
+buildRosPackage {
+  pname = "ros-humble-urdf-sim-tutorial";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/urdf_sim_tutorial-release/archive/release/humble/urdf_sim_tutorial/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "66a652f3b3e258188824fa6059bd2cfdd39aa67be22fc86c21e57226870e1d6c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller gazebo-ros position-controllers robot-state-publisher rqt-robot-steering rviz2 urdf-tutorial xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The urdf_sim_tutorial package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/wiimote-msgs/default.nix
+++ b/distros/humble/wiimote-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-wiimote-msgs";
-  version = "3.1.0-r3";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote_msgs/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "33663c760a07fbdb0145efec5ee3f64846a97d5403c7046fbae7696190e8f7b0";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "8299a421dc105d60c1d414e4e5cccbc426250fae3cea28baf4aa5e73dea2245f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/wiimote/default.nix
+++ b/distros/humble/wiimote/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bluez, cwiid, geometry-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, wiimote-msgs }:
 buildRosPackage {
   pname = "ros-humble-wiimote";
-  version = "3.1.0-r3";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "b87130711f3b06a7725a553040595a98a0ac9ccbfc64a6a91cb6582c2e1c4797";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "e14bb84ac33b7215cbd79651dc6c8945a8363d9742167174f0368d0991404ce2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-black/default.nix
+++ b/distros/iron/ament-black/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-iron-ament-black";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsandus/ament_black-release/archive/release/iron/ament_black/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "7819d61394059ec36b3017facdd42e26d4616b008c7a39cd5b44414155709010";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.unidiff pythonPackages.black ];
+
+  meta = {
+    description = ''The ability to check code against style conventions using
+    black and generate xUnit test result files.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/ament-cmake-black/default.nix
+++ b/distros/iron/ament-cmake-black/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
+buildRosPackage {
+  pname = "ros-iron-ament-cmake-black";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsandus/ament_black-release/archive/release/iron/ament_cmake_black/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "48f17e303dda862bef4aacd6ee31e94dae28182c086932f5f3b7425c722df86c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
+  propagatedBuildInputs = [ ament-black ament-cmake-test ];
+  nativeBuildInputs = [ ament-black ament-cmake-core ament-cmake-test ];
+
+  meta = {
+    description = ''The CMake API for ament_black to lint Python code using black.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.3.7-r1";
+  version = "4.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.7-1.tar.gz";
-    name = "4.3.7-1.tar.gz";
-    sha256 = "e635c9e9ed77bdf2e19b82b79fd36453b547500a9695c1301bc3d46e15ec67e9";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.8-1.tar.gz";
+    name = "4.3.8-1.tar.gz";
+    sha256 = "36c4d00dd6d1a82f86cb33c3383f921287fabb15ed4107a2c5a6b7534b5ef738";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
+ ament-black = self.callPackage ./ament-black {};
+
  ament-clang-format = self.callPackage ./ament-clang-format {};
 
  ament-clang-tidy = self.callPackage ./ament-clang-tidy {};
@@ -35,6 +37,8 @@ self: super: {
  ament-cmake = self.callPackage ./ament-cmake {};
 
  ament-cmake-auto = self.callPackage ./ament-cmake-auto {};
+
+ ament-cmake-black = self.callPackage ./ament-cmake-black {};
 
  ament-cmake-catch2 = self.callPackage ./ament-cmake-catch2 {};
 
@@ -2197,6 +2201,8 @@ self: super: {
  urdf-launch = self.callPackage ./urdf-launch {};
 
  urdf-parser-plugin = self.callPackage ./urdf-parser-plugin {};
+
+ urdf-sim-tutorial = self.callPackage ./urdf-sim-tutorial {};
 
  urdf-tutorial = self.callPackage ./urdf-tutorial {};
 

--- a/distros/iron/joy-linux/default.nix
+++ b/distros/iron/joy-linux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joy-linux";
-  version = "3.1.0-r4";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy_linux/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "9aabffb27cac0456cf28c48f496bcce808366ca0428717b0f987e8beb89711ae";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy_linux/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b4da052df766063a3d131740c7c9036ce1e17c00024d9d2763972cade5a3e9db";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joy/default.nix
+++ b/distros/iron/joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sdl2-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joy";
-  version = "3.1.0-r4";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "dd63aea3fb91b52779883b8dc5d863633da87a62786d016c2225d8904edde88d";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "5cfed6c58f725eb2dab6dad9960dc996b26cdacc568ae16bf0da8573c06d9ae0";
   };
 
   buildType = "ament_cmake";
@@ -20,9 +20,8 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = ''The joy package contains joy_node, a node that interfaces a
-    generic joystick to ROS 2. This node publishes a &quot;Joy&quot;
-    message, which contains the current state of each one of the
+    description = ''The joy package contains joy_node, a node that interfaces a generic joystick to ROS
+    2. This node publishes a &quot;Joy&quot; message, which contains the current state of each one of the
     joystick's buttons and axes.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/iron/mvsim/default.nix
+++ b/distros/iron/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-iron-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c680e35f2acd7e66a130e0b36b0bf5e810bb831089b4a258cdec584695d238c1";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "e3f8cf189e2f4d04da991b090efda455f78c96d10f83cc7d86436804774719dc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/iron/ntrip-client-node/default.nix
+++ b/distros/iron/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ntrip-client-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "f27656b3df582a126d5b5e81a66e34024b5e43edcfce3d4772a743c2b0486409";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "8d1b428f9739a2e999a1dae75fa0dc86a34f81c8b1cabb2cc8bceb635a63a99d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/sdl2-vendor/default.nix
+++ b/distros/iron/sdl2-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL2, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-sdl2-vendor";
-  version = "3.1.0-r4";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/sdl2_vendor/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "7b37c6ae14b00a034bc7c095a1d14f23a510e0471de6d58caa8e94cad30be381";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/sdl2_vendor/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c41ca90bff32b0914b41400a7449719e1773603fa54c4d3feb22da8dfff9de98";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/spacenav/default.nix
+++ b/distros/iron/spacenav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, libspnav, rclcpp, rclcpp-components, sensor-msgs, spacenavd }:
 buildRosPackage {
   pname = "ros-iron-spacenav";
-  version = "3.1.0-r4";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/spacenav/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "821583bb7e2528c2346e3879ae1d8090ddfa8c8215e0ac5387ef8eb2ab3bdb32";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/spacenav/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c7403ea6752c876f11297f681f09e363ae0187c272740b1b2e3c37a3bee559d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-dgnss-node/default.nix
+++ b/distros/iron/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "5e9d0618bafe68ec85322e20b8cbdb6b73750cc0066fa36b3b2c8f362fe5cff0";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ba02308a7581d71191637118909afacaa6d34e773f3a722da2b9dcf9de7b41ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-dgnss/default.nix
+++ b/distros/iron/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "41640b6dded7a5da319c1c34e61990ece3c2fb18d1b9734085d0be974db92457";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "85e406ab84077cca7db8ce26b1c48766654119e6e615c655d9feebe2103d0a6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-nav-sat-fix-hp-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "545e12569633d0f29f4e7ca0a80556ccc861a8343f88e7795f8cd52900dadd8c";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "d611d487273f5f44dc88a7e01831d464aa17b6af363bddbe5e2d8aa0266b1c3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-interfaces/default.nix
+++ b/distros/iron/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-interfaces";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "d74848f6b8efd8efcd887a6a66b58653809fad37ee60ba912454b536ece5e6db";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "e75b610c29b35db74cdef59ceb85d36a29ce33189b9a9b8e9b0d615441587ed5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-msgs/default.nix
+++ b/distros/iron/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-msgs";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "287d525acbb96a0b1e5a7658fd3c99a497a761d739ed464bcd54ab194cdae77e";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "cbd72f52ae5b278bfadc704cfdd1e8f0bb7459efff88561bf4d7c4fe61d3dcb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/urdf-sim-tutorial/default.nix
+++ b/distros/iron/urdf-sim-tutorial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, gazebo-ros, position-controllers, robot-state-publisher, rqt-robot-steering, rviz2, urdf-tutorial, xacro }:
+buildRosPackage {
+  pname = "ros-iron-urdf-sim-tutorial";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/urdf_sim_tutorial-release/archive/release/iron/urdf_sim_tutorial/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f6b75c542e722a6c6101abd18bac16531e4aee1ac09a30f973446fd7d8535a6d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller gazebo-ros position-controllers robot-state-publisher rqt-robot-steering rviz2 urdf-tutorial xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The urdf_sim_tutorial package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/wiimote-msgs/default.nix
+++ b/distros/iron/wiimote-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-wiimote-msgs";
-  version = "3.1.0-r4";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote_msgs/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "68707e471ceef707e1c19106722d2b7fd056b5cb41b81d0109383e16adccbd49";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "2d7536f190b776222c8db094e663e4989c4b7ca837c15bd06ef1b13175d336b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/wiimote/default.nix
+++ b/distros/iron/wiimote/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bluez, cwiid, geometry-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, wiimote-msgs }:
 buildRosPackage {
   pname = "ros-iron-wiimote";
-  version = "3.1.0-r4";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "b00aee9415aaa50a769f68eb5fbd267d45eee303c2a9b3ed603183ff1868ff94";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "ca47918cad7bbc3cd58eebfe8a942d3b840b6db33c1f38ac6552cccc0ab1a845";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.3.1-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.1-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.3-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "e115764e2e571a71aaa1d9146f4c0d795705a701583c952af77e129e2a3fbad9";
+    sha256 = "9ecf4d3ff400fbcc9906cefce457990f0b3519627cf3e8a09d7251810db3ee10";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "fcea023939c08670dcbc373c4f6f9cda2bd5f709d866ca56b6c6610eee9942b6";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "dae2f3f7e815e8d0b7c31ab68a9902503ee551de2c34e01c6681d3581ab52253";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin cmake ros-environment ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ boost cppzmq dynamic-reconfigure mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 roscpp sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq dynamic-reconfigure mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 roscpp sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ catkin cmake ];
 
   meta = {

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.3.7-r1";
+  version = "4.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.3.7-1.tar.gz";
-    name = "4.3.7-1.tar.gz";
-    sha256 = "60084c6b9b36dcb8c302d753684e8a371a3c5be0d1a4f63834b421fdaf9fc403";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.3.8-1.tar.gz";
+    name = "4.3.8-1.tar.gz";
+    sha256 = "813f77d4d34c6a82a91ecbaba6c7380f976e4e87be6f5cfbd826fe55363fbaad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libyaml-vendor/default.nix
+++ b/distros/rolling/libyaml-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config, rcpputils, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-libyaml-vendor";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "8e0cd178c9da4cc1d0f3df2f30ed2f8351added40e617339097068197ba0951d";
+    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6b3024b4e45abc38e60bb671b428220844a5f4fec99620a90a7f5f2b4169b389";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-vendor-package ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture rcpputils rcutils ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture ];
   propagatedBuildInputs = [ libyaml pkg-config ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package pkg-config ];
 

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.10.0-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "963551531cab14ebdbbc7eb517712aae60449f4a45111be801e0b24529cc0428";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "9a812aba04931c553501da2191513e8305b38810d9e82f9bb174a0bfcee922fc";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 python3Packages.pip pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libfyaml libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "27d5d82537d205281870a568c22c828c83674fb87e79baa061205c3e5771341d";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "4dfd8ead9b42262b452fed3441a1f920029109cb83fa631a5feb061ea4008c8b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "4c7f2b1bda7cebe9931b36c614dcb9d0b7f0c5988dc5f6adc2d5ccba34f91b97";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "0267faa2599a81c4e4e0b1299d0e9e1b5820277800c8942af9d0598073d009dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "42a9d2891c5f0abf5ddc4088d0e278752186d68e11c5c5dd56ab3932c12a2f64";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "832886e3854244461c11c6a9e78151964e3bb8d1d6b02e562781e232e886d1ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "5196debea5924d9146a39802c6c6cb89c9dda2fa466cb87d9f762eafdb3c5cf9";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "de4cd8e3d9ee3f8919c51d3c147a88ef2d5baa45b706086d43fb0a2a7968e28b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "51bef31c8bc9277d47e6424c34f453a12930f04b531e96512b3c335c34da6497";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "d58aac5e05a19c1569ed9c9c6f7f84ba706ab90adc433df1e1f1e21f01a89a0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "8e80de46edff802301af6b9971d608d8e538837c7782de3e99d447464c8f8d34";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "bdb546ddcf3a4442dec9a60678f7788df606f143580f3660b2eb330b5484e11c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "61599a3cfdc7384ba1cbab496fdeb432c1f36bfc3fb04f16499f4658ed9a5e8b";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "6cdee431880b10517c0d1b550069ef3d68dc88594070b35a46c221ea9959d345";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "e432a0cea91bf0bb08018456fcd3231cac59f0cf5e4885ab875e93944a67afe7";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "76125d7d855006014d436f02b92f3c6a6ab03f2664432c2382e64b55959daed1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "7cc6309b60beb120c375a600796a80de8c76bbbfafe941a52608505c8d46169f";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "67a93b5eb69de39ea02fe9939d0dd71f82b0e751a3b74cb424582c3f2055a328";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "5.3.0-r1";
+  version = "5.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "c74a7422f79716b770df59a7438e57d1da68bf7eb9eaa3f5a930f639f86f94e2";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.4.0-1.tar.gz";
+    name = "5.4.0-1.tar.gz";
+    sha256 = "9dff99c4864ff0d79b4f4bfcc8fb84ae165d0d8c2e514d261b74d4e8e43b0596";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-dds-common/default.nix
+++ b/distros/rolling/rmw-dds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-c, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-dds-common";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "de321f66a737937199762b133950e3ad1a6257b928917826be8213eb971d886f";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "172202f46c5819e0506e6078db8119e566a2144bca565ad1c90ff09365a41e04";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-reconfigure/default.nix
+++ b/distros/rolling/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-reconfigure";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1db5afeb324ff26fa017247642f27cca0f7078095179edd4c1ac0c1634981cb5";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "7ef228cbfe216c319f182aa87ae4fd40dc6ff6a3a99658d9bc6dded5af2e4a6d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "6acc7596f45264635523cb63300cba0bfe5cacb915df3c49faab5ca4cf0b9c0e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "3ba7f4930448e973a9b91395f8a500de83c5db2a0eba161b730754726230cf28";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "78b35847c8ef6ad859ea937ba91fbcee5183e7d90fcf2e2bd2b06a87aa69bd4b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "4d9c8b2a9b0552939bfd35e664eee309833486c2b62ec849089c825d1883f217";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "7a4d32ea260e908ec482951e90a9cf288f5e29e2442547e59f4ecb8a6272e23d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "d5d99056753c84971e5075a2dd5f5a9ec16405b6412a3e7a14476c3946bd434f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "775ff6e661ada8c06bf68c782ffab9d88af9caaffa0a288a417ad2356ea89a8e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "18c6fc64dc46138ff21fb980235b7f56b902041b16021f71a5c71962e2614da5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "3fa7ab4fe1494d071403509d5f5b83d948271a78683852abcc753f6d11c5b86f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "f5f4b5bbc76800fb364c75b6cb30df0e768aa2c44c9d1a244ab992ba6e2a0333";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "45c22cf0a0cb2aac92306265ec9cb4ca1aff59c386436f309a112fbc3d769705";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "d2e87bb2a1efd7ee24e07a5401239cc7d3bf5d747ae23c7b9fa3878b20ae471b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "55c24bf4e440cbf11a919d604e2e1439cdda74f57d57617cc11b9e6ae3fbd1d0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "b469d20f2883dce76dfa6ecd23314dcdee679995a465ca2900f4dd74bc7a1267";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "ef8b0b0338a259f3771be852db3c483fb81b7082b088712a5cb25efc18736b8d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "834614b612773079160401f846a1ba4c3f8994e51a1fc55ee90abc214e281aeb";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit e3eba7bb67e60108ba22ce297d72e1a9ad71311f.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *andino-bringup 0.1.0-r1*
* *andino-control 0.1.0-r1*
* *andino-description 0.1.0-r1*
* *andino-firmware 0.1.0-r1*
* *andino-gz-classic 0.1.0-r1*
* *andino-hardware 0.1.0-r1*
* *andino-navigation 0.1.0-r1*
* *andino-slam 0.1.0-r1*
* *behaviortree-cpp 4.3.7-r1 --> 4.3.8-r1*
* *controller-interface 2.32.0-r1 --> 2.33.0-r1*
* *controller-manager 2.32.0-r1 --> 2.33.0-r1*
* *controller-manager-msgs 2.32.0-r1 --> 2.33.0-r1*
* *hardware-interface 2.32.0-r1 --> 2.33.0-r1*
* *joint-limits 2.32.0-r1 --> 2.33.0-r1*
* *joy 3.1.0-r3 --> 3.2.0-r1*
* *joy-linux 3.1.0-r3 --> 3.2.0-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*
* *ros2-control 2.32.0-r1 --> 2.33.0-r1*
* *ros2-control-test-assets 2.32.0-r1 --> 2.33.0-r1*
* *ros2controlcli 2.32.0-r1 --> 2.33.0-r1*
* *rqt-controller-manager 2.32.0-r1 --> 2.33.0-r1*
* *sdl2-vendor 3.1.0-r3 --> 3.2.0-r1*
* *spacenav 3.1.0-r3 --> 3.2.0-r1*
* *transmission-interface 2.32.0-r1 --> 2.33.0-r1*
* *ur 2.2.8-r1 --> 2.2.9-r1*
* *ur-bringup 2.2.8-r1 --> 2.2.9-r1*
* *ur-calibration 2.2.8-r1 --> 2.2.9-r1*
* *ur-controllers 2.2.8-r1 --> 2.2.9-r1*
* *ur-dashboard-msgs 2.2.8-r1 --> 2.2.9-r1*
* *ur-moveit-config 2.2.8-r1 --> 2.2.9-r1*
* *urdf-sim-tutorial 1.0.1-r1*
* *wiimote 3.1.0-r3 --> 3.2.0-r1*
* *wiimote-msgs 3.1.0-r3 --> 3.2.0-r1*

Iron Changes:
-------------
* *ament-black 0.2.2-r1*
* *ament-cmake-black 0.2.2-r1*
* *behaviortree-cpp 4.3.7-r1 --> 4.3.8-r1*
* *joy 3.1.0-r4 --> 3.2.0-r1*
* *joy-linux 3.1.0-r4 --> 3.2.0-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*
* *ntrip-client-node 0.4.4-r1 --> 0.5.1-r1*
* *sdl2-vendor 3.1.0-r4 --> 3.2.0-r1*
* *spacenav 3.1.0-r4 --> 3.2.0-r1*
* *ublox-dgnss 0.4.4-r1 --> 0.5.1-r1*
* *ublox-dgnss-node 0.4.4-r1 --> 0.5.1-r1*
* *ublox-nav-sat-fix-hp-node 0.4.4-r1 --> 0.5.1-r1*
* *ublox-ubx-interfaces 0.4.4-r1 --> 0.5.1-r1*
* *ublox-ubx-msgs 0.4.4-r1 --> 0.5.1-r1*
* *urdf-sim-tutorial 1.0.1-r1*
* *wiimote 3.1.0-r4 --> 3.2.0-r1*
* *wiimote-msgs 3.1.0-r4 --> 3.2.0-r1*

Noetic Changes:
---------------
* *image-transport-codecs 2.3.1-r1 --> 2.3.3-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*

Rolling Changes:
----------------
* *behaviortree-cpp 4.3.7-r1 --> 4.3.8-r1*
* *libyaml-vendor 1.6.1-r1 --> 1.6.2-r1*
* *mrpt2 2.10.0-r1 --> 2.10.2-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*
* *rcl 7.2.0-r1 --> 7.3.0-r1*
* *rcl-action 7.2.0-r1 --> 7.3.0-r1*
* *rcl-lifecycle 7.2.0-r1 --> 7.3.0-r1*
* *rcl-yaml-param-parser 7.2.0-r1 --> 7.3.0-r1*
* *rclcpp 23.1.0-r1 --> 23.2.0-r1*
* *rclcpp-action 23.1.0-r1 --> 23.2.0-r1*
* *rclcpp-components 23.1.0-r1 --> 23.2.0-r1*
* *rclcpp-lifecycle 23.1.0-r1 --> 23.2.0-r1*
* *rclpy 5.3.0-r1 --> 5.4.0-r1*
* *rmw-dds-common 2.1.0-r1 --> 2.1.1-r1*
* *rqt-reconfigure 1.6.0-r1 --> 1.6.1-r1*
* *rviz-assimp-vendor 13.1.1-r1 --> 13.1.2-r1*
* *rviz-common 13.1.1-r1 --> 13.1.2-r1*
* *rviz-default-plugins 13.1.1-r1 --> 13.1.2-r1*
* *rviz-ogre-vendor 13.1.1-r1 --> 13.1.2-r1*
* *rviz-rendering 13.1.1-r1 --> 13.1.2-r1*
* *rviz-rendering-tests 13.1.1-r1 --> 13.1.2-r1*
* *rviz-visual-testing-framework 13.1.1-r1 --> 13.1.2-r1*
* *rviz2 13.1.1-r1 --> 13.1.2-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

