### PR TITLE
Pin ignition-common to ffmpeg version 4

### DIFF
--- a/pkgs/ignition/common/default.nix
+++ b/pkgs/ignition/common/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config, ignition
 , ignition-cmake ? ignition.cmake, ignition-math ? ignition.math
-, ignition-utils ? ignition.utils, libuuid, tinyxml-2, freeimage, gts, ffmpeg
+, ignition-utils ? ignition.utils, libuuid, tinyxml-2, freeimage, gts, ffmpeg_4
 , majorVersion ? "4"
 , version ? "4.6.2"
 , srcHash ? "sha256-VyvpTeCCwX2WBJdVd6lZrN7QomdOQnxGZFXXnT3ct0s="
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   propagatedNativeBuildInputs = [ ignition-cmake ];
-  buildInputs = [ ignition-math tinyxml-2 ignition-math gts freeimage ffmpeg ]
+  buildInputs = [ ignition-math tinyxml-2 ignition-math gts freeimage ffmpeg_4 ]
     ++ lib.optional (lib.versionAtLeast version "4") ignition-utils;
   propagatedBuildInputs = [ libuuid ];
 


### PR DESCRIPTION
This PR ensures that ignition-common builds with ffmpeg version 4, since the nixpkgs-unstable upstream version of ffmpeg is not compatible with the version of ignition-common in this overlay.

Related: https://github.com/acxz/gazebo-arch/issues/56

Notify @vBruegge