### PR TITLE
rosdistro sync, Fri Nov  3 13:39:15 2023

### DIFF
--- a/distros/humble/ament-black/default.nix
+++ b/distros/humble/ament-black/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-black";
-  version = "0.1.0-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/Timple/ament_black-release/archive/release/humble/ament_black/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "4d23c0ab86374546dc80ad9960e62ec571560068d3b0f6549e39470749c2f9f8";
+    url = "https://github.com/botsandus/ament_black-release/archive/release/humble/ament_black/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "2bbc4f8fd92ea8ba2ff4710f4f70796fd2989f1c61b659845723fc7830314e54";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ python3Packages.unidiff pythonPackages.black ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.unidiff python3Packages.uvloop pythonPackages.black ];
 
   meta = {
     description = ''The ability to check code against style conventions using

--- a/distros/humble/ament-cmake-black/default.nix
+++ b/distros/humble/ament-cmake-black/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
+{ lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-black";
-  version = "0.1.0-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/Timple/ament_black-release/archive/release/humble/ament_cmake_black/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "07045615bb575cfbd485e721dd76ce5ef2bb12e2e8dd56464325e061568de73b";
+    url = "https://github.com/botsandus/ament_black-release/archive/release/humble/ament_cmake_black/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "b841f007d2b41dbac17073a72a89f166b8001976db42811d91ac011ca82ff4db";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-core ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ ament-black ament-cmake-test ];
   nativeBuildInputs = [ ament-black ament-cmake-core ament-cmake-test ];
 

--- a/distros/humble/andino-bringup/default.nix
+++ b/distros/humble/andino-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, andino-control, andino-description, joy-linux, laser-filters, rosbag2-storage-mcap, rplidar-ros, teleop-twist-joy, twist-mux, v4l2-camera }:
+buildRosPackage {
+  pname = "ros-humble-andino-bringup";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_bringup/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "fe63198244682db93ae6b7d02faacf065c473ad97dab5e5c41ac0485c8f18915";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ andino-control andino-description joy-linux laser-filters rosbag2-storage-mcap rplidar-ros teleop-twist-joy twist-mux v4l2-camera ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Contains launch files to bring up andinobot robot.'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-control/default.nix
+++ b/distros/humble/andino-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, andino-base, andino-description, controller-manager, diff-drive-controller, joint-state-broadcaster, ros2controlcli }:
+buildRosPackage {
+  pname = "ros-humble-andino-control";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_control/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "808403866629d4d840fc04d8b1522472009eec2eceddf3a525710420ec713575";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ];
+  propagatedBuildInputs = [ andino-base andino-description controller-manager diff-drive-controller joint-state-broadcaster ros2controlcli ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_control package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-description/default.nix
+++ b/distros/humble/andino-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher-gui, robot-state-publisher, ros2launch, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-humble-andino-description";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_description/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "5e9cb8b409dc35626d1517d51ce87399dc4d07e05ecfc0d8c82d957d528bdf1a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher-gui robot-state-publisher ros2launch rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_description package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-firmware/default.nix
+++ b/distros/humble/andino-firmware/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-andino-firmware";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_firmware/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "78742561f2cb6d2743e6dfa177e3a21d04092ca4925bdbb0814e03b58350bc70";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_firmware package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-gz-classic/default.nix
+++ b/distros/humble/andino-gz-classic/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, andino-control, andino-description, control-msgs, gazebo-ros, gazebo-ros-pkgs, gazebo-ros2-control, robot-state-publisher, ros2launch, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-humble-andino-gz-classic";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_gz_classic/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "5089dbcb96fdb604cdda5aa9367b5b15791d2a029ab737c6db2b8d0f5c625299";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ andino-control andino-description control-msgs gazebo-ros gazebo-ros-pkgs gazebo-ros2-control robot-state-publisher ros2launch rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch Gazebo simulation with Andino'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-hardware/default.nix
+++ b/distros/humble/andino-hardware/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-andino-hardware";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_hardware/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "631ed8de2cc2272e64d582d343a561c1d8a09e9fa20530ada7576a247ec0231f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_hardware package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-navigation/default.nix
+++ b/distros/humble/andino-navigation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, andino-gz-classic, launch-ros, nav2-bringup, navigation2, rviz2, turtlebot3-gazebo }:
+buildRosPackage {
+  pname = "ros-humble-andino-navigation";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_navigation/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6565c39e18655689f5e1f14a0c5b5a6cf20163c3c9dab467440e9ec601119879";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ andino-gz-classic launch-ros nav2-bringup navigation2 rviz2 turtlebot3-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Bring up nav2 package with Andino.'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/andino-slam/default.nix
+++ b/distros/humble/andino-slam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-humble-andino-slam";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/andino-release/archive/release/humble/andino_slam/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "92a781dfa798cbab0d9dbf284ee5a2f451fae441511e53f756f40729bb8917b2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The andino_slam package'';
+    license = with lib.licenses; [ "BSD-Clause-3" ];
+  };
+}

--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.3.7-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.3.7-1.tar.gz";
-    name = "4.3.7-1.tar.gz";
-    sha256 = "e302ccdc45c55288d02126a737699db34ff1354e5335e75a395e7824211d14a3";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "d1b6894e7489602fca7cf0329179252b7bce0138f6bad9ec266ed13179e0a262";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/catch-ros2/default.nix
+++ b/distros/humble/catch-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-catch-ros2";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/humble/catch_ros2/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "e4ba4a5cffee11ece9a94a1236303ec46de57921c3afb2e2902c354f519e86f5";
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/humble/catch_ros2/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "c385ec7cc36c304cea5d46f8a3f431a7459368d36b1dfba4c0201c47d329970b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config-live/default.nix
+++ b/distros/humble/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config-live";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "7ec905414bbb9bfc09d1ce7afa3522bddd2892aced10a28b8defb58394f921fe";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "55445dbd03483852c595a8e3bf0ded6097d39bbd2fada7ee44543219dc43326a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-desktop/default.nix
+++ b/distros/humble/clearpath-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-desktop";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "88e2075c1b5e179c9999df7371847f7bef79110741e7e83a3cbb76369aacf613";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "24e5572aba43dbddd2cc28769c0fc0ae449b57367ca54d82cc3e55bf1e9a5925";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-viz/default.nix
+++ b/distros/humble/clearpath-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rqt-robot-monitor, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-clearpath-viz";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "61895704d80635420a8795ae0508520e4a9d5f4cc8e7dca79d7e09409537e3ce";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "9fe165c5664e633560c10045783c283f92fd598ec79189a6d747f182ee27992f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-platform-description joint-state-publisher-gui rviz2 ];
+  propagatedBuildInputs = [ clearpath-platform-description joint-state-publisher-gui rqt-robot-monitor rviz2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "79d1dcc4fb9ef6f28ce274336c9a55363d4934e8c4d8bcf0fcbe2e2ee22819bb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "81f9f7607751de4f27d1308d81c75563d8457945feab169cf6702ecd4bf07383";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "c62bfa2e03c6640ad977c0b26887f670cd997b776911ec216decadbfcd05399f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "72fbe23aee674b9c0e52ee40374c5f9e96f1e62953e8c6bdd44803d3c96231cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "da12d5d519610ad39387b92b1d749d2d425d3e84bcaa3de83e62df1d8e8b3113";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "afded5e52b3892ee7159fa0c666b427f3cdb3d6df407e4c76bc054bc83ef4212";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "3aca9ac19e47aae7f9483d128b44226f171124e9a06484f924a92d57d1d57f6d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "9b1c7761c24b09ad2d5468e24ef004844ba1dbbd8cb1539027bcb5551df9b88f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "f25d30ed5ffacdc15eed02fd8f136b0947804021ddefd0427c0a5f34611619c1";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "57d3076b8d783dfa8b57705daf925a53f8a7813fa6c20f259413922fc7a0f9e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "3857bdc75c10a91c5d98d9963b73b837b7e7070d04918e47b72d89cb7191ad55";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "b656e1f1f01cee2985f9d626e33e4519fd5fe77ebfbc3ffe7683f3ae30e7c5f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "2d46f2856b1508f55f1a27c1fdef5eca1b604f0f56166427181f86b309d21d5a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "9fc8f206a176205263b1a0fa2fbf374f4151831ba35e8bab8570257a66883049";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "70b3ab26367cd19c5d39f988e3676065b61431c52e7392da0d13d452583e26a5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "edad55e7542d19d05b16dce919a559d13dc10496f93be144d2ff157a10c37ed2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "c90ca8d8ee53d7a6b806b16101561107f101c2c67cea9778fb4866b20f2d4e82";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "70f979fdb7709f1935d2300e198c17e4c9c818ab137be976ba0a9ee5b7b3ca17";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "8215b31cf32d25e4c7849c29848737c3b24be1042f89d395dc666a53d2787afa";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "8fc65d1c62418e8f297f5223dca7af048dc58205d14b814b36955c612ef8df36";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "a43198e619dc6957dd94105d67158df41269946379fed61c5c6e34e6cb187929";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "2d73b21a346a879059581f26cb4a651a6bb9d22967fd1d45248d6aceb3675c70";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -162,6 +162,22 @@ self: super: {
 
  ament-xmllint = self.callPackage ./ament-xmllint {};
 
+ andino-bringup = self.callPackage ./andino-bringup {};
+
+ andino-control = self.callPackage ./andino-control {};
+
+ andino-description = self.callPackage ./andino-description {};
+
+ andino-firmware = self.callPackage ./andino-firmware {};
+
+ andino-gz-classic = self.callPackage ./andino-gz-classic {};
+
+ andino-hardware = self.callPackage ./andino-hardware {};
+
+ andino-navigation = self.callPackage ./andino-navigation {};
+
+ andino-slam = self.callPackage ./andino-slam {};
+
  angles = self.callPackage ./angles {};
 
  apex-containers = self.callPackage ./apex-containers {};
@@ -2535,6 +2551,8 @@ self: super: {
  urdf-launch = self.callPackage ./urdf-launch {};
 
  urdf-parser-plugin = self.callPackage ./urdf-parser-plugin {};
+
+ urdf-sim-tutorial = self.callPackage ./urdf-sim-tutorial {};
 
  urdf-test = self.callPackage ./urdf-test {};
 

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "af432ecc0f8fdb155fdd0d151a9a0d2b2464eab5c89996099e3423c783260d6d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "911e5653930df225830d3ab58596bd6a8bdc890970a26c14c22e726d1e64aa2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "e4d87915d8e310f913e01606f97d8c32a9f0cfef3ee0500590f19c76cb93a892";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "dca663cec17d3bf034f2bffef037d84854eff759c600f6b6db58ab994a84878c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joy-linux/default.nix
+++ b/distros/humble/joy-linux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joy-linux";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy_linux/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "db3542c66747f1d33c2d9aedea8b1008f875c056a6a51ca2528559b20b1af6dc";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy_linux/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2e7ed0334f225d2924b77363ea354010db817e5145fbf4baca08483da7d6b547";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joy-teleop/default.nix
+++ b/distros/humble/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joy-teleop";
-  version = "1.3.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/joy_teleop/1.3.0-2.tar.gz";
-    name = "1.3.0-2.tar.gz";
-    sha256 = "5d4c302666f6ae630b49b2573e5d724f1d690cf995a3d69082254d63903058f1";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/joy_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "26b8b70e5c0fbe70d0c720fedfe1899deeb95c003afd8ee0da7598556e99b7e3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/joy/default.nix
+++ b/distros/humble/joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sdl2-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joy";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "5dd57a85d2d77fddd44f438a90552e9e1fea066a051a90abaaed9606434ddf5b";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/joy/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "d475fc68cca7b02e7bd2200465751b1a4a40aacfab5b612704830e07069e8f36";
   };
 
   buildType = "ament_cmake";
@@ -20,9 +20,8 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = ''The joy package contains joy_node, a node that interfaces a
-    generic joystick to ROS 2. This node publishes a &quot;Joy&quot;
-    message, which contains the current state of each one of the
+    description = ''The joy package contains joy_node, a node that interfaces a generic joystick to ROS
+    2. This node publishes a &quot;Joy&quot; message, which contains the current state of each one of the
     joystick's buttons and axes.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/humble/key-teleop/default.nix
+++ b/distros/humble/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-key-teleop";
-  version = "1.3.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/key_teleop/1.3.0-2.tar.gz";
-    name = "1.3.0-2.tar.gz";
-    sha256 = "6a32b880d1918822c3f54f42de698feaa6c37486b791b2eabb5f8f64b9dbd723";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/key_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ddb72d5b8d968de1987c72e0f40918eedb207ae16972d07977d5fb13eee53a00";
   };
 
   buildType = "ament_python";

--- a/distros/humble/leo-description/default.nix
+++ b/distros/humble/leo-description/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-description";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "a4b45eef10ddb7d7d1143c12fb9c3e596c52d0602e8a3e768a376a0b2c1908e6";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "df2cc9de1f06023544339d6d2d4b76768979792990f88a2a6da3367a562ae4ab";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
   propagatedBuildInputs = [ robot-state-publisher xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/leo-msgs/default.nix
+++ b/distros/humble/leo-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-leo-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4f1718b81a99294a2cdb5d87e20778ebdfc5e3a0de0c6c2d606c0ddbcb3aef76";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a308f218b698b153faad0905c031f52a6147d52b88ca6d8da367817ac0995e92";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/leo-teleop/default.nix
+++ b/distros/humble/leo-teleop/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, joy, teleop-twist-joy, teleop-twist-keyboard }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-humble-leo-teleop";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "9c63228ed8a09142afd99c87a1923b779f710abd7a54104455f56a51662cc815";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ea75ec89a0880cecec7b01f0c16fa219184c0f1285c97208844ec1f9360ea2a2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ joy teleop-twist-joy teleop-twist-keyboard ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ joy-linux teleop-twist-joy teleop-twist-keyboard ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/leo/default.nix
+++ b/distros/humble/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-humble-leo";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "900d6a07067d946020a317f32cb3db8dbb039f0ffa0d403df75d26bbd1dabe26";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2466f7670b18809c81b1a2e6feb6924b8acc98535395c79c00276e6f75e4de55";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mouse-teleop/default.nix
+++ b/distros/humble/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-mouse-teleop";
-  version = "1.3.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/mouse_teleop/1.3.0-2.tar.gz";
-    name = "1.3.0-2.tar.gz";
-    sha256 = "2527c790d59b74852b6ece36904baa3f15090003b59ff18177ff0c95e548e2d4";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/mouse_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "fc78bf91d0c94a6e135237605067b110803447e18bf44f8f9b6786b86da8a7c7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.10.2-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.10.2-1.tar.gz";
-    name = "2.10.2-1.tar.gz";
-    sha256 = "5c8e2f2ef450bd84e98f142c394bf265adf2ddbc958e1bf17a9480767bb9d9c8";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "daeab571c665cc2f4797a3bd695843f3bf41ae9ec0f8876b62b4b1b93f81e19e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "41d9c45fe7e939dcd3eb2ba0b2622b9763d3cb89559c09cb50c9cc0d366729a3";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "c86c6291ad237224cbe0f2b16278463851c891f919714a0a0e2e7b16aea00819";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "83f596f93f55bf38bbea6ae05e8267fc90d6986d8c69318e9c7647f28e19baf0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "0843e86ac7b1e03d35d125294a88bc869e6828d886be8472c402643671fe9b40";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "104be2643b649379363156c8aaf34c032fcf7eb881d747781ff16dd64854bc02";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "7dbac2104fe699e8c09a4de7291cd6fabfd201427d733be40329aada2470b1da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "5ad2b8951b4b050254819fd5bcd857626b6dad49370015dee319d9bf3c66ec9b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "499662c5cb95bbbc84436d12c5f53db92fa04a0ef4e47653a71292e33df43101";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "320759f863d0d30efdda4bcb088776cc151ecba4d8c9454ad51ad83beefa6b99";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "cbe74c776498a04d3eae4ede9578012c2a555cce63bae8e626a1a8f77f546476";
   };
 
   buildType = "ament_python";

--- a/distros/humble/sdl2-vendor/default.nix
+++ b/distros/humble/sdl2-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL2, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-sdl2-vendor";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/sdl2_vendor/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "9ce70b671242ae4b9b05b1d4e1a2a832dcfa360eaa27d0a0428ad4b80152abf6";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/sdl2_vendor/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "a68160fd4e6de60a99af0fba39dfba31aac48b6663e8e86b746b2a4bded079d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spacenav/default.nix
+++ b/distros/humble/spacenav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, libspnav, rclcpp, rclcpp-components, sensor-msgs, spacenavd }:
 buildRosPackage {
   pname = "ros-humble-spacenav";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/spacenav/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "11ad278a0731a7fb325c90ee6636dbf95b8317f1aa0719fbcbef1e91a73df73e";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/spacenav/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "590ed5dfad67186db5a5bc1a1cefe08caf85075a48127cc322ea5bb9d5b13c24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/teleop-tools-msgs/default.nix
+++ b/distros/humble/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-teleop-tools-msgs";
-  version = "1.3.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools_msgs/1.3.0-2.tar.gz";
-    name = "1.3.0-2.tar.gz";
-    sha256 = "5e3ff3515cd38c4652bbd2aa21e60d376e8625b3f2e3bb7b974429b23e42242a";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "7684b1b0c05f404227cfe05b9a9ef5f014f9a7f83a44cd3ee5c65520b86e1542";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/teleop-tools/default.nix
+++ b/distros/humble/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-humble-teleop-tools";
-  version = "1.3.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools/1.3.0-2.tar.gz";
-    name = "1.3.0-2.tar.gz";
-    sha256 = "6c496fa73fb85214101b875dfb84576170b51e6a3f3e49bfaf82d092a032c8ad";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9f718f5c55ef540aa10dc2e1c483e499784ba4b214198732e0808d881765329d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.32.0-r1";
+  version = "2.33.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.32.0-1.tar.gz";
-    name = "2.32.0-1.tar.gz";
-    sha256 = "d49e74d7ff8db2341b3430c5eaa6620e757a6ba58039205ec52c1274a8c985cb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.33.0-1.tar.gz";
+    name = "2.33.0-1.tar.gz";
+    sha256 = "e55c8b2d11a763ef3c63c8770d7f4825b452f1b467384194f43d83469ee70e25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "988eecb90062c67d645ef7ae518e6b87f415f0144fd6a447d311c2f61a42438e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "979ddd12a795c6c8c15b08fd03156e49f1b1a81daa5499e00e54bd6596755763";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "dc152ff94cb45a07de35c6152b90638d526a53d658412def7291b9d0646d4a76";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "9d9145227bac23a689ae36e650079e83c2efa30f958c030175e03ca67abe72fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "9a4e65b1a18713714c433b30abe8429af2ccd50c8fe37b9e081ad973569c5e66";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "18762bdfcb03739a3b85726047261a2fbbd43483b1209a467091f714ad970f9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "1dc640590b63bb9605094f17ed2c42b200da046cf2710b5defe8f2546a888282";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "b2c73cf310c91fcb1a5746cd6647176881d811d299aa409ca8bd9b417e95ac74";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "eb21f652aaec1444c69cd5567d9553cc09cba13f106b2dc9d316287902a7e4ff";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "19337f3a1f3590ad67c4bc91322d3986e0ea91b5cd277ce227dc3cff37bd28fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.2.8-r1";
+  version = "2.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.8-1.tar.gz";
-    name = "2.2.8-1.tar.gz";
-    sha256 = "3bcdd234269809ce00921e120fb1ef97d232bab87c231237c1cc7d78dd84017f";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.9-1.tar.gz";
+    name = "2.2.9-1.tar.gz";
+    sha256 = "5fab58218e01c4ee9050c1117d4e3a5ee5ad8b74572d11c9ca61fe75cde5362e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/urdf-sim-tutorial/default.nix
+++ b/distros/humble/urdf-sim-tutorial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, gazebo-ros, position-controllers, robot-state-publisher, rqt-robot-steering, rviz2, urdf-tutorial, xacro }:
+buildRosPackage {
+  pname = "ros-humble-urdf-sim-tutorial";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/urdf_sim_tutorial-release/archive/release/humble/urdf_sim_tutorial/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "66a652f3b3e258188824fa6059bd2cfdd39aa67be22fc86c21e57226870e1d6c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller gazebo-ros position-controllers robot-state-publisher rqt-robot-steering rviz2 urdf-tutorial xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The urdf_sim_tutorial package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/wiimote-msgs/default.nix
+++ b/distros/humble/wiimote-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-wiimote-msgs";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote_msgs/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "33663c760a07fbdb0145efec5ee3f64846a97d5403c7046fbae7696190e8f7b0";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2e0f8977eabb494442878e8dd4f145ed197ce76b830b34ecf28fa5a2512397be";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/wiimote/default.nix
+++ b/distros/humble/wiimote/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bluez, cwiid, geometry-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, wiimote-msgs }:
 buildRosPackage {
   pname = "ros-humble-wiimote";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "b87130711f3b06a7725a553040595a98a0ac9ccbfc64a6a91cb6582c2e1c4797";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/humble/wiimote/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "473005692fdf5daae9c6005ab061eca2fbe0a8d5dc9589a2fc6f2acae0a50e39";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "f792e466a75cd44fa589d4c4430ede193dafde032eb92c819fabf81e25df55e4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "14d0f9be25ce8a0f54b775545b77a4d57d578f03ed5806bfe5b092a2c56b371e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "710114b43aee0fa4e2437315ab7a4aa30e936739955cdc18851d9e74bab5ff65";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "9318bfd1a88c6fabdc9ec5742552e62787207e77a65a81cd7adf94d8c8ced6ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-black/default.nix
+++ b/distros/iron/ament-black/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-iron-ament-black";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsandus/ament_black-release/archive/release/iron/ament_black/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "19a6a5f68d8f767aa06b624117db7e714b42526718c64b89918b67dbfe13848e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.unidiff python3Packages.uvloop pythonPackages.black ];
+
+  meta = {
+    description = ''The ability to check code against style conventions using
+    black and generate xUnit test result files.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/ament-cmake-black/default.nix
+++ b/distros/iron/ament-cmake-black/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
+buildRosPackage {
+  pname = "ros-iron-ament-cmake-black";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsandus/ament_black-release/archive/release/iron/ament_cmake_black/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "77c248f9044667c82d772c247e8cbf308be21e06e7de2cdb7f63a511c5109809";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  propagatedBuildInputs = [ ament-black ament-cmake-test ];
+  nativeBuildInputs = [ ament-black ament-cmake-core ament-cmake-test ];
+
+  meta = {
+    description = ''The CMake API for ament_black to lint Python code using black.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.3.7-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.3.7-1.tar.gz";
-    name = "4.3.7-1.tar.gz";
-    sha256 = "e635c9e9ed77bdf2e19b82b79fd36453b547500a9695c1301bc3d46e15ec67e9";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "001cefcf814c5e22d9be9bbfd4409949df5e38e94bd66ef8fb427ae650587e9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "2cb4b1cf978309b6332740ed9792f06a1723f31d515febeb6b8dc620fe6bd458";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "a8574c12e5f57131b785e6fd1d2f088f21e96fd707a05d0e7e9f05458d2e3224";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/catch-ros2/default.nix
+++ b/distros/iron/catch-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-catch-ros2";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/iron/catch_ros2/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "64d4f6f2970b47a7be4872cf5b7ebd3d5c25572545fb80c10d7d6f9a0c54467e";
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/iron/catch_ros2/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "681fe3820843cb74e5f5e9d449bcd497726e441e54963027b7dd2a99e7c94482";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "7e95501ea8e2d581eb0142cfdc90188f580a0936818a36542948fc2c742d0681";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "293e774d2f8c79a2617a663a93afad8cc72872ba098df9337f80582925efeeb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "dc44054ad5ef6590c9472a6537a09487a7108f5064ad494ed2a7083a7c59268b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "48fd36ddce7a861d01618c90e585eadb6eb78271f91273e4cd2ab1cffb7449b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "6f56cf4573864a4f7704e7e5bae94126ad08479dd22d981716015848ce73a2d3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "64c22b7c0dec52c31031e328b41a7ea56941b5ac81778a017c36ce5c640bb1f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-bridge/default.nix
+++ b/distros/iron/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-bridge";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "3da6da84d0a56963b1425e6ea3bae1b61ee43acc2087568f006cb15c68098780";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "7399546576a2094cc2b0a6ec0eed731e844ce8d8229bd2690eac961218b3a1f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-descriptions/default.nix
+++ b/distros/iron/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-descriptions";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "e66b1b47967e5cd3b3435f15290b177223156f8cab6de0b5dbc23e6d49a47a31";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "a8124d5f006cdde75bd19655085f0df9a389ba926b4579af4c7e0ffb53593d38";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-examples/default.nix
+++ b/distros/iron/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-examples";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "5b979fe132314a63841ee8b1cc21e7a7266bc824c576cb498b0d7b0cb5e04b2b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "05cf7aa647a7c19bff14f01545cb0cb68f1f09de627ac3494710fb3361b1e00d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-filters/default.nix
+++ b/distros/iron/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-filters";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "0c0d623d36cbe328a3ae545ff70cf08fe4bc7b54b32ee9f572be94df5611c834";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "fc3c602048452571320aee09735f4459f0388b0dc7291d606b03d67869b2b03c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-driver/default.nix
+++ b/distros/iron/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-driver";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "afc600756b7b5077ffe7d0f3413e27713243460e6b1d895fdef00b95765aaeea";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "c8a2768bf9d8daad1c46ee6d86e7331d3bd0e53cbc7f4929012b3d9f4a6a1043";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-msgs/default.nix
+++ b/distros/iron/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-msgs";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "96cfde7fa509b424f68fafe04d103af1588dcb57e1b9bc03ae5dc0728f06ddde";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "66d5792a36acce30adf5b7b7e28ae8095ccf70aa8241811704acd507d675097b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros/default.nix
+++ b/distros/iron/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "c9390491f0566db7e85791d198f90e8c72cdc1da2362663cd0cffeb1bebce8df";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "39445d2a722869ec1b6a0a747c89ea184d40f46d4db9d563456f594e88cc4474";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "ded85323b6cbcdced74a2ed1352403910f81e8c4224512bb94b8c9719e2a658c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "9686eae300694e24c53008a7d0614a8ba132212bc2b2269d399c4fffbe88a230";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "f705cd0805bbf9ffa8a29953149393d718ef0bcc99e8ff90ea87f6f740d3f907";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "427b53328420120521ab51f4f826dbc0923779245a051747b7f15095e95efc90";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "0818790eac730f825beee7c3d811d1c51769c5570a0dbedc15e0e40b0e9d43b8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "95dbff570c90a4f6e64194962bb92314234d144776091df6891d1a8772d594c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "1aa65cb78a5a90273b2e9f647111ed6ac30eb953e4c96afaf058010cc8f41c1d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "543550fd0aff4faddccf19fc47c1c7830b48614225f7f9ccf8d6d5d8caffca1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/foxglove-bridge/default.nix
+++ b/distros/iron/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-foxglove-bridge";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "2fed4ecbbf77b3ff902922a9ae059f182f919b4ad2e65f8d358f93a55dc167a8";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "b64d067c5f378ddf3a3962bbbcda0ac1de7a320a9953c5b382aabbc4ee814057";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
+ ament-black = self.callPackage ./ament-black {};
+
  ament-clang-format = self.callPackage ./ament-clang-format {};
 
  ament-clang-tidy = self.callPackage ./ament-clang-tidy {};
@@ -35,6 +37,8 @@ self: super: {
  ament-cmake = self.callPackage ./ament-cmake {};
 
  ament-cmake-auto = self.callPackage ./ament-cmake-auto {};
+
+ ament-cmake-black = self.callPackage ./ament-cmake-black {};
 
  ament-cmake-catch2 = self.callPackage ./ament-cmake-catch2 {};
 
@@ -151,8 +155,6 @@ self: super: {
  ament-xmllint = self.callPackage ./ament-xmllint {};
 
  angles = self.callPackage ./angles {};
-
- apex-containers = self.callPackage ./apex-containers {};
 
  apex-test-tools = self.callPackage ./apex-test-tools {};
 
@@ -705,6 +707,8 @@ self: super: {
  imu-sensor-broadcaster = self.callPackage ./imu-sensor-broadcaster {};
 
  imu-tools = self.callPackage ./imu-tools {};
+
+ interactive-marker-twist-server = self.callPackage ./interactive-marker-twist-server {};
 
  interactive-markers = self.callPackage ./interactive-markers {};
 
@@ -2197,6 +2201,8 @@ self: super: {
  urdf-launch = self.callPackage ./urdf-launch {};
 
  urdf-parser-plugin = self.callPackage ./urdf-parser-plugin {};
+
+ urdf-sim-tutorial = self.callPackage ./urdf-sim-tutorial {};
 
  urdf-tutorial = self.callPackage ./urdf-tutorial {};
 

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "e5ec1acbd86a6de3717f7a188318a1d918d8bd05ae3cd80472520aa7d6a99f1d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "dd93005ba8eae557571c547f95e3ed0e31d48f3fc4cfc4fd7b3a66a70e0ab99f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "49fb7037f91ebd728f1094ffea5eb201d0790a22f7b28e9b1406e5b84e863690";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "c9417f9623d5941461edd153522b8b5ab2d1f0c0a1528b6756f40d6cab35e9ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "db78606a26c707361c5800f1225ac8147454481ede3343f125ac400281ad68bc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "106f5d2268d34d62d580de6c6239690cf143a5f8e1f655277b729064c7a3d834";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/interactive-marker-twist-server/default.nix
+++ b/distros/iron/interactive-marker-twist-server/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, interactive-markers, rclcpp, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-iron-interactive-marker-twist-server";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/iron/interactive_marker_twist_server/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "838b6b35cff6a47c8fc6b27536e8b6ce6202a363e6195b554068f9c6b972186d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs interactive-markers rclcpp tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interactive control for generic Twist-based robots using interactive markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "1b4ee75e3ad52dac7847e898459eb02e220f61e47c712e788ff6a47330ace15a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "f688d575a0b66042548e4ef579f4837dc7d625db1b6f4002e7eceaf00ee50ab6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "74dda8044bfbc0bd057b978e45cbee3222abac0f40d9f114e0410aedc7e8e2e0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "7b39e11c0daa9ef5ce7a73e6dc911e543f336677cccb10c6ded84ea9c8fffab9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "eb225d189aa786c865d30308da122b82fc2b448ba447935d879d956b05323d42";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "742dcf3ff7937bb1ab0f2d3ba0dacc4ebc1509322e024fbee37147db7070a66f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joy-linux/default.nix
+++ b/distros/iron/joy-linux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joy-linux";
-  version = "3.1.0-r4";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy_linux/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "9aabffb27cac0456cf28c48f496bcce808366ca0428717b0f987e8beb89711ae";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy_linux/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "6269dd3406d57d52bbbbbb5046f4ae8070fd077e18cabe0571bc6e5a296a0416";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joy-teleop/default.nix
+++ b/distros/iron/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joy-teleop";
-  version = "1.4.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/joy_teleop/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "20b1f410f353276635576cbf190878778921d9dee21b4a9288f77d8c87c8370b";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/joy_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "165a99da695f1a8e81484fb2ef8f5f106f5b7ff07b8ae1d2b029f67fad9adfaa";
   };
 
   buildType = "ament_python";

--- a/distros/iron/joy/default.nix
+++ b/distros/iron/joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sdl2-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joy";
-  version = "3.1.0-r4";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "dd63aea3fb91b52779883b8dc5d863633da87a62786d016c2225d8904edde88d";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/joy/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "31d09dd03793fc58a56be5cf8dbfc4661d3c4eeae3cb89311a670e36beaa3b3c";
   };
 
   buildType = "ament_cmake";
@@ -20,9 +20,8 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = ''The joy package contains joy_node, a node that interfaces a
-    generic joystick to ROS 2. This node publishes a &quot;Joy&quot;
-    message, which contains the current state of each one of the
+    description = ''The joy package contains joy_node, a node that interfaces a generic joystick to ROS
+    2. This node publishes a &quot;Joy&quot; message, which contains the current state of each one of the
     joystick's buttons and axes.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/iron/key-teleop/default.nix
+++ b/distros/iron/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-key-teleop";
-  version = "1.4.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/key_teleop/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "7bddfdeda59f7a653876f0545a5efd28462efd64a726d9f6dc4409f669a6b0da";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/key_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "88be6e7fbabbf11c576d66aea0c77c52149788a84640eda144618e3fa2e074f6";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mcap-vendor/default.nix
+++ b/distros/iron/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-iron-mcap-vendor";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/mcap_vendor/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "d7ce28c56e41e7883c702ae3ae3d8b4625d014916f942bbe59d1209377d9dac4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/mcap_vendor/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "2753f03d0ef7438a09ce66a797badffb7c65676610bebfa156fb1c85f12426cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mouse-teleop/default.nix
+++ b/distros/iron/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-mouse-teleop";
-  version = "1.4.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/mouse_teleop/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "25749d31b1810bc211b38408907e78c546721a8809a9c518468fcb9d04748f3e";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/mouse_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9f1587d424780e41b61b5954a4cd207ead60ce2e5384b16b86d313a88592ca18";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.10.2-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.10.2-1.tar.gz";
-    name = "2.10.2-1.tar.gz";
-    sha256 = "9016ce788dafa85afee13fa123b2d11d719642caa0bf1492557ef9b9ef9948be";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "1acb05f82b28f697511b758004100dfa063250b5a05bf99fcee3cb417d94249d";
   };
 
   buildType = "cmake";

--- a/distros/iron/mvsim/default.nix
+++ b/distros/iron/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-iron-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c680e35f2acd7e66a130e0b36b0bf5e810bb831089b4a258cdec584695d238c1";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "e3f8cf189e2f4d04da991b090efda455f78c96d10f83cc7d86436804774719dc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/iron/ntrip-client-node/default.nix
+++ b/distros/iron/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ntrip-client-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "f27656b3df582a126d5b5e81a66e34024b5e43edcfce3d4772a743c2b0486409";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "8d1b428f9739a2e999a1dae75fa0dc86a34f81c8b1cabb2cc8bceb635a63a99d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "d273251402b8a06298fd4b3b4b249cb8eca55cd947066fc046525c3230c7d463";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "bcfcc3762610fdac053cd71387ae0f3706ac52dc11fd4a6e0fff329afca07e06";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/range-sensor-broadcaster/default.nix
+++ b/distros/iron/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-range-sensor-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "8f6a22e908014ac38dca943c0fe85026e0c697192836d7ffd2f5225331157c22";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "6de120da3fdc70905da9e997834394ea89ced0eddbccf71f1eaae719d578a5f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-gz-interfaces/default.nix
+++ b/distros/iron/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros-gz-interfaces";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz_interfaces/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "fd4b9055209f46da527dd565cc6ecc3470b27fc94a5347775e9d8692199a2e70";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz_interfaces/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "30dba25c1c248e66eb2bbf1144b94b502d06cfbe05b33dae7b442d6b6ee8e258";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-gz/default.nix
+++ b/distros/iron/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-iron-ros-gz";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "9e76e1d12e03429d4b2455ecd6fe37887c7ddeaf6b37f4d5f04105ec37de7c3c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "acf807dd933f1492d199cb0a1e6b42093514d87445c89c3fc9ce8a9538a1d4d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-bridge/default.nix
+++ b/distros/iron/ros-ign-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-bridge";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_bridge/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "0695a0a160c9ad70a7200efbcdf43284977414422a786400c7b72ead8f20fd2b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_bridge/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "20cbbb9032e82694cb8a8cd91d3d2ae9fc65e160cdf1b231a62efbcefcb5ed61";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-gazebo-demos/default.nix
+++ b/distros/iron/ros-ign-gazebo-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-gazebo-demos";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo_demos/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "93a7dbd25590b02b94f20d872276ea92b060866b7198c4ca8e0ab551522f512a";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo_demos/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "d8a224d5d0ddc15ccfcc584725797301159a635e0531e34e5ad5275e24910efb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-gazebo/default.nix
+++ b/distros/iron/ros-ign-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-sim }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-gazebo";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "d4fb06d727a51ee2ced1753c49c08ba1671e3c8cd8f3612894d22e3abb9473cd";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "57e095e21a7fc8131f91b48419039ea1044183c5a3ed177b4a81cb0dfe17a7cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-image/default.nix
+++ b/distros/iron/ros-ign-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-image }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-image";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_image/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "5fd69ac4625a552b3ab1f946b62eb3f5b2ecfd9fb65701daacce675b24d5e88e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_image/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "e78e7f110e4b9211d7b36fecf54180171b228ec52da6b6d9a00926172360a8a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-interfaces/default.nix
+++ b/distros/iron/ros-ign-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, ros-gz-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-interfaces";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_interfaces/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "2bdbfb548de7e53f841346d907d6f653ee53aa10b9929e7ecef0111dfede89e1";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_interfaces/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "4a4334f124b0f990cc4ee6eba0c7385fc919b25eaf5e83b1960c3ded368c0aed";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign/default.nix
+++ b/distros/iron/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-iron-ros-ign";
-  version = "0.245.0-r1";
+  version = "0.247.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign/0.245.0-1.tar.gz";
-    name = "0.245.0-1.tar.gz";
-    sha256 = "62332fdfd3099f79ffd3d09fedb1d39337b33c68b62653072c39fff11e78f4af";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign/0.247.0-1.tar.gz";
+    name = "0.247.0-1.tar.gz";
+    sha256 = "768b35cdd30962b35ab0b6d6e4ebbeb0791d6c458fd97b13a30141fb3a02da36";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "a764edfd515e2a5d40ae27428585f7c129e2401cdd0942c206feea1836eb3112";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "44aaf55da3e67e6dd3a4122dd22729fc7ad671f8c26673f4f9cbefe0e9653350";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "1a30e7dbc8094f560c2891fe4f3d49d9cd030ac861ad4c63071c6caae076c0bb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "5a1f9f0e3944180bb718816c8d1efb973f830c53cd214c6b97f7fae4bb201c30";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "a56e08d1e91c56fa13a4267b45672b916c7d217079fcf271e4933c3f703d1a24";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "af845901e8fc85fd7618523edbacacb4fa89511eb93a56f0f68c2060ea072e20";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "27cfd93e6eb3264b9dbbb07a984b06ee6653c075ea59e4a4e7d70231f71f2ce7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "0e9f240c9bdeefbfa9738645f0e8b846e535346e9720f7d8a256dd8dbac0b514";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2bag/default.nix
+++ b/distros/iron/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-iron-ros2bag";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/ros2bag/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "e954f678a96d4d4cb250aa258fb09d91d46e328efaf4bf3f8d726d0668bf286a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/ros2bag/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "57bb4442c2be637fa05b721977e5ebf0c948d483f2bee612bd1095ad7a978403";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "9bfa2c43bb231980b0eda172b0c09fdddf454611cd0a18aa69dccf1432a8ea05";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "21748d57d0d4301f5358d09049935449b682273e9f0c81210d75e43be9dbc807";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosbag2-compression-zstd/default.nix
+++ b/distros/iron/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-compression-zstd";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression_zstd/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "38cedc4cd116a17a7a4a13e0fc44f1a1c2693985a154938760cde56f398ad5cc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression_zstd/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "06b6e35beedc0f92e16b408ef0f56914930dd5732c8ad45e66875256d6d18369";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-compression/default.nix
+++ b/distros/iron/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-compression";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "2a8027f3dc13991007154c27c0a67f32753e09197be477a87979fe103fc7fef5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "80dffda59110ad6e92ccd5801565edb121b0a2ee2e471b224059e298faee8651";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-cpp/default.nix
+++ b/distros/iron/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-cpp";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_cpp/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "58e3abf19be1802a00a7e54eef8673a71d877358af5435f994f499364ba1baa7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_cpp/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "4e07d576e7109a822564277de79ebb0a8e6a20bba8e3812c63fd7155d39c6638";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-examples-cpp/default.nix
+++ b/distros/iron/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-examples-cpp";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_cpp/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "fb34ca6ec80aefd43ff617bb75e92464215ee43faf442ab18265c44c1bd18b45";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_cpp/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "81c05b9a865a3fdb5340ddfe17031f9bc4cd3051175fb82e2f0b6ddace19aef8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-examples-py/default.nix
+++ b/distros/iron/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-examples-py";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_py/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "51f158856d5363406efbf1b4cfde250ff6c280310bfbaab8bf57c0456e70b43c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_py/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "386db4bda40bb559ba7219419a77c886e70b059f22cc6a1aa4e376d7fc8fa749";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosbag2-interfaces/default.nix
+++ b/distros/iron/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-interfaces";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_interfaces/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "31a371e49818715e39a9e2730d0b4aff7743357ddb5cdc0079b3dec38da45f90";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_interfaces/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "abe203e3e3b4da7ee97c7967cbe58d86309390026f69d9ba149a6e047f52f9b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/iron/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-performance-benchmarking-msgs";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking_msgs/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "88d38e92af1bfc65108aaf1660139e0added8ad19590958e89463c6a1d0b553e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking_msgs/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "0725791590ee95d4a20f2ad644e4c50914d89feae2779bb67b938dcd16e73d52";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-performance-benchmarking/default.nix
+++ b/distros/iron/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-performance-benchmarking";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "9ca8aa7efb552c251d64d8ec5747bc8a078ba88d87b112c3b4b8b445ce6250e6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "d031d90bf1d2cff860c34a90385a0e62467f49a8c98f1d90d0a143acd44d8545";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-py/default.nix
+++ b/distros/iron/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-py";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_py/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "959678402ef75a4e953a250c8a90ab62e51cae3efa0de9d1b2410778ebea79f0";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_py/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "347994e98e5f5b40134d4cc64963b5623915d27c3eb0688ca733cb7ec6fff3ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-default-plugins/default.nix
+++ b/distros/iron/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-default-plugins";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_default_plugins/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "12c20427a7bd456ba03a33efcdeb7a1cc8c5648f6ad057e31162c2f1365601fd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_default_plugins/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "6c410a82998afd5f72d3e31a748667a502311c485f49fe7f15a9650a94b5fe0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-mcap/default.nix
+++ b/distros/iron/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-mcap";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_mcap/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "374efecd544ff45db1cbc3ed8c126d67ed5106c96508b8971c34f6b7c9e0b72f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_mcap/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "39650b40be31a2680f530e27d3365ec9f8ecbcc0f0098bf66cdf4d064f971df0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-sqlite3/default.nix
+++ b/distros/iron/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-sqlite3";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_sqlite3/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "7e610a1678c44a2bd0a13bb96bfc642d769013e0a1825a64f63593cf7c1f16cf";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_sqlite3/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "f5192d2eab6aa3b633ccabad375b76e8ca99f39257ef67e4694d8ec192ee57b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage/default.nix
+++ b/distros/iron/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "90b72cdf7162f8657d110c3399d822364c6d5f4a2f63f43d11bf824448856e8b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "368b0046fae0d6a910f0107859b1dd227a2f834d2c06d3774fb4a0da41b0bf2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-test-common/default.nix
+++ b/distros/iron/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-test-common";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_common/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "9016fa184c76271ee8e35abb24a3b22eb267b465fe2f7976366ec643cd56bf68";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_common/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "5594693f9752fd76ce052fdf70129cff27221001563ec613a9f3fc40e5b1c2c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-test-msgdefs/default.nix
+++ b/distros/iron/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-test-msgdefs";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_msgdefs/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "5244c76db4404082f98801eedcd4c385f7a0c26c4d8efa08cd750f7f6d8cb9d5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_msgdefs/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "9dcda7d301c58895038b4eacf2b1e38feb24a0da7ad2049c3fe3bd010db089f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-tests/default.nix
+++ b/distros/iron/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-tests";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_tests/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "ecdb9ba9c693f19b1a5e240c802597a5150f4d3a24820f696c7b9965eda868f1";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_tests/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "09e2bb44386b796e91b5a97075179e408c116b28636c22312c1e4a42275a8283";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-transport/default.nix
+++ b/distros/iron/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-transport";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_transport/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "d1219661ac8b15fffa618a813b73dc3f03fc26def2ac83014182b9269f64a3cd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_transport/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "af48882cb8a6a7a1407922d568bb34e8af7fdbea8631020160c0feb36fb0d4d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2/default.nix
+++ b/distros/iron/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "2bf301e88fc78614bd332c36ec84baf4bc9d9bc20b38e0ac30097cb343126d4a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "b2ec2c7a60d0c051d359e35446d8a15c46bf2aac1433b79f76743dc6e42685ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "7a5a68b21acdbfd3df2864a9d93143d28d3253248006302af969412f236518c3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "ca2b9704a83d5d98f1ec6e205c62544dc68e7b8749cf9ed0da08519c179151a7";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "e468c16dbeefc56ee0e1490400ebd1d9003321b3e7d16006c83bb028f9d916e5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "547a92877776712c23c1729fd963e923b80dba148ec02b92e2402870de52bc75";
   };
 
   buildType = "ament_python";

--- a/distros/iron/sdl2-vendor/default.nix
+++ b/distros/iron/sdl2-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL2, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-sdl2-vendor";
-  version = "3.1.0-r4";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/sdl2_vendor/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "7b37c6ae14b00a034bc7c095a1d14f23a510e0471de6d58caa8e94cad30be381";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/sdl2_vendor/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "dbb35e2aba716494a81557003004a8ba7469314cbcb1527bf26a2c97105110ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/shared-queues-vendor/default.nix
+++ b/distros/iron/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-shared-queues-vendor";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/shared_queues_vendor/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "54ed9b3ed8f351f454ad27fdb0fc92f58735e8e4b7305743fe82dc6f246ffa59";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/shared_queues_vendor/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "7b1a989aed52c1f2b5b31ec2940cd6879c7a5cf20efb824a3bad60b4ebedad72";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/spacenav/default.nix
+++ b/distros/iron/spacenav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, libspnav, rclcpp, rclcpp-components, sensor-msgs, spacenavd }:
 buildRosPackage {
   pname = "ros-iron-spacenav";
-  version = "3.1.0-r4";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/spacenav/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "821583bb7e2528c2346e3879ae1d8090ddfa8c8215e0ac5387ef8eb2ab3bdb32";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/spacenav/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "a663daeefc87c4fe01c8316e1059cc7780987bcccf1c7dcb754835e9184ca724";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/sqlite3-vendor/default.nix
+++ b/distros/iron/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-iron-sqlite3-vendor";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/sqlite3_vendor/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "156a1ccd7b7f74b947052d8caf2bffdf9803a36914a1ea432a83865218d9803a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/sqlite3_vendor/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "1721b530f9aaf81be8a57446d05803e52f0bc508db12c4b10ec08de46b99cbf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "a23eb4302014d44e57c5276086362ef9c07a7d075633f8537b4bd2e84b5cf0cb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "cbb5f22512afcc67fd7d988485d1c2bd7d399f0b292405d15eeef2f37eaacea3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/teleop-tools-msgs/default.nix
+++ b/distros/iron/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-teleop-tools-msgs";
-  version = "1.4.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools_msgs/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "7a10c3b3768450c4024b854f9e923c4f48a62cd7f17f76b13ae417822bb62e4c";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "827c11392f46cc40694f90d6238782c8b4d5c20403e5a1d93af899f8ab235701";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/teleop-tools/default.nix
+++ b/distros/iron/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-iron-teleop-tools";
-  version = "1.4.0-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "51b29d5dd31db37726bef22fd971252a95a293095dbdb800f557a8144151c8a5";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "51a5a7e053aa12f5c167450dd9d9dcffff25cd54f0f6664b5d1ee10b9b5468c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "829f72e4537c90e20cae473b4d8a4bfc17c69562e82d86c7822c491513ff327b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "d285b81da467fd6aabe917c4b11bc08eb638aab42f19ce9a2cfe95320ee95932";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "299f2db4efb0794e3b7ecb5d921fe3666f411174c02723a39325180f870dea10";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "2692cb867f4a6f234363de29a628855bf883b15a4902bcd05707c261f50558ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "0a0c20fe26251e2fab5e3220f6990a8b50489617bfe013fc6cefab806c2228a6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "81e1e04ab57b954c88ecf34ba8fe8d5b0dfed0ef4e9ba2f25e516c61d1594f46";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-dgnss-node/default.nix
+++ b/distros/iron/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "5e9d0618bafe68ec85322e20b8cbdb6b73750cc0066fa36b3b2c8f362fe5cff0";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ba02308a7581d71191637118909afacaa6d34e773f3a722da2b9dcf9de7b41ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-dgnss/default.nix
+++ b/distros/iron/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "41640b6dded7a5da319c1c34e61990ece3c2fb18d1b9734085d0be974db92457";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "85e406ab84077cca7db8ce26b1c48766654119e6e615c655d9feebe2103d0a6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-nav-sat-fix-hp-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "545e12569633d0f29f4e7ca0a80556ccc861a8343f88e7795f8cd52900dadd8c";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "d611d487273f5f44dc88a7e01831d464aa17b6af363bddbe5e2d8aa0266b1c3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-interfaces/default.nix
+++ b/distros/iron/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-interfaces";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "d74848f6b8efd8efcd887a6a66b58653809fad37ee60ba912454b536ece5e6db";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "e75b610c29b35db74cdef59ceb85d36a29ce33189b9a9b8e9b0d615441587ed5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-msgs/default.nix
+++ b/distros/iron/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-msgs";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "287d525acbb96a0b1e5a7658fd3c99a497a761d739ed464bcd54ab194cdae77e";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "cbd72f52ae5b278bfadc704cfdd1e8f0bb7459efff88561bf4d7c4fe61d3dcb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/urdf-sim-tutorial/default.nix
+++ b/distros/iron/urdf-sim-tutorial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, gazebo-ros, position-controllers, robot-state-publisher, rqt-robot-steering, rviz2, urdf-tutorial, xacro }:
+buildRosPackage {
+  pname = "ros-iron-urdf-sim-tutorial";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/urdf_sim_tutorial-release/archive/release/iron/urdf_sim_tutorial/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f6b75c542e722a6c6101abd18bac16531e4aee1ac09a30f973446fd7d8535a6d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller gazebo-ros position-controllers robot-state-publisher rqt-robot-steering rviz2 urdf-tutorial xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The urdf_sim_tutorial package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "27b632484548883490d8addcd1731d03216c7863079956fcdf7ae7cd5b290511";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "927982d930b27234bb5949f2135ea5234f7c8b9ae781c2c367be541d056dbd40";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/wiimote-msgs/default.nix
+++ b/distros/iron/wiimote-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-wiimote-msgs";
-  version = "3.1.0-r4";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote_msgs/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "68707e471ceef707e1c19106722d2b7fd056b5cb41b81d0109383e16adccbd49";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b753efe37d763fdfd2a4efc1fc94079a30eb963243dc0cb7adef958ad0e55ece";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/wiimote/default.nix
+++ b/distros/iron/wiimote/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bluez, cwiid, geometry-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, wiimote-msgs }:
 buildRosPackage {
   pname = "ros-iron-wiimote";
-  version = "3.1.0-r4";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote/3.1.0-4.tar.gz";
-    name = "3.1.0-4.tar.gz";
-    sha256 = "b00aee9415aaa50a769f68eb5fbd267d45eee303c2a9b3ed603183ff1868ff94";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/iron/wiimote/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "64a298fe83ee0f829a39bd37c4230bcd053af5ef0e9a4671ffe0a7c614b8adc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zstd-vendor/default.nix
+++ b/distros/iron/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-iron-zstd-vendor";
-  version = "0.22.3-r1";
+  version = "0.22.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/zstd_vendor/0.22.3-1.tar.gz";
-    name = "0.22.3-1.tar.gz";
-    sha256 = "f1f57194591c3ef638395fb9856a7be153e31f98ce65079282c941593856ab58";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/zstd_vendor/0.22.4-1.tar.gz";
+    name = "0.22.4-1.tar.gz";
+    sha256 = "05f0554489bc75bae22237a28312538a21553e7d0502bf5fd81380efc2f440b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.9-r3";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.9-3.tar.gz";
-    name = "1.0.9-3.tar.gz";
-    sha256 = "a9fc3414d5071e21f2cd854e18e25bb4e479e64292de1ba10dc2ad40c98a969c";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "6f3d1ff26c34164a77ff5447752ec39c2cc10645c250ea91b535ea8f4c8637d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-configuration-msgs/default.nix
+++ b/distros/noetic/clearpath-configuration-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-configuration-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_configuration_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "8ab4aaf233887c16af34f407db03e0ecf5b0173a20eedd7bc9e5046b9766ef94";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package containing the message definitions for the Clearpath Robotics OutdoorNav configuration module.'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-control-msgs/default.nix
+++ b/distros/noetic/clearpath-control-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-control-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_control_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "1dff4b4ce2b6352531acbd2bc8d7fe0f8587979eebfb11bdee00243ab00620ba";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package containing the message definitions for the Clearpath Robotics OutdoorNav control selection module.'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-dock-msgs/default.nix
+++ b/distros/noetic/clearpath-dock-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-dock-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_dock_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "2884ca14f2225a0ac0bc3d09dd6a37f3cc734129ad53c56c8db82279766a42e1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package containing the message definitions for the Clearpath Robotics OutdoorNav dock module.'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-localization-msgs/default.nix
+++ b/distros/noetic/clearpath-localization-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-localization-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_localization_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "3256ae117febd9aa03184454e70d51ef5e3a461e14698bf79e19a664dba77f19";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package containing the message definitions for the Clearpath Robotics OutdoorNav localization module.'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-mission-manager-msgs/default.nix
+++ b/distros/noetic/clearpath-mission-manager-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, clearpath-navigation-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-mission-manager-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_mission_manager_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "131754327cbf05f16374de6d3cb0791ccda337e3478bbf65c013e77921f60430";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ clearpath-navigation-msgs message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The clearpath_mission_manager_msgs package'';
+    license = with lib.licenses; [ "Clearpath-Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-mission-scheduler-msgs/default.nix
+++ b/distros/noetic/clearpath-mission-scheduler-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, clearpath-mission-manager-msgs, clearpath-navigation-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-mission-scheduler-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_mission_scheduler_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "e5de136398bf54b0f55f9445f97e75793eabf4108f3381408e47282e3c487688";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs clearpath-mission-manager-msgs clearpath-navigation-msgs message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The clearpath_mission_scheduler_msgs package'';
+    license = with lib.licenses; [ "Clearpath-Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-msgs/default.nix
+++ b/distros/noetic/clearpath-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, clearpath-configuration-msgs, clearpath-control-msgs, clearpath-dock-msgs, clearpath-localization-msgs, clearpath-mission-manager-msgs, clearpath-mission-scheduler-msgs, clearpath-navigation-msgs, clearpath-platform-msgs, clearpath-safety-msgs, dingo-msgs, husky-msgs, jackal-msgs, ridgeback-msgs, warthog-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "619e19f54bb97a67cb94ade14e543e4def1b9f7ff34f08f07b1b53a5ca394aa6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ clearpath-configuration-msgs clearpath-control-msgs clearpath-dock-msgs clearpath-localization-msgs clearpath-mission-manager-msgs clearpath-mission-scheduler-msgs clearpath-navigation-msgs clearpath-platform-msgs clearpath-safety-msgs dingo-msgs husky-msgs jackal-msgs ridgeback-msgs warthog-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for Clearapth messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/clearpath-navigation-msgs/default.nix
+++ b/distros/noetic/clearpath-navigation-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-navigation-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_navigation_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "ec332edcfbdda8212208ab25aa7a9b3b7dd36383814d14f4421c931f114c7826";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-generation message-runtime nav-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package containing the message definitions for the Clearpath Robotics OutdoorNav navigation module.'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-onav-api-examples-lib/default.nix
+++ b/distros/noetic/clearpath-onav-api-examples-lib/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, clearpath-msgs, geometry-msgs, nav-msgs, python3Packages, rospy, sensor-msgs, std-msgs, wireless-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-onav-api-examples-lib";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_api_examples_lib/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "811a1e17ff73542c8353c16a349a19c192d62c89d9b8a926637b06c36c1d666f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ clearpath-msgs geometry-msgs nav-msgs python3Packages.pyproj rospy sensor-msgs std-msgs wireless-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Examples library to show how to use CPR OutdoorNav API'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-onav-api-examples/default.nix
+++ b/distros/noetic/clearpath-onav-api-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-onav-api-examples";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_api_examples/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "59af02945534b246abf04afb9f8ee82062e2fbc477bb2178d3109ea856c65795";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Examples to show how to use CPR OutdoorNav API'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/clearpath-onav-examples/default.nix
+++ b/distros/noetic/clearpath-onav-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, clearpath-onav-api-examples, clearpath-onav-api-examples-lib }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-onav-examples";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_examples/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "17d2b112e183a927006dbbfe4ca91000aa3b92761002cc20c8c550828d8aa61b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ clearpath-onav-api-examples clearpath-onav-api-examples-lib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Examples to show how to use CPR OutdoorNav API'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/clearpath-platform-msgs/default.nix
+++ b/distros/noetic/clearpath-platform-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-platform-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_platform_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "0cc273d4fc4a401fcfecd4c032e82c78a3ee583fb6359da4de1bc3cee3ef5c04";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ genmsg std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for Clearpath Platforms.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/clearpath-safety-msgs/default.nix
+++ b/distros/noetic/clearpath-safety-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-clearpath-safety-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_safety_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "169dff001239693b742ff5bc80d3aec42e8d0f773141ce418c6d97dfc69d3e93";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package containing the message definitions for the Clearpath Robotics OutdoorNav safety module.'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/combined-robot-hw-tests/default.nix
+++ b/distros/noetic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-combined-robot-hw-tests";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw_tests/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "86d51969bc55aff67c18cf9016c5afeed7a780afb8003c27df7149732b80b794";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw_tests/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "8d8f88b984a2e30f22fe4f6638006d92dc2fb6d6e587c7573f98da6ea4ebe936";
   };
 
   buildType = "catkin";

--- a/distros/noetic/combined-robot-hw/default.nix
+++ b/distros/noetic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-combined-robot-hw";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "2ce6f5eb92e2f715af90b0500bf4755752c1c44bf4da512476bb5a0152dbf76d";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "3acfb67a5e3769131341851192a646c666106c763709696fe1cc693fa7f77c43";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-interface/default.nix
+++ b/distros/noetic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-controller-interface";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_interface/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "ed852ecb719bc3e220f37a6ab14faf0f2b2c2a6429265503bffef8c0934fd649";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_interface/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "8ad2619c87e4e83f16e4ff0e376e450bda0605cb9afed694e39b9401a4b115f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager-msgs/default.nix
+++ b/distros/noetic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-msgs";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_msgs/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "d2dffc22d89e2c629a4f48688f175c6744058d749b8cf22db703edea21c558e4";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_msgs/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "0ff26e1956397abf09b43984f1078221ff983f1443447030527b26dd4fe043c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager-tests/default.nix
+++ b/distros/noetic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-tests";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_tests/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "23441bb9d222eca1bc830c43f8babbc961b28517a4491f60239883bb63a8bd52";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_tests/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "04955a55ab4b7782eb17146fb792efb5853815b5db38eb04b365e541751ed694";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager/default.nix
+++ b/distros/noetic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "205f276492f5a5e9caf112e287e49a7579a2831fc10a9b6446dd48f44f3229fb";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "cb5393ab1084c526ecd6e957a6031b6189bba2749f963ae4b93aceb2a53d971d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cpr-onav-description/default.nix
+++ b/distros/noetic/cpr-onav-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cpr-onav-description";
-  version = "0.1.9-r1";
+  version = "0.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.9-1.tar.gz";
-    name = "0.1.9-1.tar.gz";
-    sha256 = "2a52b9d2e752b30b9c3045faa2f60b1998e2c728b03d24ca7945f0d9d9b80384";
+    url = "https://github.com/clearpath-gbp/cpr_onav_description-release/archive/release/noetic/cpr_onav_description/0.1.10-1.tar.gz";
+    name = "0.1.10-1.tar.gz";
+    sha256 = "6a5a25133b253d27a2349ec55e564c024f46770abd03f203ae5760b5ae5154e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, urdf, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "21d4ed5fb5a63734673c2ad48d28e5c7d43d22d78ed61d812ce1651dd5c77d98";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "44cc766d063aedce65889e4c49751ae699ed83ace2558133ce2e61ca1d829452";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "6dd929b12f8f6bed71e9a0a8779acff9368a533801e8c2f815b34dae9f8bcb2d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "080a3e747be940457db79ffe02e67adcdc437ad484881e1dfbad289b818251e7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "0071d2c3b76d88e511ca1c6790f5a7fa2cdf9c17706649b11376bb1afd6ff5dc";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "10e8447cc8bedfdba7434d239f6f660ab7341678abf2fd0e1af7a8cde4887722";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, depthai-ros-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "300a10359eb950699b0a8a9980c06f08b87e200324b4e98c6363f07ba3352152";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "f388f423bb05b76c69dc08ca736f09a827bf1dd5403be2a4942ef5a8c33fda28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "f2645647b8e814e6abcde422a4530ecb302de29cefed8cd2c50f2c5acfd7cd9f";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "28d85316fa366ca7c73b0a4b935f915499ad1e6650fb40848f5c74b8b7861325";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "d1a058c8bb7c272b1e93645a8f91a16a3a91b58ab4afb49260adc013ac9f3017";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "9d50c273b0ecb6b31cb14673c397ceddb792ba3cda15abc0e0f3fc74eaa9015e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "26e76c01a9b99cffac291197c070d9e056bee7188433f456aa271e005f7ff16d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "aa0cd938d405692c5cb22cdf045a3f3f45e2a4794b1713e4c1209399067022ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, resource-retriever, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "23f61632c9b7b2842b6c9bc9e6c361d9c8ab5a0ff3503829c8a8069193f69ed0";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "48c250c3e3315cc9a3d117335bad7acc0f90728ab01e444e3d2aa898c219af89";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -236,6 +236,32 @@ self: super: {
 
  clear-costmap-recovery = self.callPackage ./clear-costmap-recovery {};
 
+ clearpath-configuration-msgs = self.callPackage ./clearpath-configuration-msgs {};
+
+ clearpath-control-msgs = self.callPackage ./clearpath-control-msgs {};
+
+ clearpath-dock-msgs = self.callPackage ./clearpath-dock-msgs {};
+
+ clearpath-localization-msgs = self.callPackage ./clearpath-localization-msgs {};
+
+ clearpath-mission-manager-msgs = self.callPackage ./clearpath-mission-manager-msgs {};
+
+ clearpath-mission-scheduler-msgs = self.callPackage ./clearpath-mission-scheduler-msgs {};
+
+ clearpath-msgs = self.callPackage ./clearpath-msgs {};
+
+ clearpath-navigation-msgs = self.callPackage ./clearpath-navigation-msgs {};
+
+ clearpath-onav-api-examples = self.callPackage ./clearpath-onav-api-examples {};
+
+ clearpath-onav-api-examples-lib = self.callPackage ./clearpath-onav-api-examples-lib {};
+
+ clearpath-onav-examples = self.callPackage ./clearpath-onav-examples {};
+
+ clearpath-platform-msgs = self.callPackage ./clearpath-platform-msgs {};
+
+ clearpath-safety-msgs = self.callPackage ./clearpath-safety-msgs {};
+
  clober-msgs = self.callPackage ./clober-msgs {};
 
  clpe = self.callPackage ./clpe {};
@@ -1145,6 +1171,8 @@ self: super: {
  gmapping = self.callPackage ./gmapping {};
 
  gmcl = self.callPackage ./gmcl {};
+
+ gnsstk = self.callPackage ./gnsstk {};
 
  goal-passer = self.callPackage ./goal-passer {};
 
@@ -2566,6 +2594,8 @@ self: super: {
 
  pr2eus = self.callPackage ./pr2eus {};
 
+ pr2eus-moveit = self.callPackage ./pr2eus-moveit {};
+
  prbt-gazebo = self.callPackage ./prbt-gazebo {};
 
  prbt-grippers = self.callPackage ./prbt-grippers {};
@@ -3324,7 +3354,15 @@ self: super: {
 
  sick-safetyscanners = self.callPackage ./sick-safetyscanners {};
 
+ sick-safevisionary-base = self.callPackage ./sick-safevisionary-base {};
+
+ sick-safevisionary-driver = self.callPackage ./sick-safevisionary-driver {};
+
+ sick-safevisionary-msgs = self.callPackage ./sick-safevisionary-msgs {};
+
  sick-scan = self.callPackage ./sick-scan {};
+
+ sick-scan-xd = self.callPackage ./sick-scan-xd {};
 
  sick-tim = self.callPackage ./sick-tim {};
 

--- a/distros/noetic/geometry2/default.nix
+++ b/distros/noetic/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-noetic-geometry2";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/geometry2/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "8d0c817505a906abd6433ad2aca5f252371bbc6cd52ecf504dff680fd45dcc21";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/geometry2/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "5f7a757fc5e98a8b13bfb77d855ab40c70882f265be7a5536e1623c0f10c804c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gnsstk/default.nix
+++ b/distros/noetic/gnsstk/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages, swig }:
+buildRosPackage {
+  pname = "ros-noetic-gnsstk";
+  version = "14.0.0-r8";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/gnsstk-release/-/archive/release/noetic/gnsstk/14.0.0-8/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "f39dff1828b05129c65d105626424a1f317230b6af24fdd6b14649626393c406";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake python3 python3Packages.setuptools swig ];
+  propagatedBuildInputs = [ catkin ];
+  nativeBuildInputs = [ cmake python3Packages.setuptools ];
+
+  meta = {
+    description = ''The goal of the gnsstk project is to provide an open source library to the satellite navigation community--to free researchers to focus on research, not lower level coding.'';
+    license = with lib.licenses; [ lgpl3Only ];
+  };
+}

--- a/distros/noetic/hardware-interface/default.nix
+++ b/distros/noetic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-hardware-interface";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/hardware_interface/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "51b5289fa25d6acc0f913e683bacb910120071dd6561b540ff90173bf2751519";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/hardware_interface/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "9133ee732ebda60d6502c32889b983f16c8ad45932b80d7f38fcd9bec821e9a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hri-msgs/default.nix
+++ b/distros/noetic/hri-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hri-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "fb8abe9538673adf4cb4cd01ef5e85e3403a6dbfbc6104987aef0c3c1ce5eb2a";
+    url = "https://github.com/ros4hri/hri_msgs-release/archive/release/noetic/hri_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f30f7a5badd3640b1f41472015572eab68874f968cb77ab1c56db23b98490e88";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hri-rviz/default.nix
+++ b/distros/noetic/hri-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, hri, hri-msgs, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-hri-rviz";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "4e97fe4a9e06b2f313a754d63efd645fc42de7990060185fd8401ee4a6e6aae6";
+    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/noetic/hri_rviz/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "fa64ddd49032b1a86ffd92b01d130f856b679cea4d54201e9918e1fb4b89ab78";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.3.1-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.1-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.4-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "e115764e2e571a71aaa1d9146f4c0d795705a701583c952af77e129e2a3fbad9";
+    sha256 = "c60dbbe9e1afc3442dd8522e0c37e6caf903770872ecbdf718f250901a4fb940";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-limits-interface/default.nix
+++ b/distros/noetic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, urdf }:
 buildRosPackage {
   pname = "ros-noetic-joint-limits-interface";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/joint_limits_interface/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "d4989bdfaa71b8027e2c650c98c20d399c601856812afbf038aedb274af0aebc";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/joint_limits_interface/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "ebfdf25e96f817b174b2b7567492ed583b05fc0c932c00bc004baffbb400f8b0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-pr2eus/default.nix
+++ b/distros/noetic/jsk-pr2eus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2eus }:
 buildRosPackage {
   pname = "ros-noetic-jsk-pr2eus";
-  version = "0.3.15-r1";
+  version = "0.3.15-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/jsk_pr2eus/0.3.15-1.tar.gz";
-    name = "0.3.15-1.tar.gz";
-    sha256 = "376c42adf021c0b38119929b9b6ff8431e9a3ef145b609216f3f3c520e3f947d";
+    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/jsk_pr2eus/0.3.15-3.tar.gz";
+    name = "0.3.15-3.tar.gz";
+    sha256 = "96418335d29894832854311c01d6d6a2444ef49bd285af9ad580517a7caac092";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-bringup/default.nix
+++ b/distros/noetic/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-bringup";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "0a554fd104fa5af59540f8fb510f1285d13b8f8a177ec6131bda309bccd37d32";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ac46e68fcbc5bcceaa46d8b37a6d45831033c36d512f8570a6550ea5c32ba130";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-description/default.nix
+++ b/distros/noetic/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-description";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d4a3687c06555c145d40a39ae81900503c4667728e32b1cf75af4fd47f998af6";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "856e8a682d8b090f939bc8b18534ad2e564e30d01ea3bc2d8a7563c0b0c7768c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-desktop/default.nix
+++ b/distros/noetic/leo-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-viz }:
 buildRosPackage {
   pname = "ros-noetic-leo-desktop";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_desktop-release/archive/release/noetic/leo_desktop/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "55ac702284d3099a5989caed3caf43508e17de27a8dc1a58334df1e394144391";
+    url = "https://github.com/fictionlab-gbp/leo_desktop-release/archive/release/noetic/leo_desktop/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "12abb22b8c067d707f966d56de36391b01d6ba333ff2e1764aa09646f638fbf8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-msgs, nav-msgs, python3Packages, roscpp, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, sensor-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-leo-fw";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "bc87102d915f7bfd65aee57a81a942bd22a5729a7b77adbe308debf7238d8ee7";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "3b7a79ea35487e6a0c5b578adb7fec52d547cca7242f8889036f41b8334e68ea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-msgs/default.nix
+++ b/distros/noetic/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-leo-msgs";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "58d2a15a9e8884bfc7e49de8c32d47ffc1a72a3f943cfb5b2b821fc1f8f6a3a0";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3c3d0576fec8777e9e923fc59fbb68d64da97a2bf0bf8244726cccab592103de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-robot/default.nix
+++ b/distros/noetic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-noetic-leo-robot";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f7c674eff3757145fb1caa61d2b52d73ab8eed0946b4ca35d983d8fa1910d372";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c6a90bcd48471d92d564bb4dddb5571801e07cf3f83ddbbb37a91d83cb2d59eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-teleop/default.nix
+++ b/distros/noetic/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-noetic-leo-teleop";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "bff115326eccbbc735783352e779c6e74e4f4af390c4ff38c220985b28eb62e3";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "6665141705c39017ed4d4b32268dec7ab8862fa9946c35d58b440da77e11a0ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-viz/default.nix
+++ b/distros/noetic/leo-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, leo-description, robot-state-publisher, rviz }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, leo-description, robot-state-publisher, rviz, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-viz";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_desktop-release/archive/release/noetic/leo_viz/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "ed773e9094a5ffbfe607b216cfe80b2d1e90f6f1f03fc3d7a6f9374969d8c49f";
+    url = "https://github.com/fictionlab-gbp/leo_desktop-release/archive/release/noetic/leo_viz/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "31d7602ce42239e923ad620029814f61a61bb8b1dce33091d7c51456f01c5d10";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description robot-state-publisher rviz ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description robot-state-publisher rviz xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/leo/default.nix
+++ b/distros/noetic/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-noetic-leo";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "f7ad600b2ac91137aad450f3c657041399a9a4d3d2239e3b8d7f93be7001a220";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a95abaee37952d21ddc5b2b66d4295649556ea31057c2b6b66a09fe7f7321a61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.10.2-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.10.2-1.tar.gz";
-    name = "2.10.2-1.tar.gz";
-    sha256 = "eefeff667c2157f597fb860999779393008600f8cc0ea733474a560dafca6235";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "15f937aa6ab57ea455cf1f139ecab86764bda9d170259008572437f8559f98f6";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "fcea023939c08670dcbc373c4f6f9cda2bd5f709d866ca56b6c6610eee9942b6";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "dae2f3f7e815e8d0b7c31ab68a9902503ee551de2c34e01c6681d3581ab52253";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin cmake ros-environment ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ boost cppzmq dynamic-reconfigure mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 roscpp sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq dynamic-reconfigure mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 roscpp sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ catkin cmake ];
 
   meta = {

--- a/distros/noetic/openni2-camera/default.nix
+++ b/distros/noetic/openni2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, dynamic-reconfigure, image-transport, message-generation, message-runtime, nodelet, openni2, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-openni2-camera";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_camera/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "be6698786c1add6f19733466b7ae1d97f59b1ac340c3cb8d479532eaae953076";
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_camera/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "9cab720242b072dbe66031b1b6bec175f46d4b1de0ba66920270870d54d86427";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openni2-launch/default.nix
+++ b/distros/noetic/openni2-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depth-image-proc, image-proc, nodelet, openni2-camera, python3Packages, rgbd-launch, roslaunch, rospy, roswtf, tf, usbutils }:
 buildRosPackage {
   pname = "ros-noetic-openni2-launch";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_launch/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "eb365e4d85b763816ba56ad2b2d369d519a801907b1b5ef66e695981191f2483";
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_launch/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "c5f4657621bbde2c43bf3494d169604ba6d77c236e456a2168b4d9acfe1e4cb0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openzen-sensor/default.nix
+++ b/distros/noetic/openzen-sensor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslaunch, rostest, sensor-msgs, std-msgs, std-srvs, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-openzen-sensor";
-  version = "1.3.2-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lp-research/openzen_sensor-release/archive/release/noetic/openzen_sensor/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "7d6e5ad201246d3469bf5834928532d849d3d0934e6569759fadb9e60ffb99d1";
+    url = "https://github.com/lp-research/openzen_sensor-release/archive/release/noetic/openzen_sensor/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d2a6931e13d2e6ddb0623a71397a4e9408335ec109831f0aeff988b46414f85c";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''ROS driver for LP-Research inertial measurement units and satellite navigation senors'';
+    description = ''ROS driver for LP-Research OpenZen'';
     license = with lib.licenses; [ mit "BSL-1.0" lgpl3Only bsdOriginal ];
   };
 }

--- a/distros/noetic/paho-mqtt-c/default.nix
+++ b/distros/noetic/paho-mqtt-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl }:
 buildRosPackage {
   pname = "ros-noetic-paho-mqtt-c";
-  version = "1.3.12-r1";
+  version = "1.3.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.12-1.tar.gz";
-    name = "1.3.12-1.tar.gz";
-    sha256 = "0bcc3de9384430075576881f4136cff15e89f54688522e385c78ef4849ff3614";
+    url = "https://github.com/nobleo/paho.mqtt.c-release/archive/release/noetic/paho-mqtt-c/1.3.13-1.tar.gz";
+    name = "1.3.13-1.tar.gz";
+    sha256 = "d6c8a247024a82ae18c5c87835ed130d0deeb964d0caf9b49dbe581d54583058";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pr2eus-moveit/default.nix
+++ b/distros/noetic/pr2eus-moveit/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, moveit-msgs, moveit-planners-ompl, pr2-gazebo, pr2eus, roseus, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-pr2eus-moveit";
+  version = "0.3.15-r3";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/pr2eus_moveit/0.3.15-3.tar.gz";
+    name = "0.3.15-3.tar.gz";
+    sha256 = "99b7121252a81953aa0ea54ec71f442ac207ed364775eec3ee72aaa8ab598c3c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ moveit-planners-ompl pr2-gazebo rostest ];
+  propagatedBuildInputs = [ control-msgs moveit-msgs pr2eus roseus ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''pr2eus_moveit'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2eus/default.nix
+++ b/distros/noetic/pr2eus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, dwa-local-planner, dynamic-reconfigure, euscollada, fake-localization, map-server, move-base-msgs, nav-msgs, pr2-controllers-msgs, pr2-description, pr2-gazebo, pr2-mechanism-msgs, pr2-msgs, pr2-navigation-config, pr2-navigation-slam, robot-state-publisher, roseus, rosgraph-msgs, rostest, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-pr2eus";
-  version = "0.3.15-r1";
+  version = "0.3.15-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/pr2eus/0.3.15-1.tar.gz";
-    name = "0.3.15-1.tar.gz";
-    sha256 = "97c4f5da735e98fd507c2344c9f0cdd544855a584e015f5a1f2a7406c514bef5";
+    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/pr2eus/0.3.15-3.tar.gz";
+    name = "0.3.15-3.tar.gz";
+    sha256 = "6c262ab311df2cedfae2cf70166cc1b7fb3abc5ca26a342882f2fba1cdfbd45a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-control/default.nix
+++ b/distros/noetic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-noetic-ros-control";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/ros_control/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "0cc79d68db8a2eeec518498db0d6d806e0137c9984e5a4ecd297db5741871245";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/ros_control/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "6664b1f5f7623c07f607c5e9a6e2b067af014ba3a2065745952b378556297924";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-controller-manager/default.nix
+++ b/distros/noetic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, python3Packages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-controller-manager";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/rqt_controller_manager/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "86fffa5683360ad7909e1fcd7fe940cc93e0ac25df749ebd39c79c628bf75d5f";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/rqt_controller_manager/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "57c0affd8d4ab3fba0a601ad6b93f7bc684c5486d1cfab72c773afea0e5686d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-safevisionary-base/default.nix
+++ b/distros/noetic/sick-safevisionary-base/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-sick-safevisionary-base";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safevisionary_base-release/archive/release/noetic/sick_safevisionary_base/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a2580274c658ec440ab3fc87e9199b71e15a7f7759d4631fd4f8fc84a6b3824f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The package provides the basic hardware interface to the SICK Safevisionary sensor'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/sick-safevisionary-driver/default.nix
+++ b/distros/noetic/sick-safevisionary-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, roscpp, sensor-msgs, sick-safevisionary-base, sick-safevisionary-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sick-safevisionary-driver";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safevisionary_ros1-release/archive/release/noetic/sick_safevisionary_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "45941b34797628cc27c9a7a2a4a2d9532fd1f20646139e232dfa4cc0b81494af";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cv-bridge image-transport roscpp sensor-msgs sick-safevisionary-base sick-safevisionary-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides an interface to read the sensor output of a SICK Safevisionary sensor in ROS.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/sick-safevisionary-msgs/default.nix
+++ b/distros/noetic/sick-safevisionary-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sick-safevisionary-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safevisionary_ros1-release/archive/release/noetic/sick_safevisionary_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "24f93dc83933059eade5303b70d8b8e249ada52ad38e3b36f0dc6c075449e881";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides the interface descriptions to communicate with a SICk Safevisionary Sensor over ROS'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/sick-scan-xd/default.nix
+++ b/distros/noetic/sick-scan-xd/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslib, rospy, rviz, sensor-msgs, std-msgs, tf, tf2, tf2-ros, visualization-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-sick-scan-xd";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "e2290874d3c137e0a9ef0a6fea0034034f4dac952599a339857c4a448714d9e1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater dynamic-reconfigure geometry-msgs message-runtime nav-msgs roscpp roslib rospy rviz sensor-msgs std-msgs tf tf2 tf2-ros visualization-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS 1 and 2 driver for SICK scanner'';
+    license = with lib.licenses; [ "Apache-License,-Version-2.0,-see-"http-www.apache.org-licenses-LICENSE-2.0"" ];
+  };
+}

--- a/distros/noetic/tf2-bullet/default.nix
+++ b/distros/noetic/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bullet, catkin, geometry-msgs, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-bullet";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_bullet/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "f47f0a21eccf4d95cfad04a7e26b6641c7ad9278751e57e1f751124a357d3318";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_bullet/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "60c9dc1e9743218c4c012819b3f09a5caeedcddab2ee41e5e95cd6bbcd541aea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-eigen/default.nix
+++ b/distros/noetic/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-eigen";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_eigen/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "541e32b2e1d4f1bd17a59974fda4bd38d007b4f4c82cfa022bf0b0972cb45606";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_eigen/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "6758c100e693708ebb0b0a5566fb9dda5bdb66581e831d0a0bedf813a947bf8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-geometry-msgs/default.nix
+++ b/distros/noetic/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl, python3Packages, ros-environment, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-geometry-msgs";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_geometry_msgs/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "0a95161adcce88b73ad19ce5987c66cc6718b22b97e5a24911cc67204d4db02c";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_geometry_msgs/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "65ee0f2b31f4a7e00a00e10645c72a9eb82d16bf7b3652b2512f124014a5b8ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-kdl/default.nix
+++ b/distros/noetic/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, orocos-kdl, ros-environment, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-kdl";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_kdl/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "78bda9fac5cf7f76b53b4058cba45ee2ba714cedc6ada646049d1bee0df1dd67";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_kdl/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "f706d2ab7d6be921dc85a10c0d7eb656d60d00b00332a0b4388c470b5dbe9818";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-msgs/default.nix
+++ b/distros/noetic/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation }:
 buildRosPackage {
   pname = "ros-noetic-tf2-msgs";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_msgs/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "eee7164069d9f5950cc1196f5dfc26c455cdccbe84980a1a43fbccb4b383f723";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_msgs/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "90186a27936fab807993a65b9cd37f0d75cb6ac5f94ec42a20b6b0647a5025b9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-py/default.nix
+++ b/distros/noetic/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-py";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_py/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "ad94eb1bf317274039dac8eb17981af2864cc5949e24ba762564abafca263d53";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_py/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "85116cfca21a47310aa075f5b9a3c718b5a5c4bf55f8310eff90d9249ba219ea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-ros/default.nix
+++ b/distros/noetic/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-filters, roscpp, rosgraph, rospy, rostest, std-msgs, tf2, tf2-msgs, tf2-py, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-tf2-ros";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_ros/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "6cb6ebf52c8de736ee197bbe05f77f453e30d160e4eaedde9f66ff716f8f084a";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_ros/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "15a92e64deab87ec27986b6d16d690bef7979cefbe2346a0fc1e37090acb3881";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-sensor-msgs/default.nix
+++ b/distros/noetic/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, python3Packages, rospy, rostest, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-sensor-msgs";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_sensor_msgs/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "67977cf9d6c45ce1ddcd0959beafc53858075c35d7ff4b54af24c744cd84ad2c";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_sensor_msgs/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "9abd5230feb17b73b983cfbee8f19c0cbda9b9fce4aefa94d4f1960956180d87";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-tools/default.nix
+++ b/distros/noetic/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-tools";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_tools/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "b8f321481b85e2ce16643ba0356f417858bc08e8bd70954645d3db89a8bf67cf";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_tools/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "5240dc9950b1e8f042cfbd49fa0043985ef02677d247099bcb4ca6dfa3f645a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2/default.nix
+++ b/distros/noetic/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, console-bridge, geometry-msgs, rostime, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-tf2";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "1c195dcff3720e85819e47b753ce85e26cee5da9fb7c41533cc03782333fafe5";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "92205cf32422e07d31a0c849cc8a93ec7bdabee88b80fa425d683b4a12efb135";
   };
 
   buildType = "catkin";

--- a/distros/noetic/transmission-interface/default.nix
+++ b/distros/noetic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-transmission-interface";
-  version = "0.19.6-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/transmission_interface/0.19.6-1.tar.gz";
-    name = "0.19.6-1.tar.gz";
-    sha256 = "755e35de9c948073f5f97bcef76dfc4f9d851e6d1f18b892acf3ea8355315485";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/transmission_interface/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "c5c35327da825cb3f6f8105dd6ad272936eb5e0a2fa11d91f603e6291680fa44";
   };
 
   buildType = "catkin";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "2488c10245e49911625f3bbf4b71d19202ca279834257b3c36c8fe3ffb7b3211";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "84359cb7a1de61bd691aa6c385de3d28830956600ef6a14788748a0abb9ad8f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "c8daa6921851f2026edc2655b47242ad8bf365a64293f62818ba41524ba03c93";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "53bffb5fcc7f7bfb6024f96198dc0cf4f9dae8bca9bbe0231f72f8f9a9f8222b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.3.7-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.3.7-1.tar.gz";
-    name = "4.3.7-1.tar.gz";
-    sha256 = "60084c6b9b36dcb8c302d753684e8a371a3c5be0d1a4f63834b421fdaf9fc403";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "a9aee08e922314f3e56dce99bf10ef6f58113ef9e12058129944e70e55aa0002";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "416fc394fd0e05594fa0f1cf773ff5c895b1226220e7db59e2230089284fe729";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "9538279cf54109b31a21d9b3e95c2acf9a85c6ef02ff2f126927d518cb7a9e89";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bosch-locator-bridge/default.nix
+++ b/distros/rolling/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-bosch-locator-bridge";
-  version = "2.1.9-r2";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/rolling/bosch_locator_bridge/2.1.9-2.tar.gz";
-    name = "2.1.9-2.tar.gz";
-    sha256 = "986ef7b10e7eaacb01c433cde46522421c3df944e9bef3a8d47f1750ce7e1d98";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/rolling/bosch_locator_bridge/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "977e220c7f4d7ba3ec3eeb3d636a0eb713ed1f58158c629cf648def85d42483b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/catch-ros2/default.nix
+++ b/distros/rolling/catch-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-catch-ros2";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/rolling/catch_ros2/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "fa1709a9486c489ade25f08d6d7350ff5693619699421d5e615f79703df9c80b";
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/rolling/catch_ros2/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "1bd0fd185ad9d8b5ffca939a7eb0eea7c170509cbd3260a789b00a0797aef204";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "678dcd99c7dd14a74eb0720f24fd13ea9fe470d45853e0328febe63a2d12a1a4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "2bcfc7e9d42019bf451a64f9f2f7f4e802e7120ed0f2df341b0f4e2e9836db73";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "87cd5c619bf67bb7216adc708423abaac7ea790f0d15a25853cf090e4f069715";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "0e6bf0b6aa8dd3a4e771f1d341f26277ddcbab2049faf9bf68028f9116860adb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "c07a0614e32d94528b325d0173e557128d8820884113b5d3cae070f68dc3c999";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "c30e26cece1aefed12b8c6fcc67e5a766772aaa3e99323fc102dfed312342c9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "ba431d4e20ce182c6dd6c8ef1ce4628348988289e75f1f6867fe220f8a0ba571";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "e9cbd961beb359b1522ebf97f4f183af6df7b2a370ce4af51402394748a94fda";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "2c8f7f7a639a1790b7c631440fdd8079ea03a7aaf351b7b83e4a8afa083a5975";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "4c3d075a90446924f589e762a656bff5a599f7addab8ae5438b6416602a37c2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "6698ad614a2dd8b1fcb04439dfe41c72ecb97680a693511ae413157ec1083d5b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "f0ee72e500c9a5b5b715d8e9a9fe6d97dc7ae22c7b5ccc5d3cbd44c8337f4082";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "e4aac8e4aa288616186b48e949ba2e754b382f76e9821974ef8a49300da1396b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "d3db6a96f638fbd664f4897bb36a36549073791206e273a55171bceed5239340";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "74e7e9224a458c2a9ef261410b1c476bbc84260476a56512f8689a40d854e98f";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "6a020ac6a575618e4301eb5868d727daca5787985d1fcd8688a59ffa07563409";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-msgs/default.nix
+++ b/distros/rolling/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-msgs";
-  version = "2.2.0-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/rolling/foxglove_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "29e1e0d7cb63f1531f3183173d3d0a12dd62d202dcb097c3ad39ff47dd03eb7a";
+    url = "https://github.com/ros2-gbp/ros_foxglove_msgs-release/archive/release/rolling/foxglove_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "a77eb4c4f95aa9d975701c99acaa789b3514c7dc71224fedf548be0bc25c5228";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -150,8 +150,6 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
- apex-containers = self.callPackage ./apex-containers {};
-
  apex-test-tools = self.callPackage ./apex-test-tools {};
 
  apriltag = self.callPackage ./apriltag {};
@@ -672,6 +670,8 @@ self: super: {
 
  imu-tools = self.callPackage ./imu-tools {};
 
+ interactive-marker-twist-server = self.callPackage ./interactive-marker-twist-server {};
+
  interactive-markers = self.callPackage ./interactive-markers {};
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
@@ -1169,6 +1169,8 @@ self: super: {
  point-cloud-transport-plugins = self.callPackage ./point-cloud-transport-plugins {};
 
  point-cloud-transport-py = self.callPackage ./point-cloud-transport-py {};
+
+ point-cloud-transport-tutorial = self.callPackage ./point-cloud-transport-tutorial {};
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "3af67362f7768be06f7530eddca0691deaa94bbdd8f1bb89cd21a7367b2a4078";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "2fb43a4b7555b3fc97a6c9129a78056ff91e3f858bb70ee4bc4b5a9952202aef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "467662a4fac62d1b6e0727a366588588fe54d401e4218efbdd307273535a458d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "426802d49ed97df8e9ad709d0fed40471abdca2c8ac0bda60c8476f3dd972c75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "50fad4feca97defc606618af3d6ff8e40aeefde67b4fc20b60d958d2873aee0f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "a1593be9184cbdfa1c643a452a4593c8cc99c090a5d54ba6e81966ab4d1cc845";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/interactive-marker-twist-server/default.nix
+++ b/distros/rolling/interactive-marker-twist-server/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, interactive-markers, rclcpp, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-interactive-marker-twist-server";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/rolling/interactive_marker_twist_server/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "66b1b4b1ff3046dd23af3f88373f1fe6e7cf645c1882e2878e93bef3a382a060";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs interactive-markers rclcpp tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interactive control for generic Twist-based robots using interactive markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "e3550a0c83c4f4c6f8b74204ff11c5a2b70e37d65f401ae664f518c44cfab3b2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "74cb90f5395930d2170220e55931fef28ec85deefce365f783e3925c145f1e2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "c17a2e2f4fc3d0fa0928921ee28a90887e560fa0f0e56fe44cc113a49893f840";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "752bdb78e50648afa2e1f373365c2ad586d1e68735b7554994d2bca23881a592";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "17fed421d67da1f91262780a21bb06b09afbf4a6f73b7220be3d3813f2c84a77";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "200b58b939d2ef4bae1fa9c3bc14bb7fc21fe53296e0294f3ca0d5aae83b0a8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joy-linux/default.nix
+++ b/distros/rolling/joy-linux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joy-linux";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/joy_linux/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "a23fd91ccae5aa30fff1ba03159fa4edeba135215b0476ff5d128624c91e9ed2";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/joy_linux/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "8d6e155a8a5f9235edd47d2d74383d4cfb2356d2b8d4c103fdb054c148a739cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joy-teleop/default.nix
+++ b/distros/rolling/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joy-teleop";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/joy_teleop/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "13d3daf88d58412b48881db7b9dcf70f56389dd87f1a0d6ee4eef2b659fce1fc";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/joy_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e99cdc9cef1b193823e5b200be770caeae7bff8a9ab27356495f65f11c564a71";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/joy/default.nix
+++ b/distros/rolling/joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sdl2-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joy";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/joy/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "c34b43cc0a9de3a2ce0ab6b7a74304681c1faa829974019c648be8919f2b3eaa";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/joy/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "02e1a15babd1d9460302ea1dfc2fe2392a5eca59e2c76387bae99785d7139274";
   };
 
   buildType = "ament_cmake";
@@ -20,9 +20,8 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
-    description = ''The joy package contains joy_node, a node that interfaces a
-    generic joystick to ROS 2. This node publishes a &quot;Joy&quot;
-    message, which contains the current state of each one of the
+    description = ''The joy package contains joy_node, a node that interfaces a generic joystick to ROS
+    2. This node publishes a &quot;Joy&quot; message, which contains the current state of each one of the
     joystick's buttons and axes.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/rolling/key-teleop/default.nix
+++ b/distros/rolling/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-key-teleop";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/key_teleop/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "384d5202f67a16e32c95509087a5ce03aeee70e53c9b1d846bf6b0d06f8b3cc8";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/key_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "688dc0500ba10d31f3ccfe20ff76ede40eb81d6445a3c3cc9933e54095ca08af";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/libstatistics-collector/default.nix
+++ b/distros/rolling/libstatistics-collector/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-libstatistics-collector";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c881d1658818f498fc87493d0eb209f9071c2848dcd9209d7f5f497568b0b902";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "b6c79600aa03d0c1168ead3fe58bf7b953622ca705b61204c48daf5a79cc5d5d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture rcutils rosidl-default-generators rosidl-default-runtime std-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces rcl rcpputils statistics-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces rcl rcpputils rmw statistics-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/libyaml-vendor/default.nix
+++ b/distros/rolling/libyaml-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config, rcpputils, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-libyaml-vendor";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "8e0cd178c9da4cc1d0f3df2f30ed2f8351added40e617339097068197ba0951d";
+    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6b3024b4e45abc38e60bb671b428220844a5f4fec99620a90a7f5f2b4169b389";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-vendor-package ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture rcpputils rcutils ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture ];
   propagatedBuildInputs = [ libyaml pkg-config ];
   nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package pkg-config ];
 

--- a/distros/rolling/mouse-teleop/default.nix
+++ b/distros/rolling/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-mouse-teleop";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/mouse_teleop/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "de07a73d38bda23a712868a68995a5f3e9d55330dbfaff06a3ab968f2512f351";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/mouse_teleop/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "4607c5ca60bf7a817d5db2e5b29ae765cac6549e0564676d8cef79d0425f2cb8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.10.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "963551531cab14ebdbbc7eb517712aae60449f4a45111be801e0b24529cc0428";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "f8ca3b535c16d6a393f438869e1e5e6d351be736e8764e23f55c883d76596e80";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 python3Packages.pip pythonPackages.pybind11 ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libfyaml libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "27d5d82537d205281870a568c22c828c83674fb87e79baa061205c3e5771341d";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "4dfd8ead9b42262b452fed3441a1f920029109cb83fa631a5feb061ea4008c8b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 ros2launch sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/ntrip-client-node/default.nix
+++ b/distros/rolling/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ntrip-client-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "575b331217a7f10f311eb4e511d934e94a382b198950aefcb04cdcb708cec92e";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "de82c3059868fc1d0ef030e2a84e6de7a1e33216c2f6c86a0b83521065bf2048";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-tutorial/default.nix
+++ b/distros/rolling/point-cloud-transport-tutorial/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, point-cloud-transport, point-cloud-transport-plugins, rclcpp, rcpputils, rosbag2-cpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-point-cloud-transport-tutorial";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/point_cloud_transport_tutorial-release/archive/release/rolling/point_cloud_transport_tutorial/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "fdd82a0e5006df6c90619c80fbe2aaca7ceb5d639dc1079bcb66529f139eca33";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ];
+  propagatedBuildInputs = [ point-cloud-transport point-cloud-transport-plugins rclcpp rcpputils rosbag2-cpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Tutorial for point_cloud_transport.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "7c159cef1fe8f1fcb4ddd071f5df5bd496b4db1a49616534722d64ba19e53e24";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "68ee0e05312ee19c7e7f2ea17e425d96840a841d25b2ba70b455e0c56e25b6a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "0273c84b877372df06200f5a2b52c28302d673f20376fad35a700dc1fee9819c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "13e2ac692446d12283d67d736ec4fd5dba19b9425fc8da9528305050295d9170";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "4c7f2b1bda7cebe9931b36c614dcb9d0b7f0c5988dc5f6adc2d5ccba34f91b97";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "0267faa2599a81c4e4e0b1299d0e9e1b5820277800c8942af9d0598073d009dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "42a9d2891c5f0abf5ddc4088d0e278752186d68e11c5c5dd56ab3932c12a2f64";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "832886e3854244461c11c6a9e78151964e3bb8d1d6b02e562781e232e886d1ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "5196debea5924d9146a39802c6c6cb89c9dda2fa466cb87d9f762eafdb3c5cf9";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "de4cd8e3d9ee3f8919c51d3c147a88ef2d5baa45b706086d43fb0a2a7968e28b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "7.2.0-r1";
+  version = "7.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.2.0-1.tar.gz";
-    name = "7.2.0-1.tar.gz";
-    sha256 = "51bef31c8bc9277d47e6424c34f453a12930f04b531e96512b3c335c34da6497";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.3.0-1.tar.gz";
+    name = "7.3.0-1.tar.gz";
+    sha256 = "d58aac5e05a19c1569ed9c9c6f7f84ba706ab90adc433df1e1f1e21f01a89a0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "8e80de46edff802301af6b9971d608d8e538837c7782de3e99d447464c8f8d34";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "bdb546ddcf3a4442dec9a60678f7788df606f143580f3660b2eb330b5484e11c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "61599a3cfdc7384ba1cbab496fdeb432c1f36bfc3fb04f16499f4658ed9a5e8b";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "6cdee431880b10517c0d1b550069ef3d68dc88594070b35a46c221ea9959d345";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "e432a0cea91bf0bb08018456fcd3231cac59f0cf5e4885ab875e93944a67afe7";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "76125d7d855006014d436f02b92f3c6a6ab03f2664432c2382e64b55959daed1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "23.1.0-r1";
+  version = "23.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/23.1.0-1.tar.gz";
-    name = "23.1.0-1.tar.gz";
-    sha256 = "7cc6309b60beb120c375a600796a80de8c76bbbfafe941a52608505c8d46169f";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/23.2.0-1.tar.gz";
+    name = "23.2.0-1.tar.gz";
+    sha256 = "67a93b5eb69de39ea02fe9939d0dd71f82b0e751a3b74cb424582c3f2055a328";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "5.3.0-r1";
+  version = "5.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "c74a7422f79716b770df59a7438e57d1da68bf7eb9eaa3f5a930f639f86f94e2";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.4.0-1.tar.gz";
+    name = "5.4.0-1.tar.gz";
+    sha256 = "9dff99c4864ff0d79b4f4bfcc8fb84ae165d0d8c2e514d261b74d4e8e43b0596";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-dds-common/default.nix
+++ b/distros/rolling/rmw-dds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-c, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-dds-common";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "de321f66a737937199762b133950e3ad1a6257b928917826be8213eb971d886f";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "172202f46c5819e0506e6078db8119e566a2144bca565ad1c90ff09365a41e04";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "4db3754434fb96f8ff486b420dc01d5279ad6099cd17f35d2c7d4132f48f4a20";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "8f3ca488365e766e602203166780a50fe7e5faa98cb43949bd89ae521a6e7571";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "d705c7684fa606b1e8120cbad77f27027968208336cd7a9d5c39a50e156690ba";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "10cb20545d03a5e31bd25234fa0e78c8b93cd4d94e048ca2087663df1989cdf6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "26f0ea6f74a689db51a8286a635fe2d7682ca2a738c8e2d94981e2eff442291c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "1ac1821540519a1b438701d9a3d3f5dcfe37d072cdac8e8a08ea8d46f3da1247";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "4c9529a7cc8f3a970cbbb81522a7e52a7ef98d66e17e2302e0a05ff8603d9786";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "cbb34cf9edc340ec78e067ad5a36bedf908348a085115eb11dfdc378431cf31d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "89a74d0023521bcf62101958886fa7886a6a05e80bd62d567e0f3740603f528c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "a8ad353741420e35cd8e706d34b7248f89d5978b0461b15aac95c8cfdedfb430";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "da77ba32f7db78d237001d3b63e67c46cd066cf2a419d3d68269a5d86f2bd683";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "4508cfe7b12d37c2b4e6af75d1dc4ed2aafcfa59d8834061c902d227c3f6255c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "7959113ca20fd7d6c16a45f9385b278433ceb779c1658702fe3a4cf103c19f2b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "daadfa159c8daa02ddafc009a7300389dc043cd05c5c0d05868c80c3d87eb105";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-reconfigure/default.nix
+++ b/distros/rolling/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-reconfigure";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1db5afeb324ff26fa017247642f27cca0f7078095179edd4c1ac0c1634981cb5";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "7ef228cbfe216c319f182aa87ae4fd40dc6ff6a3a99658d9bc6dded5af2e4a6d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "6acc7596f45264635523cb63300cba0bfe5cacb915df3c49faab5ca4cf0b9c0e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "3ba7f4930448e973a9b91395f8a500de83c5db2a0eba161b730754726230cf28";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "78b35847c8ef6ad859ea937ba91fbcee5183e7d90fcf2e2bd2b06a87aa69bd4b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "4d9c8b2a9b0552939bfd35e664eee309833486c2b62ec849089c825d1883f217";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "7a4d32ea260e908ec482951e90a9cf288f5e29e2442547e59f4ecb8a6272e23d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "d5d99056753c84971e5075a2dd5f5a9ec16405b6412a3e7a14476c3946bd434f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "775ff6e661ada8c06bf68c782ffab9d88af9caaffa0a288a417ad2356ea89a8e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "18c6fc64dc46138ff21fb980235b7f56b902041b16021f71a5c71962e2614da5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "3fa7ab4fe1494d071403509d5f5b83d948271a78683852abcc753f6d11c5b86f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "f5f4b5bbc76800fb364c75b6cb30df0e768aa2c44c9d1a244ab992ba6e2a0333";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "45c22cf0a0cb2aac92306265ec9cb4ca1aff59c386436f309a112fbc3d769705";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "d2e87bb2a1efd7ee24e07a5401239cc7d3bf5d747ae23c7b9fa3878b20ae471b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "55c24bf4e440cbf11a919d604e2e1439cdda74f57d57617cc11b9e6ae3fbd1d0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "b469d20f2883dce76dfa6ecd23314dcdee679995a465ca2900f4dd74bc7a1267";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.1.1-r1";
+  version = "13.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.1-1.tar.gz";
-    name = "13.1.1-1.tar.gz";
-    sha256 = "ef8b0b0338a259f3771be852db3c483fb81b7082b088712a5cb25efc18736b8d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.2-1.tar.gz";
+    name = "13.1.2-1.tar.gz";
+    sha256 = "834614b612773079160401f846a1ba4c3f8994e51a1fc55ee90abc214e281aeb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sdl2-vendor/default.nix
+++ b/distros/rolling/sdl2-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL2, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-sdl2-vendor";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/sdl2_vendor/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "5ab3fc262ea3ae9c998b0ccba911e4ef4154d749e6ea854543160f489d7cbf39";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/sdl2_vendor/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "fe713c500b98928198a42ef4a182afda6fd2846da06be293cf4657ac458ecb49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/spacenav/default.nix
+++ b/distros/rolling/spacenav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, libspnav, rclcpp, rclcpp-components, sensor-msgs, spacenavd }:
 buildRosPackage {
   pname = "ros-rolling-spacenav";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/spacenav/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "4b432074d19a265478687f6f0e15bef94679c18f5ce270da0f544f8b52e4f020";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/spacenav/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "e05a02e20317f20f0a8abdc98b39e56ff92274754a755b67ad7a2c08a237e0b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "456f8c875762793a710b6e6d757a3be0c1cab6d534a8cb549b99a9cc2f89dbe9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "588af617bb55d36bc2ff464134c64336b80733823c6790d4cd9cc411aa3927ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/teleop-tools-msgs/default.nix
+++ b/distros/rolling/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-teleop-tools-msgs";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ac97094592332f0633d99a4ce7488394cddffc9736d576d58364a97d6eb6e741";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "f37a607654734fb082bcf01dcc4082a1ea1d2ff6cdf2332fe504293186b352e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/teleop-tools/default.nix
+++ b/distros/rolling/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-rolling-teleop-tools";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2938dd0ac829cc0fc58b56fe09da8bf1c14c766016330dd6b916a816ccea113c";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b2a6b14a082ad4084ac9e6682409352362ef26514f936b4a910c006c85342eb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "3.19.1-r1";
+  version = "3.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.19.1-1.tar.gz";
-    name = "3.19.1-1.tar.gz";
-    sha256 = "5f7fce401c176dcda640162defb575accb877e55d98d5e27de370f94636488b2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.20.0-1.tar.gz";
+    name = "3.20.0-1.tar.gz";
+    sha256 = "42a449cb555990e5a18d6971309fff6e84e6dd48c26e7d9952224f109f5fe33f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "3184afc73fa295f5610a3fb642c3f50363b2f01fe5dda52bcbeced59d5de4609";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "56798aeb130c99525e36db65ca8e5dc96fdc0b18bfa5dc9c45432315f58a5730";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "2b054768a59df5652dcee36cc67eb14d5dd1168b1b453ebfff1e7c6098c13773";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "7d61402cdaaeec57493356c29e3a92b565cd64043b536c435e7cb54932c93151";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss-node/default.nix
+++ b/distros/rolling/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "97ff15c55ea439959859ac050d0f5f80cfc42765b8f0e37d2d99bdf0fe1f1cd5";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "83f9688e1d221c6fd0fffb37befe56ff38d73739c78a93f908d1211e5e88d1df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss/default.nix
+++ b/distros/rolling/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "935cfe1cd6f2fe599aeaa3f881f6aae3eeff74de5a22323c2a312d8f79f84adb";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "8923316678cedbb9b6e62bb0a09e4aa9d81d659123fd22a1e1dc657f89083bdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-nav-sat-fix-hp-node";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "6bfcce4a947ba403d1cdfb85f20db9ab693ee659d982f79acbff8cee04d7ccad";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "d6502d7067d8c02893988a3c183158ef9bf0afe9349b1f44918f0bd95c4ca0b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-interfaces/default.nix
+++ b/distros/rolling/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-interfaces";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "5367c1ed50cee40afedba1fd30e8266b8926754e2ebf5046c0cb1d426d61107f";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "54e6015289e658bad68a4379224ec515f69b98ece7389ba81b9e98724c747dbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-msgs/default.nix
+++ b/distros/rolling/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-msgs";
-  version = "0.4.4-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "b73f9965cb0c83b7a78c13757936877fe477f5514a8959227063845439992589";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "5579d28fd806515860f1804617ba9eb40432becec7f810c89cc9565a5a98a515";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "3.16.0-r1";
+  version = "3.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.16.0-1.tar.gz";
-    name = "3.16.0-1.tar.gz";
-    sha256 = "d4e1f9f1957322ce7b4152dfcfb79608924bdafdf7bf6229e0fc7c9930699d95";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/3.17.0-1.tar.gz";
+    name = "3.17.0-1.tar.gz";
+    sha256 = "77cc70cfc3872b2965f60fcb0a0a8da2776844011780b322b7a960e8ebf140f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/wiimote-msgs/default.nix
+++ b/distros/rolling/wiimote-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-wiimote-msgs";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/wiimote_msgs/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "ce0289c6b9808916c7714c7d36590e7fcd3fef9e1bc72b4becb97e1b48349366";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/wiimote_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "438e0aeb41b23c54fc5aea520e419e2f71c80593b6427886c91a602eb90757b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/wiimote/default.nix
+++ b/distros/rolling/wiimote/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bluez, cwiid, geometry-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, wiimote-msgs }:
 buildRosPackage {
   pname = "ros-rolling-wiimote";
-  version = "3.1.0-r3";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/wiimote/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "081c0f716caf62a5d6b95069329c674f7ecd8ce8ffa21cae648708965fb4a3c0";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/rolling/wiimote/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "ac3988556ac191613024ece4bd0bccaeb1601dd5a324e5477fe079e3b03b8a04";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit e3eba7bb67e60108ba22ce297d72e1a9ad71311f.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ament-black 0.1.0-r1 --> 0.2.3-r1*
* *ament-cmake-black 0.1.0-r1 --> 0.2.3-r1*
* *andino-bringup 0.1.0-r1*
* *andino-control 0.1.0-r1*
* *andino-description 0.1.0-r1*
* *andino-firmware 0.1.0-r1*
* *andino-gz-classic 0.1.0-r1*
* *andino-hardware 0.1.0-r1*
* *andino-navigation 0.1.0-r1*
* *andino-slam 0.1.0-r1*
* *behaviortree-cpp 4.3.7-r1 --> 4.4.0-r1*
* *catch-ros2 0.1.0-r1 --> 0.2.0-r1*
* *clearpath-config-live 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-desktop 0.1.1-r1 --> 0.1.2-r1*
* *clearpath-viz 0.1.1-r1 --> 0.1.2-r1*
* *controller-interface 2.32.0-r1 --> 2.33.0-r1*
* *controller-manager 2.32.0-r1 --> 2.33.0-r1*
* *controller-manager-msgs 2.32.0-r1 --> 2.33.0-r1*
* *depthai-bridge 2.8.1-r2 --> 2.8.2-r1*
* *depthai-descriptions 2.8.1-r2 --> 2.8.2-r1*
* *depthai-examples 2.8.1-r2 --> 2.8.2-r1*
* *depthai-filters 2.8.1-r2 --> 2.8.2-r1*
* *depthai-ros 2.8.1-r2 --> 2.8.2-r1*
* *depthai-ros-driver 2.8.1-r2 --> 2.8.2-r1*
* *depthai-ros-msgs 2.8.1-r2 --> 2.8.2-r1*
* *foxglove-bridge 0.7.2-r1 --> 0.7.3-r1*
* *hardware-interface 2.32.0-r1 --> 2.33.0-r1*
* *joint-limits 2.32.0-r1 --> 2.33.0-r1*
* *joy 3.1.0-r3 --> 3.3.0-r1*
* *joy-linux 3.1.0-r3 --> 3.3.0-r1*
* *joy-teleop 1.3.0-r2 --> 1.5.0-r1*
* *key-teleop 1.3.0-r2 --> 1.5.0-r1*
* *leo 1.1.0-r1 --> 1.2.0-r1*
* *leo-description 1.1.0-r1 --> 1.2.0-r1*
* *leo-msgs 1.1.0-r1 --> 1.2.0-r1*
* *leo-teleop 1.1.0-r1 --> 1.2.0-r1*
* *mouse-teleop 1.3.0-r2 --> 1.5.0-r1*
* *mrpt2 2.10.2-r1 --> 2.11.2-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*
* *ros2-control 2.32.0-r1 --> 2.33.0-r1*
* *ros2-control-test-assets 2.32.0-r1 --> 2.33.0-r1*
* *ros2controlcli 2.32.0-r1 --> 2.33.0-r1*
* *rqt-controller-manager 2.32.0-r1 --> 2.33.0-r1*
* *sdl2-vendor 3.1.0-r3 --> 3.3.0-r1*
* *spacenav 3.1.0-r3 --> 3.3.0-r1*
* *teleop-tools 1.3.0-r2 --> 1.5.0-r1*
* *teleop-tools-msgs 1.3.0-r2 --> 1.5.0-r1*
* *transmission-interface 2.32.0-r1 --> 2.33.0-r1*
* *ur 2.2.8-r1 --> 2.2.9-r1*
* *ur-bringup 2.2.8-r1 --> 2.2.9-r1*
* *ur-calibration 2.2.8-r1 --> 2.2.9-r1*
* *ur-controllers 2.2.8-r1 --> 2.2.9-r1*
* *ur-dashboard-msgs 2.2.8-r1 --> 2.2.9-r1*
* *ur-moveit-config 2.2.8-r1 --> 2.2.9-r1*
* *urdf-sim-tutorial 1.0.1-r1*
* *wiimote 3.1.0-r3 --> 3.3.0-r1*
* *wiimote-msgs 3.1.0-r3 --> 3.3.0-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.16.0-r1 --> 3.17.0-r1*
* *admittance-controller 3.16.0-r1 --> 3.17.0-r1*
* *ament-black 0.2.3-r1*
* *ament-cmake-black 0.2.3-r1*
* *behaviortree-cpp 4.3.7-r1 --> 4.4.0-r1*
* *bicycle-steering-controller 3.16.0-r1 --> 3.17.0-r1*
* *catch-ros2 0.1.0-r1 --> 0.2.0-r1*
* *controller-interface 3.19.1-r1 --> 3.20.0-r1*
* *controller-manager 3.19.1-r1 --> 3.20.0-r1*
* *controller-manager-msgs 3.19.1-r1 --> 3.20.0-r1*
* *depthai-bridge 2.8.1-r1 --> 2.8.2-r1*
* *depthai-descriptions 2.8.1-r1 --> 2.8.2-r1*
* *depthai-examples 2.8.1-r1 --> 2.8.2-r1*
* *depthai-filters 2.8.1-r1 --> 2.8.2-r1*
* *depthai-ros 2.8.1-r1 --> 2.8.2-r1*
* *depthai-ros-driver 2.8.1-r1 --> 2.8.2-r1*
* *depthai-ros-msgs 2.8.1-r1 --> 2.8.2-r1*
* *diff-drive-controller 3.16.0-r1 --> 3.17.0-r1*
* *effort-controllers 3.16.0-r1 --> 3.17.0-r1*
* *force-torque-sensor-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *forward-command-controller 3.16.0-r1 --> 3.17.0-r1*
* *foxglove-bridge 0.7.2-r1 --> 0.7.3-r1*
* *gripper-controllers 3.16.0-r1 --> 3.17.0-r1*
* *hardware-interface 3.19.1-r1 --> 3.20.0-r1*
* *imu-sensor-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *interactive-marker-twist-server 2.1.0-r1*
* *joint-limits 3.19.1-r1 --> 3.20.0-r1*
* *joint-state-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *joint-trajectory-controller 3.16.0-r1 --> 3.17.0-r1*
* *joy 3.1.0-r4 --> 3.3.0-r1*
* *joy-linux 3.1.0-r4 --> 3.3.0-r1*
* *joy-teleop 1.4.0-r2 --> 1.5.0-r1*
* *key-teleop 1.4.0-r2 --> 1.5.0-r1*
* *mcap-vendor 0.22.3-r1 --> 0.22.4-r1*
* *mouse-teleop 1.4.0-r2 --> 1.5.0-r1*
* *mrpt2 2.10.2-r1 --> 2.11.2-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*
* *ntrip-client-node 0.4.4-r1 --> 0.5.1-r1*
* *position-controllers 3.16.0-r1 --> 3.17.0-r1*
* *range-sensor-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *ros-gz 0.245.0-r1 --> 0.247.0-r1*
* *ros-gz-interfaces 0.245.0-r1 --> 0.247.0-r1*
* *ros-ign 0.245.0-r1 --> 0.247.0-r1*
* *ros-ign-bridge 0.245.0-r1 --> 0.247.0-r1*
* *ros-ign-gazebo 0.245.0-r1 --> 0.247.0-r1*
* *ros-ign-gazebo-demos 0.245.0-r1 --> 0.247.0-r1*
* *ros-ign-image 0.245.0-r1 --> 0.247.0-r1*
* *ros-ign-interfaces 0.245.0-r1 --> 0.247.0-r1*
* *ros2-control 3.19.1-r1 --> 3.20.0-r1*
* *ros2-control-test-assets 3.19.1-r1 --> 3.20.0-r1*
* *ros2-controllers 3.16.0-r1 --> 3.17.0-r1*
* *ros2-controllers-test-nodes 3.16.0-r1 --> 3.17.0-r1*
* *ros2bag 0.22.3-r1 --> 0.22.4-r1*
* *ros2controlcli 3.19.1-r1 --> 3.20.0-r1*
* *rosbag2 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-compression 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-compression-zstd 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-cpp 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-examples-cpp 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-examples-py 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-interfaces 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-performance-benchmarking 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-performance-benchmarking-msgs 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-py 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-storage 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-storage-default-plugins 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-storage-mcap 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-storage-sqlite3 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-test-common 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-test-msgdefs 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-tests 0.22.3-r1 --> 0.22.4-r1*
* *rosbag2-transport 0.22.3-r1 --> 0.22.4-r1*
* *rqt-controller-manager 3.19.1-r1 --> 3.20.0-r1*
* *rqt-joint-trajectory-controller 3.16.0-r1 --> 3.17.0-r1*
* *sdl2-vendor 3.1.0-r4 --> 3.3.0-r1*
* *shared-queues-vendor 0.22.3-r1 --> 0.22.4-r1*
* *spacenav 3.1.0-r4 --> 3.3.0-r1*
* *sqlite3-vendor 0.22.3-r1 --> 0.22.4-r1*
* *steering-controllers-library 3.16.0-r1 --> 3.17.0-r1*
* *teleop-tools 1.4.0-r2 --> 1.5.0-r1*
* *teleop-tools-msgs 1.4.0-r2 --> 1.5.0-r1*
* *transmission-interface 3.19.1-r1 --> 3.20.0-r1*
* *tricycle-controller 3.16.0-r1 --> 3.17.0-r1*
* *tricycle-steering-controller 3.16.0-r1 --> 3.17.0-r1*
* *ublox-dgnss 0.4.4-r1 --> 0.5.1-r1*
* *ublox-dgnss-node 0.4.4-r1 --> 0.5.1-r1*
* *ublox-nav-sat-fix-hp-node 0.4.4-r1 --> 0.5.1-r1*
* *ublox-ubx-interfaces 0.4.4-r1 --> 0.5.1-r1*
* *ublox-ubx-msgs 0.4.4-r1 --> 0.5.1-r1*
* *urdf-sim-tutorial 1.0.1-r1*
* *velocity-controllers 3.16.0-r1 --> 3.17.0-r1*
* *wiimote 3.1.0-r4 --> 3.3.0-r1*
* *wiimote-msgs 3.1.0-r4 --> 3.3.0-r1*
* *zstd-vendor 0.22.3-r1 --> 0.22.4-r1*

Noetic Changes:
---------------
* *bosch-locator-bridge 1.0.9-r3 --> 1.0.10-r1*
* *clearpath-configuration-msgs 0.9.4-r1*
* *clearpath-control-msgs 0.9.4-r1*
* *clearpath-dock-msgs 0.9.4-r1*
* *clearpath-localization-msgs 0.9.4-r1*
* *clearpath-mission-manager-msgs 0.9.4-r1*
* *clearpath-mission-scheduler-msgs 0.9.4-r1*
* *clearpath-msgs 0.9.4-r1*
* *clearpath-navigation-msgs 0.9.4-r1*
* *clearpath-onav-api-examples 0.0.3-r1*
* *clearpath-onav-api-examples-lib 0.0.3-r1*
* *clearpath-onav-examples 0.0.3-r1*
* *clearpath-platform-msgs 0.9.4-r1*
* *clearpath-safety-msgs 0.9.4-r1*
* *combined-robot-hw 0.19.6-r1 --> 0.20.0-r1*
* *combined-robot-hw-tests 0.19.6-r1 --> 0.20.0-r1*
* *controller-interface 0.19.6-r1 --> 0.20.0-r1*
* *controller-manager 0.19.6-r1 --> 0.20.0-r1*
* *controller-manager-msgs 0.19.6-r1 --> 0.20.0-r1*
* *controller-manager-tests 0.19.6-r1 --> 0.20.0-r1*
* *cpr-onav-description 0.1.9-r1 --> 0.1.10-r1*
* *depthai-bridge 2.8.1-r1 --> 2.8.2-r1*
* *depthai-descriptions 2.8.1-r1 --> 2.8.2-r1*
* *depthai-examples 2.8.1-r1 --> 2.8.2-r1*
* *depthai-filters 2.8.1-r1 --> 2.8.2-r1*
* *depthai-ros 2.8.1-r1 --> 2.8.2-r1*
* *depthai-ros-driver 2.8.1-r1 --> 2.8.2-r1*
* *depthai-ros-msgs 2.8.1-r1 --> 2.8.2-r1*
* *foxglove-bridge 0.7.2-r1 --> 0.7.3-r1*
* *geometry2 0.7.6-r1 --> 0.7.7-r1*
* *gnsstk 14.0.0-r8*
* *hardware-interface 0.19.6-r1 --> 0.20.0-r1*
* *hri-msgs 0.8.0-r1 --> 0.9.0-r1*
* *hri-rviz 0.4.1-r1 --> 0.4.2-r1*
* *image-transport-codecs 2.3.1-r1 --> 2.3.4-r1*
* *joint-limits-interface 0.19.6-r1 --> 0.20.0-r1*
* *jsk-pr2eus 0.3.15-r1 --> 0.3.15-r3*
* *leo 2.2.0-r1 --> 2.3.0-r1*
* *leo-bringup 2.3.0-r1 --> 2.4.0-r1*
* *leo-description 2.2.0-r1 --> 2.3.0-r1*
* *leo-desktop 0.2.3-r1 --> 0.3.0-r1*
* *leo-fw 2.3.0-r1 --> 2.4.0-r1*
* *leo-msgs 2.2.0-r1 --> 2.3.0-r1*
* *leo-robot 2.3.0-r1 --> 2.4.0-r1*
* *leo-teleop 2.2.0-r1 --> 2.3.0-r1*
* *leo-viz 0.2.3-r1 --> 0.3.0-r1*
* *mrpt2 2.10.2-r1 --> 2.11.2-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*
* *openni2-camera 1.6.0-r1 --> 1.6.1-r1*
* *openni2-launch 1.6.0-r1 --> 1.6.1-r1*
* *openzen-sensor 1.3.2-r1 --> 1.2.0-r1*
* *paho-mqtt-c 1.3.12-r1 --> 1.3.13-r1*
* *pr2eus 0.3.15-r1 --> 0.3.15-r3*
* *pr2eus-moveit 0.3.15-r3*
* *ros-control 0.19.6-r1 --> 0.20.0-r1*
* *rqt-controller-manager 0.19.6-r1 --> 0.20.0-r1*
* *sick-safevisionary-base 1.0.1-r1*
* *sick-safevisionary-driver 1.0.1-r1*
* *sick-safevisionary-msgs 1.0.1-r1*
* *sick-scan-xd 3.0.3-r1*
* *tf2 0.7.6-r1 --> 0.7.7-r1*
* *tf2-bullet 0.7.6-r1 --> 0.7.7-r1*
* *tf2-eigen 0.7.6-r1 --> 0.7.7-r1*
* *tf2-geometry-msgs 0.7.6-r1 --> 0.7.7-r1*
* *tf2-kdl 0.7.6-r1 --> 0.7.7-r1*
* *tf2-msgs 0.7.6-r1 --> 0.7.7-r1*
* *tf2-py 0.7.6-r1 --> 0.7.7-r1*
* *tf2-ros 0.7.6-r1 --> 0.7.7-r1*
* *tf2-sensor-msgs 0.7.6-r1 --> 0.7.7-r1*
* *tf2-tools 0.7.6-r1 --> 0.7.7-r1*
* *transmission-interface 0.19.6-r1 --> 0.20.0-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 3.16.0-r1 --> 3.17.0-r1*
* *admittance-controller 3.16.0-r1 --> 3.17.0-r1*
* *behaviortree-cpp 4.3.7-r1 --> 4.4.0-r1*
* *bicycle-steering-controller 3.16.0-r1 --> 3.17.0-r1*
* *bosch-locator-bridge 2.1.9-r2 --> 2.1.10-r1*
* *catch-ros2 0.1.0-r1 --> 0.2.0-r1*
* *controller-interface 3.19.1-r1 --> 3.20.0-r1*
* *controller-manager 3.19.1-r1 --> 3.20.0-r1*
* *controller-manager-msgs 3.19.1-r1 --> 3.20.0-r1*
* *diff-drive-controller 3.16.0-r1 --> 3.17.0-r1*
* *effort-controllers 3.16.0-r1 --> 3.17.0-r1*
* *force-torque-sensor-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *forward-command-controller 3.16.0-r1 --> 3.17.0-r1*
* *foxglove-bridge 0.7.2-r1 --> 0.7.3-r1*
* *foxglove-msgs 2.2.0-r1 --> 3.0.0-r1*
* *gripper-controllers 3.16.0-r1 --> 3.17.0-r1*
* *hardware-interface 3.19.1-r1 --> 3.20.0-r1*
* *imu-sensor-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *interactive-marker-twist-server 2.1.0-r1*
* *joint-limits 3.19.1-r1 --> 3.20.0-r1*
* *joint-state-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *joint-trajectory-controller 3.16.0-r1 --> 3.17.0-r1*
* *joy 3.1.0-r3 --> 3.3.0-r1*
* *joy-linux 3.1.0-r3 --> 3.3.0-r1*
* *joy-teleop 1.4.0-r1 --> 1.5.0-r1*
* *key-teleop 1.4.0-r1 --> 1.5.0-r1*
* *libstatistics-collector 1.6.2-r1 --> 1.6.3-r1*
* *libyaml-vendor 1.6.1-r1 --> 1.6.2-r1*
* *mouse-teleop 1.4.0-r1 --> 1.5.0-r1*
* *mrpt2 2.10.0-r1 --> 2.11.2-r1*
* *mvsim 0.8.1-r1 --> 0.8.2-r1*
* *ntrip-client-node 0.4.4-r1 --> 0.5.1-r1*
* *point-cloud-transport-tutorial 0.0.1-r1*
* *position-controllers 3.16.0-r1 --> 3.17.0-r1*
* *range-sensor-broadcaster 3.16.0-r1 --> 3.17.0-r1*
* *rcl 7.2.0-r1 --> 7.3.0-r1*
* *rcl-action 7.2.0-r1 --> 7.3.0-r1*
* *rcl-lifecycle 7.2.0-r1 --> 7.3.0-r1*
* *rcl-yaml-param-parser 7.2.0-r1 --> 7.3.0-r1*
* *rclcpp 23.1.0-r1 --> 23.2.0-r1*
* *rclcpp-action 23.1.0-r1 --> 23.2.0-r1*
* *rclcpp-components 23.1.0-r1 --> 23.2.0-r1*
* *rclcpp-lifecycle 23.1.0-r1 --> 23.2.0-r1*
* *rclpy 5.3.0-r1 --> 5.4.0-r1*
* *rmw-dds-common 2.1.0-r1 --> 2.1.1-r1*
* *ros2-control 3.19.1-r1 --> 3.20.0-r1*
* *ros2-control-test-assets 3.19.1-r1 --> 3.20.0-r1*
* *ros2-controllers 3.16.0-r1 --> 3.17.0-r1*
* *ros2-controllers-test-nodes 3.16.0-r1 --> 3.17.0-r1*
* *ros2controlcli 3.19.1-r1 --> 3.20.0-r1*
* *rqt-controller-manager 3.19.1-r1 --> 3.20.0-r1*
* *rqt-joint-trajectory-controller 3.16.0-r1 --> 3.17.0-r1*
* *rqt-reconfigure 1.6.0-r1 --> 1.6.1-r1*
* *rviz-assimp-vendor 13.1.1-r1 --> 13.1.2-r1*
* *rviz-common 13.1.1-r1 --> 13.1.2-r1*
* *rviz-default-plugins 13.1.1-r1 --> 13.1.2-r1*
* *rviz-ogre-vendor 13.1.1-r1 --> 13.1.2-r1*
* *rviz-rendering 13.1.1-r1 --> 13.1.2-r1*
* *rviz-rendering-tests 13.1.1-r1 --> 13.1.2-r1*
* *rviz-visual-testing-framework 13.1.1-r1 --> 13.1.2-r1*
* *rviz2 13.1.1-r1 --> 13.1.2-r1*
* *sdl2-vendor 3.1.0-r3 --> 3.3.0-r1*
* *spacenav 3.1.0-r3 --> 3.3.0-r1*
* *steering-controllers-library 3.16.0-r1 --> 3.17.0-r1*
* *teleop-tools 1.4.0-r1 --> 1.5.0-r1*
* *teleop-tools-msgs 1.4.0-r1 --> 1.5.0-r1*
* *transmission-interface 3.19.1-r1 --> 3.20.0-r1*
* *tricycle-controller 3.16.0-r1 --> 3.17.0-r1*
* *tricycle-steering-controller 3.16.0-r1 --> 3.17.0-r1*
* *ublox-dgnss 0.4.4-r1 --> 0.5.1-r1*
* *ublox-dgnss-node 0.4.4-r1 --> 0.5.1-r1*
* *ublox-nav-sat-fix-hp-node 0.4.4-r1 --> 0.5.1-r1*
* *ublox-ubx-interfaces 0.4.4-r1 --> 0.5.1-r1*
* *ublox-ubx-msgs 0.4.4-r1 --> 0.5.1-r1*
* *velocity-controllers 3.16.0-r1 --> 3.17.0-r1*
* *wiimote 3.1.0-r3 --> 3.3.0-r1*
* *wiimote-msgs 3.1.0-r3 --> 3.3.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] ml_classifiers
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

